### PR TITLE
Improve build for using gstlearn from some other code

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -96,6 +96,8 @@ foreach(FLAVOR ${FLAVORS})
 
   # Rename the output library name
   set_target_properties(${FLAVOR} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+  # append a 'd' to the output file name of the debug build targets
+  set_target_properties(${FLAVOR} PROPERTIES DEBUG_POSTFIX "d")
   
   # Set library version
   set_target_properties(${FLAVOR} PROPERTIES VERSION ${PROJECT_VERSION})

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -31,6 +31,7 @@ install(
   EXPORT ${PROJECT_NAME}_corelibs
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib
+  ARCHIVE DESTINATION lib
 )
 
 # Install the includes


### PR DESCRIPTION
Two unrelated things about making it easier to use gstlearn in some other (C++) code:
* On Windows code that wants to compile/link with a DLL must have access to the .lib file, which currently isn't packaged correctly by the "install" target.
* When compiling both a debug and release version of gstlearn they use the same name which means they cannot be properly installed in the same location, which makes using them in another project more complicated. Setting a different name for the debug version (gstlearnd) means the same path can be used easily.

In practice, with those two changes, I am able to:
* compile gstlearn both in release and debug and install it to the same location (e.g. `C:\Dev\gstlearn_install`);
* use gstlearn in another project by simply adding `find_package(gstlearn PATHS "C:/Dev/gstlearn_install/share/gstlearn/cmake")` and `target_link_libraries(foo PRIVATE gstlearn::shared)`.

The second change (renaming the debug library) may have some impact to people who already use gstlearn (debug) installations manually (i.e. without accessing it through `find_package()`) so this may require further changes elsewhere?