### PR TITLE
Fix _USE_HDF5 build error

### DIFF
--- a/src/Gibbs/GibbsMMulti.cpp
+++ b/src/Gibbs/GibbsMMulti.cpp
@@ -376,7 +376,7 @@ void GibbsMMulti::_storeWeights(int icol)
   {
     // Store in hdf5 file
 #ifdef _USE_HDF5
-    _hdf5.writeDataDoublePartial(icol), _weights);
+    _hdf5.writeDataDoublePartial(icol, _weights);
 #endif
   }
 }


### PR DESCRIPTION
This commit fixes a build error (extra parenthesis) when enabling the `USE_HDF5` CMake option.

Enjoy,
Pierre