### PR TITLE
Fix Clang warnings on Ubuntu

### DIFF
--- a/include/Anamorphosis/AnamDiscrete.hpp
+++ b/include/Anamorphosis/AnamDiscrete.hpp
@@ -31,7 +31,7 @@ public:
 
   /// AAnam interface
   bool hasGaussian() const override { return false; }
-  int getNClass() const { return _nCut + 1; }
+  int getNClass() const override { return _nCut + 1; }
 
   /// Interface for AnamDiscrete
   virtual void calculateMeanAndVariance();

--- a/include/Basic/HDF5format.hpp
+++ b/include/Basic/HDF5format.hpp
@@ -256,7 +256,7 @@ void HDF5format::writeData(const VectorT<VectorNumT<T> > &data)
   char* myh5type = (char*) (typeid(a[0]).name());
   _writeAll(myh5type, (void* ) a);
   delete[] md;
-  delete a;
+  delete[] a;
 #endif
 }
 

--- a/include/Basic/WarningMacro.hpp
+++ b/include/Basic/WarningMacro.hpp
@@ -12,7 +12,7 @@
 
 // Thanks to https://www.fluentcpp.com/2019/08/30/how-to-disable-a-warning-in-cpp/
 
-#if defined(__APPLE__) // First, test __APPLE__ before __GNUC__ and _MSC_VER (because Clang defines both)
+#if defined(__clang__) // First, test __clang__ before __GNUC__ and _MSC_VER (because Clang defines both)
   #define DO_PRAGMA(X) _Pragma(#X)
   #define DISABLE_WARNING_PUSH           DO_PRAGMA(clang diagnostic push)
   #define DISABLE_WARNING_POP            DO_PRAGMA(clang diagnostic pop)

--- a/include/Calculators/CalcGridToGrid.hpp
+++ b/include/Calculators/CalcGridToGrid.hpp
@@ -39,7 +39,7 @@ protected:
   virtual bool _postprocess() override;
   virtual void _rollback() override;
 
-  virtual int  _getNVar() const;
+  virtual int  _getNVar() const override;
 
 private:
   bool _g2gCopy();

--- a/include/Calculators/CalcSimuPost.hpp
+++ b/include/Calculators/CalcSimuPost.hpp
@@ -52,7 +52,7 @@ protected:
   virtual int _getTransfoNvar() const { return 0; }
   virtual void _transformFunction(const VectorDouble& tabin, VectorDouble& tabout) const { DECLARE_UNUSED(tabin, tabout); return; }
 
-  int  _getNVar() const { return (int) _names.size(); }
+  int  _getNVar() const override { return (int) _names.size(); }
   int  _getIechout() const { return _iechout; }
   bool _getFlagUpscale() const { return _flagUpscale; }
 

--- a/include/Covariances/CovAniso.hpp
+++ b/include/Covariances/CovAniso.hpp
@@ -104,7 +104,7 @@ public:
                            int icas2,
                            int iech2,
                            MatrixSquareGeneral &mat,
-                           const CovCalcMode *mode = nullptr) const;
+                           const CovCalcMode *mode = nullptr) const override;
 
   static CovAniso* createIsotropic(const CovContext& ctxt,
                                    const ECov& type,

--- a/include/Covariances/CovBesselK.hpp
+++ b/include/Covariances/CovBesselK.hpp
@@ -37,7 +37,7 @@ public:
   void   setMarkovCoeffs(VectorDouble coeffs) override { _markovCoeffs = coeffs;}
   VectorDouble getMarkovCoeffs() const override;
   double getCorrec() const override { return _correc;}
-  void   computeCorrec(int ndim);
+  void   computeCorrec(int ndim) override;
   void   setCorrec(double val) override { _correc = val;}
   void   computeMarkovCoeffs(int dim) override;
 

--- a/include/Covariances/CovWendland2.hpp
+++ b/include/Covariances/CovWendland2.hpp
@@ -37,6 +37,6 @@ public:
 
 protected:
   double _evaluateCov(double h) const override;
-  double _evaluateCovDerivative(int degree, double h) const;
+  double _evaluateCovDerivative(int degree, double h) const override;
 };
 

--- a/include/Matrix/AMatrixDense.hpp
+++ b/include/Matrix/AMatrixDense.hpp
@@ -45,9 +45,9 @@ public:
 
   /// Interface for AMatrix
   /*! Returns if the matrix belongs to the MatrixSparse class (avoids dynamic_cast) */
-  virtual bool isDense() const { return true; }
+   bool isDense() const override { return true; }
   /*! Returns if the current matrix is Sparse */
-  virtual bool isSparse() const { return false; }
+   bool isSparse() const override { return false; }
 
   /*! Set the contents of a Column */
   virtual void setColumn(int icol, const VectorDouble& tab) override;

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -51,9 +51,9 @@ public:
 
   /// Interface for AMatrix
   /*! Returns if the current matrix is Sparse */
-  bool isSparse() const { return true; }
+  bool isSparse() const override { return true; }
   /*! Returns if the matrix belongs to the MatrixSparse class (avoids dynamic_cast) */
-  virtual bool isDense() const { return false; }
+   bool isDense() const override { return false; }
 
   /*! Set the contents of a Column */
   virtual void setColumn(int icol, const VectorDouble& tab) override;
@@ -185,7 +185,7 @@ public:
 
 protected:
   /// Interface for AMatrix
-  bool    _isPhysicallyPresent(int irow, int icol) const { DECLARE_UNUSED(irow, icol); return true; }
+  bool    _isPhysicallyPresent(int irow, int icol) const override { DECLARE_UNUSED(irow, icol); return true; }
   bool    _isCompatible(const AMatrix& m) const override
   {
     DECLARE_UNUSED(m);

--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -54,7 +54,7 @@ public:
   int     getNMeshes() const override;
   int     getApex(int imesh, int rank) const override;
   double  getCoor(int imesh, int rank, int idim) const override;
-  void    getCoordinatesInPlace(int imesh, int rank, VectorDouble& coords) const;
+  void    getCoordinatesInPlace(int imesh, int rank, VectorDouble& coords) const override;
   double  getApexCoor(int i, int idim) const override;
   void    getApexCoordinatesInPlace(int i, VectorDouble& coords) const override;
   double  getMeshSize(int imesh) const override;

--- a/include/Mesh/MeshSpherical.hpp
+++ b/include/Mesh/MeshSpherical.hpp
@@ -53,7 +53,7 @@ public:
             bool byCol,
             bool verbose = false);
   void resetProjMatrix(ProjMatrix* m, const Db *db, int rankZ = -1, bool verbose = false) const override;
-  int  getVariety() const { return 1; }
+  int  getVariety() const override { return 1; }
 
   const MatrixRectangular& getApices() const { return _apices; }
   const MatrixInt& getMeshes() const { return _meshes; }

--- a/include/Simulation/SimuRefine.hpp
+++ b/include/Simulation/SimuRefine.hpp
@@ -60,7 +60,7 @@ private:
                         int ix0,
                         int iy0,
                         int iz0);
-  int _getNDim() const;
+  int _getNDim() const override;
 
 private:
   SimuRefineParam _param;

--- a/src/Basic/HDF5format.cpp
+++ b/src/Basic/HDF5format.cpp
@@ -597,7 +597,7 @@ VectorVectorFloat HDF5format::getDataVVFloat() const
 
     delete[] dims;
     delete[] md;
-    delete data;
+    delete[] data;
     return v;
   }
   catch (H5::Exception& error)


### PR DESCRIPTION
This PR fixes all Clang warnings on Ubuntu, in 3 categories:

- the `override` keyword was missing on several virtual member function declaration. While having a similar effect to the `virtual` keyword, in C++>=11 they have a distinct meaning (c.f. https://en.cppreference.com/w/cpp/language/override) and Clang wants it enforced.
- the wrong `delete` operator was used in the hdf5 (the correct one was `delete[]`).
- in `WarningMacro.hpp`, the `__APPLE__` macro (only defined on macOS) used to detect Clang has been replaced with `__clang__`. On Ubuntu + Clang, `__APPLE__` was causing Clang to output `-Wunknown-warning-option` warnings because it did not understand `GCC diagnostic push` pragmas.

Enjoy,
Pierre