### PR TITLE
GitHub Actions: Use package managers for getting Boost & Eigen

### DIFF
--- a/.github/workflows/nonreg-tests_macos-latest-one.yml
+++ b/.github/workflows/nonreg-tests_macos-latest-one.yml
@@ -19,10 +19,6 @@ env:
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
-  BOOST_ROOT: ${{github.workspace}}/boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}/eigen
-  EIGEN_VERSION : "3.4.0"
   LLVM_ROOT : /opt/homebrew
 
 jobs:
@@ -33,7 +29,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install dependencies
-      run: brew install llvm
+      run: brew install llvm boost eigen
       
     #- name: Setup Python Version
     #  uses: actions/setup-python@v4
@@ -57,19 +53,6 @@ jobs:
     #    swig-root: ${{env.SWIG_ROOT}}
     #    generator: "Unix Makefiles"
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-unix
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-unix
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Unix Makefiles"
-
     #- name: Compile, install package and execute one R test
     #  run: |
     #    make check_test_r TEST=test_Matrix_r LLVM_ROOT=${{env.LLVM_ROOT}} SWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig EIGEN3_ROOT=${{env.EIGEN_ROOT}} BOOST_ROOT=${{env.BOOST_ROOT}}
@@ -80,4 +63,4 @@ jobs:
 
     - name: Compile, install package and execute one C++ test
       run: |
-        make dump_test_cpp TEST=test_fracture LLVM_ROOT=${{env.LLVM_ROOT}} SWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig EIGEN3_ROOT=${{env.EIGEN_ROOT}} BOOST_ROOT=${{env.BOOST_ROOT}}
+        make dump_test_cpp TEST=test_fracture LLVM_ROOT=${{env.LLVM_ROOT}} SWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install dependencies
-      run: brew install llvm
+      run: brew install llvm boost eigen
       
     - name: Setup Python Version
       uses: actions/setup-python@v4
@@ -66,21 +66,8 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-unix
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-unix
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Unix Makefiles"
-
     - name: Configure CMake
-      run: CC=${{env.LLVM_ROOT}}/opt/llvm/bin/clang CXX=${{env.LLVM_ROOT}}/opt/llvm/bin/clang++ cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DEigen3_ROOT=${{env.EIGEN_ROOT}} -DBoost_ROOT=${{env.BOOST_ROOT}}
+      run: CC=${{env.LLVM_ROOT}}/opt/llvm/bin/clang CXX=${{env.LLVM_ROOT}}/opt/llvm/bin/clang++ cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
     - name: Compile, install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --target check

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -29,10 +29,6 @@ env:
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
-  BOOST_ROOT: ${{github.workspace}}/boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}/eigen
-  EIGEN_VERSION : "3.4.0"
 
 jobs:
   build:
@@ -45,21 +41,11 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
-        sudo apt-get install -yq libhdf5-dev
-        sudo apt-get install -yq libopenmpi-dev
-
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-unix
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-unix
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Unix Makefiles"
+        sudo apt-get install -yq \
+          libhdf5-dev \
+          libopenmpi-dev \
+          libboost-dev \
+          libeigen3-dev
 
     - name: Setup Python Version
       uses: actions/setup-python@v4
@@ -84,7 +70,7 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Configure CMake
-      run: cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DEigen3_ROOT=${{env.EIGEN_ROOT}} -DBoost_ROOT=${{env.BOOST_ROOT}}
+      run: cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
     - name: Compile, install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --target check -- -j 3

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -54,11 +54,6 @@ jobs:
         python -m pip install numpy==${{env.NUMPY_VERSION}}
         python -m pip install pandas scipy mlxtend
 
-    - name: Install Python dependency
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy==${{env.NUMPY_VERSION}} mlxtend
-
     - name: Install the Boost headers
       uses: ./.github/workflows/install-boost-windows
       with:

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -28,10 +28,7 @@ env:
   GENERATOR : "Visual Studio 17 2022"
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
-  BOOST_ROOT: ${{github.workspace}}\boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}\eigen
-  EIGEN_VERSION : "3.4.0"
+  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
   #HDF5_ROOT : hdf5 #do not use "." in the name
   #HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1-zip/?wpdmdl=15723"
   #HDF5_VERSION : hdf5-1.12.1
@@ -48,27 +45,18 @@ jobs:
       with:
         python-version: ${{env.PYTHON_VERSION}}
 
+    - name: Install dependencies
+      run: |
+        vcpkg install boost-math eigen3
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install numpy==${{env.NUMPY_VERSION}}
         python -m pip install pandas scipy mlxtend
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-windows
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-windows
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: ${{env.GENERATOR}}
-
     - name: Configure CMake
-      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DBUILD_PYTHON=ON -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBoost_ROOT=${{env.BOOST_ROOT}} -DEigen3_ROOT=${{env.EIGEN_ROOT}}
+      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DBUILD_PYTHON=ON -DPython3_ROOT_DIR="${{env.pythonLocation}}"
 
     - name: Compile, install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}} --target check

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -24,10 +24,7 @@ env:
   GENERATOR : "MSYS Makefiles"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}\swig_420b
-  BOOST_ROOT: ${{github.workspace}}\boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}\eigen
-  EIGEN_VERSION : "3.4.0"
+  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
   
@@ -42,26 +39,18 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
+    - name: Install dependencies
+      run: |
+        vcpkg install boost-math eigen3
+
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-windows-action@v2
       with:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Visual Studio 17 2022"
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-windows
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-windows
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-
     - name: Configure CMake
-      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DBoost_ROOT=${{env.BOOST_ROOT}} -DEigen3_ROOT=${{env.EIGEN_ROOT}} 
+      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
     - name: Compile, install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --target check -- -j 3

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -25,10 +25,6 @@ on:
 env:
   BUILD_TYPE: Release
   BUILD_DIR : build
-  BOOST_ROOT: ${{github.workspace}}/boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}/eigen
-  EIGEN_VERSION : "3.4.0"
 #  HDF5_ROOT : hdf5 #do not use "." in the name 
 #  HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1.tar.gz/?wpdmdl=15722"
 #  HDF5_VERSION : hdf5-1.12.1
@@ -61,7 +57,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install dependencies
-      run: brew install llvm swig doxygen
+      run: brew install llvm swig doxygen boost eigen
       
     - name: Setup Python Version
       uses: actions/setup-python@v3
@@ -89,22 +85,9 @@ jobs:
 #        cmake --build . --target all --config Release -- -j 3
 #        cmake --build . --target install --config Release
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-unix
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-unix
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Unix Makefiles"
-
     - name : Create Wheels
       run : |
-        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON -DBoost_ROOT=${{env.BOOST_ROOT}} -DEigen3_ROOT=${{env.EIGEN_ROOT}} 
+        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON
         cmake --build ${{env.BUILD_DIR}} --target python_build -- -j 3
         cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -28,10 +28,7 @@ env:
   GENERATOR : "Visual Studio 16 2019"
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
-  BOOST_ROOT: ${{github.workspace}}\boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}\eigen
-  EIGEN_VERSION : "3.4.0"
+  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
   #HDF5_ROOT : hdf5 #do not use "." in the name
   #HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1-zip/?wpdmdl=15723"
   #HDF5_VERSION : hdf5-1.12.1
@@ -64,6 +61,10 @@ jobs:
         python-version: ${{matrix.python.py}}
         architecture: ${{matrix.arch.ar}}
 
+    - name: Install dependencies
+      run: |
+        vcpkg install boost-math eigen3
+
     - name: Install Python dependencies
       # Force specific old version for Numpy
       run: |
@@ -75,19 +76,6 @@ jobs:
       with:
         doxygen-root: ${{env.DOXYGEN_ROOT}}
         doxygen-version: ${{env.DOXYGEN_VERSION}}
-
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-windows
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-windows
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: ${{env.GENERATOR}}
 
 #    - name : Download and install HDF5
 #      run: | 
@@ -103,7 +91,7 @@ jobs:
 
     - name : Create Wheels
       run : |
-        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -A ${{matrix.arch.of}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}} -DBoost_ROOT=${{env.BOOST_ROOT}} -DEigen3_ROOT=${{env.EIGEN_ROOT}} 
+        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -A ${{matrix.arch.of}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
         cmake --build ${{env.BUILD_DIR}} --target python_build --config ${{env.BUILD_TYPE}}
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name : Install llvm
-      run: brew install llvm
+      run: brew install llvm boost eigen
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2
@@ -68,19 +68,6 @@ jobs:
     #    Rscript -e "install.packages(c('rlang'), repos='https://cloud.r-project.org/', dependencies = TRUE)"
     #    Rscript -e "install.packages(c('systemfonts', 'ragg', 'pkgdown', 'devtools'), repos='https://cloud.r-project.org/', dependencies = TRUE)"
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-unix
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-unix
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Unix Makefiles"
-
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:
@@ -89,7 +76,7 @@ jobs:
 
     - name : Build the package and save generated file name in the environment
       run : |
-        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DBUILD_DOXYGEN=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DEigen3_ROOT=${{env.EIGEN_ROOT}} -DBoost_ROOT=${{env.BOOST_ROOT}}
+        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DBUILD_DOXYGEN=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
         cmake --build ${{env.BUILD_DIR}} --target r_install
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.BUILD_TYPE}}/gstlearn_*.tgz)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -30,10 +30,7 @@ env:
   SWIG_ROOT : ${{github.workspace}}\swig_420b
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
-  BOOST_ROOT: ${{github.workspace}}\boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}\eigen
-  EIGEN_VERSION : "3.4.0"
+  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
   
@@ -55,6 +52,10 @@ jobs:
     - name: Install devtools
       run: Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
 
+    - name: Install dependencies
+      run: |
+        vcpkg install boost-math eigen3
+
     - name: Install Doxygen under windows
       uses: fabien-ors/install-doxygen-windows-action@v1
       with:
@@ -66,22 +67,9 @@ jobs:
       with:
         swig-root: ${{env.SWIG_ROOT}}
 
-    - name: Install the Boost headers
-      uses: ./.github/workflows/install-boost-windows
-      with:
-        boost-root: ${{env.BOOST_ROOT}}
-        boost-version: ${{env.BOOST_VERSION}}
-
-    - name: Install the Eigen headers
-      uses: ./.github/workflows/install-eigen-windows
-      with:
-        eigen-root: ${{env.EIGEN_ROOT}}
-        eigen-version: ${{env.EIGEN_VERSION}}
-        generator: "Visual Studio 16 2019"
-
     - name : Build the package and save generated file name in the environment
       run : |
-        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}} -DEigen3_ROOT=${{env.EIGEN_ROOT}} -DBoost_ROOT=${{env.BOOST_ROOT}}
+        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
         cmake --build ${{env.BUILD_DIR}} --target r_install
         $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/r/${{env.BUILD_TYPE}}/gstlearn_*.zip" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
This PR makes use of platform-dependent package managers to handle the installation of the Boost and Eigen dependencies.

More specifically, `apt` is used on Ubuntu, `brew` on macOS and `vcpkg` on Windows. Note that while the first two provide binary packages, `vcpkg` seems to be building from source.

The custom actions `install-boost-unix`, `install-boost-windows`, `install-eigen-unix` and `install-eigen-windows` are now useless and can be removed in a further PR.

Enjoy,
Pierre