### PR TITLE
GitHub Actions: Make vcpkg build x86 binaries

### DIFF
--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -62,9 +62,15 @@ jobs:
         architecture: ${{matrix.arch.ar}}
 
     - name: Install dependencies
+      if: ${{ matrix.arch.pl == 'win_amd64' }}
       run: |
         vcpkg install boost-math eigen3
-        
+
+    - name: Install dependencies
+      if: ${{ matrix.arch.pl == 'win32' }}
+      run: |
+        vcpkg install boost-math:x86-windows eigen3:x86-windows
+
     - name: Install Python dependencies
       # Force specific old version for Numpy
       run: |


### PR DESCRIPTION
The `publish_python_windows` workflow builds x86 binaries alongside x64 ones. `vcpkg` needs to be aware of the target architecture to provide the relevant packages. This PR makes `vcpkg` install x86 when required.

According to the documentation, there is a `VCPKG_TARGET_ARCHITECTURE` that should be set to target either x64 or x86 but I did not manage to make it work on GitHub Actions.

Enjoy,
Pierre