### PR TITLE
Warning fixes

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -101,8 +101,8 @@ jobs:
     - name: Use clang-check for compiler warnings
       run: |
         git ls-files \
-        | grep src \
-        | grep -E "\.cpp$|\.cxx$" \
+        | grep -E "src|include" \
+        | grep -E "\.cpp$|\.hpp$" \
         | xargs -n1 -P$(nproc) clang-check -p build --extra-arg=-Werror
 
 

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -22,7 +22,7 @@ if (MSVC)
   add_compile_options(/bigobj /W4 /wd4251 /wd4244) # Except those two warnings
 else()
   # Lots of warnings (-Wall = add some warnings, -Wextra = add a ton of warnings)
-  add_compile_options(-Wall -Wextra -Wno-deprecated-copy -Wno-unused-parameter)
+  add_compile_options(-Wall -Wextra -Wno-deprecated-copy -Wno-unused-parameter -Wundef)
   if (APPLE)
     add_compile_options(-Wno-absolute-value -Wno-inconsistent-missing-override)
   endif()

--- a/include/Basic/VectorT.hpp
+++ b/include/Basic/VectorT.hpp
@@ -253,7 +253,7 @@ String VectorT<T>::toString() const
 template <typename T>
 void VectorT<T>::_detach()
 {
-  if (_v.unique())
+  if (_v.use_count() == 1)
     return;
   _v = std::make_shared<Vector>(*_v);
 }

--- a/include/Covariances/CovHelper.hpp
+++ b/include/Covariances/CovHelper.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "gstlearn_export.hpp"
+#include "Basic/VectorT.hpp"
 
 class GSTLEARN_EXPORT CovHelper
 {

--- a/include/Estimation/CalcKrigingFactors.hpp
+++ b/include/Estimation/CalcKrigingFactors.hpp
@@ -15,6 +15,7 @@
 #include "geoslib_define.h"
 
 #include "Calculators/ACalcInterpolator.hpp"
+#include "Enum/EKrigOpt.hpp"
 
 class Db;
 class DbGrid;

--- a/include/LinearOp/ALinearOpMulti.hpp
+++ b/include/LinearOp/ALinearOpMulti.hpp
@@ -11,9 +11,8 @@
 #pragma once
 
 #include "gstlearn_export.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "LinearOp/LogStats.hpp"
-
-#include <vector>
 
 class ALinearOpMulti;
 

--- a/include/LinearOp/IOptimCost.hpp
+++ b/include/LinearOp/IOptimCost.hpp
@@ -12,6 +12,8 @@
 
 #include "gstlearn_export.hpp"
 
+#include "Basic/VectorNumT.hpp"
+
 class GSTLEARN_EXPORT IOptimCost {
 
 public:

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -216,7 +216,7 @@ protected:
   virtual int     _invert() override;
   virtual int     _solve(const VectorDouble& b, VectorDouble& x) const override;
 
-  void _clear();
+  void _clear() override;
   bool _isElementPresent(int irow, int icol) const;
 
 private:

--- a/include/Neigh/ANeigh.hpp
+++ b/include/Neigh/ANeigh.hpp
@@ -19,6 +19,7 @@
 #include "geoslib_define.h"
 
 class Db;
+class DbGrid;
 
 class GSTLEARN_EXPORT ANeigh:  public ASpaceObject, public ASerializable
 {

--- a/include/Polynomials/MonteCarlo.hpp
+++ b/include/Polynomials/MonteCarlo.hpp
@@ -12,6 +12,8 @@
 
 #include "gstlearn_export.hpp"
 
+#include "Basic/VectorNumT.hpp"
+
 #define NBSIMU_DEF 1000
 
 GSTLEARN_EXPORT double integralGaussHermite(double yc,

--- a/include/Simulation/CalcSimuFFT.hpp
+++ b/include/Simulation/CalcSimuFFT.hpp
@@ -15,6 +15,7 @@
 #include "geoslib_define.h"
 
 #include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/SimuFFTParam.hpp"
 #include "Basic/Plane.hpp"
 #include "Basic/VectorNumT.hpp"
 

--- a/include/Space/SpaceShape.hpp
+++ b/include/Space/SpaceShape.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "gstlearn_export.hpp"
+#include "geoslib_define.h"
 
 /// TODO : to be kept ?
 

--- a/include/Stats/Classical.hpp
+++ b/include/Stats/Classical.hpp
@@ -19,6 +19,8 @@
 #include "Basic/NamingConvention.hpp"
 
 class Db;
+class DbGrid;
+class Polygons;
 class Table;
 class VarioParam;
 

--- a/include/Stats/Selectivity.hpp
+++ b/include/Stats/Selectivity.hpp
@@ -18,6 +18,7 @@
 #include "Basic/VectorNumT.hpp"
 #include "Basic/ICloneable.hpp"
 #include "Basic/AStringable.hpp"
+#include "Basic/NamingConvention.hpp"
 #include "Matrix/MatrixInt.hpp"
 
 class Db;

--- a/include/Variogram/VCloud.hpp
+++ b/include/Variogram/VCloud.hpp
@@ -23,6 +23,7 @@
 
 class Db;
 class ECalcVario;
+class Polygons;
 
 /**
  * \brief

--- a/src/Basic/ASerializable.cpp
+++ b/src/Basic/ASerializable.cpp
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include <regex>
 #include <fstream>
-#if __linux__ // Not operational under MacOS
+#ifdef __linux__ // Not operational under MacOS
 #include <wordexp.h>
 #endif
 
@@ -241,7 +241,7 @@ String ASerializable::buildFileName(int status, const String& filename, bool ens
 
   String filePath = fileLocal;
 
-#if __linux__ // Not operational under MacOS
+#ifdef __linux__ // Not operational under MacOS
   // Check the presence of tilde character
   wordexp_t p;
   wordexp(fileLocal.c_str(), &p, 0);
@@ -459,7 +459,7 @@ String ASerializable::getExecDirectory()
   char buffer[MAX_PATH] = "";
   if (GetModuleFileName(NULL, buffer, MAX_PATH) != 0)
     dir = String(buffer);
-#elif __APPLE__
+#elif defined (__APPLE__)
   char buffer[PATH_MAX] = "";
   uint32_t bufsize = PATH_MAX;
   if(!_NSGetExecutablePath(buffer, &bufsize))

--- a/src/Basic/Memory.cpp
+++ b/src/Basic/Memory.cpp
@@ -20,7 +20,7 @@ unsigned long long getTotalSystemMemory()
   if (GlobalMemoryStatusEx(&status) == 0) return 0;
   return status.ullTotalPhys;
 }
-#elif __APPLE__
+#elif defined (__APPLE__)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -2082,7 +2082,6 @@ void VectorHelper::mergeInPlace(const VectorDouble& vecin, VectorDouble& vecout,
  * Transform a vector of double values as follows
  * @param tab  Vector of double values
  * @param oper_choice Operation on the diagonal term (see Utilities::operate_XXX)
- * @return
  */
 void VectorHelper::transformVD(VectorDouble& tab, int oper_choice)
 {

--- a/src/Matrix/AMatrix.cpp
+++ b/src/Matrix/AMatrix.cpp
@@ -125,8 +125,6 @@ void AMatrix::resetFromVD(int nrows, int ncols, const VectorDouble& tab, bool by
 /**
  * @brief Reset the matrix from an array of double values
  * 
- * @param nrows New number of rows
- * @param ncols New number of columns
  * @param tab The array of values
  * @param byCol True if values are column-major in the array
  */

--- a/src/Matrix/MatrixSquareGeneral.cpp
+++ b/src/Matrix/MatrixSquareGeneral.cpp
@@ -57,7 +57,6 @@ MatrixSquareGeneral::~MatrixSquareGeneral()
  * Converts a VectorVectorDouble into a Matrix
  * Note: the input argument is stored by row (if coming from [] specification)
  * @param X Input VectorVectorDouble argument
- * @param opt_eigen Option for use of Eigen Library
  * @return The returned square matrix
  *
  * @remark: the matrix is transposed implicitly while reading

--- a/src/Matrix/MatrixSquareSymmetric.cpp
+++ b/src/Matrix/MatrixSquareSymmetric.cpp
@@ -88,7 +88,6 @@ MatrixSquareSymmetric::~MatrixSquareSymmetric()
  * Converts a VectorVectorDouble into a Square Symmetric Matrix
  * Note: the input argument is stored by row (if coming from [] specification)
  * @param  X Input VectorVectorDouble argument
- * @param opt_eigen Option for use of Eigen Library
  * @return The returned square symmetric matrix
  *
  * @remark: the matrix is transposed implicitly while reading

--- a/src/Neigh/NeighBench.cpp
+++ b/src/Neigh/NeighBench.cpp
@@ -192,9 +192,7 @@ bool NeighBench::_isSameTargetBench(int iech_out) const
 /**
  * Select the neighborhood
  * @param iech_out Valid Rank of the sample in the output Db
- * @param ranks Vector of input / output sample ranks
- *
- * @return Vector of sample ranks in neighborhood (empty when error)
+ * @param ranks Vector of sample ranks in neighborhood (empty when error)
  */
 void NeighBench::getNeigh(int iech_out, VectorInt& ranks)
 {

--- a/src/Neigh/NeighCell.cpp
+++ b/src/Neigh/NeighCell.cpp
@@ -137,9 +137,7 @@ bool NeighCell::hasChanged(int iech_out) const
 /**
  * Select the neighborhood
  * @param iech_out Valid Rank of the sample in the output Db
- * @param ranks Vector of input / output sample ranks
- *
- * @return Vector of sample ranks in neighborhood (empty when error)
+ * @param ranks Vector of sample ranks in neighborhood (empty when error)
  */
 void NeighCell::getNeigh(int iech_out, VectorInt& ranks)
 {

--- a/src/Neigh/NeighImage.cpp
+++ b/src/Neigh/NeighImage.cpp
@@ -140,9 +140,7 @@ bool NeighImage::hasChanged(int iech_out) const
 /**
  * Select the neighborhood
  * @param iech_out Valid Rank of the sample in the output Db
- * @param ranks Vector of input / output sample ranks
- *
- * @return Vector of sample ranks in neighborhood (empty when error)
+ * @param ranks Vector of sample ranks in neighborhood (empty when error)
  */
 void NeighImage::getNeigh(int iech_out, VectorInt& ranks)
 {

--- a/src/Neigh/NeighMoving.cpp
+++ b/src/Neigh/NeighMoving.cpp
@@ -494,9 +494,7 @@ bool NeighMoving::hasChanged(int iech_out) const
 /**
  * Select the neighborhood
  * @param iech_out Valid Rank of the sample in the output Db
- * @param ranks Vector of input / output sample ranks
- *
- * @return Vector of sample ranks in neighborhood (empty when error)
+ * @param ranks Vector of sample ranks in neighborhood (empty when error)
  */
 void NeighMoving::getNeigh(int iech_out, VectorInt& ranks)
 {

--- a/src/Neigh/NeighUnique.cpp
+++ b/src/Neigh/NeighUnique.cpp
@@ -115,9 +115,7 @@ bool NeighUnique::hasChanged(int iech_out) const
 /**
  * Select the neighborhood
  * @param iech_out Valid Rank of the sample in the output Db
- * @param ranks Vector of input / output sample ranks
- *
- * @return Vector of sample ranks in neighborhood (empty when error)
+ * @param ranks Vector of sample ranks in neighborhood (empty when error)
  */
 void NeighUnique::getNeigh(int iech_out, VectorInt& ranks)
 {

--- a/src/Tree/neighbors_heap.cpp
+++ b/src/Tree/neighbors_heap.cpp
@@ -51,7 +51,7 @@ t_nheap	*nheap_init(int n_pts, int n_nbrs)
 	}
 	h->indices = (int**)malloc(sizeof(int*) * n_pts);
 	for (int i = 0; i < n_pts; i++)
-		h->indices[i] = (int*)calloc(sizeof(int), n_nbrs);
+      h->indices[i] = (int*)calloc(n_nbrs, sizeof(int));
 	return (h);
 }
 


### PR DESCRIPTION
This PR contains fixes for several compiler/Doxygen warnings.

In particular:
- it adds `-Wundef` to the list of compiler warnings and fixes 4 instances when this warning was raised (using `#if` instead of `#ifdef`)
- Doxygen warnings were fixed to make sure that the documentation stays relevant to the code
- missing includes/forward declarations were added to header files to make them less dependent on the inclusion order
- the `check_code` workflow was extended to also check compilation warnings/errors in header files
- a missing `override` keyword has been added
- arguments in a `calloc` call were permuted,
- `std::shared_ptr::unique` has been replaced with `use_count` (following #148's advice)

Enjoy,
Pierre
 