### PR TITLE
Small CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,13 @@ include(cmake/install.cmake)
 ####################################################
 ## PACKAGES
 
-add_subdirectory(python)
-add_subdirectory(r)
+if(BUILD_PYTHON)
+  add_subdirectory(python)
+endif()
+
+if(BUILD_R)
+  add_subdirectory(r)
+endif()
 
 ####################################################
 ## TESTING

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -20,6 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 if (MSVC)
   # Warning level 4 (4 = maximum, 0 = none)
   add_compile_options(/bigobj /W4 /wd4251 /wd4244) # Except those two warnings
+  # Silence MSVC warnings about unsafe C standard library functions
+  add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
   # Lots of warnings (-Wall = add some warnings, -Wextra = add a ton of warnings)
   add_compile_options(-Wall -Wextra -Wno-deprecated-copy -Wno-unused-parameter -Wundef)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -128,8 +128,6 @@ endif()
 
 # Set some properties on SWIG target
 set_target_properties(python_build PROPERTIES
-  # Do not build python package by default
-  EXCLUDE_FROM_ALL ON
   # Modify the generated library name
   OUTPUT_NAME ${PROJECT_NAME}
   # Compiler flags for the SWIG library

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -124,8 +124,6 @@ set(COMP_FLAGS "-D${PROJECT_NAME_UP}_STATIC_DEFINE -Wno-free-nonheap-object -Wno
 
 # Set some properties on SWIG target
 set_target_properties(r_build PROPERTIES
-  # Do not build R package by default
-  EXCLUDE_FROM_ALL ON
   # Modify the generated library name
   OUTPUT_NAME ${PROJECT_NAME}
   # Compiler flags for the SWIG library


### PR DESCRIPTION
This PR adds small improvements related to CMake:

- the Eigen, OpenMP & HDF5 dependencies are used through CMake targets, encompassing compiler flags, include directories and linking libraries in a single `target_link_libraries` call,
- a MSVC warning about insecure C standard library calls is silenced with the `_CRT_SECURE_NO_WARNINGS` definition (we don't want to use specific Microsoft alternatives to the C standard library)
- make the Python and the R wrapper build by default when `BUILD_PYTHON` or `BUILD_R` is selected. The `python_build` and `r_build` targets are still there to build them explicitly,
- wrap `add_subdirectory(python)` and `add_subdirectory(r)` under guards. This seems more idiomatic to me than `return()` in the subdir CMakeLists.

Enjoy,
Pierre