### PR TITLE
Make gstlearn builds reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,20 @@ option(USE_HDF5 "Using HDF5 support" OFF)
 # By default, do not activate NetCDF support
 #option(USE_NETCDF "Using NetCDF support" OFF)
 
-# Create gstlearn_DATE, gstlearn_YEAR and gstlearn_MONTH variables
-string(TIMESTAMP ${PROJECT_NAME}_DATE "%Y/%m/%d - %H:%M")
-string(TIMESTAMP ${PROJECT_NAME}_YEAR "%Y")
-string(TIMESTAMP ${PROJECT_NAME}_MONTH "%B")
+# Extract Git commit timestamp, hash
+find_package(Git)
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} show -s --format=%ci
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE ${PROJECT_NAME}_DATE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE ${PROJECT_NAME}_COMMIT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 # Convert project name to uppercase
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UP)

--- a/src/Core/acknowledge.cpp
+++ b/src/Core/acknowledge.cpp
@@ -53,8 +53,8 @@ void acknowledge_gstlearn(void)
 {
   // Print the header 
 
-  message("gstlearn Library (Version:%s - Date:%s)",
-          GSTLEARN_VERSION,GSTLEARN_DATE);
+  message("gstlearn Library (Version: %s - Date: %s - Commit: %s)",
+          GSTLEARN_VERSION, GSTLEARN_DATE, GSTLEARN_COMMIT);
 
   // Print the list of authors
 

--- a/version.h.in
+++ b/version.h.in
@@ -13,5 +13,6 @@
 /* Version numbers and date */
 
 #define GSTLEARN_VERSION "@gstlearn_VERSION@"     // gstlearn version (for acknowledge and identification)
-#define GSTLEARN_DATE    "@gstlearn_DATE@"        // gstlearn release date (for acknowledge and identification)
+#define GSTLEARN_DATE    "@gstlearn_DATE@"        // gstlearn git commit date (for acknowledge and identification)
+#define GSTLEARN_COMMIT  "@gstlearn_COMMIT@"      // gstlearn git commit hash (for acknowledge and identification)
 


### PR DESCRIPTION
gslearn builds are currently not reproducible: building the library in two different build directories yield libraries with different md5/sha1 sums.

This is due to the `GSTLEARN_DATE` macro, filled at configure time by CMake with a timestamp (of the configuration time). This timestamp changes each time CMake is run in any build directory.

In this PR, I propose to replace this system with information taken from the Git version control system:
- the identifier of the current commit (Git commit hash)
- and the timestamp of said commit.

As a consequence, two builds from the same Git commit should yield identical libraries.

These information are still gathered at configure time, meaning that, if a gstlearn dev creates new commits that don't require CMake to be re-run, the macros won't be updated. But I think this is still an improvement over the current situation.

Enjoy,
Pierre