### PR TITLE
GitHub Actions: Force binaries for devtools

### DIFF
--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -50,7 +50,7 @@ jobs:
         r-version: ${{matrix.r_version}}
 
     - name: Install devtools
-      run: Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR forces R to install `devtools` binary packages instead of compiling them from sources (when sources are more recent than binaries).

This should make the `publish_r_windows` workflow faster.

Enjoy,
Pierre