### PR TITLE
Enable r_doc target, switch to roxygen

### DIFF
--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -60,6 +60,9 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
+    - name: Install devtools
+      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -60,8 +60,11 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install devtools
-      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+    - name: Install roxygen2
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: roxygen2
+        install-pandoc: false
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -63,6 +63,9 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
+    - name: Install devtools
+      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -63,8 +63,11 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install devtools
-      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+    - name: Install roxygen2
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: roxygen2
+        install-pandoc: false
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -39,8 +39,11 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install devtools
-      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+    - name: Install roxygen2
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: roxygen2
+        install-pandoc: false
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
+    - name: Install devtools
+      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+
     - name: Install dependencies
       run: |
         echo '{

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -57,6 +57,9 @@ jobs:
       with:
         r-version: ${{matrix.r_version}}
         
+    - name: Install devtools
+      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+
     # Not yet operational (devtools cannot be installed) => BUILD_DOXYGEN=OFF
     #- name : Install doxygen
     #  run: brew install doxygen

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -57,8 +57,11 @@ jobs:
       with:
         r-version: ${{matrix.r_version}}
         
-    - name: Install devtools
-      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+    - name: Install roxygen2
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: roxygen2, pkgbuild
+        install-pandoc: false
 
     # Not yet operational (devtools cannot be installed) => BUILD_DOXYGEN=OFF
     #- name : Install doxygen

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -49,8 +49,11 @@ jobs:
       with:
         r-version: ${{matrix.r_version}}
 
-    - name: Install devtools
-      run: Rscript -e "options(pkgType = 'binary'); install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+    - name: Install roxygen2
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: roxygen2, pkgbuild
+        install-pandoc: false
 
     - name: Install dependencies
       run: |

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -149,7 +149,7 @@ target_include_directories(r_build PRIVATE ${R_INCLUDE_DIRS})
 target_link_libraries(r_build PRIVATE ${R_LIBRARIES})
 
 # Tell that we need to generate Rd files before building R package
-#add_dependencies(r_build r_doc) // TODO: This line should be uncommented after correction (DR)
+add_dependencies(r_build r_doc)
 
 ########################################
 # PACKAGING

--- a/r/README.md
+++ b/r/README.md
@@ -82,7 +82,7 @@ For building the *gstlearn* R package, the requirements for building *gstlearn C
 * SWIG 4.2.0 **customized by Fabien Ors** (not the official version!)
 * R 4.2 or higher
 * RTools 4.2 or higher (for Windows users only)
-* *devtools* R package (for generating R documentation)
+* *roxygen2* R package (for generating R documentation)
 * *ggplot2*, *vctrs*, *ggpubr*, *ggrepel*, *ggnewscale* R packages [Optional] (only for plotting)
 * *FNN*, *lares*, *Matrix*, *knitr*, *tidyr*, *geigen* and *callr* R packages [Optional] (only for testing R Markdown scripts)
 
@@ -130,10 +130,10 @@ make
 sudo make install
 ````
 
-6. Finally, install the R packages from an R command prompt (only devtools is mandatory):
+6. Finally, install the R packages from an R command prompt (only roxygen2 is mandatory):
 
 ````
-install.packages(c("devtools"), repos="https://cloud.r-project.org")
+install.packages(c("roxygen2"), repos="https://cloud.r-project.org")
 install.packages(c("ggplot2", "vctrs", "ggpubr", "ggrepel", "ggnewscale"), repos="https://cloud.r-project.org")
 install.packages(c("FNN", "lares", "Matrix", "knitr", "callr", "tidyr", "geigen"), repos="https://cloud.r-project.org")
 ````
@@ -175,10 +175,10 @@ make
 sudo make install
 ````
 
-6. Finally, install the R optional packages from an R command prompt (only devtools is mandatory):
+6. Finally, install the R optional packages from an R command prompt (only roxygen2 is mandatory):
 
 ````
-install.packages(c("devtools"), repos="https://cloud.r-project.org")
+install.packages(c("roxygen2"), repos="https://cloud.r-project.org")
 install.packages(c("ggplot2", "vctrs", "ggpubr", "ggrepel", "ggnewscale"), repos="https://cloud.r-project.org")
 install.packages(c("FNN", "lares", "Matrix", "knitr", "callr", "tidyr", "geigen"), repos="https://cloud.r-project.org")
 ````
@@ -223,10 +223,10 @@ make
 make install
 ````
 
-6. Finally, install the R optional packages from an R command prompt (only devtools is mandatory):
+6. Finally, install the R optional packages from an R command prompt (only roxygen2 is mandatory):
 
 ````
-install.packages(c("devtools"), repos="https://cloud.r-project.org")
+install.packages(c("roxygen2"), repos="https://cloud.r-project.org")
 install.packages(c("ggplot2", "vctrs", "ggpubr", "ggrepel", "ggnewscale"), repos="https://cloud.r-project.org")
 install.packages(c("FNN", "lares", "Matrix", "knitr", "callr", "tidyr", "geigen"), repos="https://cloud.r-project.org")
 ````

--- a/r/doc/create_doc.R
+++ b/r/doc/create_doc.R
@@ -1,3 +1,2 @@
 # Generate documentation (Rd files) from R scripts
-devtools::document(".")
-
+roxygen2::roxygenise(".")


### PR DESCRIPTION
This PR enables the `r_doc` CMake target that will generate the R documentation for the wrapper methods.

The `devtools` package has been replaced with `roxygen2`, a lighter alternative (used internally by `devtools`) that seems to work better on GitHub Actions.

Enjoy,
Pierre