### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+Fabien Ors <fabien.ors@minesparis.psl.eu> fabien-ors <fabien.ors@mines-paristech.fr>
+Fabien Ors <fabien.ors@minesparis.psl.eu> Fabien <fabien.ors@mines-paristech.fr>
+Fabien Ors <fabien.ors@minesparis.psl.eu> fabien-ors <42615550+fabien-ors@users.noreply.github.com>
+Fabien Ors <fabien.ors@minesparis.psl.eu> fabien-ors <fabien.ors@mines-paristech.de>
+Fabien Ors <fabien.ors@minesparis.psl.eu> gstlearn <86424338+gstlearn@users.noreply.github.com>
+
+Didier Renard <didier.renard@minesparis.psl.eu> drenard77810 <didier.renard@minesparis.psl.eu>
+Didier Renard <didier.renard@minesparis.psl.eu> drenard77810 <didier.renard@mines-paristech.fr>
+Didier Renard <didier.renard@minesparis.psl.eu> Didier Renard <didier.renard@mines-paristech.fr>
+Didier Renard <didier.renard@minesparis.psl.eu> drenard <drenard@ghats-fon>
+
+Nicolas Desassis <nicolas.desassis@minesparis.psl.eu> “NDesassis” <“nicolas.desassis@gmail.com”>
+Nicolas Desassis <nicolas.desassis@minesparis.psl.eu> NDesassis <nicolas.desassis@gmail.com>
+Nicolas Desassis <nicolas.desassis@minesparis.psl.eu> NDesassis <40433540+NDesassis@users.noreply.github.com>
+Nicolas Desassis <nicolas.desassis@minesparis.psl.eu> Nicolas DESASSIS <nicolas.desassis@gmail.com>
+Nicolas Desassis <nicolas.desassis@minesparis.psl.eu> ndesassis <nicolas.desassis@gmail.com>
+
+Xavier Freulon <xavier.freulon@minesparis.psl.eu> Xavier FREULON <xavier.freulon@minesparis.psl.eu>
+Xavier Freulon <xavier.freulon@minesparis.psl.eu> xfreulon <97241116+xfreulon@users.noreply.github.com>
+
+Mike Pereira <mike.pereira@minesparis.psl.eu> Mike Pereira <mike.pereira.work@gmail.com>
+Mike Pereira <mike.pereira@minesparis.psl.eu> Mike <mike.pereira@minesparis.psl.eu>
+
+Carole Doucerain <carole.doucerain@mines-paristech.fr> Carole DOUCERAIN <carole.doucerain@mines-paristech.fr>
+Carole Doucerain <carole.doucerain@mines-paristech.fr> cdoucerain <carole.doucerain@gmail.com>
+Carole Doucerain <carole.doucerain@mines-paristech.fr> cdoucerain <87132816+cdoucerain@users.noreply.github.com>
+
+Pierre Guillou <pierre.guillou@minesparis.psl.eu> Pierre Guillou <pierre.guillou@lip6.fr>


### PR DESCRIPTION
`git shortlog -sne` gives a per-user aggregate of the number of commits in a given repository. Since the definition of a "git user"/"git identity" (a name + an e-mail address) depends on what people put in their `$HOME/.gitconfig` file, one person can have several identities, sometimes with non-existing e-mail addresses.

The `.mailmap` file helps git to link one identity to another.  The format is `<masking identity> <masked identity>`, per line.

This PR adds such a file to merge distinct git identities belonging to the same person. The `minesparis.psl.eu` domain name was preferred over `mines-paristech.fr`.

With  this file, `git shortlog -sne` gives more accurate (and up-to-date) results.

Enjoy,
Pierre