### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine wheel setuptools
+        python -m pip install numpy==${{matrix.python.nu}} twine build
 
 #    - name : Download and install HDF5
 #      run : |
@@ -91,7 +91,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build -- -j 3
         cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python setup.py bdist_wheel
+        python -m build --wheel
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Python dependencies
+      run: |
+        export PATH=/opt/python/${{matrix.python}}/bin:$PATH
+        python3 -m pip install build
+
     - name : Create Wheels
       run : |
         export PATH=/opt/python/${{matrix.python}}/bin:$PATH
@@ -48,7 +53,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build -- -j 3
         cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python3 setup.py bdist_wheel --plat-name=${{env.BUILD_PLAT}}
+        python3 -m build --wheel -C="--build-option=--plat-name=${{env.BUILD_PLAT}}"
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -75,7 +75,7 @@ jobs:
       # Force specific old version for Numpy
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine wheel setuptools
+        python -m pip install numpy==${{matrix.python.nu}} twine build
 
     - name: Install Doxygen under windows
       uses: fabien-ors/install-doxygen-windows-action@v1
@@ -101,7 +101,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build --config ${{env.BUILD_TYPE}}
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python setup.py bdist_wheel --plat-name=${{matrix.arch.pl}}
+        python -m build --wheel -C="--build-option=--plat-name=${{matrix.arch.pl}}"
         cd ..\..\..
         $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -152,8 +152,13 @@ endif()
 # Generate setup.py automatically for each configuration
 # First step: replace variables (@VAR@)
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in 
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/setup.py.in
+  @ONLY
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in
+  ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in
   @ONLY
 )
 
@@ -161,6 +166,10 @@ configure_file(
 file(GENERATE
   OUTPUT ${PYTHON_PACKAGE_ROOT_FOLDER}/setup.py
   INPUT ${CMAKE_CURRENT_BINARY_DIR}/setup.py.in
+)
+file(GENERATE
+  OUTPUT ${PYTHON_PACKAGE_ROOT_FOLDER}/pyproject.toml
+  INPUT ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in
 )
 
 # Generate version.py automatically for each configuration

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "@PYTHON_PACKAGE_NAME@"
+version = "@PROJECT_VERSION@"
+authors = [
+  {name = "Team gstlearn", email = "gstlearn@groupes.mines-paristech.fr"}
+]
+description = "@PROJECT_DESCRIPTION@"
+readme = "README.md"
+license = {text = 'BSD-3-Clause'}
+requires-python = '>=3.8'
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C++",
+    "Development Status :: 4 - Beta",
+    "Environment :: Other Environment",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "numpy",
+    "matplotlib",
+    "scipy",
+    "plotly",
+    "pandas",
+    "shapely",
+]
+
+[project.urls]
+Homepage = "@PROJECT_HOMEPAGE_URL@"
+Issues = "@PROJECT_HOMEPAGE_URL@/issues"
+
+[tool.setuptools]
+py-modules = []
+packages = ["@PYTHON_PACKAGE_NAME@"]
+package-data = {"@PYTHON_PACKAGE_NAME@" = ["$<TARGET_FILE_NAME:python_build>"]}
+platforms = ["Windows", "Linux", "Mac OS-X"]

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,7 +9,7 @@
 #                                                                              #
 ################################################################################
 
-from setuptools import setup
+import setuptools
 
 # Set pure is mandatory in order to ensure that wheel names are python dependent
 # Decorate wheel output file with platform name
@@ -23,43 +23,6 @@ try:
 except ImportError:
     bdist_wheel = None
 
-def get_long_description():
-    with open("README.md", "r", encoding="utf-8") as fh:
-        long_description = fh.read()
-    return long_description
-
-# TODO : installation through setup.py will be deprecated ? https://github.com/pypa/pip/issues/8559
-setup(
-    name="@PYTHON_PACKAGE_NAME@",
-    version="@PROJECT_VERSION@",
-    author="Team gstlearn",
-    author_email="gstlearn@groupes.mines-paristech.fr",
-    description="@PROJECT_DESCRIPTION@",
-    long_description=get_long_description(),
-    long_description_content_type="text/markdown",
-    url="@PROJECT_HOMEPAGE_URL@",
-    license='BSD-3-Clause',
-    project_urls={
-        "Bug Tracker": "@PROJECT_HOMEPAGE_URL@/issues",
-    },
-    packages={"@PYTHON_PACKAGE_NAME@"},
-    package_data={"@PYTHON_PACKAGE_NAME@":["$<TARGET_FILE_NAME:python_build>"]},
-    include_package_data=True,
-    cmdclass={'bdist_wheel': bdist_wheel},
-    platforms=["Windows", "Linux", "Mac OS-X"],
-    python_requires='>=3.8',
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: C++",
-        "Development Status :: 4 - Beta",
-        "Environment :: Other Environment",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    install_requires=[
-        "numpy", "matplotlib", "scipy", "plotly",
-        "pandas", "shapely",
-    ],
+setuptools.setup(
+    cmdclass={"bdist_wheel": bdist_wheel},
 )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -10,19 +10,22 @@
 ################################################################################
 
 import setuptools
+from setuptools.command.build_ext import build_ext
 
-# Set pure is mandatory in order to ensure that wheel names are python dependent
-# Decorate wheel output file with platform name
-# https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    class bdist_wheel(_bdist_wheel):
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-except ImportError:
-    bdist_wheel = None
+
+class DummyExtensionBuild(build_ext):
+    def run(self) -> None:
+        return
+
 
 setuptools.setup(
-    cmdclass={"bdist_wheel": bdist_wheel},
+    # we add an empty dummy extension to get a platform wheel...
+    ext_modules=[
+        setuptools.Extension(
+            name="dummy_extension_for_platform_wheel",
+            sources=[],
+        )
+    ],
+    # ...and we make sure to skip its compilation
+    cmdclass={"build_ext": DummyExtensionBuild},
 )


### PR DESCRIPTION
This PR revamps the Python packaging by switching from `setup.py` to using a `pyproject.toml` (the `setup.py` method is deprecated and seems to be not supported anymore by recent versions of `pip`).

Static metadata inside `setup.py` have been moved inside the new `pyproject.toml` file. The `setup.py` file is still needed to force generated wheels to be platform wheels. However, instead of relying on the `wheel` package and overriding `bdist_wheel`, I propose to declare an empty `setuptools` native extension and override the building method. This only relies on `setuptools`.

To build wheels in packaging workflows, the `build` (https://github.com/pypa/build) tool is used instead of calling directly `setup.py`.

Enjoy,
Pierre