### PR TITLE
Force pip to download the Numpy found by CMake

### DIFF
--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy",
+    "numpy==@Python3_NumPy_VERSION@",
     "matplotlib",
     "scipy",
     "plotly",


### PR DESCRIPTION
Numpy 2.0 was released a few days ago and seems to be binary incompatible with v1.0. Since gstlearn links to Numpy via CMake, it is better to pin the Numpy version in `pyproject.toml` to the one used at compile time.

This PR forces the Numpy version in `pyproject.toml` to be the same as the one detected by CMake on the build machine.

Enjoy,
Pierre