### PR TITLE
Fix bug report URL

### DIFF
--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "@PROJECT_HOMEPAGE_URL@"
-Issues = "@PROJECT_HOMEPAGE_URL@/issues"
+Issues = "@PROJECT_HOMEPAGE_URL@/?page_id=468"
 
 [tool.setuptools]
 py-modules = []

--- a/r/DESCRIPTION.in
+++ b/r/DESCRIPTION.in
@@ -20,4 +20,4 @@ License: GPL v3
 LazyLoad: yes
 Maintainer: Team gstlearn <gstlearn@groupes.mines-paristech.fr>
 URL: @PROJECT_HOMEPAGE_URL@
-BugReports: @PROJECT_HOMEPAGE_URL@
+BugReports: @PROJECT_HOMEPAGE_URL@/?page_id=468


### PR DESCRIPTION
Bug report URL in python and R packages was wrong.
Now, we use https://gstlearn.org/?page_id=468