### PR TITLE
Tests: Copy libgstlearn.dll into gstlearn.dll

### DIFF
--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -33,10 +33,21 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Define the prepare target to create the output directory for logs
 if (WIN32)
   # Need to copy C++ shared library to tests directory
-  add_custom_target(prepare_cpp
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
-  )
+  if(MSYS)
+    add_custom_target(prepare_cpp
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
+      # have both lib${PROJECT_NAME}.dll and ${PROJECT_NAME}.dll in ${TEST_DST_DIR}
+      # this fixes a bug on MSYS when building R wrappers with shared
+      # objects before linking C++ test binaries
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEST_DST_DIR}/lib${PROJECT_NAME}.dll ${TEST_DST_DIR}/${PROJECT_NAME}.dll
+    )
+  else()
+    add_custom_target(prepare_cpp
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
+    )
+  endif()
 else()
   add_custom_target(prepare_cpp
     COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -18,10 +18,21 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${GLOBAL_DST_DIR})
 # Define the prepare target to create the output directory for logs
 if (WIN32)
   # Need to copy C++ shared library to tests directory
-  add_custom_target(prepare_data
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${GLOBAL_DST_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${GLOBAL_DST_DIR}
-  )
+  if(MSYS)
+    add_custom_target(prepare_data
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${GLOBAL_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${GLOBAL_DST_DIR}
+      # have both lib${PROJECT_NAME}.dll and ${PROJECT_NAME}.dll in ${GLOBAL_DST_DIR}
+      # this fixes a bug on MSYS when building R wrappers with shared
+      # objects before linking C++ test binaries
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GLOBAL_DST_DIR}/lib${PROJECT_NAME}.dll ${GLOBAL_DST_DIR}/${PROJECT_NAME}.dll
+    )
+  else()
+    add_custom_target(prepare_data
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${GLOBAL_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${GLOBAL_DST_DIR}
+    )
+  endif()
 else()
   add_custom_target(prepare_data
     COMMAND ${CMAKE_COMMAND} -E make_directory "${GLOBAL_DST_DIR}"


### PR DESCRIPTION
Following the swigex & swigex0 PRs, this PR makes a copy of `libgstlearn.dll` as `gstlearn.dll` inside the `tests` binaries directories on MSYS, following a conflict between the `r_build` and `check_cpp` CMake targets due to the use of shared objects for building the Python and R wrappers.

Enjoy,
Pierre