### PR TITLE
Improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/nonreg-demos-courses_ubuntu16.yml
+++ b/.github/workflows/nonreg-demos-courses_ubuntu16.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
 
 jobs:
@@ -37,13 +37,27 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Compile and execute demos and courses tests
+    - name: Configure CMake
+      run: |
+        export PATH=/opt/python/py311/bin:$PATH
+        cmake \
+          -B${{env.BUILD_DIR}} \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_R=ON
+
+    - name: Build gstlearn
+      run: |
+        cmake --build ${{env.BUILD_DIR}} --parallel 3
+
+    - name: Execute Python demos and courses tests
       run: |
         export PATH=/opt/python/py311/bin:$PATH
         alias pip="python3 -m pip"
-        cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON
-        cmake --build ${{env.BUILD_DIR}} --target check_ipynb -- -j 3
-        cmake --build ${{env.BUILD_DIR}} --target check_rmd -- -j 3
+        cmake --build ${{env.BUILD_DIR}} --target check_ipynb --parallel 3
+
+    - name: Execute R demos and courses tests
+      run: |
+        cmake --build ${{env.BUILD_DIR}} --target check_rmd --parallel 3
 
     - name: Compress output logs
       if: success() || failure()
@@ -51,7 +65,7 @@ jobs:
         cd ${{env.BUILD_DIR}}/tests
         find . -type f \( -name "*.asciidoc" -o -name "*.out" \) -print0 | tar -czvf ubuntu-logs.tar.gz --null -T -
 
-    # Keep v3 because ubuntu 16 docker
+    # Keep v3 because ubuntu 16 docker
     - name: Publish output logs as artefact
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -22,16 +22,12 @@ on:
         default: ''
 
 env:
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
-  BOOST_ROOT: ${{github.workspace}}/boost
-  BOOST_VERSION: "1.72.0"
-  EIGEN_ROOT : ${{github.workspace}}/eigen
-  EIGEN_VERSION : "3.4.0"
   LLVM_ROOT : /opt/homebrew
 
 jobs:
@@ -40,10 +36,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Install dependencies
       run: brew install llvm boost eigen
-      
+
     - name: Setup Python Version
       uses: actions/setup-python@v4
       with:
@@ -73,9 +69,21 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Configure CMake
-      run: CC=${{env.LLVM_ROOT}}/opt/llvm/bin/clang CXX=${{env.LLVM_ROOT}}/opt/llvm/bin/clang++ cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      run: |
+        cmake \
+          -B ${{env.BUILD_DIR}} \
+          -DBUILD_TESTING=ON \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_R=ON \
+          -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      env:
+        CC: ${{env.LLVM_ROOT}}/opt/llvm/bin/clang
+        CXX: ${{env.LLVM_ROOT}}/opt/llvm/bin/clang++
 
-    - name: Compile, install packages and execute non-regression tests
+    - name: Build gstlearn
+      run: cmake --build ${{env.BUILD_DIR}}
+
+    - name: Install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --target check
 
     - name: Compress output logs and neutral files
@@ -93,7 +101,7 @@ jobs:
       with:
         name: macos-nonreg-logs
         path: ${{env.BUILD_DIR}}/tests/macos-logs.tar.gz
-  
+
     - name: Publish output neutral files as artefact
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
@@ -76,10 +76,20 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Configure CMake
-      run: cmake -B ${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_R=ON -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      run: |
+        cmake \
+          -B ${{ env.BUILD_DIR }} \
+          -DBUILD_TESTING=ON \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_R=ON \
+          -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
-    - name: Compile, install packages and execute non-regression tests
-      run: cmake --build ${{env.BUILD_DIR}} --target check -- -j 3
+    - name: Build gstlearn
+      run: |
+        cmake --build ${{env.BUILD_DIR}} --parallel 3
+
+    - name: Install packages and execute non-regression tests
+      run: cmake --build ${{env.BUILD_DIR}} --parallel 3 --target check
 
     - name: Compress output logs and neutral files
       if: success() || failure()
@@ -103,4 +113,3 @@ jobs:
       with:
         name: ubuntu-neutral-files
         path: ${{github.workspace}}/ubuntu-neutral.tar.gz
-

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -25,7 +25,7 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   BUILD_DIR : build
-  GENERATOR : "Visual Studio 17 2022"
+  CMAKE_GENERATOR : "Visual Studio 17 2022"
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
@@ -60,9 +60,16 @@ jobs:
         python -m pip install pandas scipy mlxtend
 
     - name: Configure CMake
-      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DBUILD_PYTHON=ON -DPython3_ROOT_DIR="${{env.pythonLocation}}"
+      run: |
+        cmake `
+          -B${{env.BUILD_DIR}} `
+          -DBUILD_PYTHON=ON `
+          -DPython3_ROOT_DIR="${{env.pythonLocation}}"
 
-    - name: Compile, install packages and execute non-regression tests
+    - name: Build gstlearn
+      run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}}
+
+    - name: Install packages and execute non-regression tests
       run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}} --target check
 
     - name: Compress output logs and neutral files
@@ -89,7 +96,7 @@ jobs:
       with:
         name: msvc-nonreg-logs
         path: ${{env.BUILD_DIR}}/tests/msvc-logs.zip
-  
+
     - name: Publish output neutral files as artefact
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -19,15 +19,15 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug)
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
-  GENERATOR : "MSYS Makefiles"
+  CMAKE_GENERATOR : "MSYS Makefiles"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}\swig_420b
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
-  
+
   build:
     runs-on: windows-latest
 
@@ -60,10 +60,18 @@ jobs:
         generator: "Visual Studio 17 2022"
 
     - name: Configure CMake
-      run: cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      run: |
+        cmake `
+          -B${{env.BUILD_DIR}} `
+          -DBUILD_R=ON `
+          -DBUILD_PYTHON=OFF `
+          -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
-    - name: Compile, install packages and execute non-regression tests
-      run: cmake --build ${{env.BUILD_DIR}} --target check -- -j 3
+    - name: Build gstlearn
+      run: cmake --build ${{env.BUILD_DIR}} --parallel 3
+
+    - name: Install packages and execute non-regression tests
+      run: cmake --build ${{env.BUILD_DIR}} --target check --parallel 3
 
     - name: Compress output logs and neutral files
       if: success() || failure()
@@ -89,7 +97,7 @@ jobs:
       with:
         name: rtools-nonreg-logs
         path: ${{env.BUILD_DIR}}/tests/rtools-logs.zip
-  
+
     - name: Publish output neutral files as artefact
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -23,9 +23,9 @@ on:
         default: false
 
 env:
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
-#  HDF5_ROOT : hdf5 #do not use "." in the name 
+#  HDF5_ROOT : hdf5 #do not use "." in the name
 #  HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1.tar.gz/?wpdmdl=15722"
 #  HDF5_VERSION : hdf5-1.12.1
 
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Install dependencies
       run: brew install llvm swig doxygen boost eigen
-      
+
     - name: Setup Python Version
       uses: actions/setup-python@v3
       with:
@@ -76,7 +76,7 @@ jobs:
 #        7z  -o${{env.HDF5_ROOT}} x ${{env.HDF5_ROOT}}/download.tar.gz -y -bd
 #        7z  -o${{env.HDF5_ROOT}} x ${{env.HDF5_ROOT}}/download.tar -y -bd
 #        ls
-#        cd ${{env.HDF5_ROOT}} 
+#        cd ${{env.HDF5_ROOT}}
 #        ls
 #        cd CMake-${{env.HDF5_VERSION}}
 #        mkdir build
@@ -85,29 +85,42 @@ jobs:
 #        cmake --build . --target all --config Release -- -j 3
 #        cmake --build . --target install --config Release
 
+    - name : Configure CMake
+      run : |
+        cmake \
+          -B${{env.BUILD_DIR}} \
+          -DPython3_ROOT_DIR="${{env.pythonLocation}}" \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_DOXYGEN=ON
+      env:
+        CC: ${{matrix.arch.pat}}/opt/llvm/bin/clang
+        CXX: ${{matrix.arch.pat}}/opt/llvm/bin/clang++
+
+    - name : Build gstlearn
+      run : |
+        cmake --build ${{env.BUILD_DIR}} --target python_build --parallel 3
+
     - name : Create Wheels
       run : |
-        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON
-        cmake --build ${{env.BUILD_DIR}} --target python_build -- -j 3
-        cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
+        cd ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
         python -m build --wheel
         cd ../../..
-        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
+        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v3
       # Use specific artifact identifier for publishing all versions
       with:
         name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
         path: ${{env.MY_PKG}}
-    
+
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload via ssh
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/pypi-publish-action@v1
       with:
@@ -120,4 +133,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v2
       with:
         name: macos-python-package-*
-

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -23,10 +23,10 @@ on:
         default: false
 
 env:
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
   BUILD_PLAT: manylinux1_x86_64
-  
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,30 +46,40 @@ jobs:
         export PATH=/opt/python/${{matrix.python}}/bin:$PATH
         python3 -m pip install build
 
-    - name : Create Wheels
+    - name: Configure build directory
+      run: |
+        export PATH=/opt/python/${{matrix.python}}/bin:$PATH
+        cmake \
+          -B${{ env.BUILD_DIR }} \
+          -DBUILD_PYTHON=ON \
+          -DBUILD_DOXYGEN=ON
+
+    - name : Build gstlearn with Python API
+      run : |
+        cmake --build ${{env.BUILD_DIR}} --parallel 3 --target python_build
+
+    - name : Create Wheel
       run : |
         export PATH=/opt/python/${{matrix.python}}/bin:$PATH
-        cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON
-        cmake --build ${{env.BUILD_DIR}} --target python_build -- -j 3
-        cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
+        cd ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
         python3 -m build --wheel -C="--build-option=--plat-name=${{env.BUILD_PLAT}}"
         cd ../../..
-        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
+        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v3
       # Use specific artifact identifier for publishing all versions
       with:
         name: ubuntu-python-package-${{matrix.python}}
         path: ${{env.MY_PKG}}
-    
+
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload via ssh
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/pypi-publish-action@v1
       with:
@@ -82,6 +92,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v2
       with:
         name: ubuntu-python-package-*
-
-   
-

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -25,7 +25,7 @@ on:
 env:
   BUILD_TYPE: Release
   BUILD_DIR : build
-  GENERATOR : "Visual Studio 16 2019"
+  CMAKE_GENERATOR : "Visual Studio 16 2019"
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
@@ -84,9 +84,9 @@ jobs:
         doxygen-version: ${{env.DOXYGEN_VERSION}}
 
 #    - name : Download and install HDF5
-#      run: | 
+#      run: |
 #        mkdir ${{env.HDF5_ROOT}}
-#        curl --progress-bar --location --output ${{env.HDF5_ROOT}}/download.zip ${{env.HDF5_URL}}	
+#        curl --progress-bar --location --output ${{env.HDF5_ROOT}}/download.zip ${{env.HDF5_URL}}
 #        7z x ${{env.HDF5_ROOT}}/download.zip
 #        cd CMake-${{env.HDF5_VERSION}}
 #        mkdir build
@@ -95,10 +95,21 @@ jobs:
 #        cmake --build . --target all --config Release
 #        cmake --build . --target install --config Release
 
+    - name : Configure CMake
+      run : |
+        cmake `
+          -B${{env.BUILD_DIR}} `
+          -A ${{matrix.arch.of}} `
+          -DPython3_ROOT_DIR="${{env.pythonLocation}}" `
+          -DBUILD_PYTHON=ON `
+          -DBUILD_DOXYGEN=ON `
+
+    - name : Build gstlearn
+      run : |
+        cmake --build ${{env.BUILD_DIR}} --target python_build --config ${{env.BUILD_TYPE}}
+
     - name : Create Wheels
       run : |
-        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -A ${{matrix.arch.of}} -DPython3_ROOT_DIR="${{env.pythonLocation}}" -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
-        cmake --build ${{env.BUILD_DIR}} --target python_build --config ${{env.BUILD_TYPE}}
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
         python -m build --wheel -C="--build-option=--plat-name=${{matrix.arch.pl}}"
@@ -111,14 +122,14 @@ jobs:
       with:
         name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
         path: ${{env.MY_PKG}}
-    
+
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload via ssh
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/pypi-publish-action@v1
       with:
@@ -127,8 +138,7 @@ jobs:
         password: ${{secrets.TWINE_PYPI_PWD}}
         pattern: windows-python-package-*
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v2
       with:
         name: windows-python-package-*
-

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -21,9 +21,9 @@ on:
         type: boolean
         required: false
         default: false
-        
+
 env:
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
   SWIG_ROOT : ${{github.workspace}}/swig_420b
 
@@ -49,28 +49,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name : Install llvm
+    - name : Install dependencies
       run: brew install llvm boost eigen
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{matrix.r_version}}
-        
+
     - name: Install roxygen2
       uses: r-lib/actions/setup-r-dependencies@v2
       with:
         packages: roxygen2, pkgbuild
         install-pandoc: false
-
-    # Not yet operational (devtools cannot be installed) => BUILD_DOXYGEN=OFF
-    #- name : Install doxygen
-    #  run: brew install doxygen
-    #
-    #- name: Install R dependencies
-    #  run: |
-    #    Rscript -e "install.packages(c('rlang'), repos='https://cloud.r-project.org/', dependencies = TRUE)"
-    #    Rscript -e "install.packages(c('systemfonts', 'ragg', 'pkgdown', 'devtools'), repos='https://cloud.r-project.org/', dependencies = TRUE)"
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
@@ -78,25 +69,36 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name : Configure CMake
+      run : |
+        cmake \
+          -B${{env.BUILD_DIR}} \
+          -DBUILD_R=ON \
+          -DBUILD_PYTHON=OFF \
+          -DBUILD_DOXYGEN=OFF \
+          -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      env:
+        CC: ${{matrix.arch.pat}}/opt/llvm/bin/clang
+        CXX: ${{matrix.arch.pat}}/opt/llvm/bin/clang++
+
     - name : Build the package and save generated file name in the environment
       run : |
-        CC=${{matrix.arch.pat}}/opt/llvm/bin/clang CXX=${{matrix.arch.pat}}/opt/llvm/bin/clang++ cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DBUILD_DOXYGEN=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
         cmake --build ${{env.BUILD_DIR}} --target r_install
-        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.BUILD_TYPE}}/gstlearn_*.tgz)" >> "$GITHUB_ENV"
+        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/gstlearn_*.tgz)" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v3
       # Use specific artifact identifier for publishing all versions
       with:
         name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}
         path: ${{env.MY_PKG}}
-    
+
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload via ssh
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/cran-publish-action@v3
       with:
@@ -109,4 +111,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v2
       with:
         name: macos-r-package-*
-

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -23,7 +23,7 @@ on:
         default: false
 
 env:
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
 
 jobs:
@@ -37,11 +37,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Configure CMake
+      run: |
+        cmake \
+          -B${{env.BUILD_DIR}} \
+          -DBUILD_R=ON \
+          -DBUILD_PYTHON=OFF \
+          -DBUILD_DOXYGEN=ON
+
     - name: Build the package and save generated file name in the environment
       run: |
-        cmake -B${{env.BUILD_DIR}} -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DBUILD_DOXYGEN=ON
         cmake --build ${{env.BUILD_DIR}} --target r_install
-        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.BUILD_TYPE}}/gstlearn_*.tar.gz)" >> "$GITHUB_ENV"
+        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/gstlearn_*.tar.gz)" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v3
       with:
@@ -51,10 +58,10 @@ jobs:
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload to CRAN easily (ssh)
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/cran-publish-action@v3
       with:

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -24,23 +24,23 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug)
-  BUILD_TYPE: Release
+  CMAKE_BUILD_TYPE: Release
   BUILD_DIR : build
-  GENERATOR : "MSYS Makefiles"
+  CMAKE_GENERATOR : "MSYS Makefiles"
   SWIG_ROOT : ${{github.workspace}}\swig_420b
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
-  
+
   build:
     runs-on: windows-2019
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.0]
-        
+
     steps:
     - uses: actions/checkout@v3
 
@@ -74,11 +74,19 @@ jobs:
       with:
         swig-root: ${{env.SWIG_ROOT}}
 
+    - name : Configure CMake
+      run : |
+        cmake `
+          -B${{env.BUILD_DIR}} `
+          -DBUILD_R=ON `
+          -DBUILD_PYTHON=OFF `
+          -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig `
+          -DBUILD_DOXYGEN=ON
+
     - name : Build the package and save generated file name in the environment
       run : |
-        cmake -B${{env.BUILD_DIR}} -G "${{env.GENERATOR}}" -DCMAKE_BUILD_TYPE:STRING=${{env.BUILD_TYPE}} -DBUILD_R=ON -DBUILD_PYTHON=OFF -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig -DBUILD_DOXYGEN=ON -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
         cmake --build ${{env.BUILD_DIR}} --target r_install
-        $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/r/${{env.BUILD_TYPE}}/gstlearn_*.zip" -File
+        $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/gstlearn_*.zip" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
     - uses: actions/upload-artifact@v3
@@ -86,14 +94,14 @@ jobs:
       with:
         name: windows-r-package-${{matrix.r_version}}
         path: ${{env.MY_PKG}}
-    
+
   publish:
     needs: build
     if: ${{inputs.dry_publish == false}}
-    
+
     # Only ubuntu can upload to CRAN easily (ssh)
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: fabien-ors/cran-publish-action@v3
       with:


### PR DESCRIPTION
This PR cleans the GitHub Actions workflows, in particular by 
* splitting the configure, build and test steps (less log per step to check in case of an error),
* using CMake-specific environment variables
* and breaking lines around CMake configuration options (to be more diff-friendly).

Enjoy,
Pierre