### PR TITLE
GitHub Actions: Fixes for publish workflows

### DIFF
--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -43,7 +43,7 @@ jobs:
           # Double quote for version is needed otherwise 3.10 => 3.1
             {py: "3.8",  nu: 1.20.3},
             {py: "3.9",  nu: 1.20.3},
-            {py: "3.10", nu: 1.21.6},
+            {py: "3.10", nu: 1.22.4},
             {py: "3.11", nu: 1.23.5},
             {py: "3.12", nu: 1.26.3}
           ]

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install roxygen2
       uses: r-lib/actions/setup-r-dependencies@v2
       with:
-        packages: roxygen2
+        packages: roxygen2, pkgbuild
         install-pandoc: false
 
     - name: Install the customized SWIG from source


### PR DESCRIPTION
This PR contains two fixes for the publish workflows:
- an upgrade to the pinned Numpy version for the Windows/Python 3.10 workflow, due to an ABI incompatibility with scipy,
- a missing `pkgbuild` R package has been added to the macOS workflow.

Pierre