### PR TITLE
CMake: Use BUILD_TESTING to control the compilation of test binaries

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -95,6 +95,7 @@ jobs:
         cd build
         cmake \
           -DCMAKE_BUILD_TYPE=${{ matrix.opt }} \
+          -DBUILD_TESTING=ON \
           -D${{ matrix.hdf5 }} \
           $GITHUB_WORKSPACE
 
@@ -141,6 +142,7 @@ jobs:
         cd build
         cmake \
           -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_TESTING=ON \
           -DBUILD_DOXYGEN=ON \
           $GITHUB_WORKSPACE
 

--- a/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
@@ -104,6 +104,7 @@ jobs:
       run: |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DBUILD_TESTING=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DBUILD_TESTING=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -75,6 +75,7 @@ jobs:
       run: |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DBUILD_TESTING=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         cmake `
           -B${{ env.BUILD_DIR }} `
+          -DBUILD_TESTING=ON `
           -DBUILD_PYTHON=ON
 
     - name: Build the package

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         cmake `
           -B${{ env.BUILD_DIR }} `
+          -DBUILD_TESTING=ON `
           -DBUILD_R=ON `
           -DBUILD_PYTHON=OFF `
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{secrets.TWINE_PYPI_PWD}}
           pattern: "*python-package-*"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: "*python-package*"
@@ -69,7 +69,7 @@ jobs:
           repo-path: "/var/www/html/cran"
           pattern: "*r-package*"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: "*r-package*"

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -124,7 +124,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        # This will become the folder name in the server
+        # This will become the folder name in the server
         name: courses
         path: ${{ env.COURSES_FOLDER }}
 
@@ -145,7 +145,7 @@ jobs:
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{ env.PROJECT_VERSION }}"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: courses

--- a/.github/workflows/publish_data.yml
+++ b/.github/workflows/publish_data.yml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        # This will become the folder name in the server
+        # This will become the folder name in the server
         name: data
         path: doc/data
 
@@ -74,7 +74,7 @@ jobs:
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{ env.PROJECT_VERSION }}"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: data

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -126,7 +126,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        # This will become the folder name in the server
+        # This will become the folder name in the server
         name: demos
         path: ${{ env.DEMO_FOLDER }}
 
@@ -147,7 +147,7 @@ jobs:
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{ env.PROJECT_VERSION }}"
 
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: demos

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -63,7 +63,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        # This will become the folder name in the server
+        # This will become the folder name in the server
         name: doxygen
         path: ${{ env.HTML_FOLDER }}
 
@@ -84,7 +84,7 @@ jobs:
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{ env.PROJECT_VERSION }}"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: doxygen

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -135,7 +135,7 @@ jobs:
         password: ${{secrets.TWINE_PYPI_PWD}}
         pattern: macos-python-package-*
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: macos-python-package-*

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -111,7 +111,7 @@ jobs:
         password: ${{secrets.TWINE_PYPI_PWD}}
         pattern: ubuntu-python-package-*
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: ubuntu-python-package-*

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -49,7 +49,7 @@ jobs:
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},
-            {pl: win32,     ar: x86, of: Win32} # TODO : Win32 to be removed ?
+            {pl: win32,     ar: x86, of: Win32} # TODO : Win32 to be removed ?
           ]
 
     steps:
@@ -143,4 +143,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: windows-python-package-*
-

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -111,7 +111,7 @@ jobs:
         password: ${{secrets.CG_PWD}}
         repo-path: "/var/www/html/cran"
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: macos-r-package-*

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -103,7 +103,7 @@ jobs:
         password: ${{secrets.CG_PWD}}
         repo-path: "/var/www/html/cran"
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: ubuntu-r-package-${{matrix.os}}-r-${{matrix.r_version}}

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -112,7 +112,7 @@ jobs:
         password: ${{secrets.CG_PWD}}
         repo-path: "/var/www/html/cran"
 
-    # Delete the artifacts (for freeing storage space under github)
+    # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: windows-r-package-*

--- a/.github/workflows/publish_references.yml
+++ b/.github/workflows/publish_references.yml
@@ -54,7 +54,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        # This will become the folder name in the server
+        # This will become the folder name in the server
         name: references
         path: doc/references
 
@@ -75,7 +75,7 @@ jobs:
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{ env.PROJECT_VERSION }}"
   
-      # Delete the artifacts (for freeing storage space under github)
+      # Delete the artifacts (for freeing storage space under github)
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: references

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 # Options
 option(BUILD_PYTHON  "Build Python package"        OFF)
 option(BUILD_R       "Build R package"             OFF)
+option(BUILD_TESTING "Build tests"                 OFF)
 option(BUILD_DOXYGEN "Build Doxygen documentation" OFF)
 if (MINGW)
   set(BUILD_PYTHON OFF)
@@ -67,6 +68,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 message(STATUS "BUILD_PYTHON="  ${BUILD_PYTHON})
 message(STATUS "BUILD_R="       ${BUILD_R})
+message(STATUS "BUILD_TESTING=" ${BUILD_TESTING})
 message(STATUS "BUILD_DOXYGEN=" ${BUILD_DOXYGEN})
 message(STATUS "USE_HDF5="      ${USE_HDF5})
 
@@ -107,10 +109,12 @@ endif()
 ## TESTING
 
 # Add non-regression test target
-include(CTest)
-enable_testing()
+if(BUILD_TESTING)
+  include(CTest)
+  enable_testing()
 
-add_subdirectory(tests)
+  add_subdirectory(tests)
+endif()
 
 ####################################################
 ## DEMONSTRATION SCRIPTS

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ endif
 
 ifeq ($(OS),Darwin)
   ifndef LLVM_ROOT
-  	LLVM_ROOT = /opt/homebrew
+	LVM_ROOT = /opt/homebrew
   endif
   # Particular clang compiler for supporting OpenMP
   CC_CXX = CC=$(LLVM_ROOT)/opt/llvm/bin/clang CXX=$(LLVM_ROOT)/opt/llvm/bin/clang++
@@ -145,7 +145,7 @@ endif
 all: shared install
 
 cmake:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES)
+	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_TESTING=ON
 
 cmake-python:
 	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_PYTHON=ON

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(TEST_SOURCE_FILE ${TEST_SOURCES})
     # Add to executable targets list
     list(APPEND TARGETS_EXE ${TEST_NAME})
     # Define sources list for the target executable
-    add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_SOURCE_FILE})
+    add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
     # Link each test to shared library
     target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME}::shared)
     # Trigger the prepare target each time a test is compiled

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach(TEST_SOURCE_FILE ${TEST_SOURCES})
     # Add to executable targets list
     list(APPEND TARGETS_EXE ${TEST_NAME})
     # Define sources list for the target executable
-    add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_SOURCE_FILE})
+    add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
     # Link each test to shared library
     target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME}::shared)
     # Trigger the prepare target each time a test is compiled

--- a/tests/inter/CMakeLists.txt
+++ b/tests/inter/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(TEST_SOURCE_FILE ${TEST_SOURCES})
     # Retrieve source file name without extension (will become executable name)
     get_filename_component(TEST_NAME ${TEST_SOURCE_FILE} NAME_WE)
     # Define sources list for the target executable
-    add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_SOURCE_FILE})
+    add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
     # Link gstlearn to each test
     target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME}::shared)
     # Trigger the build of the test with the target build_tests


### PR DESCRIPTION
Today, the `enable_testing()` CMake command adds a CMake option, `BUILD_TESTING`, set to `ON` by default. The C++ test binaries (directories `tests/cpp`, `tests/data` & `tests/inter`) are built through a custom CMake target, `build_tests`.

This PR leverages the `BUILD_TESTING` CMake option to control whether to build the test binaries or not. The test binaries are no longer `EXCLUDE_FROM_ALL`. This option is now set to `OFF` by default and enabled in every GitHub Actions workflow that tests them (the `nonreg` ones). An intended side effect is, in these workflows, the build step of the binaries will occur in the `Build the package` step and not in the `execute non-regression tests` step (which should be more logical).

Also, some non-ASCII UTF-8 characters were removed from the workflow files (non-breaking spaces). All workflow files are now regular ASCII files.

Enjoy,
Pierre