### PR TITLE
Fix NumPy requirements

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,6 +12,10 @@ set(PYTHON_PACKAGE_NAME ${PROJECT_NAME})
 # Look for Python3
 #set(CMAKE_FIND_DEBUG_MODE TRUE)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module NumPy)
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+  Python3_NumPy_VERSION_MATCH ${Python3_NumPy_VERSION})
+set(Python3_NumPy_VERSION_MAJOR ${CMAKE_MATCH_1})
+math(EXPR Python3_NumPy_NEXT_MAJOR "${Python3_NumPy_VERSION_MAJOR} + 1")
 
 # Look for SWIG 4 [No need for customized swig]
 find_package(SWIG 4.0 REQUIRED)

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy>=@Python3_NumPy_VERSION@,<2.0",
+    "numpy>=@Python3_NumPy_VERSION@,<@Python3_NumPy_NEXT_MAJOR@",
     "matplotlib",
     "scipy",
     "plotly",

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy==@Python3_NumPy_VERSION@",
+    "numpy>=@Python3_NumPy_VERSION@,<2.0",
     "matplotlib",
     "scipy",
     "plotly",


### PR DESCRIPTION
According to https://numpy.org/doc/1.25/dev/depending_on_numpy.html, NumPy is ABI forward compatible (at least for a given major version).

This PR aims at relaxing the constraints on NumPy requirements in the `pyproject.toml` file by extracting the NumPy major version number in CMake to generate requirements in the form `>=version used for building gstlearn,<version major + 1`.

Enjoy,
Pierre