### PR TITLE
Add clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,52 @@
+---
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AlignEscapedNewlines: Right
+AlignTrailingComments: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: 'Yes'
+# AlignOperands: AlignAfterOperator # clang-format 12
+# AlignConsecutiveShortCaseStatements: # clang-format 17
+#  Enabled: true
+#  AcrossEmptyLines: true
+#  AcrossComments: true
+#  AlignCaseColons: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+# EmptyLineBeforeAccessModifier: Always # clang-format 13
+IndentCaseLabels: true
+IndentWidth: 2
+IndentPPDirectives: AfterHash
+NamespaceIndentation: All
+# PackConstructorInitializers: Never # clang-format 14
+# PPIndentWidth: 2 # clang-format 14
+PointerAlignment: Left
+# ReferenceAlignment: Left # clang-format 14
+ReflowComments: true
+SortIncludes: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpaceBeforeRangeBasedForLoopColon: false
+# SpaceBeforeSquareBrackets: false # clang-format 11
+# SpaceInEmptyBlock: false # clang-format 11
+SpaceInEmptyParentheses: false
+# SpacesInAngles: Never #clang-format 14
+SpacesInCStyleCastParentheses: false
+# SpacesInConditionalStatement: false # clang-format 11
+SpacesInContainerLiterals: false
+SpacesInSquareBrackets: false
+UseTab: Never
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,5 +17,7 @@ Checks: >-
   -readability-identifier-length,
   -readability-isolate-declaration,
   -readability-magic-numbers,
+  -readability-redundant-member-init,
+  -readability-redundant-access-specifiers,
 HeaderFilterRegex: 'include'
 UseColor: true

--- a/include/API/Style.hpp
+++ b/include/API/Style.hpp
@@ -24,6 +24,7 @@
  *
  * Since doxygen 1.8.0, Markdown support is available in doxygen comments
  * ([see here](https://www.doxygen.nl/manual/markdown.html)).<br/>
+ *
  * Look at *gstlearn* [READMEs](https://github.com/gstlearn/gstlearn)
  * for a quick overview of Markdown syntax.
  *
@@ -46,9 +47,11 @@
  * - Some coding constraints due to the [customized] SWIG for R version:
  *    - limit the use of function overriding
  *    - do not use namespace or static variables in default argument values
- *    - do not comment the argument name when it is unused (use  `DECLARE_UNUSED`)
+ *    - do not comment the argument name when it is unused (use
+ *      `DECLARE_UNUSED`)
  *    - do not use following argument names: 'in', '_*'
- *    - always inherit from pure virtual classes in last position (ex: ICloneable)
+ *    - always inherit from pure virtual classes in last position (ex:
+ *      ICloneable)
  *
  * ## C++ naming convention
  *
@@ -60,15 +63,18 @@
  * - Aliases (typedef): idem
  * - Class' methods: lower camel case (ie: loadData, getArmonicMean, isEmpty)
  * - Class' attributes (variables): idem
- * - Anything which is *private* or *protected* in a class starts with underscore (ie: _myMember)
- * - Local variables: lower case separated by underscore (i.e.: temp_value, color_idx)
- * - Methods naming;
- *   method _func() is internal to the class (private or protected)
- *   method func_() is not exported via SWIG
+ * - Anything which is *private* or *protected* in a class starts with
+ *   underscore (ie: _myMember)
+ * - Local variables: lower case separated by underscore (i.e.: temp_value,
+ *   color_idx)
+ * - Methods visibility;
+ *     Method _func() is internal to the class (private or protected)
+ *     Method func_() is not exported via SWIG (using #ifndef SWIG)
  * - Use of "InPlace" suffix:
- *   It is used in methods that modify either a member of this class or a returned argument.
- *   Important remark. The member or agument must have been correctly dimensioned beforehand;
- *   no test will be performed (in order to speed up the processing).
+ *     It is used in methods that modify either a member of this class or a
+ *     returned argument. Important remark. The member or agument must have been
+ *     correctly dimensioned beforehand; no test will be performed (in order to
+ *     speed up the processing).
  *
  * ## C++ coding rules
  *
@@ -79,17 +85,26 @@
  * - Use `const` every where
  * - Do not use old C-style (use C++ STL)
  * - Do not use `using namespace`
- * - Make the includes list as small as possible in C++ header (use forward declaration)
+ * - Make the includes list as small as possible in C++ header (use forward
+ *   declaration)
  * - Expose only what is necessary (all is private by default)
  *
- * More good practices available [here](www.possibility.com/Cpp/CppCodingStandard.html)
+ * More good practices available
+ *   [here](www.possibility.com/Cpp/CppCodingStandard.html)
+ *
+ * Important note: All C++ coding rules are configured in the .clang-format
+ *                 file. located in the root folder. Developers can use the
+ *                 "Clang format" VS code extension to benefit from the
+ *                 automatic formating feature
  *
  * ## Class' constructors/destructors
  *
  * Here are some rules regarding constructors and destructors:
- * - Always add a default constructor (no arguments or arguments with default values)
+ * - Always add a default constructor (no arguments or arguments with default
+ *   values)
  * - Always add a copy constructor (with some exceptions - see Calc* classes)
- * - Always add an assignment operator (with some exceptions - see Calc* classes)
+ * - Always add an assignment operator (with some exceptions - see Calc*
+ *   classes)
  * - Always add a virtual destructor
  *
  * ## Documenting Methods
@@ -97,25 +112,32 @@
  * Main principles for documenting class methods are the following:
  * - Add one-line comment before each public prototype in the C++ header
  * - Add a doxygen section above each method definition in the C++ body
- * - All this except for trivial methods\tooltip{getters, setters and inline functions}, constructors and destructors
- * - Define pointer for ENUM. Example to point to EMorpho Enum:  \link EMorpho.hpp EMorpho \endlink
+ * - All this except for trivial methods\tooltip{getters, setters and inline
+ *   functions}, constructors and destructors
+ * - Define pointer for ENUM. Example to point to EMorpho Enum:  \link
+ *   EMorpho.hpp EMorpho \endlink
  */
 class GSTLEARN_EXPORT Style
 {
 public:
-  Style(); // No need for one-line documentation in the header
-  Style(const Style& r); // idem
+  Style();                          // No need for one-line documentation in the header
+  Style(const Style& r);            // idem
   Style& operator=(const Style& r); // idem
-  virtual ~Style(); // idem
+  virtual ~Style();                 // idem
 
-  // Example of a method with a standard documentation (do not use doxygen here!)
-  int DocumentedStandard(int myArg) const;
-  // Example of a method with a documentation having a Latex formula (do not use doxygen here!)
-  int DocumentedWithFormula(int myArg) const;
+  // Example of a method with a standard documentation (do not use doxygen
+  // here - all the documentation is in the body file!)
+  int documentedStandard(int myArg) const;
+  // Example of a method with a documentation having a Latex formula (do not use
+  // doxygen here!)
+  int documentedWithFormula(int myArg) const;
   // Example of a method where argument is not used (do not use doxygen here!)
-  int UnusedArgument(int a);
+  int unusedArgument(int a);
+  // Just a tentative for formating while typing
+  int tentative(int a);
 
-  // Special static function (global) with a default argument (do not use doxygen here!)
+  // Special static function (global) with a default argument (do not use
+  // doxygen here!)
   static void myFunction(int myArgInt, double myArgDoubleDef = 2.);
 
   /**
@@ -130,13 +152,17 @@ public:
    * for a group of functions. This is useful when all functions handle
    * the same functionality and differ only by their name or arguments.
    *
-   * This is also a way to isolate the documentation for trivial functions and make the doxygen page of the class shorter.
+   * This is also a way to isolate the documentation for trivial functions and
+   * make the doxygen page of the class shorter.
    *  @{
    */
-  inline double              getArgDouble()       const { return _argDouble; }
-  inline int                 getArgInt()          const { return _argInt; }
-  inline const VectorDouble& getArgVectorDouble() const { return _argVectorDouble; }
-  inline const VectorInt&    getArgVectorInt()    const { return _argVectorInt; }
+  inline double getArgDouble() const { return _argDouble; }
+  inline int getArgInt() const { return _argInt; }
+  inline const VectorDouble& getArgVectorDouble() const
+  {
+    return _argVectorDouble;
+  }
+  inline const VectorInt& getArgVectorInt() const { return _argVectorInt; }
   /**@}*/
 
   /** @addtogroup Getters_1 Function that update private members value
@@ -149,10 +175,16 @@ public:
    * usually non trivial and must be defined in the C++ body files.
    * @{
    */
-  inline void setArgDouble      (double argDouble)                    { _argDouble = argDouble; }
-  inline void setArgInt         (int argInt)                          { _argInt = argInt; }
-  inline void setArgVectorDouble(const VectorDouble &argVectorDouble) { _argVectorDouble = argVectorDouble; }
-  inline void setArgVectorInt   (const VectorInt &argVectorInt)       { _argVectorInt = argVectorInt; }
+  inline void setArgDouble(double argDouble) { _argDouble = argDouble; }
+  inline void setArgInt(int argInt) { _argInt = argInt; }
+  inline void setArgVectorDouble(const VectorDouble& argVectorDouble)
+  {
+    _argVectorDouble = argVectorDouble;
+  }
+  inline void setArgVectorInt(const VectorInt& argVectorInt)
+  {
+    _argVectorInt = argVectorInt;
+  }
   /**@}*/
 
 private:
@@ -161,8 +193,8 @@ private:
 
 private:
   // Use same line documentation for private members
-  int          _argInt;          //!< Private attribute of type `int`
-  double       _argDouble;       //!< Private attribute of type `double`
-  VectorInt    _argVectorInt;    //!< Private attribute of type `VectorInt`
+  int _argInt;                   //!< Private attribute of type `int`
+  double _argDouble;             //!< Private attribute of type `double`
+  VectorInt _argVectorInt;       //!< Private attribute of type `VectorInt`
   VectorDouble _argVectorDouble; //!< Private attribute of type `VectorDouble`
 };

--- a/src/API/Style.cpp
+++ b/src/API/Style.cpp
@@ -8,20 +8,24 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include <API/Style.hpp>
+// Use double quote "" for include files from our source code
+#include "API/Style.hpp"
 #include "Basic/AStringable.hpp"
+// Use corners <> for other include files
+#include <iostream>
 
 /**
  * Default constructor
  *
- * Always use the initialization list to set the default value of each class member.
- * Put attributes in the same order than their declaration in the C++ header.
+ * Always use the initialization list to set the default value of each class
+ * member. Put attributes in the same order than their declaration in the C++
+ * header.
  */
 Style::Style()
-    : _argInt(0),
-      _argDouble(0.),
-      _argVectorInt(),
-      _argVectorDouble()
+  : _argInt(0)
+  , _argDouble(0.)
+  , _argVectorInt()
+  , _argVectorDouble()
 {
 }
 
@@ -32,25 +36,25 @@ Style::Style()
  * Put attributes in the same order than their declaration in the C++ header.
  */
 Style::Style(const Style& r)
-    : _argInt(r._argInt),
-      _argDouble(r._argDouble),
-      _argVectorInt(r._argVectorInt),
-      _argVectorDouble(r._argVectorDouble)
+  : _argInt(r._argInt)
+  , _argDouble(r._argDouble)
+  , _argVectorInt(r._argVectorInt)
+  , _argVectorDouble(r._argVectorDouble)
 {
 }
 
 /**
  * Assignment operator
  *
- * Always protect from self copy if the if statement
+ * Always protect from self copy with the if statement
  */
-Style& Style::operator=(const Style &r)
+Style& Style::operator=(const Style& r)
 {
   if (this != &r)
   {
-    _argInt = r._argInt;
-    _argDouble = r._argDouble;
-    _argVectorInt = r._argVectorInt;
+    _argInt          = r._argInt;
+    _argDouble       = r._argDouble;
+    _argVectorInt    = r._argVectorInt;
     _argVectorDouble = r._argVectorDouble;
   }
   return *this;
@@ -59,11 +63,9 @@ Style& Style::operator=(const Style &r)
 /**
  * Destructor
  *
- * Always free pointers and clear the lists of the class
+ * Always free pointers and clear the lists members of the class
  */
-Style::~Style()
-{
-}
+Style::~Style() {}
 
 /**
  * A method with standard argument documentation
@@ -72,18 +74,20 @@ Style::~Style()
  *
  * \return Description of the returned value
  */
-int Style::DocumentedStandard(int myArg) const
+int Style::documentedStandard(int myArg) const
 {
-  message("Documented Function\n");
-  message("Value of MyArg = %d\n",myArg);
+  std::cout << "Documented Function" << std::endl;
+  message("Value of MyArg = %d\n", myArg);
+  
   return 0;
 }
 
 /**
  * Documentation with Latex formula
  *
- * The distance between \f$ p1=(x_1,y_1) \f$ and \f$ p2=(x_2,y_2) \f$ is \f$\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}\f$
- * (this formula may need to do this: https://github.com/doxygen/doxygen/issues/7484#issuecomment-572503569)
+ * The distance between \f$ p1=(x_1,y_1) \f$ and \f$ p2=(x_2,y_2) \f$ is
+ * \f$\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}\f$ (this formula may need to do this:
+ * https://github.com/doxygen/doxygen/issues/7484#issuecomment-572503569)
  *
  * \see SpaceRN::getDistance
  *
@@ -91,7 +95,7 @@ int Style::DocumentedStandard(int myArg) const
  *
  * \return The value of the argument + 1
  */
-int Style::DocumentedWithFormula(int myArg) const
+int Style::documentedWithFormula(int myArg) const
 {
   message("Input Argument = %d\n", myArg);
   return _increment(myArg);
@@ -110,15 +114,16 @@ void Style::myFunction(int myArgInt, double myArgDoubleDef)
 }
 
 /**
- * A function where the argument is not used (could be the case in abstract methods)
+ * A function where the argument is not used (could be the case in abstract
+ * methods)
  *
  * \param[in] a Input argument not used (but documented)
  *
  * \return Error returned code
  */
-int Style::UnusedArgument(int a)
+int Style::unusedArgument(int a)
 {
-  // Use the SYMBO_UNSED macro to prevent compiler warning
+  // Use the DECLARE_UNUSED macro to prevent compiler warning
   // Do not comment the argument (NOT /*a*/)
   DECLARE_UNUSED(a);
   return 0;


### PR DESCRIPTION
This PR add the clang-format coding style configuration for gstlearn source code. The file .clang-format is located in the root folder of the repository. It has to be used for example with the "Clang format" VS code extension from Xaver Hellauer.
Look at Style.cpp diffs of this PR to see the changes made by the "Format selection" option (Ctrl + K Ctrl +F in VS code).

With VS code, user must add the following to his settings.json file:
```
  "C_Cpp.formatting": "clangFormat"
  "editor.defaultFormatter": "xaver.clang-format"
```
For having automatic formatting while typing/pasting, you need to add this :
```
    "editor.formatOnPaste": true,
    "editor.formatOnType": true,
```

Enjoy