### PR TITLE
Fix warnings, increase warning level

### DIFF
--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -79,6 +79,8 @@ jobs:
           -DBUILD_PYTHON=ON \
           -DBUILD_R=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      env:
+        CXXFLAGS: -Werror
 
     - name: Build the package
       run: |

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -24,7 +24,16 @@ if (MSVC)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
   # Lots of warnings (-Wall = add some warnings, -Wextra = add a ton of warnings)
-  add_compile_options(-Wall -Wextra -Wno-deprecated-copy -Wno-unused-parameter -Wundef)
+  add_compile_options(
+    -Wall
+    -Wextra
+    -Wno-deprecated-copy
+    -Wno-unused-parameter
+    -Wtype-limits
+    -Wnon-virtual-dtor
+    -Wvla
+    -Wundef
+  )
   if (APPLE)
     add_compile_options(-Wno-absolute-value -Wno-inconsistent-missing-override)
   endif()

--- a/include/Basic/AException.hpp
+++ b/include/Basic/AException.hpp
@@ -27,6 +27,7 @@ private:
   std::string _msg;
 };
 
+[[noreturn]]
 GSTLEARN_EXPORT void throw_exp(const std::string& msg = "",
                                const std::string& file = "",
                                int line = 0);

--- a/include/Db/DbGrid.hpp
+++ b/include/Db/DbGrid.hpp
@@ -341,7 +341,7 @@ public:
                                  const NamingConvention &namconv = NamingConvention("Morpho", false, false, true,
                                      ELoc::fromKey("SEL")));
 
-  void getSampleAsSTInPlace(int iech, SpaceTarget& P) const;
+  void getSampleAsSTInPlace(int iech, SpaceTarget& P) const override;
 
   VectorVectorDouble getDiscretizedBlock(const VectorInt &ndiscs,
                                          int iech = 0,

--- a/src/Simulation/SimuSpectral.cpp
+++ b/src/Simulation/SimuSpectral.cpp
@@ -306,9 +306,9 @@ int SimuSpectral::_getKey1Maximum(const spSim& spsim) const
 int SimuSpectral::_getSumValue(const spSim& spsim) const
 {
   double sum = 0;
-  for (const auto e1: spsim._tab)
+  for (const auto &e1: spsim._tab)
   {
-    for (const auto e2: e1.second)
+    for (const auto &e2: e1.second)
       sum += e2.second;
   }
   return sum;
@@ -317,7 +317,7 @@ int SimuSpectral::_getSumValue(const spSim& spsim) const
 VectorInt SimuSpectral::_getKeys2(const spSim& spsim, int key1) const
 {
   VectorInt keys;
-  for (auto e1: spsim._tab)
+  for (const auto &e1: spsim._tab)
   {
     if (e1.first != key1) continue;
 
@@ -332,7 +332,7 @@ VectorInt SimuSpectral::_getKeys2(const spSim& spsim, int key1) const
 VectorInt SimuSpectral::_getValues2(const spSim& spsim, int key1) const
 {
   VectorInt keys;
-  for (auto e1: spsim._tab)
+  for (const auto &e1: spsim._tab)
   {
     if (e1.first != key1) continue;
 

--- a/tests/inter/testInter_GibbsMMulti.cpp
+++ b/tests/inter/testInter_GibbsMMulti.cpp
@@ -98,7 +98,7 @@ int main()
   CovLMC covs(ctxt.getSpace());
   CovAniso cova(ECov::SPHERICAL,ctxt);
   cova.setRanges(ranges);
-  cova.setSill({sill});
+  cova.setSill(sill);
   covs.addCov(&cova);
   model.setCovList(&covs);
   model.display();


### PR DESCRIPTION
This PR fixes a few GCC/Clang/static analysis warnings.

New warnings are enabled for GCC and Clang:
- `-Wtype-limits` warns about tautological comparisons between types with different signedness,
- `-Wvla` prevents using Variable-Length Arrays,
- `-Wnon-virtual-dtor` ensures that destructors of base classes are always `virtual`

The `nonreg-tests` on Ubuntu now builds gstlearn on `-Werror` to prevent the introduction of warnings.

Enjoy,
Pierre