### PR TITLE
GitHub Actions: Use sccache on Ubuntu, macOS nonreg workflows

### DIFF
--- a/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
@@ -100,6 +100,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
     - name: Configure build directory
       run: |
         cmake \
@@ -108,6 +111,10 @@ jobs:
           -DBUILD_PYTHON=ON \
           -DBUILD_R=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        CMAKE_CC_COMPILER_LAUNCHER: sccache
+        CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
     - name: Build the package
       run: |

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -67,6 +67,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
     - name: Configure build directory
       run: |
         cmake \
@@ -78,6 +81,9 @@ jobs:
       env:
         CC: ${{env.LLVM_ROOT}}/opt/llvm/bin/clang
         CXX: ${{env.LLVM_ROOT}}/opt/llvm/bin/clang++
+        SCCACHE_GHA_ENABLED: "true"
+        CMAKE_CC_COMPILER_LAUNCHER: sccache
+        CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
     - name: Build the package
       run: |

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -71,6 +71,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
     - name: Configure build directory
       run: |
         cmake \
@@ -81,6 +84,9 @@ jobs:
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
       env:
         CXXFLAGS: -Werror
+        SCCACHE_GHA_ENABLED: "true"
+        CMAKE_CC_COMPILER_LAUNCHER: sccache
+        CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
     - name: Build the package
       run: |


### PR DESCRIPTION
This PR adds the support of `sccache` in the Ubuntu & macOS nonreg workflows. `sccache` will cache the object files (`.o`) generated by the compiler in a given directory. This directory will be cached across workflow runs using GitHub Actions cache (https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) automatically.

Making it work on Windows workflows is a little more involving, as `sccache` does not work well with Visual Studio solutions. I'll try to see what I can do.

Enjoy,
Pierre