### PR TITLE
Several minor changes to the conjugate gradient in ALinearOpMulti::evalInverse().

### DIFF
--- a/include/LinearOp/ALinearOpMulti.hpp
+++ b/include/LinearOp/ALinearOpMulti.hpp
@@ -41,6 +41,8 @@ public:
 
   void prepare() const;
 
+  void setUserInitialValue(bool b) { _userInitialValue = b; }
+
 protected:
   virtual void _evalDirect(const VectorVectorDouble &inv,
                            VectorVectorDouble &outv) const = 0;

--- a/include/LinearOp/ALinearOpMulti.hpp
+++ b/include/LinearOp/ALinearOpMulti.hpp
@@ -63,6 +63,7 @@ public:
   mutable VectorVectorDouble _temp;
   mutable VectorVectorDouble _p;
   mutable VectorVectorDouble _z;
+  mutable double _nb;
 
 protected:
   LogStats                   _logStats;

--- a/include/LinearOp/ALinearOpMulti.hpp
+++ b/include/LinearOp/ALinearOpMulti.hpp
@@ -34,6 +34,7 @@ public:
   virtual int size(int) const = 0;
 
   void setNIterMax(int nitermax) { _nIterMax = nitermax; }
+  void setNIterRestart(int niterrestart) { _nIterRestart = niterrestart; }
   void setEps(double eps) { _eps = eps; }
   void setPrecond(const ALinearOpMulti* precond, int status);
 
@@ -50,6 +51,7 @@ protected:
 
 private:
   int                       _nIterMax;
+  int                       _nIterRestart;
   double                    _eps;
   bool                      _precondStatus;
   bool                      _userInitialValue;

--- a/src/LinearOp/ALinearOpMulti.cpp
+++ b/src/LinearOp/ALinearOpMulti.cpp
@@ -192,9 +192,9 @@ void ALinearOpMulti::evalInverse(const VectorVectorDouble &vecin,
     else
     {
       rsnew = VH::innerProduct(_r, _r);
-      crit = rsnew / nb;
       VH::linearCombinationVVDInPlace(1., _r, rsnew / rsold, _p, _p);    // p = r+beta p
     }
+    crit = rsnew / nb;
 
     if (OptDbg::query(EDbg::CONVERGE))
       message("%d iterations (max=%d)  crit %lg \n", niter, _nIterMax, crit);

--- a/src/LinearOp/ALinearOpMulti.cpp
+++ b/src/LinearOp/ALinearOpMulti.cpp
@@ -146,6 +146,7 @@ void ALinearOpMulti::evalInverse(const VectorVectorDouble &vecin,
   {
     evalDirect(vecout, _temp); //temp = Ax0 (x0 est stocké dans outv)
     VH::subtractInPlace(_temp, vecin, _r);    //r=b-Ax0
+    nb = VH::innerProduct(_r, _r);
   }
   else
   {


### PR DESCRIPTION
This branch contains 4 separate changes, all related to the conjugate gradient solver. They don't change the results but instead just aim at making it a bit more flexible (and also fixing what I think is a bug). I've split changes in 4 commits so they can be cherry-picked individually if needed.

[22470a672340b4705e952e65148ad760b9cde13b](https://github.com/gstlearn/gstlearn/commit/22470a672340b4705e952e65148ad760b9cde13b):
The code has a flag for giving an initial value to the `vecout` argument (i.e. the X we're solving for) but there was no way to actually set this flag. This commit fixes this. Also when using this flag the `nb` variable was not properly initialised (it used `<b,b>` instead of `<b-Ax,b-Ax>`, the two being equivalent only if `x=0`).

[6f5f42ce77243ec5b1946e743edc7cb8797f7568](https://github.com/gstlearn/gstlearn/commit/6f5f42ce77243ec5b1946e743edc7cb8797f7568):
This is a bug fix when using a preconditioner, `crit` wasn't properly recomputed. I haven't really tried that code, that's just something I noticed while reading it.

[b517fa26d899e55ed616994eb3afca5c61646899](https://github.com/gstlearn/gstlearn/commit/b517fa26d899e55ed616994eb3afca5c61646899):
If setting the flag to give an initial value, calling `evalInverse()` twice is not exactly the same as doing twice as many iterations. Adding iterations requires storing some internal state (the `_p` vector). This vector is actually already stored, so all that's needed to be able to add iterations is another scalar, and making sure the internal state is not erased. This is what happens with this commit. Note that calling `evalInverse()` several times recomputes the residuals from `b - Ax` which may in theory produce tiny numerical differences with the standard incremental update, and is slightly slower (see commit below). In practice I haven't noticed anything.

[720f28b43883943cc27dd7d4709625b0339f50e0](https://github.com/gstlearn/gstlearn/commit/720f28b43883943cc27dd7d4709625b0339f50e0):
Most references I found about the conjugate gradient advise to recompute the exact value of residuals once in a while to avoid numerical accuracy issues that may happen when accumulating incremental updates to the residuals. This requires an additional matrix-vector product so it's best to not do it too often. This commit adds a parameter (set to 0 i.e. do nothing by default) to enable this.