### PR TITLE
Reduce memory copies with Eigen

### DIFF
--- a/include/LinearOp/LinearOpCGSolver.hpp
+++ b/include/LinearOp/LinearOpCGSolver.hpp
@@ -33,7 +33,8 @@ public:
   int  getIterations() const { return cg.iterations();}
   double getError() const { return  cg.error();}
 #ifndef SWIG
-  void solve(const Eigen::Map<const Eigen::VectorXd>& rhs, Eigen::VectorXd& out);
+  void solve(const Eigen::Map<const Eigen::VectorXd>& rhs,
+             Eigen::Map<Eigen::VectorXd>& out);
   void solveWithGuess(const Eigen::VectorXd& rhs,const Eigen::VectorXd& guess, Eigen::VectorXd& out);
 private:
   Eigen::ConjugateGradient<TLinOP,
@@ -56,21 +57,22 @@ template<typename TLinOP>
 void LinearOpCGSolver<TLinOP>::solve(const VectorDouble& rhs, VectorDouble& out)
 {
   Eigen::Map<const Eigen::VectorXd> myRhs(rhs.data(), rhs.size());
-  Eigen::VectorXd myOut;
+  Eigen::Map<Eigen::VectorXd> myOut(out.data(), out.size());
   // Assume outv has the good size
   solve(myRhs, myOut);
-  Eigen::Map<Eigen::VectorXd>(out.data(), out.size()) = myOut;
 }
 
 template<typename TLinOP>
 void LinearOpCGSolver<TLinOP>::solve(const VectorEigen& rhs, VectorEigen& out)
 {
-  solve(rhs.getMap(), out.getVector());
+  auto outmap = out.getMap();
+  solve(rhs.getMap(), outmap);
 }
 
 template<typename TLinOP>
-void LinearOpCGSolver<TLinOP>::solve(const Eigen::Map<const Eigen::VectorXd>& rhs,
-                                     Eigen::VectorXd& out)
+void LinearOpCGSolver<TLinOP>::solve(
+  const Eigen::Map<const Eigen::VectorXd>& rhs,
+  Eigen::Map<Eigen::VectorXd>& out)
 {
   out = cg.solve(rhs);
 }

--- a/include/LinearOp/LinearOpCGSolver.hpp
+++ b/include/LinearOp/LinearOpCGSolver.hpp
@@ -33,7 +33,7 @@ public:
   int  getIterations() const { return cg.iterations();}
   double getError() const { return  cg.error();}
 #ifndef SWIG
-  void solve(const Eigen::VectorXd& rhs, Eigen::VectorXd& out);
+  void solve(const Eigen::Map<const Eigen::VectorXd>& rhs, Eigen::VectorXd& out);
   void solveWithGuess(const Eigen::VectorXd& rhs,const Eigen::VectorXd& guess, Eigen::VectorXd& out);
 private:
   Eigen::ConjugateGradient<TLinOP,
@@ -65,11 +65,11 @@ void LinearOpCGSolver<TLinOP>::solve(const VectorDouble& rhs, VectorDouble& out)
 template<typename TLinOP>
 void LinearOpCGSolver<TLinOP>::solve(const VectorEigen& rhs, VectorEigen& out)
 {
-  solve(rhs.getVector(), out.getVector());
+  solve(rhs.getMap(), out.getVector());
 }
 
 template<typename TLinOP>
-void LinearOpCGSolver<TLinOP>::solve(const Eigen::VectorXd& rhs,
+void LinearOpCGSolver<TLinOP>::solve(const Eigen::Map<const Eigen::VectorXd>& rhs,
                                      Eigen::VectorXd& out)
 {
   out = cg.solve(rhs);

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -76,9 +76,11 @@ public:
                 bool flagCheck = true) override;
 
 #ifndef SWIG
-int addVecInPlace(const Eigen::VectorXd& xm, Eigen::VectorXd& ym) const;
-void addProdMatVecInPlaceToDest(const Eigen::VectorXd& in, Eigen::VectorXd& out,
-                                bool transpose = false) const;
+  int addVecInPlace(const Eigen::Map<const Eigen::VectorXd>& xm,
+                    Eigen::Map<Eigen::VectorXd>& ym) const;
+  void addProdMatVecInPlaceToDest(const Eigen::Map<const Eigen::VectorXd>& in,
+                                  Eigen::Map<Eigen::VectorXd>& out,
+                                  bool transpose = false) const;
 #endif
   /*! Set the contents of a Column */
   virtual void setColumn(int icol,
@@ -229,8 +231,8 @@ void addProdMatVecInPlaceToDest(const Eigen::VectorXd& in, Eigen::VectorXd& out,
 #endif
 
 #ifndef SWIG
-  public : 
-  void setDiagonal(const Eigen::VectorXd& tab);
+  public :
+  void setDiagonal(const Eigen::Map<const Eigen::VectorXd>& tab);
 #endif
 protected:
   /// Interface for AMatrix

--- a/include/Matrix/VectorEigen.hpp
+++ b/include/Matrix/VectorEigen.hpp
@@ -92,6 +92,16 @@ public:
   const Eigen::VectorXd& getVector() const { return _eigenVector; }
   /*! Get underlying Eigen vector */
   Eigen::VectorXd& getVector() { return _eigenVector; }
+  /*! Get map to underlying Eigen vector */
+  Eigen::Map<const Eigen::VectorXd> getMap() const
+  {
+    return {_eigenVector.data(), _eigenVector.size()};
+  }
+  /*! Get map to underlying Eigen vector */
+  Eigen::Map<Eigen::VectorXd> getMap()
+  {
+    return {_eigenVector.data(), _eigenVector.size()};
+  }
 
 private:
   Eigen::VectorXd _eigenVector; /// Eigen storage for vector in Eigen Library

--- a/src/LinearOp/PrecisionOpMultiMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMultiMatrix.cpp
@@ -69,7 +69,9 @@ MatrixSparse PrecisionOpMultiMatrix::_prepareMatrixNoStat(int icov, const Matrix
     {
       if (jvar <= ivar)
       {
-        diag.setDiagonal(_invCholSillsNoStat[icov][IND(ivar,jvar,nvar)]);
+        const auto& vec {_invCholSillsNoStat[icov][IND(ivar, jvar, nvar)]};
+        Eigen::Map<const Eigen::VectorXd> inv(vec.data(), vec.size());
+        diag.setDiagonal(inv);
         MatrixSparse::glueInPlace(&currentRow,&diag ,1,0);
       }
       else 
@@ -142,4 +144,3 @@ int PrecisionOpMultiMatrix::_addToDestImpl(const Eigen::VectorXd &vecin,Eigen::V
 {
   return getQ()->addToDest(vecin,vecout);
 }
-                                   

--- a/src/LinearOp/ProjMatrix.cpp
+++ b/src/LinearOp/ProjMatrix.cpp
@@ -122,7 +122,9 @@ int ProjMatrix::_addMesh2point(const Eigen::VectorXd& inv, Eigen::VectorXd& outv
     return 1;
   }
 
-  addProdMatVecInPlaceToDest(inv, outv, false);
+  Eigen::Map<const Eigen::VectorXd> invmap(inv.data(), inv.size());
+  Eigen::Map<Eigen::VectorXd> outvmap(outv.data(), outv.size());
+  addProdMatVecInPlaceToDest(invmap, outvmap, false);
   return 0;
 }
 
@@ -141,7 +143,9 @@ int ProjMatrix::_addPoint2mesh(const Eigen::VectorXd& inv, Eigen::VectorXd& outv
     return 1;
   }
 
-  addProdMatVecInPlaceToDest(inv, outv, true);
+  Eigen::Map<const Eigen::VectorXd> invmap(inv.data(), inv.size());
+  Eigen::Map<Eigen::VectorXd> outvmap(outv.data(), outv.size());
+  addProdMatVecInPlaceToDest(invmap, outvmap, true);
   return 0;
 }
 

--- a/src/LinearOp/ProjMultiMatrix.cpp
+++ b/src/LinearOp/ProjMultiMatrix.cpp
@@ -175,12 +175,16 @@ ProjMultiMatrix::ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*
 int  ProjMultiMatrix::_addPoint2mesh(const Eigen::VectorXd& inv,
                                         Eigen::VectorXd& outv) const
 {
-    _Proj.addProdMatVecInPlaceToDest(inv, outv,true);
-    return 0;
+  Eigen::Map<const Eigen::VectorXd> invmap(inv.data(), inv.size());
+  Eigen::Map<Eigen::VectorXd> outvmap(outv.data(), outv.size());
+  _Proj.addProdMatVecInPlaceToDest(invmap, outvmap, true);
+  return 0;
 }
 int  ProjMultiMatrix::_addMesh2point(const Eigen::VectorXd& inv,
                                         Eigen::VectorXd& outv) const
 {
-    _Proj.addProdMatVecInPlaceToDest(inv, outv,false);
-    return 0;
+  Eigen::Map<const Eigen::VectorXd> invmap(inv.data(), inv.size());
+  Eigen::Map<Eigen::VectorXd> outvmap(outv.data(), outv.size());
+  _Proj.addProdMatVecInPlaceToDest(invmap, outvmap, false);
+  return 0;
 }

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -97,7 +97,7 @@ int SPDEOp::krigingWithGuess(const Eigen::VectorXd& inv,
 
 int SPDEOp::_solve(const Eigen::VectorXd& in, Eigen::VectorXd& out) const
 {
-  _solver.solve(in, out);
+  _solver.solve({in.data(), in.size()}, out);
   return 0;
 }
 

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -97,7 +97,8 @@ int SPDEOp::krigingWithGuess(const Eigen::VectorXd& inv,
 
 int SPDEOp::_solve(const Eigen::VectorXd& in, Eigen::VectorXd& out) const
 {
-  _solver.solve({in.data(), in.size()}, out);
+  Eigen::Map<Eigen::VectorXd> outmap {out.data(), out.size()};
+  _solver.solve({in.data(), in.size()}, outmap);
   return 0;
 }
 

--- a/src/LinearOp/ShiftOpCs.cpp
+++ b/src/LinearOp/ShiftOpCs.cpp
@@ -529,7 +529,9 @@ void ShiftOpCs::prodLambdaOnSqrtTildeC(const VectorDouble& inv,
 int ShiftOpCs::_addToDest(const Eigen::VectorXd& inv,
                             Eigen::VectorXd& outv) const
 {
-  _S->addProdMatVecInPlaceToDest(inv, outv);
+  Eigen::Map<const Eigen::VectorXd> invmap(inv.data(), inv.size());
+  Eigen::Map<Eigen::VectorXd> outvmap(outv.data(), outv.size());
+  _S->addProdMatVecInPlaceToDest(invmap, outvmap);
   return 0;
 }
 

--- a/src/Matrix/AMatrixDense.cpp
+++ b/src/Matrix/AMatrixDense.cpp
@@ -380,12 +380,12 @@ void AMatrixDense::divideColumn(const VectorDouble& vec)
 VectorDouble AMatrixDense::prodVecMat(const VectorDouble& x, bool transpose) const
 {
   Eigen::Map<const Eigen::VectorXd> xm(x.data(), x.size());
-  Eigen::VectorXd ym;
+  VectorDouble y(transpose ? getNRows() : getNCols());
+  Eigen::Map<Eigen::VectorXd> ym(y.data(), y.size());
   if (transpose)
     ym = xm.transpose() * _eigenMatrix.transpose();
   else
     ym = xm.transpose() * _eigenMatrix;
-  VectorDouble y(ym.data(), ym.data() + ym.size());
   return y;
 }
 
@@ -393,27 +393,35 @@ VectorDouble AMatrixDense::prodVecMat(const VectorDouble& x, bool transpose) con
 VectorDouble AMatrixDense::prodMatVec(const VectorDouble& x, bool transpose) const
 {
   Eigen::Map<const Eigen::VectorXd> xm(x.data(), x.size());
-  Eigen::VectorXd ym;
+  VectorDouble y(transpose ? getNCols() : getNRows());
+  Eigen::Map<Eigen::VectorXd> ym(y.data(), y.size());
   if (transpose)
     ym = _eigenMatrix.transpose() * xm;
   else
     ym = _eigenMatrix * xm;
-  VectorDouble y(ym.data(), ym.data() + ym.size());
   return y;
 }
 
 /*! Extract a Row */
 VectorDouble AMatrixDense::getRow(int irow) const
 {
-  Eigen::VectorXd resm = _eigenMatrix.row(irow);
-  return VectorDouble(resm.data(), resm.data() + resm.size());
+  VectorDouble res(getNCols());
+  for (size_t i = 0; i < res.size(); ++i)
+  {
+    res[i] = _eigenMatrix.row(irow)[i];
+  }
+  return res;
 }
 
 /*! Extract a Column */
 VectorDouble AMatrixDense::getColumn(int icol) const
 {
-  Eigen::VectorXd resm = _eigenMatrix.col(icol);
-  return VectorDouble(resm.data(), resm.data() + resm.size());
+  VectorDouble res(getNRows());
+  for (size_t i = 0; i < res.size(); ++i)
+  {
+    res[i] = _eigenMatrix.col(icol)[i];
+  }
+  return res;
 }
 
 int AMatrixDense::_terminateEigen(const Eigen::VectorXd &eigenValues,

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -268,7 +268,7 @@ void MatrixSparse::_transposeInPlace()
   {
     Eigen::SparseMatrix<double> temp;
     temp = _eigenMatrix.transpose();
-    _eigenMatrix = temp;
+    _eigenMatrix.swap(temp);
   }
   else
   {
@@ -533,12 +533,12 @@ VectorDouble MatrixSparse::prodVecMat(const VectorDouble& x, bool transpose) con
   if (isFlagEigen())
   {
     Eigen::Map<const Eigen::VectorXd> xm(x.data(), x.size());
-    Eigen::VectorXd ym;
+    VectorDouble y(transpose ? getNRows() : getNCols());
+    Eigen::Map<Eigen::VectorXd> ym(y.data(), y.size());
     if (transpose)
       ym = xm.transpose() * _eigenMatrix.transpose();
     else
       ym = xm.transpose() * _eigenMatrix;
-    VectorDouble y(ym.data(), ym.data() + ym.size());
     return y;
   }
   VectorDouble y;
@@ -563,12 +563,12 @@ VectorDouble MatrixSparse::prodMatVec(const VectorDouble& x, bool transpose) con
   if (isFlagEigen())
   {
     Eigen::Map<const Eigen::VectorXd> xm(x.data(), x.size());
-    Eigen::VectorXd ym;
+    VectorDouble y(transpose ? getNCols() : getNRows());
+    Eigen::Map<Eigen::VectorXd> ym(y.data(), y.size());
     if (transpose)
       ym = _eigenMatrix.transpose() * xm;
     else
       ym = _eigenMatrix * xm;
-    VectorDouble y(ym.data(), ym.data() + ym.size());
     return y;
   }
   VectorDouble y;
@@ -813,8 +813,9 @@ VectorDouble MatrixSparse::extractDiag(int oper_choice) const
 {
   if (isFlagEigen())
   {
-    Eigen::VectorXd ym = _eigenMatrix.diagonal();
-    VectorDouble diag(ym.data(), ym.data() + ym.size());
+    VectorDouble diag(std::min(getNCols(), getNRows()));
+    Eigen::Map<Eigen::VectorXd> ym(diag.data(), diag.size());
+    ym = _eigenMatrix.diagonal();
     VH::transformVD(diag, oper_choice);
     return diag;
   }

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -588,8 +588,10 @@ VectorDouble MatrixSparse::prodMatVec(const VectorDouble& x, bool transpose) con
 }
 
 /*! Perform y += 'this' %*% x */
-void  MatrixSparse::addProdMatVecInPlaceToDest(const Eigen::VectorXd& in, Eigen::VectorXd& out,
-                                                      bool transpose) const
+void MatrixSparse::addProdMatVecInPlaceToDest(
+  const Eigen::Map<const Eigen::VectorXd>& in,
+  Eigen::Map<Eigen::VectorXd>& out,
+  bool transpose) const
 {
   if (isFlagEigen())
   {
@@ -824,7 +826,8 @@ VectorDouble MatrixSparse::extractDiag(int oper_choice) const
   return diag;
 }
 
-int MatrixSparse::addVecInPlace(const Eigen::VectorXd& xm, Eigen::VectorXd& ym) const
+int MatrixSparse::addVecInPlace(const Eigen::Map<const Eigen::VectorXd>& xm,
+                                Eigen::Map<Eigen::VectorXd>& ym) const
 {
   if (isFlagEigen())
   {
@@ -1721,10 +1724,9 @@ int MatrixSparse::_addToDest(const Eigen::VectorXd& inv,
     return 0;
 }
 
-void MatrixSparse::setDiagonal(const Eigen::VectorXd& tab)
+void MatrixSparse::setDiagonal(const Eigen::Map<const Eigen::VectorXd>& tab)
 {
-    Eigen::Map<const Eigen::VectorXd> vecm(tab.data(), tab.size());
-    _eigenMatrix = vecm.asDiagonal();
+  _eigenMatrix = tab.asDiagonal();
 }
 
 


### PR DESCRIPTION
This PR tries to reduce the number of copies when using Eigen. In particular, copies happen when converting between `Eigen::VectorXd`, `VectorDouble` and `VectorEigen`.

This PR leverages `Eigen::Map<Eigen::VectorXd>` to avoid unnecessary copies, in particular in `LinearOpCGSolver`, `AMatrixDense` and `AMatrixSparse`.

A lot more copies might be lurking in the code, especially when methods taking `Eigen::VectorXd` are passed `Eigen::Map` arguments. This is at least a beginning.

Pierre