### PR TITLE
Factor some allocations in MeshETurbo

### DIFF
--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -120,7 +120,7 @@ public:
 private:
   int  _defineGrid(const VectorDouble& cellsize);
   void _setNumberElementPerCell();
-  int  _getPolarized(VectorInt indg) const;
+  int  _getPolarized(const VectorInt &indg) const;
   int  _addWeights(int icas,
                    const VectorInt &indg0,
                    const VectorDouble &coor,

--- a/src/Mesh/MeshETurbo.cpp
+++ b/src/Mesh/MeshETurbo.cpp
@@ -758,7 +758,7 @@ int MeshETurbo::_addWeights(int icas,
   return 0;
 }
 
-int MeshETurbo::_getPolarized(VectorInt indg) const
+int MeshETurbo::_getPolarized(const VectorInt &indg) const
 {
   int ndim = getNDim();
   if (! _isPolarized) return(0);

--- a/src/Mesh/MeshETurbo.cpp
+++ b/src/Mesh/MeshETurbo.cpp
@@ -137,6 +137,8 @@ double MeshETurbo::getMeshSize(int /*imesh*/) const
   return size;
 }
 
+static VectorInt indg;
+
 /****************************************************************************/
 /*!
 ** Returns the Apex 'rank' of the Mesh 'imesh'
@@ -151,7 +153,7 @@ int MeshETurbo::getApex(int imesh, int rank) const
 {
   int node,icas;
   int ndim = getNDim();
-  VectorInt indg(ndim);
+  indg.resize(ndim);
 
   int jmesh = _meshIndirect.getRToA(imesh);
   _getGridFromMesh(jmesh,&node,&icas);
@@ -174,7 +176,7 @@ int MeshETurbo::getApex(int imesh, int rank) const
 
 double MeshETurbo::getCoor(int imesh, int rank, int idim) const
 {
-  VectorInt indg(getNDim());
+  indg.resize(getNDim());
 
   int irel = getApex(imesh,rank);
   int iabs = _gridIndirect.getRToA(irel);
@@ -184,7 +186,7 @@ double MeshETurbo::getCoor(int imesh, int rank, int idim) const
 
 void MeshETurbo::getCoordinatesInPlace(int imesh, int rank, VectorDouble& coords) const
 {
-  VectorInt indg(getNDim());
+  indg.resize(getNDim());
 
   int irel = getApex(imesh,rank);
   int iabs = _gridIndirect.getRToA(irel);
@@ -196,7 +198,7 @@ void MeshETurbo::getCoordinatesInPlace(int imesh, int rank, VectorDouble& coords
 
 double MeshETurbo::getApexCoor(int i, int idim) const
 { _meshIndirect.getRelSize();
-  VectorInt indg(getNDim());
+  indg.resize(getNDim());
 
   int iabs = _gridIndirect.getRToA(i);
   _grid.rankToIndice(iabs, indg);
@@ -205,7 +207,7 @@ double MeshETurbo::getApexCoor(int i, int idim) const
 
 void MeshETurbo::getApexCoordinatesInPlace(int i, VectorDouble& coords) const
 {
-  VectorInt indg(getNDim());
+  indg.resize(getNDim());
 
   int iabs = _gridIndirect.getRToA(i);
   _grid.rankToIndice(iabs, indg);
@@ -305,7 +307,7 @@ void MeshETurbo::_buildMaskInMeshing(const VectorDouble& sel)
   int nmesh = _nmeshInCompleteGrid();
   int ncorner = getNApexPerMesh();
   VectorInt indg0(ndim);
-  VectorInt indg(ndim);
+  indg.resize(ndim);
 
   // Loop on all possible meshes
   int meshNactive = 0;
@@ -778,7 +780,7 @@ int MeshETurbo::_getPolarized(const VectorInt &indg) const
  */
 void MeshETurbo::_getGridFromMesh(int imesh, int *node, int *icas) const
 {
-  VectorInt indg(getNDim());
+  indg.resize(getNDim());
   int ncas = _nPerCell;
   int rank = imesh / ncas;
   *icas    = imesh - rank * ncas;


### PR DESCRIPTION
While doing debug, I ran [heaptrack](https://github.com/KDE/heaptrack) on `test_SPDEAPI` and it showed me memory allocations that were (partly) easy to factor.

This PR focuses on the `MeshETurbo` methods. There was a `VectorInt` copy in `_getPolarized` that I replaced with a const ref. Other methods were using a `VectorInt indg` that I refactored using a global variable (I lacked a better idea).

These two improvements yield the following results in `test_SPDEAPI`:

| Metric            | Before | After |
|-------------------|--------:|-------:|
| Exec time (s)     | 23     | 11    |
| #Allocations      | 75M    | 28M   |
| #Temp allocations | 18M    | 4M    |
| Memory cons (MB) | 82 | 82 |

There is still room for improvement, namely in the handling of `VectorNum`s: if one vector is modified with a `use_count() > 1`, a vector copy is triggered before the modification. No idea yet on how to tackle that though.

I've not tested the impact on the other test executables (apart from checking their output on GitHub).

Enjoy,
Pierre