### PR TITLE
GitHub Actions: Remove 10 min idle timeout on sccache daemon

### DIFF
--- a/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_ubuntu-latest.yml
@@ -27,6 +27,7 @@ env:
   PYTHON_VERSION : "3.11"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SCCACHE_IDLE_TIMEOUT: 0
 
 jobs:
   build:


### PR DESCRIPTION
The `nonreg-demos-courses_ubuntu_latest` GitHub Actions workflow has been displaying zeroed `sccache` statistics in the workflow run summary. After several tries, I understood that `sccache`, when idle for 10 minutes (as written in its documentation), stops its daemon. The affected workflow does a lot of testing around Python and R, these take more than 10 minutes, leading to the zeroed `sccache` stats.

This PR sets the `SCCACHE_IDLE_TIMEOUT` environment variable to 0 (no timeout) to fix this issue.

Enjoy,
Pierre