### PR TITLE
Pass std::span by value

### DIFF
--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -97,21 +97,21 @@ public:
   
   #ifndef SWIG
   static void addMultiplyConstantInPlace(double val1,
-                                  const constvect &in,
-                                  vect &out,
-                                  int iad);
-  static double innerProduct(const constvect &veca, const constvect &vecb);
+                                         const constvect in,
+                                         vect out,
+                                         int iad);
+  static double innerProduct(const constvect veca, const constvect vecb);
 
-  static void addMultiplyVectVectInPlace(const constvect &in1,
-                                         const constvect &in2,
-                                         vect &out,
+  static void addMultiplyVectVectInPlace(const constvect in1,
+                                         const constvect in2,
+                                         vect out,
                                          int iad);
   static void addInPlace(const std::vector<std::vector<double>> &in1,
                               const std::vector<std::vector<double>> &in2,
                               std::vector<std::vector<double>> &outv);
-  static void addInPlace(constvect& in,vect& dest);
-                            
-  #endif
+  static void addInPlace(constvect in, vect dest);
+
+#endif
   static VectorDouble add(const VectorDouble &veca, const VectorDouble &vecb);
   static void addInPlace(VectorDouble &dest, const VectorDouble &src);
   static void addInPlace(std::vector<double>& dest, const std::vector<double> &src);

--- a/include/LinearOp/ALinearOp.hpp
+++ b/include/LinearOp/ALinearOp.hpp
@@ -30,13 +30,11 @@ public:
 
 #ifndef SWIG
   public:
-  int evalDirect(constvect& inv, vect& outv) const;
-  int addToDest(const constvect& inv, vect& outv) const;
-  int addToDest(const Eigen::VectorXd& inv,
-                Eigen::VectorXd& outv) const;
+    int evalDirect(constvect inv, vect outv) const;
+    int addToDest(const constvect inv, vect outv) const;
+    int addToDest(const Eigen::VectorXd& inv, Eigen::VectorXd& outv) const;
 
-protected:
-  virtual int _addToDest(constvect& inv,
-                         vect& outv) const = 0;
+  protected:
+    virtual int _addToDest(constvect inv, vect outv) const = 0;
 #endif
 };

--- a/include/LinearOp/ASimulable.hpp
+++ b/include/LinearOp/ASimulable.hpp
@@ -27,10 +27,10 @@ public:
 #ifndef SWIG
 
 public:
-  int evalSimulate(const constvect& whitenoise, vect &result) const;
+  int evalSimulate(const constvect whitenoise, vect result) const;
 
 protected:
-  virtual int _addSimulateToDest(const constvect& whitenoise,
-                                       vect& outv) const = 0;
+  virtual int _addSimulateToDest(const constvect whitenoise,
+                                 vect outv) const = 0;
 #endif
 };

--- a/include/LinearOp/Cholesky.hpp
+++ b/include/LinearOp/Cholesky.hpp
@@ -52,18 +52,17 @@ public:
   int  solve(const VectorDouble& b, VectorDouble& x) const;
   int  simulate(const VectorDouble& b, VectorDouble& x) const;
   #ifndef SWIG
-    int solve(const constvect& b, std::vector<double>& x) const;
-    int solve(const constvect& b, vect& x) const;
-    int  simulate(const constvect& b, vect& x) const;
-    int  addSimulateToDest(const constvect& b, vect& x) const;
-  #endif
+  int solve(const constvect b, std::vector<double>& x) const;
+  int solve(const constvect b, vect x) const;
+  int simulate(const constvect b, vect x) const;
+  int addSimulateToDest(const constvect b, vect x) const;
+#endif
   int  stdev(VectorDouble& vcur, bool flagStDev = false) const;
   double getLogDeterminant() const;
 
 #ifndef SWIG
 protected:
-  int  _addToDest(const constvect& inv,
-                        vect& outv) const override;
+  int _addToDest(const constvect inv, vect outv) const override;
 
 private:
   void _clean();

--- a/include/LinearOp/HessianOp.hpp
+++ b/include/LinearOp/HessianOp.hpp
@@ -58,9 +58,7 @@ public:
 
 #ifndef SWIG
 protected:
-  int _addToDest(const constvect& inv,
-                 vect& outv) const override;
-
+  int _addToDest(const constvect inv, vect outv) const override;
 
 private:
   bool                 _isInitialized;

--- a/include/LinearOp/IProjMatrix.hpp
+++ b/include/LinearOp/IProjMatrix.hpp
@@ -17,30 +17,28 @@ class GSTLEARN_EXPORT IProjMatrix
 public:
   IProjMatrix() { }
   virtual ~IProjMatrix() { }
-  int point2mesh(const VectorDouble& inv, VectorDouble& outv) const; 
+  int point2mesh(const VectorDouble& inv, VectorDouble& outv) const;
   int mesh2point(const VectorDouble& inv, VectorDouble& outv) const;
-  int point2mesh(const constvect& inv,vect& out) const;
-  int mesh2point(const constvect& inv,vect& out) const;
+#ifndef SWIG
+  int point2mesh(const constvect inv, vect out) const;
+  int mesh2point(const constvect inv, vect out) const;
+#endif
 
   virtual int getApexNumber() const = 0;
   virtual int getPointNumber() const = 0;
 
-  #ifndef SWIG 
-  int addMesh2point(const constvect& inv,
-                    vect& outv) const;
-  int addPoint2mesh(const constvect& inv,
-                    vect& outv) const;       
- 
-  protected:
-  virtual int _addPoint2mesh(const constvect& inv,
-                             vect& outv) const
+#ifndef SWIG
+  int addMesh2point(const constvect inv, vect outv) const;
+  int addPoint2mesh(const constvect inv, vect outv) const;
+
+protected:
+  virtual int _addPoint2mesh(const constvect inv, vect outv) const
   {
     DECLARE_UNUSED(inv);
     DECLARE_UNUSED(outv);
     return 1;
   }
-  virtual int _addMesh2point(const constvect& inv,
-                             vect& outv) const
+  virtual int _addMesh2point(const constvect inv, vect outv) const
   {
     DECLARE_UNUSED(inv);
     DECLARE_UNUSED(outv);

--- a/include/LinearOp/LinearOpCGSolver.hpp
+++ b/include/LinearOp/LinearOpCGSolver.hpp
@@ -35,12 +35,11 @@ public:
   int  getIterations() const { return cg.iterations();}
   double getError() const { return  cg.error();}
 #ifndef SWIG
-  void solve(const constvect &in, const vect &out);
+  void solve(const constvect in, const vect out);
   void solve(const Eigen::Map<const Eigen::VectorXd>& rhs,
              Eigen::Map<Eigen::VectorXd>& out);
-  
-  void solveWithGuess(const constvect& rhs, const constvect& guess,
-                                              vect & out);       
+
+  void solveWithGuess(const constvect rhs, const constvect guess, vect out);
   void solveWithGuess(const Eigen::Map<const Eigen::VectorXd>& rhs,
                       const Eigen::Map<const Eigen::VectorXd>& guess,
                       Eigen::Map<Eigen::VectorXd>& out);
@@ -87,7 +86,7 @@ void LinearOpCGSolver<TLinOP>::solveWithGuess(const Eigen::Map<const Eigen::Vect
 }
 
 template<typename TLinOP>
-void LinearOpCGSolver<TLinOP>::solve(const constvect &in, const vect &out)
+void LinearOpCGSolver<TLinOP>::solve(const constvect in, const vect out)
 {
   Eigen::Map<const Eigen::VectorXd> inm(in.data(),in.size());
   Eigen::Map<Eigen::VectorXd> outm(out.data(),out.size());
@@ -95,9 +94,9 @@ void LinearOpCGSolver<TLinOP>::solve(const constvect &in, const vect &out)
 }
 
 template<typename TLinOP>
-void LinearOpCGSolver<TLinOP>::solveWithGuess(const constvect& rhs,
-                                              const constvect& guess,
-                                              vect & out)
+void LinearOpCGSolver<TLinOP>::solveWithGuess(const constvect rhs,
+                                              const constvect guess,
+                                              vect out)
 {
   Eigen::Map<const Eigen::VectorXd> rhsm(rhs.data(),rhs.size());
   Eigen::Map<const Eigen::VectorXd> guessm(guess.data(),guess.size());

--- a/include/LinearOp/MatrixSquareSymmetricSim.hpp
+++ b/include/LinearOp/MatrixSquareSymmetricSim.hpp
@@ -47,18 +47,16 @@ public:
 
 
 protected:
-  virtual int _addSimulateToDest(const constvect& whitenoise,
-                                       vect& outv) const override;
-  virtual int _addToDest(const constvect& inv,
-                               vect& outv) const override;
-
+  virtual int _addSimulateToDest(const constvect whitenoise,
+                                 vect outv) const override;
+  virtual int _addToDest(const constvect inv, vect outv) const override;
 
 private:
   void _prepare() const; // modify only mutable objects and can be called from const method
   void _clear();
-  
-  int  _simulateSparse(const constvect& whitenoise,
-                             vect& outv) const;
+
+  int _simulateSparse(const constvect whitenoise, vect outv) const;
+
 private:
   const   AMatrix* _mat;
   bool             _inverse;
@@ -73,5 +71,4 @@ private:
   mutable VectorDouble _xl; // Lower triangular matrix (inverse of _tl)
   ////////////////////////////////////////////////////////////////////////////
   mutable Cholesky* _factorSparse; // Cholesky decomposition
-  
 };

--- a/include/LinearOp/PrecisionOp.hpp
+++ b/include/LinearOp/PrecisionOp.hpp
@@ -44,8 +44,8 @@ public:
   // Interface functions for using PrecisionOp
 
   #ifndef SWIG
-    virtual void evalInverse(const  constvect& vecin, std::vector<double>& vecout);
-  #endif
+  virtual void evalInverse(const constvect vecin, std::vector<double>& vecout);
+#endif
 
   virtual std::pair<double,double> getRangeEigenVal(int ndiscr = 100);
 
@@ -62,30 +62,23 @@ public:
 
   virtual double getLogDeterminant(int nbsimu = 1);
   #ifndef SWIG
-    virtual void gradYQX(const constvect& /*X*/,
-                         const constvect& /*Y*/,
-                         vect& /*result*/,
-                         const EPowerPT& /*power*/)
-    {};
-    virtual void gradYQXOptim(const constvect& /*X*/,
-                              const constvect& /*Y*/,
-                              vect& /*result*/,
-                              const EPowerPT& /*power*/)
-    {
-    };
-  virtual void evalDeriv(const constvect& /*inv*/,
-                         vect& /*outv*/,
+  virtual void gradYQX(const constvect /*X*/,
+                       const constvect /*Y*/,
+                       vect /*result*/,
+                       const EPowerPT& /*power*/) {};
+  virtual void gradYQXOptim(const constvect /*X*/,
+                            const constvect /*Y*/,
+                            vect /*result*/,
+                            const EPowerPT& /*power*/) {};
+  virtual void evalDeriv(const constvect /*inv*/,
+                         vect /*outv*/,
                          int /*iapex*/,
                          int /*igparam*/,
-                         const EPowerPT& /*power*/)
-  {
-  };
-  virtual void evalDerivOptim(vect& /*outv*/,
+                         const EPowerPT& /*power*/) {};
+  virtual void evalDerivOptim(vect /*outv*/,
                               int /*iapex*/,
                               int /*igparam*/,
-                              const EPowerPT& /*power*/)
-  {
-  };
+                              const EPowerPT& /*power*/) {};
   VectorVectorDouble simulate(int nbsimu = 1);
 
   #endif
@@ -96,8 +89,10 @@ public:
 //                             int /*igparam*/){};
 
   #ifndef SWIG
-  void evalPower(const constvect &inm, vect &outm, const EPowerPT& power = EPowerPT::fromKey("ONE"));
-  #endif
+  void evalPower(const constvect inm,
+                 vect outm,
+                 const EPowerPT& power = EPowerPT::fromKey("ONE"));
+#endif
   VectorDouble evalCov(int imesh);
   VectorDouble simulateOne();
 
@@ -121,11 +116,11 @@ public:
 void evalPower(const VectorDouble &inv, VectorDouble &outv, const EPowerPT& power = EPowerPT::fromKey("ONE"));
 
 protected:
-  virtual int  _addToDest(const constvect& inv,
-                          vect& outv) const override;
-  virtual int  _addSimulateToDest(const constvect& whitenoise,
-                          vect& outv) const override;
-  void _addEvalPower(const constvect& inv, vect& outv, const EPowerPT& power) const;
+  virtual int _addToDest(const constvect inv, vect outv) const override;
+  virtual int _addSimulateToDest(const constvect whitenoise,
+                                 vect outv) const override;
+  void
+  _addEvalPower(const constvect inv, vect outv, const EPowerPT& power) const;
 
 #endif
 
@@ -134,7 +129,7 @@ private:
   int  _prepareChebychev(const EPowerPT& power) const;
   int  _preparePrecisionPoly() const;
 #ifndef SWIG
-  int  _evalPoly(const EPowerPT& power,const constvect& inv, vect& outv) const;
+  int _evalPoly(const EPowerPT& power, const constvect inv, vect outv) const;
 #endif
   void _purge();
 

--- a/include/LinearOp/PrecisionOpCs.hpp
+++ b/include/LinearOp/PrecisionOpCs.hpp
@@ -37,21 +37,32 @@ public:
 
   // Interface for PrecisionOp class
   #ifndef SWIG
-  void evalInverse(const constvect& vecin, std::vector<double>& vecout) override;
-  int _addSimulateToDest(const constvect &whitenoise, vect& outv) const override;
-  int _addToDest(const constvect &inv, vect& outv) const override;
+  void evalInverse(const constvect vecin, std::vector<double>& vecout) override;
+  int _addSimulateToDest(const constvect whitenoise, vect outv) const override;
+  int _addToDest(const constvect inv, vect outv) const override;
   #endif
 
   double getLogDeterminant(int nbsimu = 1) override;
   
   //void evalDerivPoly(const VectorDouble& inv, VectorDouble& outv,int iapex,int igparam) override;
   #ifndef SWIG
-  void evalDeriv(const constvect& inv, vect& outv,int iapex,int igparam,const EPowerPT& power) override;
-  void evalDerivOptim(vect& outv,int iapex,int igparam, const EPowerPT& power) override;
-  void gradYQX(const constvect & X, 
-               const constvect &Y,
-               vect& result, const EPowerPT& power) override;
-  void gradYQXOptim(const constvect & X, const constvect &Y,vect& result, const EPowerPT& power) override;
+  void evalDeriv(const constvect inv,
+                 vect outv,
+                 int iapex,
+                 int igparam,
+                 const EPowerPT& power) override;
+  void evalDerivOptim(vect outv,
+                      int iapex,
+                      int igparam,
+                      const EPowerPT& power) override;
+  void gradYQX(const constvect X,
+               const constvect Y,
+               vect result,
+               const EPowerPT& power) override;
+  void gradYQXOptim(const constvect X,
+                    const constvect Y,
+                    vect result,
+                    const EPowerPT& power) override;
   #endif
   const MatrixSparse* getQ() const { return _Q; }
 

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -51,10 +51,8 @@ protected:
 #ifndef SWIG
 
 protected:
-  int _addToDest(const constvect& vecin,
-                 vect& vecout) const override;
-  int _addSimulateToDest(const constvect& vecin,
-                         vect& vecout) const override;
+  int _addToDest(const constvect vecin, vect vecout) const override;
+  int _addSimulateToDest(const constvect vecin, vect vecout) const override;
 #endif
 
 public:
@@ -71,8 +69,7 @@ protected:
   int _getNMesh() const;
 
 private:
-  virtual int _addToDestImpl(const constvect& vecin,
-                             vect& vecout) const;
+  virtual int _addToDestImpl(const constvect vecin, vect vecout) const;
   bool _checkReady() const;
   virtual void _buildQop();
   bool _isValidModel(Model* model);

--- a/include/LinearOp/PrecisionOpMultiConditional.hpp
+++ b/include/LinearOp/PrecisionOpMultiConditional.hpp
@@ -73,7 +73,7 @@ protected:
     void simulateOnMeshings(std::vector<std::vector<double>> &result) const;
     void simulateOnMeshing(std::vector<double>& result,int icov = 0) const;
     void simulateOnDataPointFromMeshings(const std::vector<std::vector<double>>& simus,std::vector<double>& result) const;
-    void evalInvCov(const constvect& inv, std::vector<double>& result) const;
+    void evalInvCov(const constvect inv, std::vector<double>& result) const;
     double computeQuadratic(const std::vector<double>& x) const;
 
 #endif

--- a/include/LinearOp/PrecisionOpMultiMatrix.hpp
+++ b/include/LinearOp/PrecisionOpMultiMatrix.hpp
@@ -31,8 +31,9 @@ public:
   const MatrixSparse* getQ() const;
   private:
   #ifndef SWIG
-  virtual int _addToDestImpl(const constvect &vecin, vect &vecout) const override;
-  #endif
+    virtual int _addToDestImpl(const constvect vecin,
+                               vect vecout) const override;
+#endif
   MatrixSparse _prepareMatrixNoStat(int icov, const MatrixSparse* Q) const;
   MatrixSparse _prepareMatrixStationary(int icov, const MatrixSparse* Q) const;
   void _prepareMatrix();

--- a/include/LinearOp/ProjConvolution.hpp
+++ b/include/LinearOp/ProjConvolution.hpp
@@ -57,20 +57,19 @@ private:
 
   
 
-  #ifndef SWIG        
+#ifndef SWIG
   private:
-  void _convolve(const constvect &valonvertex,
-                 vect &valonseismic) const;
-  void _convolveT(const constvect &valonseismic,
-                  vect &valonvertex) const;
-  bool _isVecDimCorrect(const constvect &valonseismic,
-                        const constvect &valonvertex) const;   
+    void _convolve(const constvect valonvertex, vect valonseismic) const;
+    void _convolveT(const constvect valonseismic, vect valonvertex) const;
+    bool _isVecDimCorrect(const constvect valonseismic,
+                          const constvect valonvertex) const;
+
   protected:
-  int _addPoint2mesh(const constvect& valonseismic,
-                     vect& valonvertex) const override;
-  int _addMesh2point(const constvect& valonvertex,
-                     vect& valonseismic) const override;
-  #endif
+    int _addPoint2mesh(const constvect valonseismic,
+                       vect valonvertex) const override;
+    int _addMesh2point(const constvect valonvertex,
+                       vect valonseismic) const override;
+#endif
 
 private:
   VectorDouble                _convolution;

--- a/include/LinearOp/ProjMatrix.hpp
+++ b/include/LinearOp/ProjMatrix.hpp
@@ -41,12 +41,12 @@ public:
   virtual String toString(const AStringFormat* strfmt = nullptr) const override;
 
   /// Interface for IProjMatrix
-  
-  #ifndef SWIG
+
+#ifndef SWIG
   protected:
-    int _addMesh2point(const constvect& inv, vect& outv) const override;
-    int _addPoint2mesh(const constvect& inv, vect& outv) const override;
-  #endif 
+    int _addMesh2point(const constvect inv, vect outv) const override;
+    int _addPoint2mesh(const constvect inv, vect outv) const override;
+#endif
   public:
 
   int getApexNumber() const override { return getNCols(); }

--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -27,10 +27,8 @@ public:
 
 #ifndef SWIG           
   protected:
-  virtual int _addPoint2mesh(const constvect& inv,
-                                   vect& outv) const override;
-  virtual int _addMesh2point(const constvect& inv,
-                                   vect& outv) const override;
+    virtual int _addPoint2mesh(const constvect inv, vect outv) const override;
+    virtual int _addMesh2point(const constvect inv, vect outv) const override;
 #endif
 
 private : 
@@ -58,6 +56,4 @@ std::vector<int> _apexNumbers;
 bool _silent;
 mutable std::vector<double> _work;
 mutable std::vector<double> _workmesh;
-
-
 };

--- a/include/LinearOp/ProjMultiMatrix.hpp
+++ b/include/LinearOp/ProjMultiMatrix.hpp
@@ -28,15 +28,12 @@ public:
   const MatrixSparse* getProj() const { return &_Proj;} 
 #ifndef SWIG           
   protected:
-  virtual int _addPoint2mesh(const constvect& inv,
-                             vect& outv) const override;
-  virtual int _addMesh2point(const constvect& inv,
-                             vect& outv) const override;
+    virtual int _addPoint2mesh(const constvect inv, vect outv) const override;
+    virtual int _addMesh2point(const constvect inv, vect outv) const override;
 #endif
 private:
   MatrixSparse  _Proj;
   void _clear() override;
 private:
   bool _toClean;
-
 };

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -53,30 +53,31 @@ public:
                                   const MatrixRectangular& drifts) const;
 #ifndef SWIG
 public:
-  int kriging(const constvect& inv,
-                    vect& out) const;
-  int krigingWithGuess(const constvect& inv,
-                       const constvect& guess,
-                             vect& out) const;
-  void evalInvCov(const constvect &inv, vect& result) const;
- 
+  int kriging(const constvect inv, vect out) const;
+  int krigingWithGuess(const constvect inv,
+                       const constvect guess,
+                       vect out) const;
+  void evalInvCov(const constvect inv, vect result) const;
+
 protected:
-  int _addToDest(const constvect& inv, vect& outv) const override;
-  int _addSimulateToDest(const constvect& whitenoise, vect& outv) const override;
+  int _addToDest(const constvect inv, vect outv) const override;
+  int _addSimulateToDest(const constvect whitenoise, vect outv) const override;
 
 private: 
   int _getNDat() const {return _ndat;}
-  virtual int _solve(const constvect& in,vect& out) const;
-  int _solveWithGuess(const constvect& in,const constvect &guess,vect& out) const;
+  virtual int _solve(const constvect in, vect out) const;
+  int _solveWithGuess(const constvect in,
+                      const constvect guess,
+                      vect out) const;
 
-  int _buildRhs(const constvect& inv) const;
+  int _buildRhs(const constvect inv) const;
 #endif
 
 private:
   void _prepare(bool w1 = true, bool w2 = true) const;
 #ifndef SWIG
 private:
-  virtual int _addToDestImpl(const constvect& inv, vect& outv) const;
+  virtual int _addToDestImpl(const constvect inv, vect outv) const;
 #endif
 
 protected:

--- a/include/LinearOp/SPDEOpMatrix.hpp
+++ b/include/LinearOp/SPDEOpMatrix.hpp
@@ -29,8 +29,8 @@ public:
 
 #ifndef SWIG
 private:
-  int _addToDestImpl(const constvect& inv, vect& outv) const override;
-  int _solve(const constvect& inv, vect& outv) const override;
+  int _addToDestImpl(const constvect inv, vect outv) const override;
+  int _solve(const constvect inv, vect outv) const override;
 #endif
 
 private:

--- a/include/LinearOp/ScaleOp.hpp
+++ b/include/LinearOp/ScaleOp.hpp
@@ -35,7 +35,7 @@ public:
 
 #ifndef SWIG
 protected:
-  int _addToDest(const constvect& inv, vect& outv) const override;
+  int _addToDest(const constvect inv, vect outv) const override;
 #endif
 
 private:

--- a/include/LinearOp/ShiftOpCs.hpp
+++ b/include/LinearOp/ShiftOpCs.hpp
@@ -62,8 +62,9 @@ class GSTLEARN_EXPORT ShiftOpCs:
     ShiftOpCs& operator=(const ShiftOpCs& shift);
     virtual ~ShiftOpCs();
     void normalizeLambdaBySills(const AMesh*);
-    int _addToDest(const constvect& inv,
-                   vect& outv) const override;
+#ifndef SWIG
+    int _addToDest(const constvect inv, vect outv) const override;
+#endif
 
     static ShiftOpCs* create(const AMesh* amesh, const CovAniso* cova,
                              const Db* dbout = nullptr, 
@@ -98,13 +99,11 @@ class GSTLEARN_EXPORT ShiftOpCs:
     void prodLambda(const VectorDouble& x, VectorDouble& y,
                     const EPowerPT& power) const;
   #ifndef SWIG
-    void prodLambda(const constvect& x, vect& y,
-                    const EPowerPT& power) const;
-    void prodLambda(const VectorDouble& x, vect& y,
-                    const EPowerPT& power) const;
-    void prodLambda(const constvect& x, VectorDouble& y,
-                    const EPowerPT& power) const;
-  #endif
+    void prodLambda(const constvect x, vect y, const EPowerPT& power) const;
+    void prodLambda(const VectorDouble& x, vect y, const EPowerPT& power) const;
+    void
+    prodLambda(const constvect x, VectorDouble& y, const EPowerPT& power) const;
+#endif
     void prodLambdaOnSqrtTildeC(const VectorDouble& inv, VectorDouble& outv,
                                 double puis = 2) const;
     double getMaxEigenValue() const;

--- a/include/Matrix/AMatrix.hpp
+++ b/include/Matrix/AMatrix.hpp
@@ -174,8 +174,10 @@ public:
   /*! Perform 'y' = 'this' * 'x' */
   void prodMatVecInPlace(const VectorDouble& x, VectorDouble& y, bool transpose = false) const;
   #ifndef SWIG
-    int prodMatVecInPlace(const constvect& x, vect& y, bool transpose = false) const;
-  #endif
+  int prodMatVecInPlace(const constvect x,
+                        vect y,
+                        bool transpose = false) const;
+#endif
   void prodMatVecInPlacePtr(const double* x, double* y, bool transpose = false) const;
   /*! Perform 'y' = 'x' * 'this' */
   void prodVecMatInPlace(const VectorDouble& x, VectorDouble& y, bool transpose = false) const;
@@ -213,7 +215,8 @@ public:
                       
 
 #ifndef SWIG
-  virtual int addProdMatVecInPlace(const constvect& x, vect& y, bool transpose= false) const;
+  virtual int
+  addProdMatVecInPlace(const constvect x, vect y, bool transpose = false) const;
 
   /*! Get value operator override */
   double  operator()(int row, int col) const { return getValue(row, col); }

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -77,8 +77,8 @@ public:
 #ifndef SWIG
   int addVecInPlace(const Eigen::Map<const Eigen::VectorXd>& xm,
                     Eigen::Map<Eigen::VectorXd>& ym) const;
-  void addProdMatVecInPlaceToDest(const constvect& in,
-                                  vect& out,
+  void addProdMatVecInPlaceToDest(const constvect in,
+                                  vect out,
                                   bool transpose = false) const;
 #endif
   /*! Set the contents of a Column */
@@ -191,10 +191,10 @@ public:
   int    solveCholesky(const VectorDouble& b, VectorDouble& x);
 
   #ifndef SWIG
-    int  solveCholesky(const constvect& b, std::vector<double>& x);
-    int  simulateCholesky(const constvect &b, vect &x);
-    int  addVecInPlace(const constvect& x, vect& y);
-  #endif
+  int solveCholesky(const constvect b, std::vector<double>& x);
+  int simulateCholesky(const constvect b, vect x);
+  int addVecInPlace(const constvect x, vect y);
+#endif
   
   int    simulateCholesky(const VectorDouble &b, VectorDouble &x);
   double computeCholeskyLogDeterminant();
@@ -225,14 +225,13 @@ public:
 
 #ifndef SWIG
   protected:
-  virtual int _addToDest(const constvect& inv,
-                          vect& outv) const override;
+    virtual int _addToDest(const constvect inv, vect outv) const override;
 #endif
 
 #ifndef SWIG
   public :
   void setDiagonal(const Eigen::Map<const Eigen::VectorXd>& tab);
-  void setDiagonal(const constvect& tab);
+  void setDiagonal(const constvect tab);
 #endif
 protected:
   /// Interface for AMatrix

--- a/include/Polynomials/APolynomial.hpp
+++ b/include/Polynomials/APolynomial.hpp
@@ -40,17 +40,22 @@ public:
   virtual void evalOp(MatrixSparse* Op,
                       const VectorDouble& inv,
                       VectorDouble& outv) const { DECLARE_UNUSED(Op,inv,outv);} //TODO write it by calling Eigen version;
-  virtual void evalOp(MatrixSparse* Op, const constvect& inv, vect& outv) const = 0;
+  virtual void
+  evalOp(MatrixSparse* Op, const constvect inv, vect outv) const = 0;
 
   virtual void evalOpTraining(MatrixSparse* Op,
-                      const constvect& inv,
-                      std::vector<std::vector<double>>& outv,
-                      std::vector<double>& work) const { DECLARE_UNUSED(Op,inv,outv,work); };
-  VectorDouble evalOp(MatrixSparse* Op, const constvect& inv) const;
-  
+                              const constvect inv,
+                              std::vector<std::vector<double>>& outv,
+                              std::vector<double>& work) const
+  {
+    DECLARE_UNUSED(Op, inv, outv, work);
+  };
+  VectorDouble evalOp(MatrixSparse* Op, const constvect inv) const;
+
   //virtual void evalOp(const ALinearOpMulti* Op,const std::vector<Eigen::VectorXd>& inv, std::vector<Eigen::VectorXd>& outv) const;
 
-  virtual void addEvalOp(ALinearOp* Op,const constvect& inv, vect& outv) const = 0;
+  virtual void
+  addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const = 0;
 #endif
   VectorDouble getCoeffs() const { return _coeffs; }
   void setCoeffs(const VectorDouble& coeffs) {_coeffs = coeffs;}

--- a/include/Polynomials/Chebychev.hpp
+++ b/include/Polynomials/Chebychev.hpp
@@ -33,8 +33,8 @@ public:
 
   /// Interface for Apolynomial
 #ifndef SWIG
-  void evalOp(MatrixSparse* S,const constvect& x, vect& y) const override;
-  void addEvalOp(ALinearOp* Op,const constvect& inv, vect& outv) const override;
+  void evalOp(MatrixSparse* S, const constvect x, vect y) const override;
+  void addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const override;
 
   /* void evalOp(const ALinearOpMulti *Op,
               const std::vector<Eigen::VectorXd> &inv,

--- a/include/Polynomials/ClassicalPolynomial.hpp
+++ b/include/Polynomials/ClassicalPolynomial.hpp
@@ -52,18 +52,15 @@ public:
   //                      Eigen::VectorXd& outv,const std::vector<Eigen::VectorXd>& workpoly,int iapex,int igparam)const;
   // void evalOp(const ALinearOpMulti* /*Op*/,
   //            const std::vector<Eigen::VectorXd>& /*inv*/,
-  //           std::vector<Eigen::VectorXd>& /*outv*/) const override { } 
-              
+  //           std::vector<Eigen::VectorXd>& /*outv*/) const override { }
 
-  void evalOpTraining(MatrixSparse *Op,
-                      const constvect &inv,
-                      std::vector<std::vector<double>> &store,
-                      std::vector<double> &work) const override;
-  void evalOpCumul(MatrixSparse *Op,
-                   const constvect &inv,
-                   vect &outv) const;
-  void evalOp(MatrixSparse* Op, const constvect& inv, vect& outv) const override;
-  void addEvalOp(ALinearOp* Op, const constvect& inv, vect& outv) const override;
+  void evalOpTraining(MatrixSparse* Op,
+                      const constvect inv,
+                      std::vector<std::vector<double>>& store,
+                      std::vector<double>& work) const override;
+  void evalOpCumul(MatrixSparse* Op, const constvect inv, vect outv) const;
+  void evalOp(MatrixSparse* Op, const constvect inv, vect outv) const override;
+  void addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const override;
 #endif
   
 #ifndef SWIG

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -1239,7 +1239,7 @@ void VectorHelper::addInPlace(VectorDouble &dest, const VectorDouble &src)
   }
 }
 
-void VectorHelper::addInPlace(constvect& in,vect& dest)
+void VectorHelper::addInPlace(constvect in, vect dest)
 {
   const double* inp = in.data();
   double * outp = dest.data();
@@ -1547,9 +1547,9 @@ void VectorHelper::addMultiplyConstantInPlace(double val1,
       *(outp++) += val1 * *(inp++);
     }
 }
-void VectorHelper::addMultiplyVectVectInPlace(const constvect &in1,
-                                              const constvect &in2,
-                                              vect &out,
+void VectorHelper::addMultiplyVectVectInPlace(const constvect in1,
+                                              const constvect in2,
+                                              vect out,
                                               int iad)
 { //TODO check if one can use eigen operators
     double * outp = out.data() + iad;
@@ -1562,8 +1562,8 @@ void VectorHelper::addMultiplyVectVectInPlace(const constvect &in1,
 }
 
 void VectorHelper::addMultiplyConstantInPlace(double val1,
-                                              const constvect &in,
-                                              vect &out,
+                                              const constvect in,
+                                              vect out,
                                               int iad)
 {
     double * outp = out.data() + iad;
@@ -2149,7 +2149,7 @@ double VectorHelper::innerProduct(const std::vector<double> &veca, const std::ve
   return innerProduct(veca.data(), vecb.data(), size);  
 }
 
-double VectorHelper::innerProduct(const constvect &veca, const constvect &vecb)
+double VectorHelper::innerProduct(const constvect veca, const constvect vecb)
 {
     return innerProduct(veca.data(), vecb.data(), veca.size());
 }

--- a/src/LinearOp/ALinearOp.cpp
+++ b/src/LinearOp/ALinearOp.cpp
@@ -30,12 +30,12 @@ int ALinearOp::addToDest(const Eigen::VectorXd& inv,
 
 }
 
-int ALinearOp::addToDest(const constvect& inv, vect& outv) const
+int ALinearOp::addToDest(const constvect inv, vect outv) const
 {
   return _addToDest(inv,outv);
 }
 
-int ALinearOp::evalDirect(constvect& inv, vect& outv) const
+int ALinearOp::evalDirect(constvect inv, vect outv) const
 {
   std::fill(outv.begin(),outv.end(),0.);
   return addToDest(inv, outv);

--- a/src/LinearOp/ASimulable.cpp
+++ b/src/LinearOp/ASimulable.cpp
@@ -37,7 +37,7 @@ int ASimulable::evalSimulate(const VectorDouble& whitenoise,
   return evalSimulate(ws, outs);
 }
 
-int ASimulable::evalSimulate(const constvect& whitenoise, vect &result) const
+int ASimulable::evalSimulate(const constvect whitenoise, vect result) const
 {
   std::fill(result.begin(),result.end(),0.);
   return _addSimulateToDest(whitenoise, result);

--- a/src/LinearOp/Cholesky.cpp
+++ b/src/LinearOp/Cholesky.cpp
@@ -81,8 +81,7 @@ void Cholesky::evalInverse(const VectorDouble &vecin, VectorDouble &vecout) cons
 ** \param[out] outv      Array of output values
 **
 *****************************************************************************/
-int  Cholesky::_addToDest(const constvect& inv,
-                          vect& outv) const
+int Cholesky::_addToDest(const constvect inv, vect outv) const
 {
   if (!isValid()) return 1;
 
@@ -142,7 +141,7 @@ void Cholesky::_compute()
   }
 }
 
-int Cholesky::solve(const constvect& b, std::vector<double>& x) const
+int Cholesky::solve(const constvect b, std::vector<double>& x) const
 {
   if (! isValid()) return 1;
 
@@ -164,7 +163,7 @@ int Cholesky::solve(const constvect& b, std::vector<double>& x) const
   return 0;
 }
 
-int Cholesky::solve(const constvect& b, vect& x) const
+int Cholesky::solve(const constvect b, vect x) const
 {
   if (! isValid()) return 1;
 
@@ -241,7 +240,7 @@ int Cholesky::simulate(const VectorDouble& b, VectorDouble& x) const
   return 0;
 }
 
-int Cholesky::addSimulateToDest(const constvect& b, vect& x) const
+int Cholesky::addSimulateToDest(const constvect b, vect x) const
 {
   if (! isValid()) return 1;
   int size = _matCS->getNRows();
@@ -269,7 +268,7 @@ int Cholesky::addSimulateToDest(const constvect& b, vect& x) const
   return 0;
 }
 
-int Cholesky::simulate(const constvect& b, vect& x) const
+int Cholesky::simulate(const constvect b, vect x) const
 {
   if (! isValid()) return 1;
   int size = _matCS->getNRows();

--- a/src/LinearOp/HessianOp.cpp
+++ b/src/LinearOp/HessianOp.cpp
@@ -119,8 +119,7 @@ int HessianOp::init(PrecisionOp*  pmat,
 ** \param[out] outv      Array of output values
 **
 *****************************************************************************/
-int HessianOp::_addToDest(const constvect& inv,
-                          vect& outv) const
+int HessianOp::_addToDest(const constvect inv, vect outv) const
 {
   if (!_isInitialized) my_throw("'HessianOp' must be initialized beforehand");
   

--- a/src/LinearOp/IProjMatrix.cpp
+++ b/src/LinearOp/IProjMatrix.cpp
@@ -17,42 +17,34 @@ int IProjMatrix::mesh2point(const VectorDouble& inv,
                                   VectorDouble& outv) const
 {
   outv.resize(getPointNumber());
-  constvect myInv(inv.data(), inv.size());
-  vect myOut(outv);
-  return mesh2point(myInv, myOut);  
+  return mesh2point(inv.getVector(), outv.getVector());
 }
 
 int IProjMatrix::point2mesh(const VectorDouble& inv,
                            VectorDouble& outv) const
 {
   outv.resize(getApexNumber());
-  constvect myInv(inv.data(), inv.size());
-  vect myOut(outv);
-  return point2mesh(myInv, myOut); 
+  return point2mesh(inv.getVector(), outv.getVector());
 }
 
-int IProjMatrix::addMesh2point(const constvect& inv,
-                    vect& outv) const
+int IProjMatrix::addMesh2point(const constvect inv, vect outv) const
 {
   return _addMesh2point(inv,outv);
 }
 
-int IProjMatrix::addPoint2mesh(const constvect& inv,
-                    vect& outv) const
+int IProjMatrix::addPoint2mesh(const constvect inv, vect outv) const
 {
   return _addPoint2mesh(inv, outv);
-}    
+}
 
-int IProjMatrix::mesh2point(const constvect& inv,
-                    vect& outv) const
+int IProjMatrix::mesh2point(const constvect inv, vect outv) const
 {
   std::fill(outv.begin(),outv.end(),0.);
   return _addMesh2point(inv,outv);
 }
 
-int IProjMatrix::point2mesh(const constvect& inv,
-                    vect& outv) const
+int IProjMatrix::point2mesh(const constvect inv, vect outv) const
 { 
   std::fill(outv.begin(),outv.end(),0.);
   return _addPoint2mesh(inv, outv);
-}    
+}

--- a/src/LinearOp/MatrixSquareSymmetricSim.cpp
+++ b/src/LinearOp/MatrixSquareSymmetricSim.cpp
@@ -63,8 +63,7 @@ MatrixSquareSymmetricSim::MatrixSquareSymmetricSim()
   _sparse = dynamic_cast<MatrixSparse*>(this) != nullptr;
 }
 
-int MatrixSquareSymmetricSim::_addToDest(const constvect& inv,
-                                               vect& outv) const
+int MatrixSquareSymmetricSim::_addToDest(const constvect inv, vect outv) const
 {  
   if (_inverse)
   {
@@ -74,8 +73,8 @@ int MatrixSquareSymmetricSim::_addToDest(const constvect& inv,
   messerr("MatrixSquareSymmetricSim::_addToDest not implemented for inverse = false.");
   return 1;
 }
-int MatrixSquareSymmetricSim::_addSimulateToDest(const constvect& whitenoise,
-                                                       vect& outv) const
+int MatrixSquareSymmetricSim::_addSimulateToDest(const constvect whitenoise,
+                                                 vect outv) const
 {  
 
 

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -153,16 +153,14 @@ PrecisionOp* PrecisionOp::create(const AMesh* mesh,
   return new PrecisionOp(mesh, cova, verbose);
 }
 
-int PrecisionOp::_addToDest(const constvect& inv,
-                          vect& outv) const
+int PrecisionOp::_addToDest(const constvect inv, vect outv) const
 {
     _addEvalPower(inv, outv, EPowerPT::ONE);
     return 0;
 
 }
 
-int PrecisionOp::_addSimulateToDest(const constvect& whitenoise,
-                          vect& outv) const
+int PrecisionOp::_addSimulateToDest(const constvect whitenoise, vect outv) const
 {
     _addEvalPower(whitenoise, outv, EPowerPT::MINUSHALF);
     return 0;
@@ -309,15 +307,18 @@ int PrecisionOp::reset(const ShiftOpCs* shiftop,
   evalPower(vecin, vecout, EPowerPT::ONE);
 }
  */
-void PrecisionOp::evalPower(const constvect& inm, vect& outm, const EPowerPT& power)
+void PrecisionOp::evalPower(const constvect inm,
+                            vect outm,
+                            const EPowerPT& power)
 {
   std::fill(outm.begin(),outm.end(),0.);
   for (int i = 0; i < (int)outm.size(); i++)
   _addEvalPower(inm, outm, power);
 }
 
-
-void PrecisionOp::_addEvalPower(const constvect& inv, vect& outv, const EPowerPT& power) const
+void PrecisionOp::_addEvalPower(const constvect inv,
+                                vect outv,
+                                const EPowerPT& power) const
 {
   const constvect* inPtr = &inv;
   if (_work.size() == 0) _work.resize(getSize());
@@ -348,8 +349,8 @@ void PrecisionOp::_addEvalPower(const constvect& inv, vect& outv, const EPowerPT
 }
 
 int PrecisionOp::_evalPoly(const EPowerPT& power,
-                           const constvect& inv,
-                           vect& outv) const 
+                           const constvect inv,
+                           vect outv) const
 {
   constvect invs(inv);
   if (_preparePoly(power) != 0) return 1;
@@ -385,7 +386,8 @@ int PrecisionOp::_evalPoly(const EPowerPT& power,
   return 0;
 }
 
-void PrecisionOp::evalInverse(const constvect& vecin, std::vector<double>& vecout)
+void PrecisionOp::evalInverse(const constvect vecin,
+                              std::vector<double>& vecout)
 {
   if (_work.size() != vecin.size()) _work.resize(vecin.size());
   vect vecouts(vecout);

--- a/src/LinearOp/PrecisionOpCs.cpp
+++ b/src/LinearOp/PrecisionOpCs.cpp
@@ -47,9 +47,9 @@ PrecisionOpCs::~PrecisionOpCs()
   delete _chol;
 }
 
-void PrecisionOpCs::gradYQX(const constvect & X, 
-                            const constvect &Y,
-                            vect& result,
+void PrecisionOpCs::gradYQX(const constvect X,
+                            const constvect Y,
+                            vect result,
                             const EPowerPT& power)
 {
   if (_work2.size() == 0) _work2.resize(getSize());
@@ -89,9 +89,10 @@ void PrecisionOpCs::gradYQX(const constvect & X,
   }
 }
 
-
-void PrecisionOpCs::gradYQXOptim(const constvect & X, const constvect &Y,
-                                 vect& result, const EPowerPT& power)
+void PrecisionOpCs::gradYQXOptim(const constvect X,
+                                 const constvect Y,
+                                 vect result,
+                                 const EPowerPT& power)
 {
   if (_work2.size() == 0) _work2.resize(getSize());
   if (_work3.size() == 0) _work3.resize(getSize());
@@ -130,12 +131,13 @@ void PrecisionOpCs::gradYQXOptim(const constvect & X, const constvect &Y,
   }
 }
 
-int PrecisionOpCs::_addToDest(const constvect &inv, vect &outv) const
+int PrecisionOpCs::_addToDest(const constvect inv, vect outv) const
 {
   return _Q->addToDest(inv, outv);
-} 
+}
 
-int PrecisionOpCs::_addSimulateToDest(const constvect& whitenoise, vect& outv) const
+int PrecisionOpCs::_addSimulateToDest(const constvect whitenoise,
+                                      vect outv) const
 {
   if (_chol == nullptr)
     _chol = new Cholesky(_Q);
@@ -143,7 +145,8 @@ int PrecisionOpCs::_addSimulateToDest(const constvect& whitenoise, vect& outv) c
   return 0;
 }
 
-void PrecisionOpCs::evalInverse(const constvect& vecin, std::vector<double>& vecout)
+void PrecisionOpCs::evalInverse(const constvect vecin,
+                                std::vector<double>& vecout)
 {
   _Q->solveCholesky(vecin, vecout);
 }
@@ -155,7 +158,8 @@ double PrecisionOpCs::getLogDeterminant(int nbsimu)
   return _Q->computeCholeskyLogDeterminant();
 }
 
-void PrecisionOpCs::evalDeriv(const constvect& inv, vect& outv,int iapex,int igparam, const EPowerPT& power)
+void PrecisionOpCs::evalDeriv(
+  const constvect inv, vect outv, int iapex, int igparam, const EPowerPT& power)
 {
   DECLARE_UNUSED(iapex,igparam)
   if (_work.size()==0) _work.resize(getSize());
@@ -181,7 +185,7 @@ void PrecisionOpCs::evalDeriv(const constvect& inv, vect& outv,int iapex,int igp
   getShiftOp()->prodLambda(outv, outv, EPowerPT::ONE);
 }
 
-void PrecisionOpCs::evalDerivOptim(vect& outv,
+void PrecisionOpCs::evalDerivOptim(vect outv,
                                    int iapex,
                                    int igparam,
                                    const EPowerPT& power)

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -346,8 +346,7 @@ String PrecisionOpMulti::toString(const AStringFormat* strfmt) const
   return sstr.str();
 }
 
-int PrecisionOpMulti::_addToDestImpl(const constvect& vecin,
-                                     vect& vecout) const
+int PrecisionOpMulti::_addToDestImpl(const constvect vecin, vect vecout) const
 {
   if (!_checkReady()) return 1;
   if (_getNVar() > 1)
@@ -364,8 +363,7 @@ int PrecisionOpMulti::_addToDestImpl(const constvect& vecin,
   }
 }
 
-int PrecisionOpMulti::_addToDest(const constvect& vecin,
-                                 vect& vecout) const
+int PrecisionOpMulti::_addToDest(const constvect vecin, vect vecout) const
 {
   return _addToDestImpl(vecin,vecout);
   
@@ -376,8 +374,8 @@ int PrecisionOpMulti::_addToDest(const constvect& vecin,
  * @param vecout Output array
  */
 
-int PrecisionOpMulti::_addSimulateToDest(const constvect& vecin,
-                                               vect& vecout) const
+int PrecisionOpMulti::_addSimulateToDest(const constvect vecin,
+                                         vect vecout) const
 {
   if (!_checkReady()) return 1;
   EVALOP(vecin,vecout,_cholSills,getCholeskyTL,evalSimulate,iad_struct + jvar * napices,true,y,jvar,nvar,ivar,jvar)

--- a/src/LinearOp/PrecisionOpMultiConditional.cpp
+++ b/src/LinearOp/PrecisionOpMultiConditional.cpp
@@ -337,7 +337,8 @@ void PrecisionOpMultiConditional::_allocate(int i) const
   }
 }
 
-void PrecisionOpMultiConditional::evalInvCov(const constvect& inv, std::vector<double>& result) const
+void PrecisionOpMultiConditional::evalInvCov(const constvect inv,
+                                             std::vector<double>& result) const
 {
   _allocate(0);
   _allocate(1);

--- a/src/LinearOp/PrecisionOpMultiMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMultiMatrix.cpp
@@ -135,7 +135,8 @@ void PrecisionOpMultiMatrix::_buildQop()
   }
 }
 
-int PrecisionOpMultiMatrix::_addToDestImpl(const constvect &vecin, vect &vecout) const
+int PrecisionOpMultiMatrix::_addToDestImpl(const constvect vecin,
+                                           vect vecout) const
 {
   return getQ()->addToDest(vecin, vecout);
 }

--- a/src/LinearOp/ProjConvolution.cpp
+++ b/src/LinearOp/ProjConvolution.cpp
@@ -126,8 +126,8 @@ void ProjConvolution::_buildShiftVector()
   }
 }
 
-bool ProjConvolution::_isVecDimCorrect(const constvect &valonseismic,
-                                       const constvect &valonvertex) const
+bool ProjConvolution::_isVecDimCorrect(const constvect valonseismic,
+                                       const constvect valonvertex) const
 {
   if ((int) valonvertex.size() != getApexNumber())
   {
@@ -156,8 +156,8 @@ bool ProjConvolution::_isVecDimCorrect(const constvect &valonseismic,
  * @param valonvertex  Output vector defined on the Coarse Grid
  * @return
  */
-int ProjConvolution::_addPoint2mesh(const constvect &valonseismic,
-                                    vect &valonvertex) const
+int ProjConvolution::_addPoint2mesh(const constvect valonseismic,
+                                    vect valonvertex) const
 {
   if (! _isVecDimCorrect(valonseismic, valonvertex)) return 1;
 
@@ -187,8 +187,8 @@ int ProjConvolution::_addPoint2mesh(const constvect &valonseismic,
  * @param valonseismic  Output vector defined on the Seismic grid
  * @return
  */
-int ProjConvolution::_addMesh2point(const constvect &valonvertex,
-                                    vect &valonseismic) const
+int ProjConvolution::_addMesh2point(const constvect valonvertex,
+                                    vect valonseismic) const
 {
   if (! _isVecDimCorrect(valonseismic, valonvertex)) return 1;
 
@@ -215,8 +215,8 @@ int ProjConvolution::_addMesh2point(const constvect &valonvertex,
   return 0;
 }
 
-void ProjConvolution::_convolve(const constvect &valonvertex,
-                                vect &valonseismic) const
+void ProjConvolution::_convolve(const constvect valonvertex,
+                                vect valonseismic) const
 {
   int count = (int) valonseismic.size();
   int size  = _getConvSize();
@@ -241,8 +241,8 @@ void ProjConvolution::_convolve(const constvect &valonvertex,
   }
 }
 
-void ProjConvolution::_convolveT(const constvect &valonseismic,
-                                 vect &valonvertex) const
+void ProjConvolution::_convolveT(const constvect valonseismic,
+                                 vect valonvertex) const
 {
   std::fill(valonvertex.begin(),valonvertex.end(), 0.);
   int count = (int) valonseismic.size();

--- a/src/LinearOp/ProjMatrix.cpp
+++ b/src/LinearOp/ProjMatrix.cpp
@@ -108,7 +108,7 @@ void ProjMatrix::resetFromMeshAndDb(const Db* db, const AMesh* a_mesh, int rankZ
   return 0;
 }
  */
-int ProjMatrix::_addMesh2point(const constvect& inv, vect& outv) const
+int ProjMatrix::_addMesh2point(const constvect inv, vect outv) const
 {
   if ((int) inv.size() != getApexNumber())
   {
@@ -127,7 +127,7 @@ int ProjMatrix::_addMesh2point(const constvect& inv, vect& outv) const
   return 0;
 }
 
-int ProjMatrix::_addPoint2mesh(const constvect& inv, vect& outv) const
+int ProjMatrix::_addPoint2mesh(const constvect inv, vect outv) const
 {
   if ((int) inv.size() != getPointNumber())
   {

--- a/src/LinearOp/ProjMulti.cpp
+++ b/src/LinearOp/ProjMulti.cpp
@@ -168,7 +168,7 @@ ProjMulti::ProjMulti(const std::vector<std::vector<const IProjMatrix*>> &projs, 
     _init();
 }
 
-int  ProjMulti::_addPoint2mesh(const constvect& inv, vect& outv) const
+int ProjMulti::_addPoint2mesh(const constvect inv, vect outv) const
 {   
     vect wms;
     int iadvar = 0;
@@ -195,8 +195,7 @@ int  ProjMulti::_addPoint2mesh(const constvect& inv, vect& outv) const
     }
     return 0;
 }
-int  ProjMulti::_addMesh2point(const constvect& inv,
-                                     vect& outv) const
+int ProjMulti::_addMesh2point(const constvect inv, vect outv) const
 {
     vect ws;
     int iadvar = 0;

--- a/src/LinearOp/ProjMultiMatrix.cpp
+++ b/src/LinearOp/ProjMultiMatrix.cpp
@@ -174,14 +174,12 @@ ProjMultiMatrix::ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*
     }   
 }
 
-int  ProjMultiMatrix::_addPoint2mesh(const constvect& inv,
-                                     vect& outv) const
+int ProjMultiMatrix::_addPoint2mesh(const constvect inv, vect outv) const
 {
   _Proj.addProdMatVecInPlaceToDest(inv, outv, true);
   return 0;
 }
-int  ProjMultiMatrix::_addMesh2point(const constvect& inv,
-                                     vect& outv) const
+int ProjMultiMatrix::_addMesh2point(const constvect inv, vect outv) const
 {
   _Proj.addProdMatVecInPlaceToDest(inv, outv, false);
   return 0;

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -49,13 +49,12 @@ void SPDEOp::_prepare(bool w1, bool w2) const
   if (w2) _workdat2.resize(_getNDat());
 }
 
-int SPDEOp::_addToDest(const constvect& inv, vect& outv) const
+int SPDEOp::_addToDest(const constvect inv, vect outv) const
 {
   return _addToDestImpl(inv, outv);
 }
 
-int SPDEOp::_addSimulateToDest(const constvect& whitenoise,
-                               vect& outv) const
+int SPDEOp::_addSimulateToDest(const constvect whitenoise, vect outv) const
 {
   DECLARE_UNUSED(whitenoise);
   DECLARE_UNUSED(outv);
@@ -85,35 +84,35 @@ VectorDouble SPDEOp::krigingWithGuess(const VectorDouble& dat,
   return outv;
 }
 
-int SPDEOp::kriging(const constvect& inv, vect& out) const
+int SPDEOp::kriging(const constvect inv, vect out) const
 {
   _buildRhs(inv);
   return _solve(_rhs, out);
 }
 
-int SPDEOp::krigingWithGuess(const constvect& inv,
-                             const constvect& guess,
-                             vect& out) const
+int SPDEOp::krigingWithGuess(const constvect inv,
+                             const constvect guess,
+                             vect out) const
 {
   _buildRhs(inv);
   return _solveWithGuess(_rhs, guess, out);
 }
 
-int SPDEOp::_solve(const constvect& in, vect& out) const
+int SPDEOp::_solve(const constvect in, vect out) const
 {
   _solver.solve(in, out);
   return 0;
 }
 
-int SPDEOp::_solveWithGuess(const constvect& in,
-                            const constvect& guess,
-                            vect& out) const
+int SPDEOp::_solveWithGuess(const constvect in,
+                            const constvect guess,
+                            vect out) const
 {
   _solver.solveWithGuess(in, guess, out);
   return 0;
 }
 
-int SPDEOp::_buildRhs(const constvect& inv) const
+int SPDEOp::_buildRhs(const constvect inv) const
 {
   _rhs.resize(_Q->getSize());
   vect w1(_workdat1);
@@ -132,8 +131,7 @@ int SPDEOp::_buildRhs(const constvect& inv) const
 ** \param[out] outv    Array of output values
 **
 *****************************************************************************/
-int SPDEOp::_addToDestImpl(const constvect& inv,
-                           vect& outv) const
+int SPDEOp::_addToDestImpl(const constvect inv, vect outv) const
 {
   _prepare();
   vect w1s(_workdat1);
@@ -144,7 +142,7 @@ int SPDEOp::_addToDestImpl(const constvect& inv,
   return _Q->addToDest(inv, outv);
 }
 
-void SPDEOp::evalInvCov(const constvect &inv, vect &result) const
+void SPDEOp::evalInvCov(const constvect inv, vect result) const
 {
   // InvNoise - InvNoise * Proj' * (Q + Proj * InvNoise * Proj')^-1 * Proj * InvNoise
   

--- a/src/LinearOp/SPDEOpMatrix.cpp
+++ b/src/LinearOp/SPDEOpMatrix.cpp
@@ -33,7 +33,7 @@ SPDEOpMatrix::~SPDEOpMatrix()
   delete _chol; 
 }
 
-int SPDEOpMatrix::_solve(const constvect& inv, vect& outv) const
+int SPDEOpMatrix::_solve(const constvect inv, vect outv) const
 {
   if (_chol == nullptr)
   {
@@ -51,8 +51,7 @@ int SPDEOpMatrix::_solve(const constvect& inv, vect& outv) const
 ** \param[out] outv    Array of output values
 **
 *****************************************************************************/
-int SPDEOpMatrix::_addToDestImpl(const constvect& inv,
-                                 vect& outv) const
+int SPDEOpMatrix::_addToDestImpl(const constvect inv, vect outv) const
 {
  return _QpAinvNoiseAt.addToDest(inv,outv);
 }

--- a/src/LinearOp/ScaleOp.cpp
+++ b/src/LinearOp/ScaleOp.cpp
@@ -27,8 +27,7 @@ ScaleOp::~ScaleOp() {}
 ** \param[out] outv    Array of output values
 **
 *****************************************************************************/
-int ScaleOp::_addToDest(const constvect& inv,
-                        vect& outv) const
+int ScaleOp::_addToDest(const constvect inv, vect outv) const
 {
   for (int i = 0, n = _n; i < n; i++)
     outv[i] += _scale * inv[i];

--- a/src/LinearOp/ShiftOpCs.cpp
+++ b/src/LinearOp/ShiftOpCs.cpp
@@ -361,8 +361,8 @@ void ShiftOpCs::normalizeLambdaBySills(const AMesh* mesh)
   }
 }
 
-void ShiftOpCs::prodLambda(const constvect& x,
-                           vect& y,
+void ShiftOpCs::prodLambda(const constvect x,
+                           vect y,
                            const EPowerPT& power) const
 {
   if (power == EPowerPT::ONE)
@@ -392,7 +392,7 @@ void ShiftOpCs::prodLambda(const constvect& x,
 }
 
 void ShiftOpCs::prodLambda(const VectorDouble& x,
-                           vect& y,
+                           vect y,
                            const EPowerPT& power) const
 {
   if (power == EPowerPT::ONE)
@@ -421,7 +421,7 @@ void ShiftOpCs::prodLambda(const VectorDouble& x,
   }
 }
 
-void ShiftOpCs::prodLambda(const constvect& x,
+void ShiftOpCs::prodLambda(const constvect x,
                            VectorDouble& y,
                            const EPowerPT& power) const
 {
@@ -500,8 +500,7 @@ void ShiftOpCs::prodLambdaOnSqrtTildeC(const VectorDouble& inv,
  ** \remarks 'S' is a member that stands as a sparse matrix
  **
  *****************************************************************************/
-int ShiftOpCs::_addToDest(const constvect& inv,
-                          vect& outv) const
+int ShiftOpCs::_addToDest(const constvect inv, vect outv) const
 {
   _S->addProdMatVecInPlaceToDest(inv, outv);
   return 0;

--- a/src/Matrix/AMatrix.cpp
+++ b/src/Matrix/AMatrix.cpp
@@ -445,7 +445,9 @@ void AMatrix::prodMatVecInPlace(const VectorDouble& x, VectorDouble& y, bool tra
   _addProdMatVecInPlaceToDestPtr(x.data(),y.data(),transpose);
 }
 
-int AMatrix::addProdMatVecInPlace(const constvect& x, vect& y, bool transpose) const
+int AMatrix::addProdMatVecInPlace(const constvect x,
+                                  vect y,
+                                  bool transpose) const
 {
   if (_flagCheckAddress)
   {
@@ -471,7 +473,7 @@ int AMatrix::addProdMatVecInPlace(const constvect& x, vect& y, bool transpose) c
   return 0;
 }
 
-int AMatrix::prodMatVecInPlace(const constvect& x, vect& y, bool transpose) const
+int AMatrix::prodMatVecInPlace(const constvect x, vect y, bool transpose) const
 {
   if (_flagCheckAddress)
   {

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -197,7 +197,7 @@ int MatrixSparse::solveCholesky(const VectorDouble& b, VectorDouble& x)
   return _factor->solve(b, x);
 }
 
-int MatrixSparse::solveCholesky(const constvect& b, std::vector<double>& x)
+int MatrixSparse::solveCholesky(const constvect b, std::vector<double>& x)
 {
   int ncols = getNCols();
   if ((int) b.size() != ncols)
@@ -237,7 +237,7 @@ int MatrixSparse::simulateCholesky(const VectorDouble &b, VectorDouble &x)
     _factor = new Cholesky(this);
   return _factor->simulate(b, x);
 }
-int MatrixSparse::simulateCholesky(const constvect &b, vect &x)
+int MatrixSparse::simulateCholesky(const constvect b, vect x)
 {
   int ncols = getNCols();
   if ((int) b.size() != ncols)
@@ -590,8 +590,8 @@ VectorDouble MatrixSparse::prodMatVec(const VectorDouble& x, bool transpose) con
 }
 
 /*! Perform y += 'this' %*% x */
-void MatrixSparse::addProdMatVecInPlaceToDest(const constvect& in,
-                                              vect& out,
+void MatrixSparse::addProdMatVecInPlaceToDest(const constvect in,
+                                              vect out,
                                               bool transpose) const
 {
   Eigen::Map<const Eigen::VectorXd> inm(in.data(),in.size());
@@ -852,7 +852,7 @@ int MatrixSparse::addVecInPlace(const VectorDouble& x, VectorDouble& y)
   return (!cs_gaxpy(_csMatrix, x.data(), y.data()));
 }
 
-int MatrixSparse::addVecInPlace(const constvect& xm, vect& ym)
+int MatrixSparse::addVecInPlace(const constvect xm, vect ym)
 {
   if (isFlagEigen())
   {
@@ -1722,15 +1722,14 @@ void MatrixSparse::gibbs(int iech,
   (*sk) = sqrt(1. / (*sk));
 }
 
-int MatrixSparse::_addToDest(const constvect& inv,
-                          vect& outv) const
+int MatrixSparse::_addToDest(const constvect inv, vect outv) const
 {   Eigen::Map<const Eigen::VectorXd> inm(inv.data(),inv.size());
     Eigen::Map<Eigen::VectorXd> outm(outv.data(),outv.size());
     outm += _eigenMatrix * inm;
     return 0;
 }
 
-void MatrixSparse::setDiagonal(const constvect& tab)
+void MatrixSparse::setDiagonal(const constvect tab)
 {
   Eigen::Map<const Eigen::VectorXd> tabm(tab.data(),tab.size());
   setDiagonal(tabm);

--- a/src/Polynomials/APolynomial.cpp
+++ b/src/Polynomials/APolynomial.cpp
@@ -50,7 +50,7 @@ APolynomial & APolynomial::operator=(const APolynomial& p)
   return *this;
 }
 #ifndef SWIG
-VectorDouble APolynomial::evalOp(MatrixSparse* Op, const constvect& in) const
+VectorDouble APolynomial::evalOp(MatrixSparse* Op, const constvect in) const
 {
   VectorDouble result(in.size());
   vect results(result);

--- a/src/Polynomials/Chebychev.cpp
+++ b/src/Polynomials/Chebychev.cpp
@@ -261,7 +261,7 @@ void Chebychev::_fillCoeffs(const std::function<double(double)>& f,double a, dou
 } */
 
 #ifndef SWIG
-void Chebychev::evalOp(MatrixSparse* S,const constvect& x,vect& y) const
+void Chebychev::evalOp(MatrixSparse* S, const constvect x, vect y) const
 {
   VectorDouble tm1, tm2, px, tx;
   int nvertex;
@@ -323,7 +323,7 @@ void Chebychev::evalOp(MatrixSparse* S,const constvect& x,vect& y) const
   delete T1;
 }
 
-void Chebychev::addEvalOp(ALinearOp* Op,const constvect& inv, vect& outv) const
+void Chebychev::addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const
 {
   DECLARE_UNUSED(Op);
   DECLARE_UNUSED(inv);

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -44,7 +44,9 @@ double ClassicalPolynomial::eval(double x) const
 // Horner scheme starting from the lowest degree
 // (since it adds the result to the input vector, the classical scheme can t be used)
 #ifndef SWIG
-void ClassicalPolynomial::evalOpCumul(MatrixSparse* Op, const constvect& inv, vect& outv) const
+void ClassicalPolynomial::evalOpCumul(MatrixSparse* Op,
+                                      const constvect inv,
+                                      vect outv) const
 {
   int n = static_cast<int> (inv.size());
   VectorDouble work(n);
@@ -80,7 +82,9 @@ void ClassicalPolynomial::evalOpCumul(MatrixSparse* Op, const constvect& inv, ve
   }
 }
 
-void ClassicalPolynomial::addEvalOp(ALinearOp* Op,const constvect& inv, vect& outv) const
+void ClassicalPolynomial::addEvalOp(ALinearOp* Op,
+                                    const constvect inv,
+                                    vect outv) const
 {
   int n = static_cast<int> (inv.size());
 
@@ -124,8 +128,8 @@ void ClassicalPolynomial::addEvalOp(ALinearOp* Op,const constvect& inv, vect& ou
 
 // Classical Hörner scheme starting from the highest degree
 void ClassicalPolynomial::evalOp(MatrixSparse* Op,
-                                 const constvect& inv,
-                                 vect & outv) const
+                                 const constvect inv,
+                                 vect outv) const
 {
   int n = static_cast<int>(inv.size());
   std::vector<double> work(n);
@@ -144,10 +148,11 @@ void ClassicalPolynomial::evalOp(MatrixSparse* Op,
 }
 
 // Classical Hörner scheme starting from the highest degree
-void ClassicalPolynomial::evalOpTraining(MatrixSparse *Op,
-                                         const constvect &inv,
-                                         std::vector<std::vector<double>> &store,
-                                         std::vector<double> &work) const
+void ClassicalPolynomial::evalOpTraining(
+  MatrixSparse* Op,
+  const constvect inv,
+  std::vector<std::vector<double>>& store,
+  std::vector<double>& work) const
 {
   int n = static_cast<int>(inv.size());
 


### PR DESCRIPTION
Since `std::span` are non-owning pointers, they can be passed by value instead of by reference.

This PR converts all uses of `std::span` as parameters to pass-by-value. It can help to shorten function calls, in particular with `VectorDouble`s (c.f. src/LinearOp/IProjMatrix.cpp): C++ seems to forbid passing temporaries as const references, but passing them by value is OK.

Enjoy,
Pierre