### PR TITLE
Avoid heap allocations of litterals with std::string_view

### DIFF
--- a/include/Basic/String.hpp
+++ b/include/Basic/String.hpp
@@ -20,8 +20,8 @@
 
 GSTLEARN_EXPORT void skipBOM(std::ifstream &ins);
 
-GSTLEARN_EXPORT String toUpper(const String &string);
-GSTLEARN_EXPORT String toLower(const String &string);
+GSTLEARN_EXPORT String toUpper(const std::string_view string);
+GSTLEARN_EXPORT String toLower(const std::string_view string);
 
 GSTLEARN_EXPORT void toUpper(String &string);
 GSTLEARN_EXPORT void toLower(String &string);

--- a/include/Covariances/CovLMCTapering.hpp
+++ b/include/Covariances/CovLMCTapering.hpp
@@ -74,7 +74,7 @@ public:
 
   int init(const ETape& tapetype, double taperange);
 
-  const String& getName() const;
+  std::string_view getName() const;
   double getTapeRange() const { return _tapeRange; }
   void setTapeRange(double range) { _tapeRange = range; }
 

--- a/include/Enum/AEnum.hpp
+++ b/include/Enum/AEnum.hpp
@@ -19,18 +19,19 @@
 #include "Basic/String.hpp"
 #include <iostream>
 #include <map>
+#include <string_view>
 
 class GSTLEARN_EXPORT AEnum
 {
 public:
   //! Return the enum key as a string (max 10 characters)
-  inline const String& getKey() const { return _key; }
+  inline const std::string_view getKey() const { return _key; }
 
   //! Return enum value as an integer value (max 32 enum)
   inline int getValue() const { return _value; }
 
   //! Return the enum description as a string
-  inline const String& getDescr() const { return _descr; }
+  inline const std::string_view& getDescr() const { return _descr; }
 
 #ifndef SWIG
   // Remove this: too much dangerous (implicit casts)
@@ -55,7 +56,7 @@ public:
   void printEnum() const;
 
 protected:
-  AEnum(const String& key, int value, const String& descr)
+  AEnum(const std::string_view key, int value, const std::string_view descr)
   : _key(key), _value(value), _descr(descr)
   {
   }
@@ -70,9 +71,9 @@ protected:
   // would be embarked in SWIG... who does not know it.
  
 private:
-  String _key;
+  std::string_view _key;
   int    _value;
-  String _descr;
+  std::string_view _descr;
 };
 
 #define ENUM_ITEM(NAME, x,y,z) E_ ## x = y,
@@ -109,8 +110,8 @@ public:\
   const NAME& toFront();\
   const NAME& getEnum() const;\
   int getValue() const;\
-  const String& getKey() const;\
-  const String& getDescr() const;\
+  const std::string_view getKey() const;\
+  const std::string_view getDescr() const;\
 \
 private:\
   NAME ## Map::iterator _stditer;\
@@ -125,7 +126,7 @@ public:\
   ~NAME();\
   NAME(const NAME&) = default;\
   NAME(int value);\
-  NAME(const String& key);\
+  NAME(const std::string_view key);\
   NAME& operator=(const NAME&) = default;\
 \
   static size_t getSize();\
@@ -134,15 +135,15 @@ public:\
   static VectorString getAllKeys();\
   static VectorString getAllDescr();\
 \
-  static bool existsKey(const String& key);\
+  static bool existsKey(const std::string_view key);\
   static bool existsValue(int value);\
-  static const NAME& fromKey(const String& key);\
+  static const NAME& fromKey(const std::string_view key);\
   static const NAME& fromValue(int value);\
   static std::vector<NAME> fromKeys(const VectorString& keys);\
   static std::vector<NAME> fromValues(const VectorInt& values);\
 \
 private:\
-  NAME(const String& key, int value, const String& descr);\
+  NAME(const std::string_view key, int value, const std::string_view descr);\
 \
   static NAME ## Map      _map;\
   static NAME ## Iterator _iterator;\
@@ -178,12 +179,12 @@ NAME::NAME(int value)\
 {\
 }\
 \
-NAME::NAME(const String& key)\
+NAME::NAME(const std::string_view key)\
 : AEnum(fromKey(key))\
 {\
 }\
 \
-NAME::NAME(const String& key, int value, const String& descr)\
+NAME::NAME(const std::string_view key, int value, const std::string_view descr)\
 : AEnum(key, value, descr)\
 {\
   if (_map.find(value) != _map.end())\
@@ -223,7 +224,7 @@ VectorString NAME::getAllKeys()\
   auto it(getIterator());\
   while (it.hasNext())\
   {\
-    keys.push_back((*it).getKey());\
+    keys.push_back(String{(*it).getKey()});\
     it.toNext();\
   }\
   return keys;\
@@ -235,13 +236,13 @@ VectorString NAME::getAllDescr()\
   auto it(getIterator());\
   while (it.hasNext())\
   {\
-    descr.push_back((*it).getDescr());\
+    descr.push_back(String{(*it).getDescr()});\
     it.toNext();\
   }\
   return descr;\
 }\
 \
-bool NAME::existsKey(const String& key)\
+bool NAME::existsKey(const std::string_view key)\
 {\
   auto it = _map.begin();\
   while (it != _map.end())\
@@ -258,7 +259,7 @@ bool NAME::existsValue(int value)\
   return (_map.find(value) != _map.end());\
 }\
 \
-const NAME& NAME::fromKey(const String& key)\
+const NAME& NAME::fromKey(const std::string_view key)\
 {\
   auto it = _map.begin();\
   while (it != _map.end())\
@@ -339,12 +340,12 @@ int NAME ## Iterator::getValue() const\
   return (_stditer->second->getValue());\
 }\
 \
-const String& NAME ## Iterator::getKey() const\
+const std::string_view NAME ## Iterator::getKey() const\
 {\
   return (_stditer->second->getKey());\
 }\
 \
-const String& NAME ## Iterator::getDescr() const\
+const std::string_view NAME ## Iterator::getDescr() const\
 {\
   return (_stditer->second->getDescr());\
 }\

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -372,6 +372,10 @@
   {
     return PyUnicode_FromString(convertFromCpp(value));
   }
+  template <> PyObject* objectFromCpp(const std::string_view& value)
+  {
+    return PyUnicode_FromString(convertFromCpp(String{value}));
+  }
   template <> PyObject* objectFromCpp(const float& value)
   {
     return PyFloat_FromDouble(static_cast<double>(convertFromCpp(value)));
@@ -518,6 +522,10 @@
     }
   }
   $1 = reinterpret_cast<NamingConvention *>(localNC);
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) const std::string_view {
+  $1 = PyString_Check($input) ? 1 : 0;
 }
 
 //////////////////////////////////////////////////////////////

--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -300,6 +300,10 @@
   {
     return Rf_ScalarString(Rf_mkChar(convertFromCpp(value).c_str()));
   }
+  template <> SEXP objectFromCpp(const std::string_view& value)
+  {
+    return Rf_ScalarString(Rf_mkChar(convertFromCpp(String{value}).c_str()));
+  }
   template <> SEXP objectFromCpp(const float& value)
   {
     return Rf_ScalarReal(static_cast<double>(convertFromCpp(value)));

--- a/src/Basic/ArgumentTest.cpp
+++ b/src/Basic/ArgumentTest.cpp
@@ -228,7 +228,7 @@ void argumentTestStringOverload(const VectorString& values)
 
 void argumentTestEnum(const ETests& value)
 {
-  message("Case : Value = %d - Descr = %s\n", value.getValue(),value.getDescr().c_str());
+  message("Case : Value = %d - Descr = %s\n", value.getValue(),value.getDescr().data());
 }
 
 int argumentReturnInt(int value)

--- a/src/Basic/String.cpp
+++ b/src/Basic/String.cpp
@@ -45,16 +45,16 @@ std::regex _protectRegexp(const String &match)
   return regexpr;
 }
 
-String toUpper(const String &string)
+String toUpper(const std::string_view string)
 {
-  String str = string;
+  String str{string};
   toUpper(str);
   return (str);
 }
 
-String toLower(const String &string)
+String toLower(const std::string_view string)
 {
-  String str = string;
+  String str{string};
   toLower(str);
   return (str);
 }

--- a/src/Calculators/CalcSimuPost.cpp
+++ b/src/Calculators/CalcSimuPost.cpp
@@ -347,7 +347,7 @@ void CalcSimuPost::_statisticsFunction(const VectorVectorDouble &Y_p,
     stat_table.setSkipDescription(true);
 
     for (int istat = 0; istat < nstat; istat++)
-      stat_table.setColumnName(istat, _stats[istat].getDescr());
+      stat_table.setColumnName(istat, String{_stats[istat].getDescr()});
 
     for (int ivar = 0; ivar < _getNEff(); ivar++)
     {

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -5131,7 +5131,7 @@ void _image_smoother(DbGrid *dbgrid,
 
   DbGrid* dbaux =
     DbGrid::create(nx, dbgrid->getDXs(), dbgrid->getX0s(), dbgrid->getAngles(),
-                   ELoadBy::COLUMN, tab, {"test"}, {ELoc::Z.getKey()}, 1);
+                   ELoadBy::COLUMN, tab, {"test"}, {String{ELoc::Z.getKey()}}, 1);
 
   int nb_neigh = dbaux->getSampleNumber(true);
   dbaux->rankToIndice(nb_neigh/2, indn0);

--- a/src/Covariances/CovHelper.cpp
+++ b/src/Covariances/CovHelper.cpp
@@ -60,7 +60,7 @@ VectorString CovHelper::getAllCovariances(int  ndim,
 
     // Check if the covariance is valid
     if (_isSelected(cov, ndim, minorder, hasrange, flagSimtub, flagSimuSpectral))
-      vs.push_back(it.getKey());
+      vs.push_back(String{it.getKey()});
 
     delete cov;
     it.toNext();

--- a/src/Covariances/CovLMCTapering.cpp
+++ b/src/Covariances/CovLMCTapering.cpp
@@ -247,7 +247,7 @@ void CovLMCTapering::evalMatInPlace(const SpacePoint &p1,
   ACov::evalMatInPlace(p1, p2, mat, mode);
 }
 
-const String& CovLMCTapering::getName() const
+std::string_view CovLMCTapering::getName() const
 {
   return _tapeType.getDescr();
 }

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -4448,7 +4448,7 @@ void Db::statisticsBySample(const VectorString& names,
   for (int i = 0; i < noper; i++)
   {
     const EStatOption& oper = opers[i];
-    namconv.setNamesAndLocators(this, iuidn + i, oper.getKey());
+    namconv.setNamesAndLocators(this, iuidn + i, String{oper.getKey()});
   }
 }
 

--- a/src/Db/DbLine.cpp
+++ b/src/Db/DbLine.cpp
@@ -469,7 +469,7 @@ DbLine* DbLine::createFillRandom(int ndim,
   }
 
   VectorString names = generateMultipleNames("x", ndim);
-  VectorString locnames = generateMultipleNames(ELoc::X.getKey(), ndim, "");
+  VectorString locnames = generateMultipleNames(String{ELoc::X.getKey()}, ndim, "");
   DbLine* dbline = createFromSamples(nech, ELoadBy::SAMPLE, tab, lineCounts, names, locnames);
 
   return dbline;

--- a/src/Enum/AEnum.cpp
+++ b/src/Enum/AEnum.cpp
@@ -12,7 +12,7 @@
 #include "Basic/AStringable.hpp"
 
 void AEnum::printEnum() const {
-  _printMsg("  %2d - %11s : %s\n", _value, _key.c_str(), _descr.c_str());
+  _printMsg("  %2d - %11s : %s\n", _value, _key.data(), _descr.data());
 }
 
 /**

--- a/src/Estimation/CalcImage.cpp
+++ b/src/Estimation/CalcImage.cpp
@@ -115,7 +115,7 @@ bool CalcImage::_postprocess()
     _renameVariable(2, VectorString(), ELoc::Z, getDbin()->getLocNumber(ELoc::Z), _iattOut, String(), 1);
 
   if (_flagMorpho)
-    _renameVariable(2, VectorString(), ELoc::Z, 1, _iattOut, _oper.getKey(), _nvarMorpho);
+    _renameVariable(2, VectorString(), ELoc::Z, 1, _iattOut, String{_oper.getKey()}, _nvarMorpho);
 
   if (_flagSmooth)
     _renameVariable(2, VectorString(), ELoc::Z, 1, _iattOut, String(), 1);

--- a/src/Morpho/Morpho.cpp
+++ b/src/Morpho/Morpho.cpp
@@ -1036,7 +1036,7 @@ int db_morpho_calc(DbGrid *dbgrid,
 
   if (verbose)
   {
-    message("Morphological operation = %s\n",oper.getDescr().c_str());
+    message("Morphological operation = %s\n", oper.getDescr().data());
     message("Initial image = %d/%d\n",morpho_count(image),ntotal);
   }
 

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -491,7 +491,7 @@ int CalcSimuTurningBands::_initializeSeedBands()
 
             default:
               messerr("The structure (%s) cannot be simulated",
-                      type.getDescr().c_str());
+                      type.getDescr().data());
               messerr("using the Turning Bands algorithm");
               return 1;
           }

--- a/src/Stats/Classical.cpp
+++ b/src/Stats/Classical.cpp
@@ -342,7 +342,7 @@ VectorString statOptionToName(const std::vector<EStatOption>& opers)
   for (int i = 0; i < (int) opers.size(); i++)
   {
     const EStatOption& oper = opers[i];
-    names.push_back(oper.getKey());
+    names.push_back(String{oper.getKey()});
   }
   return names;
 }
@@ -599,7 +599,7 @@ Table dbStatisticsMono(Db *db,
           tab.push_back(median);
         else
         {
-          messerr("The operator %s is not calculated yet", opers[i].getKey().c_str());
+          messerr("The operator %s is not calculated yet", opers[i].getKey());
           return table;
         }
       }
@@ -623,8 +623,7 @@ Table dbStatisticsMono(Db *db,
           tab.push_back(TEST);
         else
         {
-          messerr("The operator %s is not calculated yet",
-                  opers[i].getKey().c_str());
+          messerr("The operator %s is not calculated yet", opers[i].getKey());
           return table;
         }
       }
@@ -641,7 +640,7 @@ Table dbStatisticsMono(Db *db,
   for (int irow=0; irow<niuid; irow++)
     table.setRowName(irow, db->getNameByUID(iuids[irow]));
   for (int icol=0; icol<noper; icol++)
-    table.setColumnName(icol, opers[icol].getDescr());
+    table.setColumnName(icol, String{opers[icol].getDescr()});
 
   return table;
 }
@@ -1735,9 +1734,9 @@ Table dbStatisticsMulti(Db *db,
 
   Table table;
   if (title.empty())
-    table.setTitle(oper.getDescr());
+    table.setTitle(String{oper.getDescr()});
   else
-    table.setTitle(concatenateStrings(":",title,oper.getDescr()));
+    table.setTitle(concatenateStrings(":",title,String{oper.getDescr()}));
   table.setSkipDescription(true);
 
   if (flagMono)

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -420,6 +420,21 @@
     messerr("Error while converting argument #$argnum of type '$type' in '$symname' function");
   }
 }
+%typemap(in, fragment="ToCpp") std::string_view
+{
+  try
+  {
+    static String tmp;
+    int errcode = convertToCpp($input, tmp);
+    $1 = tmp;
+    if (!SWIG_IsOK(errcode))
+      %argument_fail(errcode, "$type", $symname, $argnum);
+  }
+  catch(...)
+  {
+    messerr("Error while converting argument #$argnum of type '$type' in '$symname' function");
+  }
+}
 
 // Convert scalar argument by reference
 // Don't add String or char here otherwise "res2 not declared" / "alloc1 not declared"
@@ -598,10 +613,17 @@
 {
   $result = objectFromCpp($1);
 }
+%typemap(out, fragment="FromCpp") std::string_view
+{
+  String tmp{$1};
+  $result = objectFromCpp(tmp);
+}
 
 %typemap(out, fragment="FromCpp") int*,    const int*,    int&,    const int&,
                                   double*, const double*, double&, const double&,
                                   String*, const String*, String&, const String&,
+                                  std::string_view*, const std::string_view*,
+                                  std::string_view&, const std::string_view&,
                                   float*,  const float*,  float&,  const float&,
                                   UChar*,  const UChar*,  UChar&,  const UChar&,
                                   bool*,   const bool*,   bool&,   const bool&


### PR DESCRIPTION
`std::string_view` is to `std::string` what `std::span` is to `std::vector`. `std::string_view` is a C++17 feature that has a similar API to `std::string` but is constant and doesn't own the underlying buffer. In particular, `std::string_view::substr` doesn't allocate.

In gstlearn, a few methods that take a `String &` parameter are passed character literals as arguments: the Enums `fromKey` methods are a good example. Doing so will allocate a copy of the literal on the heap whereas `std::string_view` will point directly to the data segment.

In this PR, I use `std::string_view` instead of `String` around Enums. Explicit conversions to heap-allocated `Strings` are performed if needed be.

Since Enum methods are exposed to the R & Python wrappers, Swig typemaps have been introduced to convert `std::string_view` to or from heap-allocated `String`s under the hood.

Enjoy,
Pierre