### PR TITLE
New space compo

### DIFF
--- a/include/Basic/Tensor.hpp
+++ b/include/Basic/Tensor.hpp
@@ -16,7 +16,7 @@
 #include "Matrix/MatrixSquareGeneral.hpp"
 #include "Matrix/MatrixSquareSymmetric.hpp"
 
-class GSTLEARN_EXPORT Tensor : public AStringable/// TODO : public ASpaceObject
+class GSTLEARN_EXPORT Tensor : public AStringable /// TODO : public ASpaceObject
 {
 public:
   Tensor(unsigned int ndim = 2);

--- a/include/Space/ASpace.hpp
+++ b/include/Space/ASpace.hpp
@@ -18,144 +18,148 @@
 #include "Basic/VectorNumT.hpp"
 #include "Basic/ICloneable.hpp"
 
-#include <vector>
-
 class SpacePoint;
 class Tensor;
 
-class GSTLEARN_EXPORT ASpace : public AStringable, public ICloneable
+/**
+  * @brief Base classe for space definitions
+  *
+  * If the space instance is a sub-space from a parent SpaceComposit
+  * _offset is used. Otherwise it is set to 0.
+  * Example : if I am RN(1) in RN(2)+RN(1), offset is 2
+  */
+class GSTLEARN_EXPORT ASpace: public AStringable,
+                              public ICloneable
 {
 public:
-  ASpace(unsigned int ndim, bool addTime = false);
-  ASpace(const std::vector<const ASpace*>& vectspace);
+  ASpace(unsigned int ndim);
   ASpace(const ASpace& r);
   ASpace& operator=(const ASpace& r);
   virtual ~ASpace();
 
+  /// Interface for AStringable
+  String toString(const AStringFormat* strfmt = nullptr) const final;
+
   /// Return the concrete space type
   virtual ESpaceType getType() const = 0;
 
-  /// Add a space component to me (for exemple RN(1) for time dimension)
-  /// Note: The given argument is cloned
-  void addSpaceComponent(const ASpace* comp);
+  ///////////////////////////////////////////////
+  // Default behavior that can be overriden
 
-  /// Get the number of space components
-  unsigned int getNComponents() const;
+  /// Update the origin of the space
+  virtual void setOrigin(const VectorDouble& origin);
 
-  /// Interface for AStringable
-  virtual String toString(const AStringFormat* strfmt = nullptr) const final;
+  /// Get the number of dimensions
+  virtual unsigned int getNDim(int ispace = -1) const;
 
-  /// Update the origin of the space (must take into account composits)
-  void setOrigin(const VectorDouble& origin);
-
-  /// Get the number of dimensions (if ispace is negative, return the global number of )
-  unsigned int getNDim(int ispace = -1) const;
-  unsigned int getOffset(int ispace = -1) const;
+  /// Get the offset index for coordinates
+  virtual unsigned int getOffset(int ispace = -1) const;
 
   /// Return the space origin coordinates
-  const VectorDouble& getOrigin(int ispace = -1) const;
+  virtual const VectorDouble& getOrigin(int ispace = -1) const;
 
-  /// Return the dimension offset index
-  unsigned int getDimOffset() const { return _iDimOffset; }
-  unsigned int getCurrentNDim() const;
+  /// Get the number of space components
+  virtual unsigned int getNComponents() const;
 
-  /// Return true if the given space is equal to me (same dimension and space definition)
-  bool isEqual(const ASpace* space) const;
+  /// Return the space component at index ispace
+  virtual const ASpace* getComponent(int ispace = -1) const;
 
+  /// Dump a space in a string (given the space index)
+  virtual String toString(const AStringFormat* strfmt, int ispace) const;
+
+  /// Return true if the given space is equal to me (same dimension and space
+  /// definition)
+  virtual bool isEqual(const ASpace* space) const;
+
+  /// Return all the distances (one by space component) between two space points
+  virtual VectorDouble getDistances(const SpacePoint& p1,
+                                    const SpacePoint& p2) const;
+
+  ///////////////////////////////////////////////
+  /// Not to be overriden
+  
   /// Move the given space point by the given vector
   void move(SpacePoint& p1, const VectorDouble& vec) const;
 
   /// Return the distance between two space points
   double getDistance(const SpacePoint &p1,
                      const SpacePoint &p2,
-                     int ispace = 0) const;
+                     int ispace = -1) const;
 
   /// Return the distance between two space points with the given tensor
   double getDistance(const SpacePoint& p1,
                      const SpacePoint& p2,
                      const Tensor& tensor,
-                     int ispace = 0) const;
-
-  /// Return all the distances (one by space component) between two space points
-  VectorDouble getDistances(const SpacePoint &p1,
-                            const SpacePoint &p2) const;
-
-  /// Return the distance along one direction between two space points
-  double getDistance1D(const SpacePoint &p1,
-                       const SpacePoint &p2,
-                       unsigned int idim = 0) const;
+                     int ispace = -1) const;
 
   /// Return the distance in frequential domain between two space points with the given tensor
   double getFrequentialDistance(const SpacePoint& p1,
                                 const SpacePoint& p2,
                                 const Tensor& tensor,
-                                int ispace = 0) const;
+                                int ispace = -1) const;
 
   /// Return the increment vector between two space points
   VectorDouble getIncrement(const SpacePoint& p1,
                             const SpacePoint& p2,
-                            int ispace = 0) const;
-  const ASpace* getComponent(int i) const;
+                            int ispace = -1) const;
 
-  int getSpaceRankView() const { return _spaceRankView; }  
-  void setSpaceRankView(int spaceRankView)  { _spaceRankView = spaceRankView; }
-  int getCurrentOffset() const ;
+  /// Project the coordinates in the given space
+  virtual VectorDouble projCoord(const VectorDouble& coord,
+                                 int ispace = -1) const;
+  
+  /// Customize the dimension offset index of the current space
+  /// TODO : to be made private
+  void setOffset(unsigned int offset) { _offset = offset; }
+
 protected:
-
-  /// Internal usage only
-  void _setDimOffset(unsigned int idim) { _iDimOffset = idim; }
-
-  /// Dump a space in a string
-  virtual String _toString(const AStringFormat* strfmt, int idx = -1) const;
-
-  /// Return true if the given space is equal to me (same dimension and space definition)
-  virtual bool _isEqual(const ASpace* space) const;
 
   /// Move the given space point by the given vector
   virtual void _move(SpacePoint& p1, const VectorDouble& vec) const = 0;
 
   /// Return the distance between two space points
-  virtual double _getDistance(const SpacePoint &p1,
-                              const SpacePoint &p2) const = 0;
+  virtual double _getDistance(const SpacePoint& p1,
+                              const SpacePoint& p2,
+                              int ispace = -1) const = 0;
 
   /// Return the distance between two space points with the given tensor
   virtual double _getDistance(const SpacePoint& p1,
                               const SpacePoint& p2,
-                              const Tensor& tensor) const = 0;
-
-  /// Return the distance for a given pair of coordinates along one direction
-  virtual double _getDistance1D(double c1, double c2) const = 0;
+                              const Tensor& tensor,
+                              int ispace = -1) const = 0;
 
   /// Return the distance in frequential domain between two space points with the given tensor
   virtual double _getFrequentialDistance(const SpacePoint& p1,
                                          const SpacePoint& p2,
-                                         const Tensor& tensor) const = 0;
+                                         const Tensor& tensor,
+                                         int ispace = -1) const = 0;
 
   /// Return the increment vector between two space points
   virtual VectorDouble _getIncrement(const SpacePoint& p1,
-                                     const SpacePoint& p2) const = 0;
-
+                                     const SpacePoint& p2,
+                                     int ispace = -1) const = 0;
+  
   /// Return the increment vector between two space points in a given vector
-  virtual void _getIncrementInPlace(const SpacePoint &p1, 
-                                    const SpacePoint &p2,
-                                    VectorDouble &ptemp) const = 0;
+  virtual void _getIncrementInPlace(const SpacePoint& p1,
+                                    const SpacePoint& p2,
+                                    VectorDouble& ptemp,
+                                    int ispace = -1) const = 0;
+
+protected:
+  /// Customize the dimension offset index of the current space
+  //void _setOffset(unsigned int offset) { _offset = offset; }
   
 protected:
-  /// Number of space dimensions (not taking into account composits)
+  /// Number of space dimensions
   unsigned int _nDim;
-  /// Coordinates of the origin (not taking into account composits)
+  /// Coordinates of the origin (size = _nDim)
   VectorDouble _origin;
-  /// Dimension offset index (for space composit)
-  unsigned int _iDimOffset;
+  /// Dimension offset index (0 if single space, relative if sub-space)
+  unsigned int _offset;
 
-  /// Space composits list
-  std::vector<ASpace *> _comps;
-  /// Numnber of space dimensions  (taking into account composits)
-  unsigned int _globalNDim;
-  /// Coordinates of the global origin (taking into account composits)
-  VectorDouble _globalOrigin;
-  int _spaceRankView; // Idée de Didier
-  // The next vectors are specified as working members in order to avoid too many allocations
+  /// The next vectors are specified as working members in order to avoid too many allocations
   mutable VectorDouble _work1;
   mutable VectorDouble _work2;
+
+  /// Privilege to SpaceComposit only
+  //friend class SpaceComposit; /// TODO : this has no effect (see _setOffset). Why ?
 };

--- a/include/Space/ASpaceObject.hpp
+++ b/include/Space/ASpaceObject.hpp
@@ -91,8 +91,8 @@ protected:
 GSTLEARN_EXPORT void defineDefaultSpace(const ESpaceType& type,
                                         unsigned int ndim = 2,
                                         double param      = 0.);
-/// (Re)Defining the unique default global space
-GSTLEARN_EXPORT void defineDefaultSpace(const ASpace* space);
+/// Set the unique default global space from another one
+GSTLEARN_EXPORT void setDefaultSpace(const ASpace* space);
 
 /// Return a clone of the unique default global space
 GSTLEARN_EXPORT const ASpace* cloneDefaultSpace();

--- a/include/Space/ASpaceObject.hpp
+++ b/include/Space/ASpaceObject.hpp
@@ -72,11 +72,6 @@ public:
   VectorDouble getDistances(const SpacePoint& p1,
                             const SpacePoint& p2) const;
 
-  /// Return the distance along one direction between two space points
-  double getDistance1D(const SpacePoint& p1,
-                       const SpacePoint& p2,
-                       int idim) const;
-
   /// Return the increment vector between two space points for the current space context
   VectorDouble getIncrement(const SpacePoint& p1,
                             const SpacePoint& p2,
@@ -95,8 +90,10 @@ protected:
 /// (Re)Defining the unique default global space
 GSTLEARN_EXPORT void defineDefaultSpace(const ESpaceType& type,
                                         unsigned int ndim = 2,
-                                        double param = 0.,
-                                        bool addtime = false);
+                                        double param      = 0.);
+/// (Re)Defining the unique default global space
+GSTLEARN_EXPORT void defineDefaultSpace(const ASpace* space);
+
 /// Return a clone of the unique default global space
 GSTLEARN_EXPORT const ASpace* cloneDefaultSpace();
 

--- a/include/Space/SpaceComposite.hpp
+++ b/include/Space/SpaceComposite.hpp
@@ -13,38 +13,67 @@
 #include "gstlearn_export.hpp"
 
 #include "Space/ASpace.hpp"
-#include "Basic/VectorNumT.hpp"
+#include "Enum/ESpaceType.hpp"
+
+#include <vector>
 
 class SpacePoint;
+class Tensor;
 
-class GSTLEARN_EXPORT SpaceSN: public ASpace
+class GSTLEARN_EXPORT SpaceComposite : public ASpace
 {
 public:
-  SpaceSN(unsigned int ndim, double radius);
-  SpaceSN(const SpaceSN &r);
-  SpaceSN& operator=(const SpaceSN &r);
-  virtual ~SpaceSN();
+  SpaceComposite();
+  SpaceComposite(const std::vector<const ASpace*>& vectspace);
+  SpaceComposite(const SpaceComposite& r);
+  SpaceComposite& operator=(const SpaceComposite& r);
+  virtual ~SpaceComposite();
 
   /// ICloneable interface
-  IMPLEMENT_CLONING(SpaceSN)
+  IMPLEMENT_CLONING(SpaceComposite)
 
   /// Return the concrete space type
-  ESpaceType getType() const override { return ESpaceType::SN; };
+  ESpaceType getType() const override { return ESpaceType::COMPOSITE; }
 
-  /// Return the sphere radius
-  double getRadius() const { return _radius; }
+  /// Update the origin of the space
+  void setOrigin(const VectorDouble& origin) override;
 
-  /// Dump a space in a string
-  virtual String toString(const AStringFormat* strfmt,
-                          int idx = -1) const override;
+  /// Get the number of dimensions
+  unsigned int getNDim(int ispace = -1) const override;
 
-  /// Return true if the given space is equal to me
-  virtual bool isEqual(const ASpace *space) const override;
+  /// Get the offset index for coordinates
+  unsigned int getOffset(int ispace = -1) const override;
+  
+  /// Return the space origin coordinates
+  const VectorDouble& getOrigin(int ispace = -1) const override;
+
+  /// Get the number of space components
+  unsigned int getNComponents() const override;
+
+  /// Return the space component at index ispace
+  const ASpace* getComponent(int ispace = -1) const override;
+
+  /// Dump a space in a string (given the space index)
+  String toString(const AStringFormat* strfmt, int ispace) const override;
+
+  /// Return true if the given space is equal to me (same dimension and space
+  /// definition)
+  bool isEqual(const ASpace* space) const override;
+
+  /// Return all the distances (one by space component) between two space points
+  VectorDouble getDistances(const SpacePoint& p1,
+                            const SpacePoint& p2) const override;
+  
+  /////////////////////////////////////////////
+  
+  /// Add a space component to me (for exemple RN(1) for time dimension)
+  /// Note: The given argument is cloned
+  void addSpaceComponent(const ASpace* comp);
 
 protected:
 
   /// Move the given space point by the given vector
-  void _move(SpacePoint &p1, const VectorDouble &vec) const override;
+  void _move(SpacePoint& p1, const VectorDouble& vec) const override;
 
   /// Return the distance between two space points
   double _getDistance(const SpacePoint& p1,
@@ -57,17 +86,19 @@ protected:
                       const Tensor& tensor,
                       int ispace = -1) const override;
 
-  /// Return the distance in frequential domain between two space points with the given tensor
+  /// Return the distance in frequential domain between two space points with
+  /// the given tensor
   double _getFrequentialDistance(const SpacePoint& p1,
                                  const SpacePoint& p2,
                                  const Tensor& tensor,
                                  int ispace = -1) const override;
 
-  /// Return the increment vector between two space points for the current space context
+  /// Return the increment vector between two space points for the current space
+  /// context
   VectorDouble _getIncrement(const SpacePoint& p1,
                              const SpacePoint& p2,
                              int ispace = -1) const override;
-  
+
   /// Return the increment vector between two space points in a given vector
   void _getIncrementInPlace(const SpacePoint& p1,
                             const SpacePoint& p2,
@@ -75,7 +106,10 @@ protected:
                             int ispace = -1) const override;
 
 private:
-  /// Sphere radius
-  double _radius;
-};
+  /// Destroy components and empty vector
+  void _destroyComponents();
 
+private:
+  /// Space composits list
+  std::vector<ASpace *> _comps;
+};

--- a/include/Space/SpacePoint.hpp
+++ b/include/Space/SpacePoint.hpp
@@ -16,34 +16,27 @@
 #include "Basic/VectorNumT.hpp"
 #include "Space/ASpaceObject.hpp"
 
-//#include "Basic/VectorT.hpp"
-
 class GSTLEARN_EXPORT SpacePoint : public ASpaceObject
 {
 public:
   SpacePoint(const ASpace* space = nullptr);
   SpacePoint(const SpacePoint& r);
-  SpacePoint(const VectorDouble& coord,int iech = -1,
+  SpacePoint(const VectorDouble& coord, int iech = -1,
              const ASpace* space = nullptr);
-  private:
-  #ifndef SWIG
-  SpacePoint(vect coord, const ASpace* space, int iech);
-  #endif
-  public:
   SpacePoint& operator=(const SpacePoint& r);
   virtual ~SpacePoint();
 
   SpacePoint spacePointOnSubspace(int ispace = -1) const;
 
+  /// TODO : should aslo test the space definition
   bool operator==(const SpacePoint& v) const { return (_coord == v._coord); }
 
   constvect getCoords() const;
   
-  vect getCoordRef() { return vect(_coord,getNDim()); }
+  vect getCoordRef() { return vect(_coord.data(), getNDim()); }
   double getCoord(int idim) const; 
   void setCoord(double coord);
   void setCoord(int i, double val) { _coord[i] = val; }
-  void setCoords(vect coords);
   void setCoords(const VectorDouble& coord);
   void setCoords(const double* coord, int size);
   void setIech(int iech) const { _iech = iech; }
@@ -56,13 +49,11 @@ public:
   /// Move me by the given vector
   void move(const VectorDouble& vec);
   /// Return the distance between me and another point
-  double getDistance(const SpacePoint& pt, int ispace = 0) const;
+  double getDistance(const SpacePoint& pt, int ispace = -1) const;
   /// Return all the distance (space composits) between me and another point
   VectorDouble getDistances(const SpacePoint& pt) const;
-  /// Return the distance along one direction between me and another point
-  double getDistance1D(const SpacePoint &pt, int idim = 0) const;
   /// Return the increment vector between me and another point
-  VectorDouble getIncrement(const SpacePoint& pt, int ispace = 0) const;
+  VectorDouble getIncrement(const SpacePoint& pt, int ispace = -1) const;
   /// Fill with TEST values to simulate a missing Space Point
   void setFFFF();
   /// Check if the SpacePoint is actually defined
@@ -82,8 +73,7 @@ public:
 
 protected:
   /// Points coordinates (whatever the space context)
-  double* _coord;
-  bool _deleteCoord;
+  VectorDouble _coord;
   mutable int _iech;
   mutable bool _target;
 };

--- a/include/Space/SpaceRN.hpp
+++ b/include/Space/SpaceRN.hpp
@@ -18,18 +18,16 @@
 class SpacePoint;
 class Tensor;
 
-class GSTLEARN_EXPORT SpaceRN : public ASpace {
-
+class GSTLEARN_EXPORT SpaceRN: public ASpace
+{
 public:
-  SpaceRN(unsigned int ndim, bool addtime = false);
+  SpaceRN(unsigned int ndim);
   SpaceRN(const SpaceRN& r);
   SpaceRN& operator=(const SpaceRN& r);
   virtual ~SpaceRN();
 
   /// ICloneable interface
   IMPLEMENT_CLONING(SpaceRN)
-
-  static SpaceRN* create(unsigned int ndim, bool addtime = false);
 
   /// Return the concrete space type
   ESpaceType getType() const override { return ESpaceType::RN; }
@@ -39,27 +37,30 @@ protected:
   void _move(SpacePoint &p1, const VectorDouble &vec) const override;
 
   /// Return the distance between two space points
-  double _getDistance(const SpacePoint &p1, const SpacePoint &p2) const override;
+  double _getDistance(const SpacePoint& p1,
+                      const SpacePoint& p2,
+                      int ispace = -1) const override;
 
   /// Return the distance between two space points with the given tensor
-  double _getDistance(const SpacePoint &p1,
-                      const SpacePoint &p2,
-                      const Tensor &tensor) const override;
-
-  /// Return the distance for a given pair of coordinates along one direction
-  double _getDistance1D(double c1, double c2) const override;
+  double _getDistance(const SpacePoint& p1,
+                      const SpacePoint& p2,
+                      const Tensor& tensor,
+                      int ispace = -1) const override;
 
   /// Return the distance in frequential domain between two space points with the given tensor
   double _getFrequentialDistance(const SpacePoint& p1,
                                  const SpacePoint& p2,
-                                 const Tensor& tensor) const override;
+                                 const Tensor& tensor,
+                                 int ispace = -1) const override;
 
   /// Return the increment vector between two space points for the current space context
   VectorDouble _getIncrement(const SpacePoint& p1,
-                             const SpacePoint& p2) const override;
-
+                             const SpacePoint& p2,
+                             int ispace = -1) const override;
+  
   /// Return the increment vector between two space points in a given vector
-  void _getIncrementInPlace(const SpacePoint &p1,
-                            const SpacePoint &p2,
-                            VectorDouble &ptemp) const override;
+  void _getIncrementInPlace(const SpacePoint& p1,
+                            const SpacePoint& p2,
+                            VectorDouble& ptemp,
+                            int ispace = -1) const override;
 };

--- a/src/Covariances/CovGneiting.cpp
+++ b/src/Covariances/CovGneiting.cpp
@@ -14,10 +14,9 @@
 #include "Covariances/ACov.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "Space/ASpace.hpp"
+#include "Space/SpaceComposite.hpp"
 #include "Space/SpacePoint.hpp"
 #include "Covariances/CovCalcMode.hpp"
-#include "Space/SpaceRN.hpp"
-#include "geoslib_define.h"
 #include <vector>
 
 CovGneiting::CovGneiting(const CovAniso* covS,const CovAniso* covTemp, double separability)
@@ -34,7 +33,8 @@ CovGneiting::CovGneiting(const CovAniso* covS,const CovAniso* covTemp, double se
     messerr("It has been set to 0");
   }
   delete _space;
-  ASpace* space = dynamic_cast<ASpace*>(covS->getSpace()->clone());
+  SpaceComposite* space = new SpaceComposite();
+  space->addSpaceComponent(covS->getSpace());
   space->addSpaceComponent(covTemp->getSpace()); 
   _space = space;
 }
@@ -47,7 +47,6 @@ ACov(r)
 , _separability(r._separability)
 , _covSCopy(*r._covS)
 {
-
 }
 
 CovGneiting& CovGneiting::operator=(const CovGneiting &r)
@@ -64,10 +63,8 @@ CovGneiting& CovGneiting::operator=(const CovGneiting &r)
   return *this;
 }
 
-
 CovGneiting::~CovGneiting()
 {
-
 }
 
 void CovGneiting::_optimizationSetTarget(const SpacePoint &pt) const 
@@ -100,7 +97,6 @@ double CovGneiting::eval(const SpacePoint& p1,
                     int jvar,
                     const CovCalcMode* mode) const
 {
-
   auto p1_0 = p1.spacePointOnSubspace(0);
   auto p2_0 = p2.spacePointOnSubspace(0);
   auto p1_1 = p1.spacePointOnSubspace(1);
@@ -115,5 +111,4 @@ double CovGneiting::eval(const SpacePoint& p1,
   double cs = _covSCopy.eval(p1_0, p2_0, ivar, jvar, mode);
   
   return cs * ct; 
-
 }

--- a/src/Space/ASpace.cpp
+++ b/src/Space/ASpace.cpp
@@ -10,76 +10,29 @@
 /******************************************************************************/
 #include "Space/ASpace.hpp"
 #include "Space/SpacePoint.hpp"
-#include "Space/SpaceRN.hpp"
+#include "geoslib_define.h"
 
 #include <iostream>
 #include <sstream>
-#include <vector>
 
-ASpace::ASpace(unsigned int ndim, bool addTime)
-    : AStringable(),
-      _nDim(ndim),
-      _origin(VectorDouble(ndim, 0.)),
-      _iDimOffset(0),
-      _comps(),
-      _globalNDim(ndim),
-      _globalOrigin(VectorDouble(ndim, 0.)),
-      _spaceRankView(0),
-      _work1(ndim),
-      _work2(ndim)
+ASpace::ASpace(unsigned int ndim)
+  : AStringable()
+  , _nDim(ndim)
+  , _origin(VectorDouble(ndim, 0.))
+  , _offset(0)
+  , _work1(ndim)
+  , _work2(ndim)
 {
-  if (ndim <= 0)
-  {
-    _nDim = 2;
-  }
-
-  if(addTime)
-  {
-    // Time dimension is Euclidean
-    // neglecting Eistein's relativity theory :-)
-    SpaceRN* ts = new SpaceRN(1);
-    addSpaceComponent(ts); // ts is cloned, so delete it
-    delete ts;
-  }
 }
-
-ASpace::ASpace(const std::vector<const ASpace*>& vectspace)
-    : AStringable()
-{
-  if (vectspace[0] == nullptr) return;
-
-  _nDim = vectspace[0]->getNDim();
-  _origin = VectorDouble(_nDim, 0.);
-  _iDimOffset = 0;
-  _globalNDim = _nDim;
-  _globalOrigin = VectorDouble(_nDim, 0.);
-  _spaceRankView = 0;
-  _work1.resize(_nDim);
-  _work2.resize(_nDim);
-  
-  for (const auto* sp : vectspace)
-  {
-    addSpaceComponent(sp);
-  }
-}
-
 
 ASpace::ASpace(const ASpace& r)
-    : AStringable(r),
-      _nDim(r._nDim),
-      _origin(r._origin),
-      _iDimOffset(r._iDimOffset),
-      _comps(),
-      _globalNDim(r._globalNDim),
-      _globalOrigin(r._globalOrigin),
-      _spaceRankView(r._spaceRankView),
-      _work1(r._globalNDim), // No need to copy the contents, just allocate
-      _work2(r._globalNDim)
+  : AStringable(r)
+  , _nDim(r._nDim)
+  , _origin(r._origin)
+  , _offset(r._offset)
+  , _work1(r._nDim) // No need to copy the contents, just allocate
+  , _work2(r._nDim)
 {
-  for(auto* c : r._comps)
-  {
-    _comps.push_back(dynamic_cast<ASpace*>(c->clone()));
-  }
 }
 
 ASpace& ASpace::operator=(const ASpace& r)
@@ -89,149 +42,130 @@ ASpace& ASpace::operator=(const ASpace& r)
     AStringable::operator=(r);
     _nDim = r._nDim;
     _origin = r._origin;
-    _iDimOffset = r._iDimOffset;
-    _globalNDim = r._globalNDim;
-    _globalOrigin = r._globalOrigin;
-    _spaceRankView = r._spaceRankView;
+    _offset = r._offset;
     _work1 = r._work1;
     _work2 = r._work2;
-    for(auto* c : r._comps)
-    {
-      _comps.push_back(dynamic_cast<ASpace*>(c->clone()));
-    }
   }
   return *this;
 }
 
-ASpace::~ASpace()
-{
-  for(auto* c : _comps)
-  {
-    delete c;
-  }
-}
-int ASpace::getCurrentOffset() const
-{
-  int rankView = getSpaceRankView();
-  return  getOffset(rankView);
-}
-  
+ASpace::~ASpace() {}
 
-unsigned int ASpace::getCurrentNDim() const
-{
-  int rankView = getSpaceRankView();
-  return  getNDim(rankView);
-}
-void ASpace::addSpaceComponent(const ASpace* comp)
-{
-  ASpace* sp = dynamic_cast<ASpace*>(comp->clone());
-  sp->_setDimOffset(_globalNDim);
-  _comps.push_back(sp);
-  _globalNDim += sp->getNDim(0);
-  const VectorDouble& o = sp->getOrigin(0);
-  _globalOrigin.insert(_globalOrigin.end(), o.begin(), o.end());
-}
-
-unsigned int ASpace::getNComponents() const
-{
-  return (int)_comps.size() + 1;
-}
-
+/// Interface for AStringable
 String ASpace::toString(const AStringFormat* strfmt) const
 {
   std::stringstream sstr;
-  int idx = getNComponents() > 1 ? 1 : -1;
-  sstr << _toString(strfmt, idx);
-  for(auto* c : _comps)
-  {
-    if (strfmt != nullptr && strfmt->getLevel() == 0)
-      sstr << " + ";
-    idx++;
-    sstr << c->_toString(strfmt, idx);
-  }
-  if (strfmt != nullptr && strfmt->getLevel() == 0)
-    sstr << std::endl;
+  sstr << toString(strfmt, -1);
+  if (strfmt != nullptr && strfmt->getLevel() == 0) sstr << std::endl;
   return sstr.str();
 }
 
+/// Update the origin of the space
 void ASpace::setOrigin(const VectorDouble& origin)
 {
-  /// TODO : not true whatever the space
-  if (origin.size() != _globalNDim)
+  if (origin.size() != getNDim())
   {
     std::cout << "Error: Inconsistent space origin. Origin not changed." << std::endl;
     return;
   }
-  _globalOrigin = origin;
-  auto first = origin.cbegin();
-  auto last = origin.cbegin() + _origin.size();
-  _origin.assign(first, last);
-  for(auto* c : _comps)
-  {
-    first = last;
-    last = last + c->getNDim();
-    c->setOrigin(VectorDouble(first, last));
-  }
+  _origin = origin;
 }
 
+/// Get the number of dimensions
 unsigned int ASpace::getNDim(int ispace) const
 {
-  if (ispace < 0 || ispace >= (int)getNComponents())
-    return _globalNDim;
-  if (ispace == 0)
-    return _nDim;
-  return _comps[ispace - 1]->getNDim(0);
+  DECLARE_UNUSED(ispace)
+  return _nDim;
 }
 
+/// Get the offset index for coordinates
 unsigned int ASpace::getOffset(int ispace) const
 {
-  if (ispace < 0 || ispace >= (int)getNComponents())
-    return 0;
-  if (ispace == 0)
-    return _iDimOffset;
-  return _comps[ispace - 1]->getOffset(0);
+  DECLARE_UNUSED(ispace)
+  return _offset;
 }
 
+/// Return the space origin coordinates
 const VectorDouble& ASpace::getOrigin(int ispace) const
 {
-  if (ispace < 0 || ispace >= (int)getNComponents())
-    return _globalOrigin;
-  if (ispace == 0)
-    return _origin;
-  return _comps[ispace-1]->getOrigin(0);
+  DECLARE_UNUSED(ispace)
+  return _origin;
 }
 
+/// Get the number of space components
+unsigned int ASpace::getNComponents() const
+{
+  return 1;
+}
+
+/// Return the space component at index ispace
+const ASpace* ASpace::getComponent(int ispace) const
+{
+  DECLARE_UNUSED(ispace)
+  return this;
+}
+
+/// Dump a space in a string (given the space index)
+String ASpace::toString(const AStringFormat* strfmt, int ispace) const
+{
+  std::stringstream sstr;
+  if (strfmt != nullptr && strfmt->getLevel() == 0)
+  {
+    sstr << getType().getKey() << "(" << getNDim() << ")";
+  }
+  else
+  {
+    if (ispace < 0)
+    {
+      sstr << "Space Type      = " << getType().getKey() << std::endl;
+      sstr << "Space Dimension = " << getNDim() << std::endl;
+    }
+    else
+    {
+      sstr << "Space Type      [" << ispace << "] = " << getType().getKey() << std::endl;
+      sstr << "Space Dimension [" << ispace << "] = " << getNDim() << std::endl;
+    }
+  }
+  return sstr.str();
+}
+
+/// Return true if the given space is equal to me (same dimension and space definition)
 bool ASpace::isEqual(const ASpace* space) const
 {
-  bool equal = getNComponents() == space->getNComponents() && _isEqual(space);
-  for(unsigned int i = 0; equal && i < _comps.size(); i++)
-  {
-    equal &= _comps[i]->isEqual(space->_comps[i]);
-  }
-  return equal;
+  return (getNComponents() == space->getNComponents() &&
+          getType() == space->getType() &&
+          getNDim() == space->getNDim() &&
+          getOrigin() == space->getOrigin() &&
+          getOffset() == space->getOffset());
 }
 
+/// Return all the distances (one by space component) between two space points
+VectorDouble ASpace::getDistances(const SpacePoint& p1,
+                                  const SpacePoint& p2) const
+{
+  VectorDouble dis;
+  if (p1.getNDim() != p2.getNDim())
+  {
+    std::cout << "Error: Inconsistent point dimension. Return empty distances"
+              << std::endl;
+    return dis;
+  }
+  dis.push_back(_getDistance(p1, p2));
+  return dis;
+}
+
+/// Move the given space point by the given vector
 void ASpace::move(SpacePoint& p1, const VectorDouble& vec) const
 {
-  if (vec.size() != _globalNDim)
+  if (vec.size() <= 0 ||
+      vec.size() < getOffset() + getNDim() ||
+      vec.size() != p1.getNDim())
   {
-    std::cout << "Error: Inconsistent vector dimension. Point not moved." << std::endl;
+    std::cout << "Error: Inconsistent vector dimension. Point not moved."
+              << std::endl;
     return;
   }
   _move(p1, vec);
-  for (auto* sp : _comps)
-  {
-    sp->_move(p1, vec);
-  }
-}
-
-const ASpace* ASpace::getComponent(int i) const
-{
-  if (i == 0)
-    return this;
-  if (i > 0 && i <= (int)_comps.size())
-    return _comps[i-1];
-  return nullptr;
 }
 
 /// Return the distance between two space points
@@ -239,9 +173,13 @@ double ASpace::getDistance(const SpacePoint &p1,
                            const SpacePoint &p2,
                            int ispace) const
 {
-  if (ispace <= 0 || ispace >= (int)getNComponents())
-    return _getDistance(p1, p2);
-  return _comps[ispace-1]->_getDistance(p1, p2);
+  if (p1.getNDim() != p2.getNDim())
+  {
+    std::cout << "Error: Inconsistent space dimension. Return TEST."
+              << std::endl;
+    return TEST;
+  }
+  return _getDistance(p1, p2, ispace);
 }
 
 /// Return the distance between two space points with the given tensor
@@ -250,49 +188,14 @@ double ASpace::getDistance(const SpacePoint& p1,
                            const Tensor& tensor,
                            int ispace) const
 {
-  if (ispace <= 0 || ispace >= (int)getNComponents())
-    return _getDistance(p1, p2, tensor);
-  return _comps[ispace-1]->_getDistance(p1, p2, tensor);
-}
-
-/// Return all the distances (one by space component) between two space points
-VectorDouble ASpace::getDistances(const SpacePoint &p1,
-                                  const SpacePoint &p2) const
-{
-  VectorDouble dis;
-  dis.push_back(_getDistance(p1, p2));
-  for (auto* sp : _comps)
-  {
-    dis.push_back(sp->_getDistance(p1, p2));
-  }
-  return dis;
-}
-
-/// Return the distance along one direction between two space points
-double ASpace::getDistance1D(const SpacePoint &p1,
-                             const SpacePoint &p2,
-                             unsigned int idim) const
-{
-  if (idim >= _globalNDim)
+  if (p1.getNDim() != p2.getNDim())
+  /// TODO : test Tensor dimension
   {
     std::cout << "Error: Inconsistent space dimension. Return TEST."
               << std::endl;
     return TEST;
   }
-
-  if (idim < _nDim)
-    return _getDistance1D(p1.getCoord(idim), p2.getCoord(idim));
-
-  unsigned int jdim = idim - _nDim;
-  for (auto* sp : _comps)
-  {
-    unsigned int ndim = sp->getNDim(0);
-    if (jdim < ndim)
-      return sp->_getDistance1D(p1.getCoord(idim), p2.getCoord(idim));
-    jdim -= ndim;
-  }
-
-  return TEST;
+  return _getDistance(p1, p2, tensor, ispace);
 }
 
 /// Return the distance in frequential domain between two space points with the given tensor
@@ -301,9 +204,14 @@ double ASpace::getFrequentialDistance(const SpacePoint& p1,
                                       const Tensor& tensor,
                                       int ispace) const
 {
-  if (ispace <= 0 || ispace >= (int)getNComponents())
-    return _getFrequentialDistance(p1, p2, tensor);
-  return _comps[ispace - 1]->_getFrequentialDistance(p1, p2, tensor);
+  if (p1.getNDim() != p2.getNDim())
+  /// TODO : test tensor size
+  {
+    std::cout << "Error: Inconsistent point dimensions. Return TEST."
+              << std::endl;
+    return TEST;
+  }
+  return _getFrequentialDistance(p1, p2, tensor, ispace);
 }
 
 /// Return the increment vector between two space points
@@ -311,40 +219,24 @@ VectorDouble ASpace::getIncrement(const SpacePoint& p1,
                                   const SpacePoint& p2,
                                   int ispace) const
 {
-  if (ispace <= 0 || ispace >= (int)getNComponents())
-    return _getIncrement(p1, p2);
-  return _comps[ispace - 1]->_getIncrement(p1, p2);
+  if (p1.getNDim() != p2.getNDim())
+  /// TODO : test tensor size
+  {
+    std::cout << "Error: Inconsistent point dimensions. Return empty vector."
+              << std::endl;
+    return VectorDouble();
+  }
+  return _getIncrement(p1, p2, ispace);
+}
+
+VectorDouble ASpace::projCoord(const VectorDouble& coord, int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents()) return coord;
+  const ASpace* sp = getComponent(ispace);
+  auto first       = coord.cbegin() + sp->getOffset();
+  auto last        = first          + sp->getNDim();
+  /// TODO : Memory copies !
+  return VectorDouble(first, last);
 }
 
 /////////////////////////////////////////////////////////
-
-String ASpace::_toString(const AStringFormat* strfmt, int idx) const
-{
-  std::stringstream sstr;
-  if (strfmt != nullptr && strfmt->getLevel() == 0)
-  {
-    sstr << getType().getKey() << "(" << getNDim(0) << ")";
-  }
-  else
-  {
-    if (idx < 0)
-    {
-      sstr << "Space Type      = " << getType().getKey() << std::endl;
-      sstr << "Space Dimension = " << getNDim(0) << std::endl;
-    }
-    else
-    {
-      sstr << "Space Type      [" << idx << "] = " << getType().getKey() << std::endl;
-      sstr << "Space Dimension [" << idx << "] = " << getNDim(0) << std::endl;
-    }
-  }
-  return sstr.str();
-}
-
-bool ASpace::_isEqual(const ASpace* space) const
-{
-  return (getNDim()      == space->getNDim()   &&
-          getType()      == space->getType()   &&
-          getOrigin()    == space->getOrigin() &&
-          getDimOffset() == space->getDimOffset());
-}

--- a/src/Space/ASpaceObject.cpp
+++ b/src/Space/ASpaceObject.cpp
@@ -104,13 +104,6 @@ VectorDouble ASpaceObject::getDistances(const SpacePoint& p1,
   return (_space->getDistances(p1, p2));
 }
 
-double ASpaceObject::getDistance1D(const SpacePoint& p1,
-                                   const SpacePoint& p2,
-                                   int idim) const
-{
-  return (_space->getDistance1D(p1, p2, idim));
-}
-
 VectorDouble ASpaceObject::getIncrement(const SpacePoint& p1,
                                         const SpacePoint& p2,
                                         int ispace) const
@@ -123,7 +116,6 @@ VectorDouble ASpaceObject::getIncrement(const SpacePoint& p1,
  * (To be used only during creation ... in particular when reading NF)
  * @param ndim
  */
-// TODO: this function should be removed as dangerous
 void ASpaceObject::setNDim(int ndim)
 {
   if (_space->getType() != ESpaceType::RN)
@@ -140,9 +132,8 @@ void ASpaceObject::setNDim(int ndim)
  * @param type Space type (RN, SN, ...)
  * @param ndim Number of dimensions
  * @param param Optional space parameter (ex: radius of the sphere)
- * @param addtime Optional add time dimension (composit space)
  */
-void defineDefaultSpace(const ESpaceType& type, unsigned int ndim, double param, bool addtime)
+void defineDefaultSpace(const ESpaceType& type, unsigned int ndim, double param)
 {
   delete defaultSpace;
 
@@ -152,12 +143,12 @@ void defineDefaultSpace(const ESpaceType& type, unsigned int ndim, double param,
     {
       ndim = 2;
       if (param <= 0.) param = EARTH_RADIUS;
-      defaultSpace = new SpaceSN(ndim, param, addtime);
+      defaultSpace = new SpaceSN(ndim, param);
       break;
     }
     case ESpaceType::E_RN:
     {
-      defaultSpace = new SpaceRN(ndim, addtime);
+      defaultSpace = new SpaceRN(ndim);
       break;
     }
     default:
@@ -165,6 +156,17 @@ void defineDefaultSpace(const ESpaceType& type, unsigned int ndim, double param,
       my_throw("Unknown space type!");
     }
   }
+}
+
+/**
+ * @brief Defining the default space from another one
+ * 
+ * @param space 
+ */
+void defineDefaultSpace(const ASpace* space)
+{
+  delete defaultSpace;
+  defaultSpace = dynamic_cast<ASpace*>(space->clone());
 }
 
 const ASpace* cloneDefaultSpace()

--- a/src/Space/ASpaceObject.cpp
+++ b/src/Space/ASpaceObject.cpp
@@ -163,7 +163,7 @@ void defineDefaultSpace(const ESpaceType& type, unsigned int ndim, double param)
  * 
  * @param space 
  */
-void defineDefaultSpace(const ASpace* space)
+void setDefaultSpace(const ASpace* space)
 {
   delete defaultSpace;
   defaultSpace = dynamic_cast<ASpace*>(space->clone());

--- a/src/Space/SpaceComposite.cpp
+++ b/src/Space/SpaceComposite.cpp
@@ -1,0 +1,264 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#include "Space/SpaceComposite.hpp"
+
+#include "Space/SpacePoint.hpp"
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+SpaceComposite::SpaceComposite()
+  : ASpace(0)
+  , _comps()
+{
+}
+
+SpaceComposite::SpaceComposite(const std::vector<const ASpace*>& vectspace)
+  : ASpace(0)
+  , _comps()
+{
+  for (const auto* sp : vectspace)
+  {
+    addSpaceComponent(sp);
+  }
+}
+
+SpaceComposite::SpaceComposite(const SpaceComposite& r)
+  : ASpace(r)
+  , _comps()
+{
+  for(auto* c : r._comps)
+  {
+    _comps.push_back(dynamic_cast<ASpace*>(c->clone()));
+  }
+}
+
+SpaceComposite& SpaceComposite::operator=(const SpaceComposite& r)
+{
+  if (this != &r)
+  {
+    _destroyComponents();
+    ASpace::operator=(r);
+    for(auto* c : r._comps)
+    {
+      _comps.push_back(dynamic_cast<ASpace*>(c->clone()));
+    }
+  }
+  return *this;
+}
+
+SpaceComposite::~SpaceComposite()
+{
+  _destroyComponents();
+}
+
+void SpaceComposite::setOrigin(const VectorDouble& origin)
+{
+  if (origin.size() != ASpace::getNDim())
+  {
+    std::cout << "Error: Inconsistent space origin. Origin not changed." << std::endl;
+    return;
+  }
+  _origin = origin;
+  auto first = origin.cbegin();
+  auto last = origin.cbegin();
+  for(auto* c : _comps)
+  {
+    first = last;
+    last = last + c->getNDim();
+    c->setOrigin(VectorDouble(first, last));
+  }
+}
+
+unsigned int SpaceComposite::getNDim(int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+    return ASpace::getNDim();
+  return _comps[ispace]->getNDim();
+}
+
+unsigned int SpaceComposite::getOffset(int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+    return ASpace::getOffset();
+  return _comps[ispace]->getOffset();
+}
+
+const VectorDouble& SpaceComposite::getOrigin(int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+    return ASpace::getOrigin();
+  return _comps[ispace]->getOrigin();
+}
+
+unsigned int SpaceComposite::getNComponents() const
+{
+  return (int)_comps.size();
+}
+
+const ASpace* SpaceComposite::getComponent(int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+    return ASpace::getComponent(); // Return this if wrong ispace
+  return _comps[ispace];
+}
+
+String SpaceComposite::toString(const AStringFormat* strfmt, int ispace) const
+{
+  DECLARE_UNUSED(ispace)
+  std::stringstream sstr;
+  sstr << ASpace::toString(strfmt, -1);
+  if (strfmt != nullptr && strfmt->getLevel() == 0) sstr << ": ";
+  unsigned int nc = getNComponents();
+  for (unsigned int idx = 0; idx < nc; idx++)
+  {
+    const auto* c = getComponent(idx);
+    sstr << c->toString(strfmt, idx);
+    if (idx < nc - 1 && strfmt != nullptr && strfmt->getLevel() == 0) sstr << " + ";
+  }
+  if (strfmt != nullptr && strfmt->getLevel() == 0) sstr << std::endl;
+  return sstr.str();
+}
+
+bool SpaceComposite::isEqual(const ASpace* space) const
+{
+  if (!ASpace::isEqual(space)) return false;
+  unsigned int nc = getNComponents();
+  for (unsigned int idx = 0; idx < nc; idx++)
+  {
+    const auto* c1 = getComponent(idx);
+    const auto* c2 = space->getComponent(idx);
+    if (!c1->isEqual(c2)) return false;
+  }
+  return true;
+}
+
+VectorDouble SpaceComposite::getDistances(const SpacePoint& p1,
+                                          const SpacePoint& p2) const
+{
+  VectorDouble dis;
+  if (p1.getNDim() != p2.getNDim())
+  {
+    std::cout << "Error: Inconsistent point dimension. Return empty distances"
+              << std::endl;
+    return dis;
+  }
+  for (auto* sp: _comps)
+  {
+    dis.push_back(sp->getDistance(p1, p2));
+  }
+  return dis;
+}
+
+/////////////////////////////////////////////////////////
+
+void SpaceComposite::addSpaceComponent(const ASpace* comp)
+{
+  ASpace* sp = dynamic_cast<ASpace*>(comp->clone());
+  sp->ASpace::setOffset(getNDim()); // TODO : I want this to be private and me a friend of ASpace
+  _comps.push_back(sp);
+  _nDim += sp->getNDim();
+  const VectorDouble& o = sp->getOrigin(0);
+  _origin.insert(_origin.end(), o.begin(), o.end());
+  _work1.resize(_nDim);
+  _work2.resize(_nDim);
+}
+
+/////////////////////////////////////////////////////////
+
+void SpaceComposite::_move(SpacePoint& p1, const VectorDouble& vec) const
+{
+  for (auto* sp: _comps)
+  {
+    sp->move(p1, vec);
+  }
+}
+
+/// Return the distance between two space points
+double SpaceComposite::_getDistance(const SpacePoint& p1,
+                                    const SpacePoint& p2,
+                                    int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+    return getDistances(p1, p2).norm(); // Return the norm of sub-distances vector
+  return _comps[ispace]->getDistance(p1, p2);
+}
+
+/// Return the distance between two space points with the given tensor
+double SpaceComposite::_getDistance(const SpacePoint& p1,
+                                    const SpacePoint& p2,
+                                    const Tensor& tensor,
+                                    int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+  {
+    std::cout << "Error: Inconsistent space dimension. Return TEST."
+              << std::endl;
+    return TEST;
+  }
+  return _comps[ispace]->getDistance(p1, p2, tensor);
+}
+
+/// Return the distance in frequential domain between two space points with the
+/// given tensor
+double SpaceComposite::_getFrequentialDistance(const SpacePoint& p1,
+                                              const SpacePoint& p2,
+                                              const Tensor& tensor,
+                                              int ispace) const
+{
+  if (ispace < 0 || ispace >= (int)getNComponents())
+  {
+    std::cout << "Error: Inconsistent space dimension. Return TEST."
+              << std::endl;
+    return TEST;
+  }
+  return _comps[ispace]->getFrequentialDistance(p1, p2, tensor);
+}
+
+/// Return the increment vector between two space points
+VectorDouble SpaceComposite::_getIncrement(const SpacePoint& p1,
+                                           const SpacePoint& p2,
+                                           int ispace) const
+{
+  _getIncrementInPlace(p1, p2, _work1, ispace);
+  return _work1;
+}
+
+/// Return the increment vector between two space points in a given vector
+void SpaceComposite::_getIncrementInPlace(const SpacePoint& p1,
+                                          const SpacePoint& p2,
+                                          VectorDouble& ptemp,
+                                          int ispace) const
+{
+  ptemp.clear();
+  if (ispace < 0 || ispace >= (int)getNComponents())
+  {
+    for (auto* sp: _comps)
+    {
+      VectorDouble inc = sp->getIncrement(p1, p2);
+      ptemp.insert(ptemp.begin(), inc.begin(), inc.end());
+    }
+  }
+  else
+  {
+    ptemp = _comps[ispace]->getIncrement(p1, p2);
+  }
+}
+
+/// Destroy components and empty vector
+void SpaceComposite::_destroyComponents()
+{
+  for (auto* c: _comps)
+  {
+    delete c;
+  }
+}

--- a/src/Space/SpaceRN.cpp
+++ b/src/Space/SpaceRN.cpp
@@ -15,8 +15,8 @@
 
 #include <math.h>
 
-SpaceRN::SpaceRN(unsigned int ndim, bool addtime)
-    : ASpace(ndim, addtime)
+SpaceRN::SpaceRN(unsigned int ndim)
+  : ASpace(ndim)
 {
 }
 
@@ -38,14 +38,11 @@ SpaceRN::~SpaceRN()
 {
 }
 
-SpaceRN* SpaceRN::create(unsigned int ndim, bool addtime)
-{
-  return new SpaceRN(ndim, addtime);
-}
-
 void SpaceRN::_move(SpacePoint &p1, const VectorDouble &vec) const
 {
-  for (unsigned int i = _iDimOffset; i < _nDim + _iDimOffset; i++)
+  unsigned int offset = getOffset();
+  unsigned int ndim = getNDim();
+  for (unsigned int i = offset; i < ndim + offset; i++)
   {
     p1.setCoord(i, p1.getCoord(i) + vec[i]);
   }
@@ -61,11 +58,16 @@ void SpaceRN::_move(SpacePoint &p1, const VectorDouble &vec) const
  \note The code has been optimized in order to avoid using '_work1' for storing
  \note temporary results
  */
-double SpaceRN::_getDistance(const SpacePoint &p1, const SpacePoint &p2) const
+double SpaceRN::_getDistance(const SpacePoint& p1,
+                             const SpacePoint& p2,
+                             int ispace) const
 {
+  DECLARE_UNUSED(ispace);
   double dist = 0.;
   double delta = 0.;
-  for (unsigned int i = _iDimOffset; i < _nDim + _iDimOffset; i++)
+  unsigned int offset = getOffset();
+  unsigned int ndim   = getNDim();
+  for (unsigned int i = offset; i < ndim + offset; i++)
   {
     delta = p2.getCoord(i) - p1.getCoord(i);
     dist += delta * delta;
@@ -73,10 +75,12 @@ double SpaceRN::_getDistance(const SpacePoint &p1, const SpacePoint &p2) const
   return sqrt(dist);
 }
 
-double SpaceRN::_getDistance(const SpacePoint &p1,
-                             const SpacePoint &p2,
-                             const Tensor &tensor) const
+double SpaceRN::_getDistance(const SpacePoint& p1,
+                             const SpacePoint& p2,
+                             const Tensor& tensor,
+                             int ispace) const
 {
+  DECLARE_UNUSED(ispace);
   _getIncrementInPlace(p1, p2, _work1);
 
   if (!tensor.isFlagDefinedByInverse2())
@@ -88,32 +92,35 @@ double SpaceRN::_getDistance(const SpacePoint &p1,
   return sqrt(VH::innerProduct(_work1, _work2));
 }
 
-double SpaceRN::_getDistance1D(double c1, double c2) const
+double SpaceRN::_getFrequentialDistance(const SpacePoint& p1,
+                                        const SpacePoint& p2,
+                                        const Tensor& tensor,
+                                        int ispace) const
 {
-  return c2 - c1;
-}
-
-double SpaceRN::_getFrequentialDistance(const SpacePoint &p1,
-                                        const SpacePoint &p2,
-                                        const Tensor &tensor) const
-{
+  DECLARE_UNUSED(ispace);
   _getIncrementInPlace(p1, p2, _work1);
   tensor.applyDirectSwapInPlace(_work1, _work2);
   return VH::norm(_work2);
 }
 
-VectorDouble SpaceRN::_getIncrement(const SpacePoint &p1,
-                                    const SpacePoint &p2) const
+VectorDouble SpaceRN::_getIncrement(const SpacePoint& p1,
+                                    const SpacePoint& p2,
+                                    int ispace) const
 {
+  DECLARE_UNUSED(ispace);
   _getIncrementInPlace(p1, p2, _work1);
   return _work1;
 }
 
-void SpaceRN::_getIncrementInPlace(const SpacePoint &p1,
-                                   const SpacePoint &p2,
-                                   VectorDouble &ptemp) const
+void SpaceRN::_getIncrementInPlace(const SpacePoint& p1,
+                                   const SpacePoint& p2,
+                                   VectorDouble& ptemp,
+                                   int ispace) const
 {
+  DECLARE_UNUSED(ispace);
   int j = 0;
-  for (unsigned int i = _iDimOffset; i < _nDim + _iDimOffset; i++)
+  unsigned int offset = getOffset();
+  unsigned int ndim   = getNDim();
+  for (unsigned int i = offset; i < ndim + offset; i++)
     ptemp[j++] = p2.getCoord(i) - p1.getCoord(i);
 }

--- a/src/Space/SpaceSN.cpp
+++ b/src/Space/SpaceSN.cpp
@@ -14,9 +14,9 @@
 #include "Basic/AException.hpp"
 #include "Geometry/GeometryHelper.hpp"
 
-SpaceSN::SpaceSN(unsigned int ndim, double radius, bool addtime)
-    : ASpace(ndim, addtime),
-      _radius(radius)
+SpaceSN::SpaceSN(unsigned int ndim, double radius)
+  : ASpace(ndim)
+  , _radius(radius)
 {
   if (ndim != 2)
   my_throw("SN is only implemented for ndim=2 (sphere)");
@@ -42,10 +42,10 @@ SpaceSN::~SpaceSN()
 {
 }
 
-String SpaceSN::_toString(const AStringFormat* strfmt, int idx) const
+String SpaceSN::toString(const AStringFormat* strfmt, int idx) const
 {
   std::stringstream sstr;
-  sstr << ASpace::_toString(strfmt, idx);
+  sstr << ASpace::toString(strfmt, idx);
   if (strfmt == nullptr || strfmt->getLevel() == 1)
   {
     if (idx < 0)
@@ -60,9 +60,9 @@ String SpaceSN::_toString(const AStringFormat* strfmt, int idx) const
   return sstr.str();
 }
 
-bool SpaceSN::_isEqual(const ASpace *space) const
+bool SpaceSN::isEqual(const ASpace *space) const
 {
-  if (!ASpace::_isEqual(space)) return false;
+  if (!ASpace::isEqual(space)) return false;
   const SpaceSN* s = dynamic_cast<const SpaceSN*>(space);
   return s != nullptr && _radius == s->_radius;
 }
@@ -70,47 +70,49 @@ bool SpaceSN::_isEqual(const ASpace *space) const
 void SpaceSN::_move(SpacePoint &p1, const VectorDouble &vec) const
 {
   /// TODO : SpaceSN::_move
-  for (unsigned int i = _iDimOffset; i < _nDim + _iDimOffset; i++)
+  unsigned int offset = getOffset();
+  unsigned int ndim   = getNDim();
+  for (unsigned int i = offset; i < ndim + offset; i++)
   {
     p1.setCoord(i, p1.getCoord(i) + vec[i]);
   }
 }
 
-double SpaceSN::_getDistance(const SpacePoint &p1, 
-                             const SpacePoint &p2) const
+double SpaceSN::_getDistance(const SpacePoint& p1,
+                             const SpacePoint& p2,
+                             int ispace) const
 {
-  return GH::geodeticAngularDistance(p1.getCoord(_iDimOffset),
-                                     p1.getCoord(_iDimOffset + 1),
-                                     p2.getCoord(_iDimOffset),
-                                     p2.getCoord(_iDimOffset + 1),
+  DECLARE_UNUSED(ispace)
+  unsigned int offset = getOffset();
+  return GH::geodeticAngularDistance(p1.getCoord(offset),
+                                     p1.getCoord(offset + 1),
+                                     p2.getCoord(offset),
+                                     p2.getCoord(offset + 1),
                                      _radius);
 }
 
 double SpaceSN::_getDistance(const SpacePoint& p1,
                              const SpacePoint& p2,
-                             const Tensor& tensor) const
+                             const Tensor& tensor,
+                             int ispace) const
 {
+  DECLARE_UNUSED(ispace)
   /// TODO : SpaceSN::_getDistance with tensor
   DECLARE_UNUSED(tensor);
-  return GH::geodeticAngularDistance(p1.getCoord(_iDimOffset),
-                                     p1.getCoord(_iDimOffset + 1),
-                                     p2.getCoord(_iDimOffset),
-                                     p2.getCoord(_iDimOffset + 1), 
+  unsigned int offset = getOffset();
+  return GH::geodeticAngularDistance(p1.getCoord(offset),
+                                     p1.getCoord(offset + 1),
+                                     p2.getCoord(offset),
+                                     p2.getCoord(offset + 1), 
                                      _radius);
-}
-
-double SpaceSN::_getDistance1D(double c1, double c2) const
-{
-  /// TODO : SpaceSN::_getDistance1D
-  DECLARE_UNUSED(c1);
-  DECLARE_UNUSED(c2);
-  return 0;
 }
 
 double SpaceSN::_getFrequentialDistance(const SpacePoint& p1,
                                         const SpacePoint& p2,
-                                        const Tensor& tensor) const
+                                        const Tensor& tensor,
+                                        int ispace) const
 {
+  DECLARE_UNUSED(ispace)
   /// TODO : SpaceSN::_getFrequentialDistance
   DECLARE_UNUSED(p1);
   DECLARE_UNUSED(p2);
@@ -118,20 +120,25 @@ double SpaceSN::_getFrequentialDistance(const SpacePoint& p1,
   return 0.;
 }
 
-VectorDouble SpaceSN::_getIncrement(const SpacePoint &p1,
-                                    const SpacePoint &p2) const
+VectorDouble SpaceSN::_getIncrement(const SpacePoint& p1,
+                                    const SpacePoint& p2,
+                                    int ispace) const
 {
+  DECLARE_UNUSED(ispace)
   _getIncrementInPlace(p1, p2, _work1);
   return _work1;
 }
 
-/// Return the increment vector between two space points in a given vector
-void SpaceSN::_getIncrementInPlace(const SpacePoint &p1,
-                                   const SpacePoint &p2,
-                                   VectorDouble &ptemp) const
+void SpaceSN::_getIncrementInPlace(const SpacePoint& p1,
+                                   const SpacePoint& p2,
+                                   VectorDouble& ptemp,
+                                   int ispace) const
 {
+  DECLARE_UNUSED(ispace)
   /// TODO : SpaceSN::_getIncrementInPlace
   int j = 0;
-  for (unsigned int i = _iDimOffset; i < _nDim + _iDimOffset; i++)
+  unsigned int offset = getOffset();
+  unsigned int ndim   = getNDim();
+  for (unsigned int i = offset; i < ndim + offset; i++)
     ptemp[j++] = p2.getCoord(i) - p1.getCoord(i);
 }

--- a/src/all_sources.cmake
+++ b/src/all_sources.cmake
@@ -193,6 +193,7 @@ set(SRC
   Space/SpaceTarget.cpp
   Space/ASpaceObject.cpp
   Space/ASpace.cpp
+  Space/SpaceComposite.cpp
   Spatial/Projection.cpp
   Spatial/SpatialIndices.cpp
   Variogram/AVario.cpp

--- a/swig/swig_exp.i
+++ b/swig/swig_exp.i
@@ -133,6 +133,7 @@
 %include Boolean/ModelBoolean.hpp
 
 %include Space/ASpace.hpp
+%include Space/SpaceComposite.hpp
 %include Space/ASpaceObject.hpp
 %include Space/SpacePoint.hpp
 %include Space/SpaceTarget.hpp

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -105,6 +105,7 @@
   #include "Boolean/ModelBoolean.hpp"
   
   #include "Space/ASpace.hpp"
+  #include "Space/SpaceComposite.hpp"
   #include "Space/ASpaceObject.hpp"
   #include "Space/SpacePoint.hpp"
   #include "Space/SpaceTarget.hpp"

--- a/tests/cpp/output/test_Space.ref
+++ b/tests/cpp/output/test_Space.ref
@@ -1,16 +1,19 @@
+Space Type      = COMPOSITE
+Space Dimension = 3
+Space Type      [0] = RN
+Space Dimension [0] = 2
 Space Type      [1] = RN
-Space Dimension [1] = 2
-Space Type      [2] = RN
-Space Dimension [2] = 1
-RN(2) + RN(1)
+Space Dimension [1] = 1
+COMPOSITE(3): RN(2) + RN(1)
+
 Global dimension: 3
 Dimension space #0: 2
 Dimension space #1: 1
 Global distances: [4.272 5]
+
 Distance space #0: 4.272
 Distance space #1: 5
-Increments space #0: [-1.5 -4 0]
+Increments space #0: [-1.5 -4]
+
 Increments space #1: [5]
-Distance dim#0: -1.5
-Distance dim#1: -4
-Distance dim#2: 5
+

--- a/tests/cpp/test_Gneiting.cpp
+++ b/tests/cpp/test_Gneiting.cpp
@@ -12,8 +12,6 @@
 #include "Covariances/CovAniso.hpp"
 #include "Covariances/CovGneiting.hpp"
 #include "Db/Db.hpp"
-#include "Db/DbGrid.hpp"
-#include "Db/DbHelper.hpp"
 #include "Model/Model.hpp"
 #include "Space/ASpaceObject.hpp"
 #include "Space/SpacePoint.hpp"

--- a/tests/cpp/test_Space.cpp
+++ b/tests/cpp/test_Space.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Basic/File.hpp"
 #include "Space/ASpaceObject.hpp"
-#include "Space/ASpace.hpp"
+#include "Space/SpaceComposite.hpp"
+#include "Space/SpaceRN.hpp"
 #include "Space/SpacePoint.hpp"
 #include <iostream>
 
@@ -23,14 +24,16 @@ int main(int argc, char *argv[])
   sfn << gslBaseName(__FILE__) << ".out";
   StdoutRedirect sr(sfn.str(), argc, argv);
 
-  defineDefaultSpace(ESpaceType::RN, 2, 0., true); // 2D RN space with time
-  const auto* sp = getDefaultSpace();
+  // 2D Space + Time (for example)
+  SpaceComposite sp({new SpaceRN(2), new SpaceRN(1)});
+  defineDefaultSpace(&sp);
 
-  sp->display();
-  sp->display(0);
+  const ASpace* psp = getDefaultSpace();
+  psp->display();  // Long description (level 1)
+  psp->display(0); // Short description (level 0)
 
-  SpacePoint pt1({4.5, 6.5, 10},-1);
-  SpacePoint pt2({3.0, 2.5, 15},-1);
+  SpacePoint pt1({4.5, 6.5, 10});
+  SpacePoint pt2({3.0, 2.5, 15});
 
   std::cout << "Global dimension: " << pt1.getNDim() << std::endl;
   std::cout << "Dimension space #0: " << pt1.getNDim(0) << std::endl;
@@ -45,10 +48,6 @@ int main(int argc, char *argv[])
 
   std::cout << "Increments space #0: " << pt1.getIncrement(pt2, 0).toString() << std::endl;
   std::cout << "Increments space #1: " << pt1.getIncrement(pt2, 1).toString() << std::endl;
-
-  std::cout << "Distance dim#0: " << pt1.getDistance1D(pt2, 0) << std::endl;
-  std::cout << "Distance dim#1: " << pt1.getDistance1D(pt2, 1) << std::endl;
-  std::cout << "Distance dim#2: " << pt1.getDistance1D(pt2, 2) << std::endl;
 
   return 0;
 }

--- a/tests/cpp/test_Space.cpp
+++ b/tests/cpp/test_Space.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 
   // 2D Space + Time (for example)
   SpaceComposite sp({new SpaceRN(2), new SpaceRN(1)});
-  defineDefaultSpace(&sp);
+  setDefaultSpace(&sp);
 
   const ASpace* psp = getDefaultSpace();
   psp->display();  // Long description (level 1)

--- a/tests/py/output/test_Gneiting.ref
+++ b/tests/py/output/test_Gneiting.ref
@@ -1,10 +1,10 @@
 Gneiting eval 0.02067599923072759
 Displaying the first two coordinates (spatial) of the first space point
-    12.000     3.000     1.000
+    12.000     3.000
 Displaying the last coordinate (temporal) of the first space point
      1.000
 Displaying the first two coordinates (spatial) of the second space point
-     4.000     5.000     2.000
+     4.000     5.000
 Displaying the last coordinate (temporal) of the second space point
      2.000
 Difference for temporal covariance 0.0


### PR DESCRIPTION
This fixes the non-reg on MacOs.
SpaceComposit class must be used for the definition of space having multiple components (ex: RN(2) + RN(1)  <=>  2D space + time)