### PR TITLE
GitHub Actions: Update publish workflows to be compatible with C++20

### DIFF
--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -41,8 +41,8 @@ jobs:
             {py: "3.11"},
             {py: "3.12"}
           ]
-        # Only one old Linux and a generic platform name BUILD_PLAT
-        os: [ubuntu-20.04]
+        # Only one "old"" Linux and a generic platform name BUILD_PLAT
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -35,8 +35,8 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         # Only last version of R for Linux (fake source package)
         r_version: [4.4.1]
-        # Only one old Linux
-        os: [ubuntu-20.04]
+        # Only one "old" Linux
+        os: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -106,4 +106,4 @@ jobs:
     # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
-        name: ubuntu-r-package-${{matrix.os}}-r-${{matrix.r_version}}
+        name: ubuntu-r-package-*

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -35,7 +35,7 @@ env:
 jobs:
 
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
@@ -74,6 +74,7 @@ jobs:
       uses: fabien-ors/install-swig-windows-action@v2
       with:
         swig-root: ${{env.SWIG_ROOT}}
+        generator: "Visual Studio 17 2022"
 
     - name : Configure build directory
       run : |


### PR DESCRIPTION
This PR updates the Ubuntu & Windows `publish` workflows to switch to more recent versions of said OSes.
Namely, Ubuntu 20.04 is updated to 22.04 and Windows 2019 to 2022.

Note that Ubuntu 20.04 and Windows 2019 are still in use in the `coverage` workflows. Depending on the availability of the C++20 features inside the C++ standard library, we may need to upgrade them too.

Note 2: the macOS 12 jobs of the `publish` workflows seem to take a quite large amount of time (more than 2h) t. Warning messages show that macOS 12 is not supported anymore by brew. As a consequence, LLVM is built from source instead of downloading binaries.

Pierre