### PR TITLE
Reduce allocations around MeshETurbo, Grid & Rotation

### DIFF
--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -77,10 +77,12 @@ public:
   VectorDouble getCellCoordinatesByCorner(int node,
                                           const VectorInt& shift = VectorInt(),
                                           const VectorDouble& dxsPerCell = VectorDouble()) const;
+#ifndef SWIG
   double indiceToCoordinate(int idim0,
-                            const VectorInt& indice,
-                            const VectorDouble& percent = VectorDouble(),
-                            bool flag_rotate=true) const;
+                            const constvectint indice,
+                            const constvect percent = {},
+                            bool flag_rotate        = true) const;
+#endif // SWIG
   VectorDouble indicesToCoordinate(const VectorInt& indice,
                                    const VectorDouble& percent = VectorDouble()) const;
   void indicesToCoordinateInPlace(const VectorInt& indice,
@@ -95,8 +97,10 @@ public:
   void rankToCoordinatesInPlace(int rank,
                                 VectorDouble& coor,
                                 const VectorDouble& percent = VectorDouble()) const;
-  int     indiceToRank(const VectorInt& indice) const;
-  void    rankToIndice(int rank,VectorInt& indices, bool minusOne = false) const;
+#ifndef SWIG
+  int     indiceToRank(const constvectint indice) const;
+  void    rankToIndice(int rank, vectint indices, bool minusOne = false) const;
+#endif // SWIG
   VectorInt coordinateToIndices(const VectorDouble &coor,
                                 bool centered = false,
                                 double eps = EPSILON6) const;
@@ -179,5 +183,5 @@ private:
   // Some working vectors, defined in order to avoid too many allocations
   mutable VectorInt    _iwork0;
   mutable VectorDouble _work1;
-  mutable VectorDouble _work2;
+  mutable std::vector<double> _work2;
 };

--- a/include/Geometry/Rotation.hpp
+++ b/include/Geometry/Rotation.hpp
@@ -42,6 +42,10 @@ public:
   void setIdentity();
   void rotateDirect(const VectorDouble& inv, VectorDouble& outv) const;
   void rotateInverse(const VectorDouble& inv, VectorDouble& outv) const;
+#ifndef SWIG
+  void rotateDirect(const std::vector<double>& inv, std::vector<double>& outv) const;
+  void rotateInverse(const std::vector<double>& inv, std::vector<double>& outv) const;
+#endif // SWIG
   bool isIdentity() const { return !_flagRot; }
   bool isSame(const Rotation& rot) const;
 

--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -118,12 +118,12 @@ public:
 private:
   int  _defineGrid(const VectorDouble& cellsize);
   void _setNumberElementPerCell();
-  int  _getPolarized(const VectorInt &indg) const;
+  int  _getPolarized(const constvectint indg) const;
   int  _addWeights(int icas,
-                   const VectorInt &indg0,
-                   const VectorDouble &coor,
-                   VectorInt &indices,
-                   VectorDouble &lambda,
+                   const constvectint indg0,
+                   const constvect coor,
+                   const vectint indices,
+                   const vect lambda,
                    bool verbose = false) const;
   void _deallocate();
   void _getGridFromMesh(int imesh, int *node, int *icas) const;

--- a/include/geoslib_define.h
+++ b/include/geoslib_define.h
@@ -87,6 +87,8 @@ DISABLE_WARNING_BASE_NOT_EXPORTED_FROM_DLL
 
 typedef std::span<const double> constvect;
 typedef std::span<double> vect ;
+using constvectint = std::span<const int>;
+using vectint = std::span<int>;
 
 #endif
 

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -447,8 +447,8 @@ VectorDouble Grid::getCoordinatesByRank(int rank, bool flag_rotate) const
 }
 
 double Grid::indiceToCoordinate(int idim0,
-                                const VectorInt& indice,
-                                const VectorDouble& percent,
+                                const constvectint indice,
+                                const constvect percent,
                                 bool flag_rotate) const
 {
   /* Calculate the coordinates in the grid system */
@@ -526,7 +526,7 @@ void Grid::rankToCoordinatesInPlace(int rank, VectorDouble& coor, const VectorDo
   return indicesToCoordinateInPlace(_iwork0, coor, percent);
 }
 
-int Grid::indiceToRank(const VectorInt& indice) const
+int Grid::indiceToRank(const constvectint indice) const
 {
   int ival = indice[_nDim-1];
   if (ival < 0 || ival >= _nx[_nDim-1]) return(-1);
@@ -548,12 +548,11 @@ int Grid::indiceToRank(const VectorInt& indice) const
  * \remarks: The number of nodes in the grid per direction
  * \remarks: must be adapted (subtracting 1) due to interval.
  */
-void Grid::rankToIndice(int rank, VectorInt& indices, bool minusOne) const
+void Grid::rankToIndice(int rank, vectint indices, bool minusOne) const
 {
   int minus = (minusOne) ? 1 : 0;
 
   const int* nxadd = _nx.data(); // for optimization, use address rather than []
-  int* indadd      = indices.data();
   int nval         = 1;
   for (int idim = 0; idim < _nDim; idim++)
     nval *= (*(nxadd + idim) - minus);
@@ -563,7 +562,7 @@ void Grid::rankToIndice(int rank, VectorInt& indices, bool minusOne) const
   {
     nval /= (*(nxadd + idim) - minus);
     newind           = rank / nval;
-    *(indadd + idim) = newind;
+    indices[idim] = newind;
     rank -= newind * nval;
   }
 }

--- a/src/Basic/Rotation.cpp
+++ b/src/Basic/Rotation.cpp
@@ -139,6 +139,11 @@ String Rotation::toString(const AStringFormat* strfmt) const
 
 void Rotation::rotateDirect(const VectorDouble& inv, VectorDouble& outv) const
 {
+  this->rotateDirect(inv.getVector(), outv.getVector());
+}
+
+void Rotation::rotateDirect(const std::vector<double>& inv, std::vector<double>& outv) const
+{
   if (!_flagRot)
     outv = inv;
   else
@@ -146,6 +151,11 @@ void Rotation::rotateDirect(const VectorDouble& inv, VectorDouble& outv) const
 }
 
 void Rotation::rotateInverse(const VectorDouble& inv, VectorDouble& outv) const
+{
+  this->rotateInverse(inv.getVector(), outv.getVector());
+}
+
+void Rotation::rotateInverse(const std::vector<double>& inv, std::vector<double>& outv) const
 {
   if (!_flagRot)
     outv = inv;

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -673,3 +673,21 @@
     SWIG_exception_fail(SWIG_ArgError(errcode), "in method $symname, wrong return value: $type");
 }
 
+%extend Grid {
+  double indiceToCoordinate(int idim0, const VectorInt& indice,
+                            const VectorDouble& percent = {},
+                            bool flag_rotate            = true) const
+  {
+    return $self->indiceToCoordinate(idim0, indice.getVector(), percent.getVector(), flag_rotate);
+  }
+
+  int indiceToRank(const VectorInt &indice) const
+  {
+    return $self->indiceToRank(indice.getVector());
+  }
+
+  void rankToIndice(int rank, VectorInt &indices, bool minusOne = false) const
+  {
+    return $self->rankToIndice(rank, indices.getVector(), minusOne);
+  }
+};


### PR DESCRIPTION
Following #287, this PR reduces the number of allocations shown by [heaptrack](https://github.com/KDE/heaptrack) when running `test_SPDEAPI`.

Several techiques were used:
- replacing or complementing methods taking `VectorInt &` or `VectorDouble &` by corresponding methods taking `std::span<int>` or `vect`,
- replacing `VectorDouble` local variables or class members with `std::vector<double>`,
- using global `std::vector` variables to reuse storage,
- using Swig's `%extend` to make sure the correct `Grid` methods are used in the C++ code but not in the wrappers.

This table shows the evolution of `heaptrack`'s metrics on `test_SPDEAPI`:

| Metric            | Before | After |
|-------------------|-------:|------:|
| Exec time (s)     | 12     | 8     |
| #Allocations      | 26M    | 12M   |
| #Temp allocations | 3.1M   | 3.0M  |
| Memory cons (MB)  | 82     | 82    |

There's still a lot of allocations remaining, especially around matrices. Some will be hard to remove (those pertaining to Eigen), others less so (`VectorDouble`). I'll try to work on the latter.

Pierre