### PR TITLE
Avoid #include<span>, prefer vect/constvect typedef

### DIFF
--- a/include/Matrix/AMatrixDense.hpp
+++ b/include/Matrix/AMatrixDense.hpp
@@ -15,7 +15,6 @@
 
 #include "Matrix/AMatrix.hpp"
 #include "Basic/WarningMacro.hpp"
-#include <span>
 
 #ifndef SWIG
 DISABLE_WARNING_PUSH
@@ -102,7 +101,7 @@ public:
   virtual VectorDouble getRow(int irow) const override;
   /*! Extract a Column */
   virtual VectorDouble getColumn(int icol) const override;
-  std::span<const double> getColumnPtr(int icol) const;
+  constvect getColumnPtr(int icol) const;
   /*! Multiply matrix 'x' by matrix 'y' and store the result in 'this' */
   virtual void prodMatMatInPlace(const AMatrix *x,
                                  const AMatrix *y,

--- a/src/Basic/AStringable.cpp
+++ b/src/Basic/AStringable.cpp
@@ -14,7 +14,6 @@
 #include "Basic/Utilities.hpp"
 #include "Basic/OptCst.hpp"
 
-#include <span>
 #include <iostream>
 #include <sstream>
 #include <typeinfo>

--- a/src/Matrix/AMatrixDense.cpp
+++ b/src/Matrix/AMatrixDense.cpp
@@ -93,11 +93,11 @@ double AMatrixDense::_getValueByRank(int irank) const
   return *(_eigenMatrix.data() + irank);
 }
 
-std::span<const double> AMatrixDense::getColumnPtr(int icol) const
+constvect AMatrixDense::getColumnPtr(int icol) const
 {
   const auto a = _eigenMatrix.col(icol);
-  int n = getNRows();
-  return std::span<const double>(a.data(),n);
+  size_t n = getNRows();
+  return {a.data(), n};
 }
 void AMatrixDense::_setValueByRank(int irank, double value)
 {


### PR DESCRIPTION
This PR removes a few `#include <span>` that were outside of `geoslib_define.h` and also replaces explicit `std::span<const double>` with `constvect`.

This increases consistency and helps users that want to switch to another `span` implementation.

Pierre