### PR TITLE
CMake: Install headers in include/gstlearn/gstlearn directory

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -25,6 +25,7 @@ endif()
 target_include_directories(shared PUBLIC
   # Installed includes are made PUBLIC for client who links the shared library
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}/${PROJECT_NAME}>"
 )
 
 # Install the shared library
@@ -39,18 +40,18 @@ install(
 # Install the includes
 install(
   DIRECTORY   ${INCLUDES}
-  DESTINATION include/${PROJECT_NAME}
+  DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}
 )
 
 # Install the export header file
 install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_export.hpp
-        DESTINATION include/${PROJECT_NAME}
+        DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}
 )
 
 # Install the version header file
 install(
   FILES ${PROJECT_BINARY_DIR}/version.h
-  DESTINATION include/${PROJECT_NAME}
+  DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}
 )
 
 # Install doxygen html directories (optional)


### PR DESCRIPTION
This PR modifies the installation directory of gstlearn's header files from `$prefix/include/gstlearn` to `$prefix/include/gstlearn/gstlearn`. This way, users of gstlearn's C++ API will be able do, for instance, `#include <gstlearn/Basic/Grid.hpp>` instead of / in addition to `#include <Basic/Grid.hpp>`, which might be confusing since there is no mention of gstlearn.

Since gstlearn's headers contain gstlearn includes that don't follow the `#include <gstlearn/...>` scheme, the `INSTALL_INTERFACE` should be adapted to also include the `$prefix/include/gstlearn/gstlearn` directory. Otherwise gstlearn headers won't be able to find each other.

Fix #319.

Enjoy,
Pierre