### PR TITLE
Fix noisy MSVC warning in Eigen headers

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # https://cmake.org/cmake/help/latest/command/add_compile_options.html
 if (MSVC)
   # Warning level 4 (4 = maximum, 0 = none)
-  add_compile_options(/bigobj /W4 /wd4251 /wd4244) # Except those two warnings
+  add_compile_options(/bigobj /W4 /wd4251 /wd4244 /wd4127) # Except those two warnings
   # Silence MSVC warnings about unsafe C standard library functions
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()


### PR DESCRIPTION
This PR makes MSVC ignore the C4127 warning (https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127?view=msvc-170) because it can be noisy with Eigen.

Fix #327.

Pierre