### PR TITLE
GitHub Actions: Update publish/coverage workflows with latest macOS, Python

### DIFF
--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -17,12 +17,10 @@ jobs:
     strategy:
       matrix:
         # Double quote for version is needed otherwise 3.10 => 3.1
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # See the list here: https://github.com/actions/runner-images#available-images
         os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-13, macos-14]
         exclude:
-          - os: macos-14
-            python: "3.8"
           - os: macos-14
             python: "3.9"
           

--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -19,9 +19,11 @@ jobs:
         # Double quote for version is needed otherwise 3.10 => 3.1
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-13, macos-14]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-13, macos-14, macos-15]
         exclude:
           - os: macos-14
+            python: "3.9"
+          - os: macos-15
             python: "3.9"
           
     steps:

--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -19,13 +19,11 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-14]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-13, macos-14, macos-15]
         exclude:
-          - os: macos-12
-            r_version: 4.3.3
-          - os: macos-12
-            r_version: 4.4.1
           - os: macos-14
+            r_version: 4.0.5
+          - os: macos-15
             r_version: 4.0.5
           - os: windows-2022
             r_version: 4.0.5

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -37,19 +37,17 @@ jobs:
         # Python version + Numpy version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8"},
             {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
-            {py: "3.12"}
+            {py: "3.12"},
+            {py: "3.13"}
           ]
         arch: [
             {ar: x86_64, os: macos-12, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew}
           ]
         exclude:
-          - arch: {os: macos-14}
-            python: {py: "3.8"}
           - arch: {os: macos-14}
             python: {py: "3.9"}
 

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -44,11 +44,14 @@ jobs:
             {py: "3.13"}
           ]
         arch: [
-            {ar: x86_64, os: macos-12, pat: /usr/local},
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew}
+            {ar: x86_64, os: macos-13, pat: /usr/local},
+            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
           ]
         exclude:
           - arch: {os: macos-14}
+            python: {py: "3.9"}
+          - arch: {os: macos-15}
             python: {py: "3.9"}
 
     steps:

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -35,11 +35,11 @@ jobs:
         # Python version + Numpy version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8"},
             {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
-            {py: "3.12"}
+            {py: "3.12"},
+            {py: "3.13"}
           ]
         # Only one "old"" Linux and a generic platform name BUILD_PLAT
         os: [ubuntu-22.04]

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -41,11 +41,11 @@ jobs:
         # Python version + Numpy version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.8"},
             {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
-            {py: "3.12"}
+            {py: "3.12"},
+            {py: "3.13"}
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -35,15 +35,14 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
         arch: [
-            {ar: x86_64, os: macos-12, pat: /usr/local},
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew}
+            {ar: x86_64, os: macos-13, pat: /usr/local},
+            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
          ]
         exclude:
-          - arch: {os: macos-12}
-            r_version: 4.3.3
-          - arch: {os: macos-12}
-            r_version: 4.4.1
           - arch: {os: macos-14}
+            r_version: 4.0.5
+          - arch: {os: macos-15}
             r_version: 4.0.5
 
     steps:


### PR DESCRIPTION
This PR updates the `publish` and `coverage` GitHub Actions workflows by:
- adding macOS 13 (x86) and macOS 15 (arm64),
- adding Python 3.13,
- retiring macOS 12 (x86) and
- retiring Python 3.8.

Enjoy,
Pierre