### PR TITLE
GitHub Actions: Add test jobs to publish workflows

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -121,8 +121,57 @@ jobs:
         name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: ${{matrix.arch.os}}
+    strategy:
+      matrix:
+        python: [
+        # Double quote for version is needed otherwise 3.10 => 3.1
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"},
+            {py: "3.13"}
+          ]
+        arch: [
+            {ar: x86_64, os: macos-13},
+            {ar: arm64,  os: macos-14},
+            {ar: arm64,  os: macos-15}
+          ]
+        exclude:
+          - arch: {os: macos-14}
+            python: {py: "3.9"}
+          - arch: {os: macos-15}
+            python: {py: "3.9"}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
+
+    - name: Setup Python Version
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python.py}}
+
+    - name: Install macOS dependencies
+      run: brew install llvm
+
+    - name: Install gstlearn Python package
+      run: pip install ./$(ls *.whl)
+
+    - name: Test installed Python package
+      run: |
+        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload via ssh

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -96,8 +96,45 @@ jobs:
         name: ubuntu-python-package-${{matrix.os}}-${{matrix.python.py}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        python: [
+        # Double quote for version is needed otherwise 3.10 => 3.1
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"},
+            {py: "3.13"}
+          ]
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ubuntu-python-package-${{matrix.os}}-${{matrix.python.py}}
+
+    - name: Setup Python Version
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python.py}}
+
+    - name: Install gstlearn Python package
+      run: pip install ./$(ls *.whl)
+
+    - name: Test installed Python package
+      run: |
+        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload via ssh

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -124,8 +124,48 @@ jobs:
         name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        python: [
+        # Double quote for version is needed otherwise 3.10 => 3.1
+            {py: "3.9"},
+            {py: "3.10"},
+            {py: "3.11"},
+            {py: "3.12"},
+            {py: "3.13"}
+          ]
+        arch: [
+            {pl: win_amd64, ar: x64, of: x64},
+            # GitHub's VM don't run on x86
+          ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
+
+    - name: Setup Python Version
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python.py}}
+
+    - name: Install gstlearn Python package
+      run: pip install $(ls *.whl)
+
+    - name: Test installed Python package
+      run: |
+        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload via ssh

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -95,8 +95,51 @@ jobs:
         name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: ${{matrix.arch.os}}
+    strategy:
+      matrix:
+        # Last releases from here https://cran.r-project.org/src/base/R-4/
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        arch: [
+            {ar: x86_64, os: macos-13, pat: /usr/local},
+            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+         ]
+        exclude:
+          - arch: {os: macos-14}
+            r_version: 4.0.5
+          - arch: {os: macos-15}
+            r_version: 4.0.5
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}
+
+    - name: Setup R Version
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{matrix.r_version}}
+
+    - name: Install macOS dependencies
+      run: brew install llvm
+
+    - name: Install gstlearn R package
+      run: Rscript -e "install.packages(\"$(ls *.tgz)\", repos=NULL, type='source')"
+
+    - name: Test installed R package
+      run: |
+        Rscript -e "library('gstlearn'); acknowledge_gstlearn()"
+        Rscript tests/r/test_Arguments.R
+        Rscript tests/r/test_Assessors.R
+        Rscript tests/r/test_Matrix.R
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload via ssh
@@ -114,4 +157,3 @@ jobs:
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: macos-r-package-*
-

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -85,11 +85,43 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ubuntu-r-package-${{matrix.os}}-r-${{matrix.r_version}}
+        name: ubuntu-r-package-${{matrix.os}}-${{matrix.r_version}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        # Last releases from here https://cran.r-project.org/src/base/R-4/
+        r_version: [4.4.1]
+        # Only one "old" Linux
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ubuntu-r-package-${{matrix.os}}-${{matrix.r_version}}
+
+    - name: Setup R Version
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{matrix.r_version}}
+
+    - name: Install gstlearn R package
+      run: Rscript -e "install.packages(\"$(ls *.tar.gz)\", repos=NULL, type='source')"
+
+    - name: Test installed R package
+      run: |
+        Rscript -e "library('gstlearn'); acknowledge_gstlearn()"
+        Rscript tests/r/test_Arguments.R
+        Rscript tests/r/test_Assessors.R
+        Rscript tests/r/test_Matrix.R
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload to CRAN easily (ssh)

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -98,8 +98,39 @@ jobs:
         name: windows-r-package-${{matrix.r_version}}
         path: ${{env.MY_PKG}}
 
-  publish:
+  test:
     needs: build
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        # Last releases from here https://cran.r-project.org/src/base/R-4/
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: windows-r-package-${{matrix.r_version}}
+
+    - name: Setup R Version
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{matrix.r_version}}
+
+    - name: Install gstlearn R package
+      run: Rscript -e "install.packages(""'""./$(ls *.zip)""'"", repos=NULL, type='source')"
+      shell: bash
+
+    - name: Test installed R package
+      run: |
+        Rscript -e "library('gstlearn'); acknowledge_gstlearn()"
+        Rscript tests/r/test_Arguments.R
+        Rscript tests/r/test_Assessors.R
+        Rscript tests/r/test_Matrix.R
+
+  publish:
+    needs: test
     if: ${{inputs.dry_publish == false}}
 
     # Only ubuntu can upload to CRAN easily (ssh)


### PR DESCRIPTION
This PR adds `test` jobs to the `publish-r` and `publish-python` workflows. These test jobs do some basic testing on the packages generated by the `build` jobs before they are uploaded to `pypi` or `CRAN`. 

In fact, these are copies of the `coverage` workflows that have been put here to prevent faulty jobs to be uploaded.

Doing so in separate jobs makes testing independent on the build environment and thus helps detecting missing dependencies in gstlearn packages.

Corresponding workflow run: https://github.com/pierre-guillou/gstlearn/actions/runs/11608521333

Enjoy,
Pierre