### PR TITLE
GitHub Actions: Bring back Ubuntu 20.04 in publish workflows

### DIFF
--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
             {py: "3.13"}
           ]
         # Only one "old"" Linux and a generic platform name BUILD_PLAT
-        os: [ubuntu-22.04]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v4
@@ -77,6 +77,9 @@ jobs:
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
           -DBUILD_DOXYGEN=ON
+      env:
+        CC: gcc-10
+        CXX: g++-10
 
     - name : Build the package
       run : |
@@ -109,7 +112,7 @@ jobs:
             {py: "3.12"},
             {py: "3.13"}
           ]
-        os: [ubuntu-22.04]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -36,7 +36,7 @@ jobs:
         # Only last version of R for Linux (fake source package)
         r_version: [4.4.1]
         # Only one "old" Linux
-        os: [ubuntu-22.04]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v4
@@ -77,6 +77,9 @@ jobs:
           -DBUILD_R=ON \
           -DBUILD_DOXYGEN=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
+      env:
+        CC: gcc-10
+        CXX: g++-10
 
     - name : Build the package and save generated file name in the environment
       run : |
@@ -96,7 +99,7 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.4.1]
         # Only one "old" Linux
-        os: [ubuntu-22.04]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR brings back Ubuntu 20.04 in the `publish_python_ubuntu` and `publish_r_ubuntu` GitHub Actions workflows.

Since GCC 9, Ubuntu 20's default compiler, does not include `std::span`, GCC 10 is used instead.

Ubuntu 22's compiler is left unchanged.

Corresponding `publish_python_ubuntu` run: https://github.com/pierre-guillou/gstlearn/actions/runs/11667192637
Corresponding `publish_r_ubuntu` run:  https://github.com/pierre-guillou/gstlearn/actions/runs/11667194439

Pierre 