### PR TITLE
Schur for dual

### DIFF
--- a/3rd-party/csparse/csparse_f.h
+++ b/3rd-party/csparse/csparse_f.h
@@ -36,6 +36,7 @@ Website: https://gstlearn.org
 #ifndef _CS_F_H
 #define _CS_F_H
 
+#include <cstdio>
 #include <stdlib.h>
 #include <stddef.h>
 #include "csparse_d.h"

--- a/include/LinearOp/ShiftOpCs.hpp
+++ b/include/LinearOp/ShiftOpCs.hpp
@@ -149,7 +149,7 @@ class GSTLEARN_EXPORT ShiftOpCs:
     void _buildLambda(const AMesh* amesh);
     bool _buildLambdaGrad(const AMesh* amesh);
 
-    void _loadAux(VectorDouble & tab, const EConsElem& type, int imesh = 0);
+    static void _loadAux(VectorDouble & tab, const EConsElem& type, int imesh = 0);
     void _loadHH(const AMesh* amesh, MatrixSquareSymmetric& hh, int imesh = 0);
     void _loadHHRegular(MatrixSquareSymmetric & hh, int imesh);
     void _loadHHVariety(MatrixSquareSymmetric & hh, int imesh);

--- a/include/Matrix/MatrixRectangular.hpp
+++ b/include/Matrix/MatrixRectangular.hpp
@@ -53,8 +53,8 @@ public:
   static MatrixRectangular* sample(const AMatrix* A,
                                    const VectorInt& rowKeep = VectorInt(),
                                    const VectorInt& colKeep = VectorInt(),
-                                   bool flagInvertRow = false,
-                                   bool flagInvertCol = false);
+                                   bool flagInvertRow       = false,
+                                   bool flagInvertCol       = false);
   void unsample(const AMatrix* A,
                 const VectorInt& rowFetch,
                 const VectorInt& colFetch,

--- a/src/Estimation/KrigingCalcul.cpp
+++ b/src/Estimation/KrigingCalcul.cpp
@@ -820,29 +820,25 @@ int KrigingCalcul::_patchColCokVarianceZstar(MatrixSquareSymmetric *varZK)
   if (_needLambda0()) return 1;
   if (_needSigma0p()) return 1;
   if (_needSigma00pp()) return 1;
-  MatrixSquareSymmetric* L0tCL0 = new MatrixSquareSymmetric(_nrhs);
-  L0tCL0->prodNormMatMatInPlace(_Lambda0, _Sigma00pp, true);
+  MatrixSquareSymmetric L0tCL0(_nrhs);
+  L0tCL0.prodNormMatMatInPlace(_Lambda0, _Sigma00pp, true);
 
-  MatrixRectangular* p2 = new MatrixRectangular(_nrhs, _ncck);
-  p2->prodMatMatInPlace(_Lambda0, _Sigma0p, true, true);
-  MatrixSquareSymmetric* L0tCLK = new MatrixSquareSymmetric(_nrhs);
+  MatrixRectangular p2(_nrhs, _ncck);
+  p2.prodMatMatInPlace(_Lambda0, _Sigma0p, true, true);
+  MatrixSquareSymmetric L0tCLK(_nrhs);
 
   if (_flagSK)
   {
     if (_needLambdaSK()) return 1;
-    L0tCLK->prodMatMatInPlace(p2, _LambdaSK);
+    L0tCLK.prodMatMatInPlace(&p2, _LambdaSK);
   }
   else
   {
     if (_needLambdaUK()) return 1;
-    L0tCLK->prodMatMatInPlace(p2, _LambdaUK);
+    L0tCLK.prodMatMatInPlace(&p2, _LambdaUK);
   }
-  delete p2;
 
-  varZK->linearCombination(1., varZK, 2., L0tCLK, 1., L0tCL0);
-  delete L0tCL0;
-  delete L0tCLK;
-
+  varZK->linearCombination(1., varZK, 2., &L0tCLK, 1., &L0tCL0);
   return 0;
 }
 
@@ -880,7 +876,6 @@ int KrigingCalcul::_needStdv()
 {
   if (_Stdv != nullptr) return 0;
   if (_needSigma00()) return 1;
-
   _Stdv = new MatrixSquareSymmetric(_nrhs);
 
   if (_flagSK)
@@ -894,21 +889,18 @@ int KrigingCalcul::_needStdv()
     if (_needSigma0()) return 1;
     if (_needMuUK()) return 1;
     _Stdv                 = _Sigma00->clone();
-    MatrixRectangular* p1 = new MatrixRectangular(_nrhs, _nrhs);
-    p1->prodMatMatInPlace(_LambdaUK, _Sigma0, true);
-    MatrixRectangular* p2 = new MatrixRectangular(_nrhs, _nrhs);
-    p2->prodMatMatInPlace(_MuUK, _X0, true, true);
-    _Stdv->linearCombination(1, _Stdv, -1., p1, +1., p2);
-    delete p1;
-    delete p2;
+    MatrixRectangular p1(_nrhs, _nrhs);
+    p1.prodMatMatInPlace(_LambdaUK, _Sigma0, true);
+    MatrixRectangular p2(_nrhs, _nrhs);
+    p2.prodMatMatInPlace(_MuUK, _X0, true, true);
+    _Stdv->linearCombination(1, _Stdv, -1., &p1, +1., &p2);
 
     if (_ncck > 0)
     {
       if (_needSigma00p()) return 1;
-      MatrixSquareSymmetric* p1 = new MatrixSquareSymmetric(_nrhs);
-      p1->prodMatMatInPlace(_Sigma00p, _Lambda0, true);
-      _Stdv->linearCombination(1., _Stdv, -1., p1);
-      delete p1;
+      MatrixSquareSymmetric p1(_nrhs);
+      p1.prodMatMatInPlace(_Sigma00p, _Lambda0, true);
+      _Stdv->linearCombination(1., _Stdv, -1., &p1);
     }
   }
 
@@ -1063,12 +1055,11 @@ int KrigingCalcul::_needY0()
   if (_needX0()) return 1;
   if (_needInvSigmaSigma0()) return 1;
 
-  MatrixRectangular* LambdaSKtX = new MatrixRectangular(_nrhs, _nbfl);
-  LambdaSKtX->prodMatMatInPlace(_InvSigmaSigma0, _X, true, false);
+  MatrixRectangular LambdaSKtX(_nrhs, _nbfl);
+  LambdaSKtX.prodMatMatInPlace(_InvSigmaSigma0, _X, true, false);
 
   _Y0 = new MatrixRectangular(_nrhs, _nbfl);
-  _Y0->linearCombination(1., _X0, -1., LambdaSKtX);
-  delete LambdaSKtX;
+  _Y0->linearCombination(1., _X0, -1., &LambdaSKtX);
   return 0;
 }
 
@@ -1099,12 +1090,11 @@ int KrigingCalcul::_needMuUK()
     if (_needY0p()) return 1;
     if (_needLambda0()) return 1;
 
-    MatrixRectangular* LtY = new MatrixRectangular(_nrhs, _nbfl);
-    LtY->prodMatMatInPlace(_Lambda0, _Y0p, true);
-    LtY->linearCombination(1., _Y0, -1., LtY);
+    MatrixRectangular LtY(_nrhs, _nbfl);
+    LtY.prodMatMatInPlace(_Lambda0, _Y0p, true);
+    LtY.linearCombination(1., _Y0, -1., &LtY);
 
-    _MuUK->prodMatMatInPlace(_Sigmac, LtY, false, true);
-    delete LtY;
+    _MuUK->prodMatMatInPlace(_Sigmac, &LtY, false, true);
   }
   else
   {
@@ -1145,8 +1135,8 @@ int KrigingCalcul::_patchRHSForXvalidUnique()
   InvAlpha->invert();
 
   // Calculate a1 term
-  MatrixSquareSymmetric* omega = new MatrixSquareSymmetric(_nxvalid);
-  omega->linearCombination(1., S00, -1., InvAlpha);
+  MatrixSquareSymmetric omega(_nxvalid);
+  omega.linearCombination(1., S00, -1., InvAlpha);
 
   if (_nbfl > 0)
   {
@@ -1167,35 +1157,29 @@ int KrigingCalcul::_patchRHSForXvalidUnique()
       MatrixRectangular::sample(_X, *_rankXvalidEqs, VectorInt(), true);
 
     // Compute epsilon (up to its sign); inv(alpha) * beta
-    AMatrix* p1                = MatrixFactory::prodMatMat(InvAlpha, beta);
-    MatrixRectangular* epsilon = new MatrixRectangular(_nxvalid, _nbfl);
-    epsilon->prodMatMatInPlace(p1, X);
+    AMatrix* p1               = MatrixFactory::prodMatMat(InvAlpha, beta);
+    MatrixRectangular epsilon(_nxvalid, _nbfl);
+    epsilon.prodMatMatInPlace(p1, X);
     delete p1;
     
     // Compute a3 (transpose)
-    MatrixRectangular* a3 = new MatrixRectangular(_nxvalid, _nbfl);
-    a3->linearCombination(1., X0, 1., epsilon);
-    delete X0;
+    MatrixRectangular a3(_nxvalid, _nbfl);
+    a3.linearCombination(1., X0, 1., &epsilon);
 
     // Compute a2 (inverted)
-    MatrixSquareSymmetric* a2 = new MatrixSquareSymmetric(_nbfl);
-    a2->prodNormMatMatInPlace(X, delta, true);
-    MatrixSquareSymmetric* p3 = new MatrixSquareSymmetric(_nbfl);
-    p3->prodNormMatMatInPlace(epsilon, alpha, true);
-    a2->linearCombination(1., a2, -1., p3);
-    a2->invert();
+    MatrixSquareSymmetric a2(_nbfl);
+    a2.prodNormMatMatInPlace(X, delta, true);
+    MatrixSquareSymmetric p3(_nbfl);
+    p3.prodNormMatMatInPlace(&epsilon, alpha, true);
+    a2.linearCombination(1., &a2, -1., &p3);
+    a2.invert();
     delete delta;
-    delete epsilon;
-    delete p3;
     delete X;
 
     // Compute omega
-    MatrixSquareSymmetric* p4    = new MatrixSquareSymmetric(_nxvalid);
-    p4->prodNormMatMatInPlace(a3, a2);
-    omega->linearCombination(1., omega, -1., p4);
-    delete p4;
-    delete a2;
-    delete a3;
+    MatrixSquareSymmetric p4(_nxvalid);
+    p4.prodNormMatMatInPlace(&a3, &a2);
+    omega.linearCombination(1., &omega, -1., &p4);
 
     // Patch the Right-hand side vector (Drift part)
     _X_RHS = MatrixRectangular::sample(_X, *_rankXvalidEqs, VectorInt());
@@ -1203,13 +1187,12 @@ int KrigingCalcul::_patchRHSForXvalidUnique()
 
   // Patch the Right-hand side vector (Covariance part)
   _C_RHS = MatrixRectangular::sample(_Sigma, VectorInt(), *_rankXvalidEqs, false, false);
-  _C_RHS->unsample(omega, *_rankXvalidEqs, VectorInt());
+  _C_RHS->unsample(&omega, *_rankXvalidEqs, VectorInt());
 
   setRHS(_C_RHS, _X_RHS);
 
   setVar(S00->clone());
   delete alpha;
-  delete omega;
 
   return 0;
 }
@@ -1261,12 +1244,11 @@ int KrigingCalcul::_needLambdaSK()
     if (_needSigma0p()) return 1;
     if (_needLambda0()) return 1;
 
-    MatrixRectangular* S = new MatrixRectangular(_neq, _nrhs);
-    S->prodMatMatInPlace(_Sigma0p, _Lambda0);
-    S->linearCombination(1., _Sigma0, -1., S);
+    MatrixRectangular S(_neq, _nrhs);
+    S.prodMatMatInPlace(_Sigma0p, _Lambda0);
+    S.linearCombination(1., _Sigma0, -1., &S);
     _LambdaSK = new MatrixRectangular(_neq, _nrhs);
-    _LambdaSK->prodMatMatInPlace(_InvSigma, S);
-    delete S;
+    _LambdaSK->prodMatMatInPlace(_InvSigma, &S);
   }
   else
   {
@@ -1285,10 +1267,9 @@ int KrigingCalcul::_needLambdaUK()
   if (_needLambdaSK()) return 1;
   if (_needMuUK()) return 1;
 
-  MatrixRectangular* p1 = new MatrixRectangular(_neq, _nrhs);
-  p1->prodMatMatInPlace(_XtInvSigma, _MuUK, true, false);
-  _LambdaUK->linearCombination(1., _LambdaSK, 1., p1);
-  delete p1;
+  MatrixRectangular p1(_neq, _nrhs);
+  p1.prodMatMatInPlace(_XtInvSigma, _MuUK, true, false);
+  _LambdaUK->linearCombination(1., _LambdaSK, 1., &p1);
 
   return 0;
 }
@@ -1431,62 +1412,55 @@ int KrigingCalcul::_needLambda0()
     if (_needY0()) return 1;
   }
 
-  MatrixRectangular* Sigma0ptInvSigma = new MatrixRectangular(_ncck, _neq);
-  Sigma0ptInvSigma->prodMatMatInPlace(_Sigma0p, _InvSigma, true);
+  MatrixRectangular Sigma0ptInvSigma(_ncck, _neq);
+  Sigma0ptInvSigma.prodMatMatInPlace(_Sigma0p, _InvSigma, true);
 
   // Determine the Bottom part of the ratio
   MatrixSquareSymmetric* bot = _Sigma00pp->clone();
   
-  MatrixSquareSymmetric* bot1 = new MatrixSquareSymmetric(_ncck);
-  bot1->prodMatMatInPlace(Sigma0ptInvSigma, _Sigma0p);
+  MatrixSquareSymmetric bot1(_ncck);
+  bot1.prodMatMatInPlace(&Sigma0ptInvSigma, _Sigma0p);
 
-  MatrixRectangular* Y0pSigmac = nullptr;
+  MatrixRectangular Y0pSigmac;
   if (_nbfl > 0)
   {
-    Y0pSigmac = new MatrixRectangular(_ncck, _nbfl);
-    Y0pSigmac->prodMatMatInPlace(_Y0p, _Sigmac);
+    Y0pSigmac = MatrixRectangular(_ncck, _nbfl);
+    Y0pSigmac.prodMatMatInPlace(_Y0p, _Sigmac);
   }
   
-  MatrixSquareSymmetric* bot2 = nullptr;
+  MatrixSquareSymmetric bot2;
   if (_nbfl > 0)
   {
-    bot2 = new MatrixSquareSymmetric(_ncck);
-    bot2->prodMatMatInPlace(Y0pSigmac, _Y0p, false, true);
+    bot2 = MatrixSquareSymmetric(_ncck);
+    bot2.prodMatMatInPlace(&Y0pSigmac, _Y0p, false, true);
   }
-  bot->linearCombination(1., bot, -1., bot1, +1., bot2);
-  delete bot1;
-  delete bot2;
+  bot->linearCombination(1., bot, -1., &bot1, +1., &bot2);
 
   if (bot->invert())
   {
     delete bot;
-    delete Sigma0ptInvSigma;
     return 1;
   }
 
   // Determine the Top part of the ratio
   MatrixRectangular* top = _Sigma00p->clone();
   
-  MatrixRectangular* top1 = new MatrixRectangular(_ncck, _nrhs);
-  top1->prodMatMatInPlace(Sigma0ptInvSigma, _Sigma0);
+  MatrixRectangular top1(_ncck, _nrhs);
+  top1.prodMatMatInPlace(&Sigma0ptInvSigma, _Sigma0);
 
-  MatrixRectangular* top2 = nullptr;
+  MatrixRectangular top2;
   if (_nbfl > 0)
   {
-    top2 = new MatrixRectangular(_ncck, _nrhs);
-    top2->prodMatMatInPlace(Y0pSigmac, _Y0, false, true);
+    top2 = MatrixRectangular(_ncck, _nrhs);
+    top2.prodMatMatInPlace(&Y0pSigmac, _Y0, false, true);
   }
-  top->linearCombination(1., top, -1., top1, +1., top2);
-  delete top1;
-  delete top2;
+  top->linearCombination(1., top, -1., &top1, +1., &top2);
 
   _Lambda0 = new MatrixRectangular(_ncck, _nrhs);
   _Lambda0->prodMatMatInPlace(bot, top);
 
   delete bot;
   delete top;
-  delete Sigma0ptInvSigma;
-  delete Y0pSigmac;
 
   return 0;
   }

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -157,7 +157,6 @@ int PrecisionOp::_addToDest(const constvect inv, vect outv) const
 {
     _addEvalPower(inv, outv, EPowerPT::ONE);
     return 0;
-
 }
 
 int PrecisionOp::_addSimulateToDest(const constvect whitenoise, vect outv) const
@@ -321,18 +320,19 @@ void PrecisionOp::_addEvalPower(const constvect inv,
 {
   const constvect* inPtr = &inv;
   if (_work.size() == 0) _work.resize(getSize());
-  vect worksp(_work); 
+  vect worksp(_work);
+  
   // Pre-processing
 
   if (power == EPowerPT::ONE || power == EPowerPT::MINUSONE)
   {
-    _shiftOp->prodLambda(inv, worksp,power);
+    _shiftOp->prodLambda(inv, worksp, power);
     inPtr = (constvect*)&worksp;
   }
 
   // Polynomial evaluation
 
-  if (_evalPoly(power,*inPtr,outv) != 0)
+  if (_evalPoly(power, *inPtr, outv) != 0)
     my_throw("Computation in 'eval' interrupted due to problem in '_evalPoly'");
 
   // Post-processing
@@ -353,7 +353,7 @@ int PrecisionOp::_evalPoly(const EPowerPT& power,
 {
   constvect invs(inv);
   if (_preparePoly(power) != 0) return 1;
-  if(getTraining())
+  if (getTraining())
   {
     int degree = _polynomials[power]->getDegree();
 
@@ -372,7 +372,7 @@ int PrecisionOp::_evalPoly(const EPowerPT& power,
                                                                 invs,_workPoly,
                                                                 _work5);
 
-    for(int i=0;i<(int)inv.size();i++)
+    for (int i = 0; i < (int)inv.size(); i++)
     {
       outv[i] = _workPoly[0][i];
     }
@@ -380,7 +380,7 @@ int PrecisionOp::_evalPoly(const EPowerPT& power,
   else
   {
     vect outvs(outv);
-    _polynomials[power]->evalOp(_shiftOp->getS(),invs,outvs);
+    _polynomials[power]->evalOp(_shiftOp->getS(), invs, outvs);
   }
   return 0;
 }

--- a/src/Matrix/MatrixRectangular.cpp
+++ b/src/Matrix/MatrixRectangular.cpp
@@ -168,7 +168,7 @@ void MatrixRectangular::addColumn(int ncolumn_added)
  * @param colKeep  Set of Columns to be kept (all if not defined)
  * @param flagInvertRow when True, transform 'rowKeep' into 'rowDrop'
  * @param flagInvertCol when True, transform 'colKeep' into 'colDrop'
- * @return Pointer to the newly created Rectangular Matrix
+ * @return Newly created Rectangular Matrix
  */
 MatrixRectangular* MatrixRectangular::sample(const AMatrix* A,
                                              const VectorInt& rowKeep,

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -11,7 +11,7 @@
 #include "Polynomials/ClassicalPolynomial.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "LinearOp/ALinearOp.hpp"
-#include "LinearOp/ShiftOpCs.hpp"
+#include "Matrix/MatrixSparse.hpp"
 #include "geoslib_define.h"
 
 ClassicalPolynomial::ClassicalPolynomial()
@@ -137,7 +137,8 @@ void ClassicalPolynomial::evalOp(MatrixSparse* Op,
   for (int i = 0; i < n; i++)
     outv[i] = _coeffs.back() * inv[i];
 
-  for (int j = static_cast<int>(_coeffs.size()) - 2; j >= 0; j--)
+  int degree = (int) _coeffs.size();
+  for (int j = degree - 2; j >= 0; j--)
   {
     Op->prodMatVecInPlace(outv, ws);
     for (int i = 0; i < n; i++)

--- a/tests/cpp/output/test_Schur.ref
+++ b/tests/cpp/output/test_Schur.ref
@@ -1,6 +1,6 @@
 
-Checking Bayes option
-=====================
+Bayes option
+============
 Compare:
 - Kriging with traditional code
 - Estimation performed with 'KrigingCalcul'
@@ -11,52 +11,144 @@ Data Base Characteristics
 
 Data Base Contents
 ------------------
-                 rank       x-1       x-2       z-1       z-2
-     [  0,]     1.000     0.652     0.015     0.753    -0.454
-     [  1,]     2.000     0.483     0.557    -0.774    -0.872
-     [  2,]     3.000     0.762     0.433     0.793     0.744
+                 rank       x-1       x-2       z-1       z-2       z-3
+     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
+     [  1,]     2.000     0.483     0.557    -0.774    -0.872     0.080
+     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
 
 Using Standard Kriging procedure
 --------------------------------
 
 Bayesian Drift coefficients
 ===========================
-Prior Mean       0.353     -0.127
+Prior Mean      -0.504     -1.222      0.290
 Prior Variance-Covariance
-                  [,1]       [,2]
-       [1,]      0.187      0.000
-       [2,]      0.000      0.433
-Posterior Mean       1.080     -1.050
+                  [,1]       [,2]       [,3]
+       [1,]      0.223      0.000      0.000
+       [2,]      0.000      0.173      0.000
+       [3,]      0.000      0.000      0.213
+Posterior Mean      -0.269     -0.191      0.364
 Posterior Variance-Covariance
-                  [,1]       [,2]
-       [1,]      0.516     -0.503
-       [2,]     -0.503      0.646
-Bayes.z-1.estim      0.198
-Bayes.z-2.estim      0.074
-Bayes.z-1.stdev      0.981
-Bayes.z-2.stdev      1.130
+                  [,1]       [,2]       [,3]
+       [1,]     -0.005      0.003     -0.005
+       [2,]      0.003     -0.003     -0.004
+       [3,]     -0.005     -0.004     -0.009
+Bayes.z-1.estim      0.184
+Bayes.z-2.estim      0.082
+Bayes.z-3.estim      0.195
+Bayes.z-1.stdev      1.028
+Bayes.z-2.stdev      0.883
+Bayes.z-3.stdev      1.114
 
 Using Schur class
 -----------------
 Prior Mean
-     0.353    -0.127
+    -0.504    -1.222     0.290
 Prior Variance-Covariance Matrix
-- Number of rows    = 2
-- Number of columns = 2
-               [,  0]    [,  1]
-     [  0,]     0.187     0.000
-     [  1,]     0.000     0.433
+- Number of rows    = 3
+- Number of columns = 3
+               [,  0]    [,  1]    [,  2]
+     [  0,]     0.223     0.000     0.000
+     [  1,]     0.000     0.173     0.000
+     [  2,]     0.000     0.000     0.213
 Posterior Mean
-     0.299    -0.279
+     0.289    -0.444    -0.294
 Posterior Variance-Covariance Matrix
-- Number of rows    = 2
-- Number of columns = 2
-               [,  0]    [,  1]
-     [  0,]     0.154    -0.075
-     [  1,]    -0.075     0.192
+- Number of rows    = 3
+- Number of columns = 3
+               [,  0]    [,  1]    [,  2]
+     [  0,]     0.138    -0.074     0.056
+     [  1,]    -0.074     0.095     0.055
+     [  2,]     0.056     0.055     0.164
 Kriging Value(s)
-     0.190     0.081
+     0.190     0.080     0.189
 Standard Deviation of Estimation Error
-     0.981     0.794
+     1.028     0.885     1.118
 Variance of Estimator
-     3.748     2.457
+     4.113     3.049     4.864
+
+Collocated Option (in Unique Neighborhood):
+===========================================
+- using 'KrigingCalcul' on the Complemented Data Set
+- using 'KrigingCalcul' on Standard Data Set adding Collocated Option
+- Collocated Variable ranks:         0         2
+
+Data Base Characteristics
+=========================
+
+Data Base Contents
+------------------
+                 rank       x-1       x-2       z-1       z-2       z-3
+     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
+     [  1,]     2.000     0.483     0.557    -0.774    -0.872     0.080
+     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
+     [  3,]       N/A     0.652     0.483     0.438       N/A     0.186
+
+With Complemented input Data Base
+---------------------------------
+Kriging Value(s)
+     0.438    -0.121     0.186
+Standard Deviation of Estimation Error
+     0.000     0.040     0.000
+Variance of Estimator
+     5.167     3.830     6.110
+
+With Collocated Option
+----------------------
+Kriging Value(s)
+     0.438    -0.121     0.186
+Standard Deviation of Estimation Error
+     0.000     0.040     0.000
+Variance of Estimator
+     5.167     3.830     6.110
+
+Cross-Validation (in Unique Neighborhood)
+=========================================
+Compare the Cross-validation Option (in Unique Neighborhood):
+- using Standard Kriging on the Deplemented Data Set
+- using 'KrigingCalcul' on Initial Set with Cross-validation option
+
+Data Base Characteristics
+=========================
+
+Data Base Contents
+------------------
+                 rank       x-1       x-2       z-1       z-2       z-3
+     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
+     [  1,]     2.000     0.483     0.557    -0.774       N/A       N/A
+     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
+
+With Deplemented input Data Base
+--------------------------------
+Kriging Value(s)
+    -0.774     1.311    -0.536
+Standard Deviation of Estimation Error
+     0.000     1.150     1.858
+Variance of Estimator
+     5.167     3.442     5.096
+
+With Cross-Validation Option
+----------------------------
+Kriging Value(s)
+     1.311    -0.536
+Standard Deviation of Estimation Error
+     1.150     1.858
+Variance of Estimator
+     3.442     5.096
+
+Estimation using Dual option or not (in Unique Neighborhood):
+=============================================================
+
+Without Dual option
+-------------------
+Kriging Value(s)
+     0.189     0.081     0.190
+Standard Deviation of Estimation Error
+     1.028     0.885     1.118
+Variance of Estimator
+     4.180     3.099     4.943
+
+With Dual Option (only Estimation is available)
+-----------------------------------------------
+Kriging Value(s)
+     0.189     0.081     0.190


### PR DESCRIPTION
This PR is meant to terminate the definition of the KrigingCalcul class.
As a recall, this class is able to handle any Kriging configuration, i.e.:
- any number of variables (i.e. Kriging or Cokriging)
- Simple, Ordinary or Universal Kriging
and handle special cases such as:
- Bayesian hypothesis on drift coefficients (note that the Bayesian hypothesis on the Covariance parameters is not handled)
- Cross-validation: given a fixed set of data (Unique Neighborhood), there is a special trick for deriving the Cross-validation (using the k-fold option [leaving more than one point out]) while saving lots of calculations
- Collocated Cokriging: given a fixed set of data (Unique Neighborhood), and knowing the values of one of several variables at the Target point, there is a special trick for performing the estimation of the remaining variables at this target. Note that the collocated option has never been implemented in previous in-house software!
- Dual writing: given a fixed set of data (Unique Neighborhood), a trick enables calculating the estimation (for one or several variables) in a quicker way using the Dual writing

All these options are tested in a CPP test names test_Schur.
