### PR TITLE
Add dependency to NLopt

### DIFF
--- a/.github/actions/nlopt_static_unix/action.yml
+++ b/.github/actions/nlopt_static_unix/action.yml
@@ -1,0 +1,24 @@
+name: 'NLopt static Unix'
+description: 'Build & install NLopt static libraries on Ubuntu & macOS'
+runs:
+  using: "composite"
+  steps:
+
+    - name: Build & install nlopt static libraries
+      shell: bash
+      run: |
+        wget https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz
+        tar xvfz v2.7.1.tar.gz
+        cd nlopt-2.7.1
+        mkdir build && cd build
+        cmake \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DNLOPT_GUILE=OFF \
+          -DNLOPT_MATLAB=OFF \
+          -DNLOPT_OCTAVE=OFF \
+          -DNLOPT_PYTHON=OFF \
+          -DNLOPT_SWIG=OFF \
+          -DNLOPT_TESTS=OFF \
+          ..
+        cmake --build . --parallel 3
+        sudo cmake --build . --target install

--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -86,6 +86,7 @@ jobs:
           libopenmpi-dev \
           libboost-system-dev \
           libeigen3-dev \
+          libnlopt-dev \
           libomp-dev \
           clang-tools
 
@@ -131,6 +132,7 @@ jobs:
           libopenmpi-dev \
           libboost-system-dev \
           libeigen3-dev \
+          libnlopt-dev \
           libomp-dev \
           clang-tools \
           clang-tidy \

--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -40,6 +40,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libnlopt-dev \
           libpng-dev \
           pandoc
 

--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -41,6 +41,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libnlopt-dev \
           libpng-dev \
           pandoc
 

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -37,6 +37,7 @@ jobs:
         brew install llvm
         brew install boost
         brew install eigen
+        brew install nlopt
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -40,7 +40,8 @@ jobs:
           libhdf5-dev \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -54,6 +54,7 @@ jobs:
         conda install -c conda-forge boost
         conda install -c conda-forge eigen
         conda install -c conda-forge ninja
+        conda install -c conda-forge nlopt
         # don't interfere with pre-installed Python
         rm C:\Miniconda\python.exe
 

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo '{
-          "dependencies": [ "boost-math", "eigen3" ],
+          "dependencies": [ "boost-math", "eigen3", "nlopt" ],
           "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
         }' > vcpkg.json
         vcpkg install

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -38,7 +38,8 @@ jobs:
         sudo apt-get install -yq \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -48,7 +48,8 @@ jobs:
           libhdf5-dev \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/publish_data.yml
+++ b/.github/workflows/publish_data.yml
@@ -42,7 +42,8 @@ jobs:
         sudo apt-get install -yq \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Get project version
       id: main_step

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -49,7 +49,8 @@ jobs:
           libsuitesparse-dev \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -43,7 +43,8 @@ jobs:
           doxygen \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -75,6 +75,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install numpy twine build
 
+    - name: Build & install NLopt static libraries
+      uses: ./.github/actions/nlopt_static_unix
+
 #    - name : Download and install HDF5
 #      run : |
 #        mkdir ${{env.HDF5_ROOT}}

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install swig
-        brew install doxygen
+        brew install --formula doxygen
         brew install llvm
         brew install boost
         brew install eigen

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -70,6 +70,9 @@ jobs:
         python -m pip install numpy
         python -m pip install build
 
+    - name: Build & install NLopt static libraries
+      uses: ./.github/actions/nlopt_static_unix
+
     - name : Configure build directory
       run : |
         cmake \

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -29,6 +29,7 @@ env:
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+  VCPKG_LIBRARY_LINKAGE: static
   #HDF5_ROOT : hdf5 #do not use "." in the name
   #HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1-zip/?wpdmdl=15723"
   #HDF5_VERSION : hdf5-1.12.1
@@ -64,7 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo '{
-          "dependencies": [ "boost-math", "eigen3" ],
+          "dependencies": [ "boost-math", "eigen3", "nlopt" ],
           "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
         }' > vcpkg.json
         vcpkg install

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name : Install dependencies
       run: |
-        brew install doxygen
+        brew install --formula doxygen
         brew install llvm
         brew install boost
         brew install eigen

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -72,6 +72,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name: Build & install NLopt static libraries
+      uses: ./.github/actions/nlopt_static_unix
+
     - name : Configure build directory
       run : |
         cmake \

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -69,6 +69,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Unix Makefiles"
 
+    - name: Build & install NLopt static libraries
+      uses: ./.github/actions/nlopt_static_unix
+
     - name : Configure build directory
       run : |
         cmake \

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -31,6 +31,7 @@ env:
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+  VCPKG_LIBRARY_LINKAGE: static
 
 jobs:
 
@@ -60,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo '{
-          "dependencies": [ "boost-math", "eigen3" ],
+          "dependencies": [ "boost-math", "eigen3", "nlopt" ],
           "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
         }' > vcpkg.json
         vcpkg install

--- a/.github/workflows/publish_references.yml
+++ b/.github/workflows/publish_references.yml
@@ -43,7 +43,8 @@ jobs:
         sudo apt-get install -yq \
           libopenmpi-dev \
           libboost-dev \
-          libeigen3-dev
+          libeigen3-dev \
+          libnlopt-dev
 
     - name: Get project version
       id: main_step

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ endif
 ifdef BOOST_ROOT
   CMAKE_DEFINES := $(CMAKE_DEFINES) -DBoost_ROOT=$(BOOST_ROOT)
 endif
+ifdef NLOPT_ROOT
+  CMAKE_DEFINES := $(CMAKE_DEFINES) -DNLopt_ROOT=$(NLOPT_ROOT)
+endif
 
 .PHONY: all cmake cmake-python cmake-r cmake-python-r cmake-doxygen print_version static shared build_tests doxygen install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@
 #  - TEST=<test-target> Name of the test target to be launched (e.g. test_Model_py or test_simTub)
 #  - EIGEN3_ROOT=<path> Path to Eigen3 library (optional)
 #  - BOOST_ROOT=<path>  Path to Boost library (optional)
+#  - NLOPT_ROOT=<path>  Path to NLopt library (optional)
 #  - LLVM_ROOT=<path>   Path to llvm compiler for MacOS only (optional)
 #  - SWIG_EXEC=<path>   Path to swig executable (optional)
 #

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ sudo apt install doxygen
 sudo apt install libboost-all-dev
 sudo apt install libeigen3-dev
 sudo apt install libhdf5-dev
+sudo apt install libnlopt-dev
 ```
 
 #### MacOS
@@ -214,6 +215,7 @@ brew install doxygen
 brew install libboost-all-dev
 brew install libeigen3-dev
 brew install libhdf5-dev
+brew install nlopt
 ```
 
 Define environment variables for the appropriate clang compiler (adapt llvm installation path):
@@ -246,6 +248,7 @@ Download and install the following tools using default options during installati
 6. Doxygen (optional) [from here](https://www.doxygen.nl/download.html) (*Binary distribution* [setup.exe] - remind the installation folder, we assume it is `C:\Program Files\doxygen`)
 7. LaTeX and Ghostscripts following instructions [here](https://www.doxygen.nl/manual/install.html#install_bin_windows)
 8. Eigen3 library [from here](https://eigen.tuxfamily.org) (Clone the repository in a folder of your choice and follow the instructions below)
+9. NLopt library [from here](https://nlopt.readthedocs.io/en/latest/) (Clone the repository in a folder of your choice and follow the instructions below)
 
 ##### Install Eigen3 headers using CMake
 
@@ -256,6 +259,18 @@ cd C:\Eigen_src\eigen
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=C:/eigen_3_4_0
+cmake --build . --target install
+```
+
+##### Install NLopt using CMake
+
+Assume that you have cloned the [NLopt GitHub repository](https://github.com/stevengj/nlopt) in the following folder: `C:\NLopt_src\nlopt`. Open a command prompt by running `cmd.exe` and execute the following commands (adapt the Eigen source code path in the first command and the Eigen version in the INSTALL_PREFIX below):
+
+```
+cd C:\NLopt_src\nlopt
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=C:/NLopt
 cmake --build . --target install
 ```
 
@@ -319,6 +334,7 @@ pacman -Sy mingw-w64-x86_64-hdf5
 pacman -Sy mingw-w64-x86_64-texlive-latex-recommended
 pacman -Sy mingw-w64-x86_64-texlive-science
 pacman -Sy mingw-w64-x86_64-doxygen
+pacman -Sy mingw-w64-x86_64-nlopt
 ````
 
 ### Important Notes

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For **compiling and installing** *gstlearn* C++ library, the following tools mus
     * R users: MinGW 7 (RTools 4.2) or higher
 * Boost header files 1.65 or higher
 * Eigen3 header files 3.4 or higher
+* NLopt library 2.7 or higher
 * Doxygen [Optional] 1.8.3 or higher with LaTeX and Ghostscripts
 * HDF5 [Optional] C++ library and header files 1.8 or higher
 
@@ -264,7 +265,7 @@ cmake --build . --target install
 
 ##### Install NLopt using CMake
 
-Assume that you have cloned the [NLopt GitHub repository](https://github.com/stevengj/nlopt) in the following folder: `C:\NLopt_src\nlopt`. Open a command prompt by running `cmd.exe` and execute the following commands (adapt the Eigen source code path in the first command and the Eigen version in the INSTALL_PREFIX below):
+Assume that you have cloned the [NLopt GitHub repository](https://github.com/stevengj/nlopt) in the following folder: `C:\NLopt_src\nlopt`. Open a command prompt by running `cmd.exe` and execute the following commands (adapt the NLopt source code path in the first command and the NLopt version in the INSTALL_PREFIX below):
 
 ```
 cd C:\NLopt_src\nlopt
@@ -350,11 +351,12 @@ pacman -Sy mingw-w64-x86_64-nlopt
 * Using MinGW on a Windows where another compiler is also installed may need to add `-G "MSYS Makefiles"` in the first cmake command above.
 * Using Visual Studio on a Windows where another compiler is also installed may need to add `-G "Visual Studio 16 2019"` in the first command (adapt version).
 * If you want to build and install the *Debug* version, you must replace `Release` by `Debug` above. If you use the shortcut Makefile, you can use `DEBUG=1` after the `make` command
-* You may need to precise the location of Boost, Eigen3, HDF5 or Doxygen installation directory. In that case, add the following variables in the first cmake command above:
+* You may need to precise the location of Boost, Eigen3, HDF5, Doxygen or NLopt installation directory. In that case, add the following variables in the first cmake command above:
    * `-DBoost_ROOT="path/to/boost"`
    * `-DEigen3_ROOT="path/to/eigen3"`
    * `-DHDF5_ROOT="path/to/hdf5"`
    * `-DDoxygen_ROOT="path/to/doxygen"`
+   * `-DNLopt_ROOT="path/to/nlopt"`
 
 ### Uninstall the Library
 
@@ -431,6 +433,7 @@ The *gstlearn* C++ library also depends on the following third-party libraries (
 | Boost          | see licenses   | https://www.boost.org                                          | see Boost headers
 | Eigen3         | MPL2           | https://eigen.tuxfamily.org                                    | see Eigen headers
 | HDF5           | see licenses   | https://www.hdfgroup.org                                       | Copyright 2006 by The HDF Group
+| NLopt          | see licenses   | https://nlopt.readthedocs.io/en/latest/                        | see NLopt headers
 
 
 ### Data files

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -92,6 +92,14 @@ if(Eigen3_FOUND)
     message(STATUS "Found Eigen3 version ${Eigen3_VERSION} in ${Eigen3_DIR}")
 endif()
 
+# Look for NLOPT
+find_package(NLopt REQUIRED)
+if (NLopt_FOUND)
+    message(STATUS "Found NLopt ${NLOPT_VERSION} from ${NLOPT_CONFIG_FILE}")
+else()
+    message(FATAL_ERROR "NLopt not found")
+endif()
+
 # Look for HDF5
 if (USE_HDF5)
   # Use static library for HDF5 under Windows (no more issue with DLL location)
@@ -157,6 +165,9 @@ foreach(FLAVOR ${FLAVORS})
   # Target for header-only dependencies. (Boost include directory)
   target_link_libraries(${FLAVOR} PRIVATE Boost::boost)
   
+  # Link to NLopt
+  target_link_libraries(${FLAVOR} PUBLIC NLopt::nlopt)
+
   # Link to HDF5
   if (USE_HDF5)
     # Define _USE_HDF5 macro

--- a/doc/licenses/nlopt_license.txt
+++ b/doc/licenses/nlopt_license.txt
@@ -1,0 +1,39 @@
+NLopt combines several free/open-source nonlinear optimization
+libraries by various authors.  See the COPYING, COPYRIGHT, and README
+files in the subdirectories for the original copyright and licensing
+information of these packages.
+
+The compiled NLopt library, i.e. the combined work of all of the
+included optimization routines, is licensed under the conjunction of
+all of these licensing terms. By default, the most restrictive terms
+are for the code in the "luksan" directory, which is licensed under
+the GNU Lesser General Public License (GNU LGPL), version 2.1 or
+later (see luksan/COPYRIGHT). That means that, by default, the compiled
+NLopt library is governed by the terms of the LGPL.
+
+---------------------------------------------------------------------------
+
+However, NLopt also offers the option to be built without the code in
+the "luksan" directory. In this case, NLopt, including any modifications
+to the abovementioned packages, are licensed under the standard "MIT License:"
+
+Copyright (c) 2007-2024 Massachusetts Institute of Technology
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/python/README.md
+++ b/python/README.md
@@ -264,12 +264,13 @@ cmake --build build --target check_ipynb --config Release
 * Using Visual Studio on a Windows where MinGW is also installed may need to add `-G "Visual Studio 16 2019"` in the first command (adapt version).
 * The Windows C++ Compiler used must be the same that the one used for compiling Python (Visual C++). Using another compiler than Visual C++ is not supported.
 * If you want to build and install the *Debug* version, you must replace `Release` by `Debug` above
-* You may need to precise the location of Boost, Eigen3, SWIG, Doxygen or HDF5 installation directory. In that case, add the following variables in the first cmake command above:
+* You may need to precise the location of Boost, Eigen3, SWIG, Doxygen, HDF5 or NLopt installation directory. In that case, add the following variables in the first cmake command above:
   * `-DBoost_ROOT="path/to/boost"`
   * `-DEigen3_ROOT="path/to/eigen3"`
   * `-DSWIG_ROOT="path/to/swig"`
   * `-DDoxygen_ROOT="path/to/doxygen"`
   * `-DHDF5_ROOT="path/to/hdf5"`
+  * `-DNLopt_ROOT="path/to/nlopt"`
 
 
 ### Remove Installed Package

--- a/r/README.md
+++ b/r/README.md
@@ -285,12 +285,13 @@ make check_r
 * Under Windows, using RTools is mandatory for compiling R packages
 * Under Windows, you may need to add `-G "MSYS Makefiles"` to the first cmake command above
 * If you want to build and install the *Debug* version, you must replace `Release` by `Debug` above
-* You may need to precise the location of Boost, Eigen3, SWIG, Doxygen or HDF5 installation directory. In that case, add the following variables in the first cmake command above:
+* You may need to precise the location of Boost, Eigen3, SWIG, Doxygen, HDF5 or NLopt installation directory. In that case, add the following variables in the first cmake command above:
   * `-DBoost_ROOT="path/to/boost"`
   * `-DEigen3_ROOT="path/to/eigen3"`
   * `-DSWIG_ROOT="path/to/swig"`
   * `-DDoxygen_ROOT="path/to/doxygen"`
-  * `-DHDF5_ROOT="path/to/hdf5"``
+  * `-DHDF5_ROOT="path/to/hdf5"`
+  * `-DNLopt_ROOT="path/to/nlopt"`
 
 ### Remove Installed Package
 

--- a/tests/cpp/output/test_nlopt.ref
+++ b/tests/cpp/output/test_nlopt.ref
@@ -1,0 +1,3 @@
+End optimization
+x = 3 5
+Minimum value of the objective 0

--- a/tests/cpp/test_nlopt.cpp
+++ b/tests/cpp/test_nlopt.cpp
@@ -1,0 +1,67 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+
+/**
+ * This test aims to test the use of the nlopt library for optimization.
+ * Only a quadratic function is minimized in this example.
+ */
+#include <iostream>
+#include "Basic/File.hpp"
+#include "geoslib_define.h"
+#include <sstream>
+#include <nlopt.h>
+
+// Function to minimize
+double myfunc(unsigned n, const double *x, double *grad, void *my_func_data = nullptr)
+{
+    DECLARE_UNUSED(n);
+    DECLARE_UNUSED(my_func_data);
+    if (grad) {
+        grad[0] = 2 * (x[0] - 3);
+    }
+    return (x[0] - 3) * (x[0] - 3);
+}
+
+int main(int argc, char *argv[])
+{
+    std::stringstream sfn;
+    sfn << gslBaseName(__FILE__) << ".out";
+    StdoutRedirect sr(sfn.str(), argc, argv);
+    nlopt_opt opt= nlopt_create(NLOPT_LD_LBFGS, 2);
+
+    // Bounds for each parameter
+    nlopt_set_lower_bound(opt, 0, 1);
+    nlopt_set_lower_bound(opt, 1, -10);
+    nlopt_set_upper_bound(opt, 0, 5);
+    nlopt_set_upper_bound(opt, 1, 10);
+
+
+    nlopt_set_min_objective(opt, myfunc, nullptr);
+
+    // Set the tolerance for the stopping criteria
+    nlopt_set_xtol_rel(opt,EPSILON4);
+
+    // Starting point
+    double x[2] = {1., 5.0};
+
+    double minf; // minimum value of the objective function
+    try {
+        nlopt_optimize(opt,x, &minf);
+        std::cout << "End optimization" << std::endl;
+        std::cout << "x = " << x[0] << " " << x[1] << std::endl;
+        std::cout << "Minimum value of the objective " << minf << std::endl;
+    }
+    catch (std::exception &e) {
+        std::cerr << "Error in the optimization: " << e.what() << std::endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR takes over #332 to provide support to the [NLopt](https://nlopt.readthedocs.io/en/latest/) library inside gstlearn.
Since the library is not header only, either a shared library is needed at runtime or gstlearn is built with a static NLopt library. For now, NLopt is only used in a test source file so it is not exposed to users of gstlearn's C++ API.

The `nonreg` and `publish` workflows have been updated to take NLopt into account. For the `nonreg` workflows, the system package system is used. For the `publish` workflows, a static build of NLopt is performed, either through `vcpkg` on Windows or with a custom composite action for Ubuntu and macOS.

Corresponding `publish` workflow run: https://github.com/pierre-guillou/gstlearn/actions/runs/11685081744

Pierre