### PR TITLE
Python: Lower the constraint bound on NumPy runtime dependency

### DIFF
--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -23,7 +23,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy>=@Python3_NumPy_VERSION@,<@Python3_NumPy_NEXT_MAJOR@",
+    # from the oldest supported numpy to the next major version of the
+    # numpy install used in building gstlearn
+    "numpy>=1.24,<@Python3_NumPy_NEXT_MAJOR@",
     "matplotlib",
     "scipy",
     "plotly",


### PR DESCRIPTION
Using the build time NumPy version as a lower bound for the Python dependency range is too much of a constraint, in particular when trying to install gstlearn with Python packages that need older but compatible versions of NumPy (tensorflow).

Indeed, building gstlearn with NumPy>=2.0 makes the Python package still compatible with NumPy
1 (c.f. https://numpy.org/doc/2.1/dev/depending_on_numpy.html#numpy-2-0-specific-advice).

Instead of using the NumPy version from build time, rather use the latest supported version of NumPy as a lower bound for the run-time Python package dependency range.

As of now, NumPy 1.24 is the oldest supported version (to be dropped at the end of 2024, c.f. https://numpy.org/neps/nep-0029-deprecation_policy.html).

Corresponding `publish` workflow run: https://github.com/pierre-guillou/gstlearn/actions/runs/11719429979

Pierre