### PR TITLE
Improve performance around serialization

### DIFF
--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -75,7 +75,7 @@ protected:
   template <typename T>
   static bool _recordWriteVec(std::ostream& os,
                                const String& title,
-                               const VectorT<T>& vec);
+                               const std::vector<T>& vec);
 
   template <typename T>
   static bool _recordRead(std::istream& is,
@@ -139,7 +139,7 @@ bool ASerializable::_recordWrite(std::ostream& os,
 template <typename T>
 bool ASerializable::_recordWriteVec(std::ostream& os,
                                     const String& title,
-                                    const VectorT<T>& vec)
+                                    const std::vector<T>& vec)
 {
   if (os.good())
   {

--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -120,7 +120,7 @@ bool ASerializable::_recordWrite(std::ostream& os,
       if (title.empty())
         os << STRING_NA << " ";
       else
-        os << STRING_NA << " # " << title << std::endl;
+        os << STRING_NA << " # " << title << '\n';
     }
     else
     {
@@ -129,7 +129,7 @@ bool ASerializable::_recordWrite(std::ostream& os,
       if (title.empty())
         os << val << " ";
       else
-        os << val << " # " << title << std::endl;
+        os << val << " # " << title << '\n';
       os.precision(prec);
     }
   }
@@ -144,7 +144,7 @@ bool ASerializable::_recordWriteVec(std::ostream& os,
   if (os.good())
   {
     if (!title.empty())
-      os << "# " << title << std::endl;
+      os << "# " << title << '\n';
 
     int prec = os.precision();
     os.precision(15);
@@ -155,7 +155,7 @@ bool ASerializable::_recordWriteVec(std::ostream& os,
       else
         os << val << " ";
     }
-    os << std::endl;
+    os << '\n';
     os.precision(prec);
   }
   return os.good();

--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -85,10 +85,12 @@ public:
 #endif // SWIG
   VectorDouble indicesToCoordinate(const VectorInt& indice,
                                    const VectorDouble& percent = VectorDouble()) const;
-  void indicesToCoordinateInPlace(const VectorInt& indice,
-                                  VectorDouble& coor,
-                                  const VectorDouble& percent = VectorDouble(),
-                                  bool flag_rotate=true) const;
+#ifndef SWIG
+  void indicesToCoordinateInPlace(const constvectint indice,
+                                  const vect coor,
+                                  const constvect percent = {},
+                                  bool flag_rotate        = true) const;
+#endif // SWIG
   double rankToCoordinate(int idim0,
                           int rank,
                           const VectorDouble& percent = VectorDouble()) const;
@@ -140,6 +142,7 @@ public:
 
   void iteratorInit(const VectorInt& order = VectorInt());
   VectorInt iteratorNext(void);
+  void iteratorNext(std::vector<int>& indices);
   bool empty() const;
 
   void dilate(int mode,
@@ -176,7 +179,7 @@ private:
   // Iterator
   int       _iter;
   int       _nprod;
-  VectorInt _counts;
+  std::vector<int> _counts;
   VectorInt _order;
   VectorInt _indices;
 

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -219,7 +219,7 @@ public:
                               bool flagAddSampleRank = true);
   /**@}*/
 
-  const VectorDouble& getArrays() const { return _array; }
+  const std::vector<double>& getArrays() const { return _array; }
 
   /** @addtogroup DB_Names Manipulating Names of the variables contained in a Db
    * \ingroup DB
@@ -427,6 +427,7 @@ public:
   VectorInt getUIDsByLocator(const ELoc& locatorType) const;
   VectorInt getUIDsByColIdx(const VectorInt& icols) const;
   VectorInt getAllUIDs() const;
+  void getAllUIDs(std::vector<int>& iuids) const;
 
   void copyByUID(int iuidIn, int iuidOut);
   void copyByCol(int icolIn, int icolOut);
@@ -464,7 +465,7 @@ public:
   void   updArray(int iech, int iuid, const EOperator& oper, double value);
   void   updArrayVec(const VectorInt& iechs, int iuid, const EOperator& oper, VectorDouble& values);
   VectorDouble getArrayByUID(int iuid, bool useSel = false) const;
-  VectorDouble getArrayBySample(int iech) const;
+  void getArrayBySample(std::vector<double>& vals, int iech) const;
   void   setArrayBySample(int iech, const VectorDouble& vec);
 
   void getSamplesAsSP(std::vector<SpacePoint>& pvec,const ASpace* space,bool useSel = false) const;
@@ -904,7 +905,7 @@ protected:
   String _summaryString(void) const;
 
 private:
-  const VectorInt& _getUIDcol() const { return _uidcol; }
+  const std::vector<int>& _getUIDcol() const { return _uidcol; }
   VectorString _getNames() const { return _colNames; }
   int _getUIDcol(int iuid) const;
   int _getAddress(int iech, int icol) const;
@@ -953,8 +954,8 @@ protected:
 private:
   int _ncol;                 //!< Number of Columns of data
   int _nech;                 //!< Number of samples
-  VectorDouble _array;       //!< Array of values
-  VectorInt _uidcol;         //!< UID to Column
+  std::vector<double> _array; //!< Array of values
+  std::vector<int> _uidcol;   //!< UID to Column
   VectorString _colNames;    //!< Names of the variables
   std::vector<PtrGeos> _p;   //!< Locator characteristics
 };

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -475,9 +475,9 @@ VectorDouble Grid::indicesToCoordinate(const VectorInt& indice,
   return _work1;
 }
 
-void Grid::indicesToCoordinateInPlace(const VectorInt& indice,
-                                      VectorDouble& coor,
-                                      const VectorDouble& percent,
+void Grid::indicesToCoordinateInPlace(const constvectint indice,
+                                      const vect coor,
+                                      const constvect percent,
                                       bool flag_rotate) const
 {
   if ((int)coor.size() < _nDim)
@@ -817,7 +817,7 @@ void Grid::iteratorInit(const VectorInt& order)
       {
         messerr("When provided, 'order' should contain all Space dimensions. Iterator cancelled.");
         _iter = 0;
-        _counts = VectorInt();
+        _counts = {};
         _order = VectorInt();
         return;
       }
@@ -837,11 +837,19 @@ void Grid::iteratorInit(const VectorInt& order)
  */
 VectorInt Grid::iteratorNext(void)
 {
+
+  VectorInt indices(_nDim);
+  iteratorNext(indices.getVector());
+  return indices;
+}
+
+void Grid::iteratorNext(std::vector<int>& indices)
+{
   int idim;
   int iech = _iter;
   int nval = _nprod;
 
-  VectorInt indices(_nDim);
+  indices.resize(_nDim);
   for (int jdim = _nDim - 1; jdim >= 0; jdim--)
   {
     int order = _order[jdim];
@@ -854,7 +862,6 @@ VectorInt Grid::iteratorNext(void)
 
   // Increment the iterator
   if (_iter < _nprod - 1) _iter++;
-  return indices;
 }
 
 bool Grid::empty() const

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -644,11 +644,12 @@ void DbGrid::_createGridCoordinates(int icol0)
 
   // Generate the vector of coordinates
 
-  VectorDouble coors(ndim);
+  std::vector<double> coors(ndim);
+  std::vector<int> indices;
   _grid.iteratorInit();
   for (int iech = 0; iech < getSampleNumber(); iech++)
   {
-    VectorInt indices = _grid.iteratorNext();
+    _grid.iteratorNext(indices);
     _grid.indicesToCoordinateInPlace(indices, coors);
     for (int idim = 0; idim < ndim; idim++)
       setArray(iech, icol0 + idim, coors[idim]);

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -835,4 +835,12 @@
   {
     return $self->rankToIndice(rank, indices.getVector(), minusOne);
   }
+
+  void indicesToCoordinateInPlace(const VectorInt& indice,
+                                  VectorDouble& coor,
+                                  const VectorDouble& percent = VectorDouble(),
+                                  bool flag_rotate=true) const
+  {
+    return $self->indicesToCoordinateInPlace(indice, coor, percent, flag_rotate);
+  }
 };


### PR DESCRIPTION
This PR provides several performance improvements around the serialization of `DbGrid`.

@NDesassis provided me with the following Python script:

```py
import gstlearn as gl
db = gl.DbGrid.create(nx = [200,200,200])
db.dumpToNF("toto.csv")
```

Using sampling profilers (such as [samply](https://github.com/mstange/samply)) I have been able to reduce the time spent in this script by a factor of 2.

Most of the performance gains were due to avoiding buffer flushes (`std::endl`). The remaining were obtained by factoring allocations (replacing `VectorNum`s with `std::vector`s / `std::span`s to avoid the cost of `std::shared_ptr`, pass by reference instead of returning locally-allocated vectors, using global variables to reuse storage, etc.).

Now a large majority of the serialization time is spent into `operator<<(double)`.

Here are some Samply/Heaptrack metrics:

|Metric|Before|After|
|----------|----------|-------|
| Exec time (samply) | 15s | 7.5s |
| Exec time (heaptrack) | 48s | 12s |
| #Samples  (samply) | 15k | 7.3k |
| Mem consumption | 272 MB | 272 MB |
| Allocations | 88081640 | 81651 |
| Temp. allocations | 8042940 | 42948 |

This is a first step for #203.

Pierre