### PR TITLE
GitHub Actions: Fix link issue with NLopt on Windows

### DIFF
--- a/.github/actions/nlopt_static_windows/action.yml
+++ b/.github/actions/nlopt_static_windows/action.yml
@@ -1,5 +1,5 @@
-name: 'NLopt static Unix'
-description: 'Build & install NLopt static libraries on Ubuntu & macOS'
+name: 'NLopt static Windows'
+description: 'Build & install NLopt static libraries on Windows'
 runs:
   using: "composite"
   steps:
@@ -20,7 +20,6 @@ runs:
           -DNLOPT_SWIG=OFF \
           -DNLOPT_TESTS=OFF \
           ..
-        cmake --build . --parallel 3
-        sudo cmake --build . --target install
+        cmake --build . --config Release --parallel 3 --target install
       env:
         CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -54,7 +54,6 @@ jobs:
         conda install -c conda-forge boost
         conda install -c conda-forge eigen
         conda install -c conda-forge ninja
-        conda install -c conda-forge nlopt
         # don't interfere with pre-installed Python
         rm C:\Miniconda\python.exe
 
@@ -63,6 +62,9 @@ jobs:
 
     - name: Set up Visual Studio shell
       uses: egor-tensin/vs-shell@v2
+
+    - name: Build & install NLopt static libraries
+      uses: ./.github/actions/nlopt_static_windows
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -24,7 +24,6 @@ env:
   CMAKE_GENERATOR : "MSYS Makefiles"
   R_VERSION : "4.3.2"
   SWIG_ROOT : ${{github.workspace}}\swig_420b
-  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
 
@@ -47,11 +46,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo '{
-          "dependencies": [ "boost-math", "eigen3", "nlopt" ],
-          "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
-        }' > vcpkg.json
-        vcpkg install
+        pacman -Sy --noconfirm mingw-w64-x86_64-boost
+        pacman -Sy --noconfirm mingw-w64-x86_64-eigen3
+        pacman -Sy --noconfirm mingw-w64-x86_64-nlopt
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-windows-action@v2

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -29,7 +29,6 @@ env:
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
-  VCPKG_LIBRARY_LINKAGE: static
   #HDF5_ROOT : hdf5 #do not use "." in the name
   #HDF5_URL : "https://www.hdfgroup.org/package/cmake-hdf5-1-12-1-zip/?wpdmdl=15723"
   #HDF5_VERSION : hdf5-1.12.1
@@ -65,7 +64,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo '{
-          "dependencies": [ "boost-math", "eigen3", "nlopt" ],
+          "dependencies": [ "boost-math", "eigen3" ],
           "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
         }' > vcpkg.json
         vcpkg install
@@ -83,6 +82,11 @@ jobs:
       with:
         doxygen-root: ${{env.DOXYGEN_ROOT}}
         doxygen-version: ${{env.DOXYGEN_VERSION}}
+
+    - name: Build & install nlopt static libraries
+      uses: ./.github/actions/nlopt_static_windows
+      env:
+        CMAKE_GENERATOR_PLATFORM: ${{ matrix.arch.of }}
 
 #    - name : Download and install HDF5
 #      run: |


### PR DESCRIPTION
This PR fixes link issues with NLopt on GitHub Actions Windows VMs (c.f. for instance #353).

The solution consists in building NLopt ourselves instead of relying on package systems. Static libraries should be preferred to shared ones, at least for the Python wrapper. A new composite action has been introduced to take care of that. It is quite similar to the one used for Ubuntu and macOS, we can merge the two if needed be.

For the `nonreg-tests_windows-latest-rtools` workflow, switching from vcpkg to using pacman-provided NLopt packages seems to overcome the issue in `create_doc.R`.

Pierre