### PR TITLE
Add a preprocessor variable GSTLEARN_VERSION_NUMBER in version.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ execute_process(
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UP)
 
 # Fix version.h automatically
+# Define a numerical version number (usable in e.g. #if ( VERSION >= ...))
+MATH( EXPR gstlearn_VERSION_NUMBER "${gstlearn_VERSION_MAJOR} * 10000 + ${gstlearn_VERSION_MINOR} * 100 + ${gstlearn_VERSION_PATCH}" )
 configure_file(version.h.in version.h)
 
 # Detect presence of multi configuration generators

--- a/version.h.in
+++ b/version.h.in
@@ -13,6 +13,7 @@
 /* Version numbers and date */
 
 #define GSTLEARN_VERSION "@gstlearn_VERSION@"     // gstlearn version (for acknowledge and identification)
+#define GSTLEARN_VERSION_NUMBER @gstlearn_VERSION_NUMBER@     // gstlearn version (for acknowledge and identification)
 #define GSTLEARN_DATE    "@gstlearn_DATE@"        // gstlearn git commit date (for acknowledge and identification)
 #define GSTLEARN_COMMIT  "@gstlearn_COMMIT@"      // gstlearn git commit hash (for acknowledge and identification)
 


### PR DESCRIPTION
The variable GSTLEARN_VERSION cannot really be used for anything else than displaying it because it's a string (so we cannot do e.g. #if GSTLEARN_VERSION == "1.5.0"). We could pass the individual bits of the version as defined by CMake (major, minor, patch), but my experience is that it is convenient to wrap them in a single number.

GSTLEARN_VERSION_NUMBER is built as MAJOR*10000 + 100*MINOR + PATCH which leaves space for up to 99 minor/patches, so in practice it usually fine.

This fixes #362 