### PR TITLE
Link to NLopt as PRIVATE so that projects using gstlearn don't need NLopt

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -170,7 +170,7 @@ foreach(FLAVOR ${FLAVORS})
   target_link_libraries(${FLAVOR} PRIVATE Boost::boost)
   
   # Link to NLopt
-  target_link_libraries(${FLAVOR} PUBLIC NLopt::nlopt)
+  target_link_libraries(${FLAVOR} PRIVATE NLopt::nlopt)
 
   # Link to HDF5
   if (USE_HDF5)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -69,6 +69,12 @@ foreach(TEST_SOURCE_FILE ${TEST_SOURCES})
     add_dependencies(${TEST_NAME} prepare_cpp)
     # Trigger the build of the test with the target build_tests
     add_dependencies(build_tests ${TEST_NAME})
+
+    # test_nlopt.cpp explicitly calls NLopt so it must link with it (gstlearn::shared
+    # links it as PRIVATE to hide it from projects using it).
+    if("${TEST_NAME}" STREQUAL "test_nlopt")
+      target_link_libraries(${TEST_NAME} PRIVATE NLopt::nlopt)
+    endif()
 endforeach(TEST_SOURCE_FILE ${TEST_SOURCES})
 
 # Display test output in case of failure

--- a/tests/cpp/test_ModelFitting.cpp
+++ b/tests/cpp/test_ModelFitting.cpp
@@ -34,8 +34,6 @@
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
 
-#include <nlopt.h>
-
 static Vario* _computeVariogram(Db* db, const ECalcVario& calcul)
 {
   double hmax            = db->getExtensionDiagonal();


### PR DESCRIPTION
Since gstlearn uses the static library version of NLopt, there is no need for projects using gstlearn to know anything about it, so it can be a PRIVATE dependency.

This fixes issue #368 