### PR TITLE
Fix R/MacOS non-reg & R 4.4.2 support

### DIFF
--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
-        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.2]
         # See the list here: https://github.com/actions/runner-images#available-images
         os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-13, macos-14, macos-15]
         exclude:
           - os: macos-13
             r_version: 4.3.3
           - os: macos-13
-            r_version: 4.4.1
+            r_version: 4.4.2
           - os: macos-14
             r_version: 4.0.5
           - os: macos-15
@@ -47,6 +47,12 @@ jobs:
           brew install llvm
         fi
       shell: bash
+
+    # https://github.com/r-lib/actions/issues/948
+    - name: Uninstall pkgconfig due to setup-R error
+      if: ${{ vars.RUNNER == 'macos-14' }}
+      run: |
+        brew uninstall pkg-config@0.29.2
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/nonreg-tests_macos-latest-one.yml
+++ b/.github/workflows/nonreg-tests_macos-latest-one.yml
@@ -42,6 +42,11 @@ jobs:
     #    python -m pip install numpy==${{env.NUMPY_VERSION}}
     #    python -m pip install pandas scipy
 
+    # https://github.com/r-lib/actions/issues/948
+    #- name: Uninstall pkgconfig due to setup-R error
+    #  run: |
+    #    brew uninstall pkg-config@0.29.2
+
     #- name: Setup R Version
     #  uses: r-lib/actions/setup-r@v2
     #  with:

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -50,6 +50,11 @@ jobs:
         python -m pip install numpy
         python -m pip install pandas scipy mlxtend
 
+    # https://github.com/r-lib/actions/issues/948
+    - name: Uninstall pkgconfig due to setup-R error
+      run: |
+        brew uninstall pkg-config@0.29.2
+
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2
       with:

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.arch.os}}
     strategy:
       matrix:
-        # Python version + Numpy version
+        # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
             {py: "3.9"},

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
             {py: "3.12"},
             {py: "3.13"}
           ]
-        # Only one "old"" Linux and a generic platform name BUILD_PLAT
+        # Only one "old" Linux and a generic platform name BUILD_PLAT
         os: [ubuntu-20.04]
 
     steps:

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -188,3 +188,4 @@ jobs:
     - uses: geekyeggo/delete-artifact@v5
       with:
         name: windows-python-package-*
+

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
-        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.2]
         arch: [
             {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
@@ -54,6 +54,12 @@ jobs:
         brew install llvm
         brew install boost
         brew install eigen
+
+    # https://github.com/r-lib/actions/issues/948
+    - name: Uninstall pkgconfig due to setup-R error
+      if: ${{ vars.RUNNER == 'macos-14' }}
+      run: |
+        brew uninstall pkg-config@0.29.2
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2
@@ -104,7 +110,7 @@ jobs:
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
-        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.2]
         arch: [
             {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
@@ -122,6 +128,12 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}
+
+    # https://github.com/r-lib/actions/issues/948
+    - name: Uninstall pkgconfig due to setup-R error
+      if: ${{ vars.RUNNER == 'macos-14' }}
+      run: |
+        brew uninstall pkg-config@0.29.2
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         # Only last version of R for Linux (fake source package)
-        r_version: [4.4.1]
+        r_version: [4.4.2]
         # Only one "old" Linux
         os: [ubuntu-20.04]
 
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
-        r_version: [4.4.1]
+        r_version: [4.4.2]
         # Only one "old" Linux
         os: [ubuntu-20.04]
 

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         # TODO : R 4.0.5 and 4.1.3 no more supported under windows? To be removed?
-        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.2]
 
     steps:
     - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
-        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.1]
+        r_version: [4.0.5, 4.1.3, 4.2.3, 4.3.3, 4.4.2]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Release 1.6.0
 - ExtractDiag() of a PrecisionOp in Matrix-free version (test_PrecisionOp.py)
 - Function areEqual() is renamed in isEqual()
 - Functions isEqualExtended() are added to compare 2 scalar or 2 vectors
+- R 4.4.2 support
 
 Release 1.5.1
 =============


### PR DESCRIPTION
Add a workaround in GHA workflows to permits installing R on MacOS-14 runners.
This should fix the non-regression and the publish workflows.

Upgrade to R 4.4.2 dependency.