### PR TITLE
Modify set locator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.6.0
 =============
-- in Db::setLocator, if locatorIndex is set to -1, the new locator is ADDED to already existing ones (this even becomes default value for all setLocator* methods).
+- in Db::setLocator, if locatorIndex is set to -1, the new locator is ADDED to already existing ones.
 - The library 'nlopt' is know used to perform optimization. At time, it should replace FOXLEG in the Automatic Structure Recognition (model_auto).
 - The argument 'domain' has been added to API functions 'krigingSPDE', 'simulateSPDE' and 'logLikelihoddSPDE'. It allows specifying the extension of the domain covered by the SPDE meshing. If not defined, it is elaborated starting from argument 'dbin' and/or 'dbout'.
 - ExtractDiag() of a PrecisionOp in Matrix-free version (test_PrecisionOp.py)

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.6.0
 =============
+- in Db::setLocator, if locatorItem is set to -1, the new locator is ADDED to already existing ones.
 - The library 'nlopt' is know used to perform optimization. At time, it should replace FOXLEG in the Automatic Structure Recognition (model_auto).
 - The argument 'domain' has been added to API functions 'krigingSPDE', 'simulateSPDE' and 'logLikelihoddSPDE'. It allows specifying the extension of the domain covered by the SPDE meshing. If not defined, it is elaborated starting from argument 'dbin' and/or 'dbout'.
 - ExtractDiag() of a PrecisionOp in Matrix-free version (test_PrecisionOp.py)

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.6.0
 =============
-- in Db::setLocator, if locatorItem is set to -1, the new locator is ADDED to already existing ones.
+- in Db::setLocator, if locatorIndex is set to -1, the new locator is ADDED to already existing ones (this even becomes default value for all setLocator* methods).
 - The library 'nlopt' is know used to perform optimization. At time, it should replace FOXLEG in the Automatic Structure Recognition (model_auto).
 - The argument 'domain' has been added to API functions 'krigingSPDE', 'simulateSPDE' and 'logLikelihoddSPDE'. It allows specifying the extension of the domain covered by the SPDE meshing. If not defined, it is elaborated starting from argument 'dbin' and/or 'dbout'.
 - ExtractDiag() of a PrecisionOp in Matrix-free version (test_PrecisionOp.py)

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -264,32 +264,32 @@ public:
   void clearSelection() { clearLocators(ELoc::SEL); }
   void setLocatorByUID(int iuid,
                        const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                       int locatorIndex = -1,
+                       int locatorIndex = 0,
                        bool cleanSameLocator = false);
   void setLocatorByColIdx(int icol,
                           const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                          int locatorIndex = -1,
+                          int locatorIndex = 0,
                           bool cleanSameLocator = false);
   void setLocator(const String& name,
                   const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                  int locatorIndex = -1,
+                  int locatorIndex = 0,
                   bool cleanSameLocator = false);
   void setLocators(const VectorString &names,
                    const ELoc &locatorType = ELoc::fromKey("UNKNOWN"),
-                   int locatorIndex = -1,
+                   int locatorIndex = 0,
                    bool cleanSameLocator = false);
   void setLocatorsByUID(int number,
                         int iuid,
                         const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                        int locatorIndex = -1,
+                        int locatorIndex = 0,
                         bool cleanSameLocator = false);
   void setLocatorsByUID(const VectorInt& iuids,
                         const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                        int locatorIndex = -1,
+                        int locatorIndex = 0,
                         bool cleanSameLocator = false);
   void setLocatorsByColIdx(const VectorInt& icols,
                            const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                           int locatorIndex = -1,
+                           int locatorIndex = 0,
                            bool cleanSameLocator = false);
 
   void addColumnsByVVD(const VectorVectorDouble& tab,

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -264,32 +264,32 @@ public:
   void clearSelection() { clearLocators(ELoc::SEL); }
   void setLocatorByUID(int iuid,
                        const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                       int locatorIndex = 0,
+                       int locatorIndex = -1,
                        bool cleanSameLocator = false);
   void setLocatorByColIdx(int icol,
                           const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                          int locatorIndex = 0,
+                          int locatorIndex = -1,
                           bool cleanSameLocator = false);
   void setLocator(const String& name,
                   const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                  int locatorIndex = 0,
+                  int locatorIndex = -1,
                   bool cleanSameLocator = false);
   void setLocators(const VectorString &names,
                    const ELoc &locatorType = ELoc::fromKey("UNKNOWN"),
-                   int locatorIndex = 0,
+                   int locatorIndex = -1,
                    bool cleanSameLocator = false);
   void setLocatorsByUID(int number,
                         int iuid,
                         const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                        int locatorIndex = 0,
+                        int locatorIndex = -1,
                         bool cleanSameLocator = false);
   void setLocatorsByUID(const VectorInt& iuids,
                         const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                        int locatorIndex = 0,
+                        int locatorIndex = -1,
                         bool cleanSameLocator = false);
   void setLocatorsByColIdx(const VectorInt& icols,
                            const ELoc& locatorType = ELoc::fromKey("UNKNOWN"),
-                           int locatorIndex = 0,
+                           int locatorIndex = -1,
                            bool cleanSameLocator = false);
 
   void addColumnsByVVD(const VectorVectorDouble& tab,
@@ -905,6 +905,7 @@ protected:
   String _summaryString(void) const;
 
 private:
+  int _getNextLocator(const ELoc& locatorType) const;
   const std::vector<int>& _getUIDcol() const { return _uidcol; }
   VectorString _getNames() const { return _colNames; }
   int _getUIDcol(int iuid) const;

--- a/src/API/PGSSPDE.cpp
+++ b/src/API/PGSSPDE.cpp
@@ -50,7 +50,7 @@ void PGSSPDE::compute(Db *dbout,
   {
     iuids[igrf] = _spdeTab[igrf]->compute(dbout, 1);
   }
-  dbout->setLocatorsByUID(iuids, ELoc::SIMU);
+  dbout->setLocatorsByUID(iuids, ELoc::SIMU, 0);
 
   if (_calcul == ESPDECalcMode::SIMUCOND)
     _ruleProp->categoryToThresh(_data);

--- a/src/Calculators/CalcMigrate.cpp
+++ b/src/Calculators/CalcMigrate.cpp
@@ -660,7 +660,7 @@ bool CalcMigrate::_postprocess()
                     _iattOut, String(), 1);
 
   if (_flagLocate)
-    getDbout()->setLocatorsByUID(nvar, _iattOut, _locatorType);
+    getDbout()->setLocatorsByUID(nvar, _iattOut, _locatorType, 0);
 
   return true;
 }

--- a/src/Core/db.cpp
+++ b/src/Core/db.cpp
@@ -1075,7 +1075,7 @@ int db_proportion(Db *db, DbGrid *dbgrid, int nfac1max, int nfac2max, int *nclou
 
   int iptr = dbgrid->addColumnsByConstant(nclass, 0.);
   if (iptr < 0) return 1;
-  dbgrid->setLocatorsByUID(nclass, iptr, ELoc::P);
+  dbgrid->setLocatorsByUID(nclass, iptr, ELoc::P, 0);
 
   /* Loop on the samples of the input data Db */
 

--- a/src/Core/dbtools.cpp
+++ b/src/Core/dbtools.cpp
@@ -1759,11 +1759,11 @@ Db* db_regularize(Db *db, DbGrid *dbgrid, int flag_center)
   if (dbnew == nullptr) goto label_end;
 
   ecr = 0;
-  dbnew->setLocatorsByUID(ndim, ecr, ELoc::X);
+  dbnew->setLocatorsByUID(ndim, ecr, ELoc::X, 0);
   ecr += ndim;
-  dbnew->setLocatorByUID(ecr, ELoc::C);
+  dbnew->setLocatorByUID(ecr, ELoc::C, 0);
   ecr += 1;
-  dbnew->setLocatorsByUID(nvar, ecr, ELoc::Z);
+  dbnew->setLocatorsByUID(nvar, ecr, ELoc::Z, 0);
   ecr += nvar;
   DECLARE_UNUSED(ecr);
 

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -3078,7 +3078,7 @@ int krigsum(Db *dbin,
 
   // Locally turn the problem to a Monovariate case to have it accepted
   dbin->clearLocators(ELoc::Z);
-  dbin->setLocatorByUID(iuids[0], ELoc::Z);
+  dbin->setLocatorByUID(iuids[0], ELoc::Z, 0);
   KrigingSystem ksys(dbin, dbout, model, neigh);
   if (ksys.updKrigOptEstim(iptr_est, -1, -1)) return 1;
   if (ksys.setKrigOptFlagLTerm(true)) return 1;
@@ -3089,7 +3089,7 @@ int krigsum(Db *dbin,
   for (int ivar = 0; ivar < nvar; ivar++)
   {
     dbin->clearLocators(ELoc::Z);
-    dbin->setLocatorByUID(iuids[ivar], ELoc::Z);
+    dbin->setLocatorByUID(iuids[ivar], ELoc::Z, 0);
     if (ksys.updKrigOptEstim(iptr_est + ivar, -1, -1)) return 1;
     (void) gslSPrintf(string, "Kriging of variable #%d at sample", ivar + 1);
 

--- a/src/Core/potential.cpp
+++ b/src/Core/potential.cpp
@@ -2057,13 +2057,13 @@ static void st_estimate_data(Pot_Env *pot_env,
     if (! uid_pot.empty())
     {
       db_target->setArray(iech, uid_pot[0], result[0]);
-      db_target->setLocatorsByUID(uid_pot, ELoc::Z);
+      db_target->setLocatorsByUID(uid_pot, ELoc::Z, 0);
     }
     if (! uid_grad.empty())
     {
       for (int idim = 0; idim < pot_env->ndim; idim++)
         db_target->setArray(iech, uid_grad[idim], result[idim + 1]);
-      db_target->setLocatorsByUID(uid_grad, ELoc::G);
+      db_target->setLocatorsByUID(uid_grad, ELoc::G, 0);
     }
   }
 }

--- a/src/Core/simtub.cpp
+++ b/src/Core/simtub.cpp
@@ -1128,7 +1128,7 @@ int simbipgs(Db *dbin,
     if (flag_cond)
     {
       dbin->clearLocators(ELoc::Z);
-      dbin->setLocatorByUID(iatt_z[ipgs], ELoc::Z);
+      dbin->setLocatorByUID(iatt_z[ipgs], ELoc::Z, 0);
     }
     if (st_check_simtub_environment(dbin, dbout, models[ipgs][0], neigh))
       goto label_end;
@@ -1205,7 +1205,7 @@ int simbipgs(Db *dbin,
     if (flag_cond)
     {
       dbin->clearLocators(ELoc::Z);
-      dbin->setLocatorByUID(iatt_z[ipgs], ELoc::Z);
+      dbin->setLocatorByUID(iatt_z[ipgs], ELoc::Z, 0);
     }
 
     if (ipgs == 0)

--- a/src/Core/spde.cpp
+++ b/src/Core/spde.cpp
@@ -7351,7 +7351,7 @@ static void st_define_locators(M2D_Environ *m2denv,
   int ivar;
 
   ivar = 1;
-  db->setLocatorsByUID(ndim, ivar, ELoc::X);
+  db->setLocatorsByUID(ndim, ivar, ELoc::X, 0);
   ivar += ndim;
   for (int ilayer = 0; ilayer < nlayer; ilayer++)
   {
@@ -7360,7 +7360,7 @@ static void st_define_locators(M2D_Environ *m2denv,
     if (ilayer < nvar) db->setLocatorByUID(ivar, ELoc::Z, ilayer);
     ivar++;
   }
-  if (m2denv->flag_ed) db->setLocatorsByUID(nlayer, ivar, ELoc::F);
+  if (m2denv->flag_ed) db->setLocatorsByUID(nlayer, ivar, ELoc::F, 0);
 }
 
 /****************************************************************************/
@@ -8781,7 +8781,7 @@ int m2d_gibbs_spde(Db *dbin,
     {
       // Modify the locator to ELoc::GAUSFAC before grouping to CE estimation
 
-      dbout->setLocatorsByUID(nbsimu * nlayer, iatt_out, ELoc::GAUSFAC);
+      dbout->setLocatorsByUID(nbsimu * nlayer, iatt_out, ELoc::GAUSFAC, 0);
 
       if (db_simulations_to_ce(dbout, ELoc::GAUSFAC, nbsimu, nlayer, &iptr_ce,
                                &iptr_cstd)) goto label_end;

--- a/src/Core/stats.cpp
+++ b/src/Core/stats.cpp
@@ -702,7 +702,7 @@ int db_upscale(DbGrid *dbgrid1, DbGrid *dbgrid2, int orient, int verbose)
   ncol = 3;
   iptr = dbgrid2->addColumnsByConstant(ncol, TEST);
   if (iptr < 0) goto label_end;
-  dbgrid2->setLocatorsByUID(ncol, iptr, ELoc::Z);
+  dbgrid2->setLocatorsByUID(ncol, iptr, ELoc::Z, 0);
 
   /* Core allocation */
 

--- a/src/Core/surface.cpp
+++ b/src/Core/surface.cpp
@@ -695,14 +695,14 @@ int db_trisurf(Db *db,
   }
   iptr_sel = db->addColumnsByConstant(1, 1.);
   if (iptr_sel < 0) goto label_end;
-  db->setLocatorByUID(iptr_sel, ELoc::SEL);
+  db->setLocatorByUID(iptr_sel, ELoc::SEL, 0);
 
   /* Set the new 2-D coordinates and turn the third coordinate into variable */
 
   db->clearLocators(ELoc::X);
   for (int idim = 0; idim < 2; idim++)
     db->setLocatorByUID(iptr_proj[idim], ELoc::X, idim);
-  db->setLocatorByUID(iptr_proj[ndim - 1], ELoc::Z);
+  db->setLocatorByUID(iptr_proj[ndim - 1], ELoc::Z, 0);
 
   /* Loop on the set of points per Fault */
 

--- a/src/Core/thresh.cpp
+++ b/src/Core/thresh.cpp
@@ -570,7 +570,7 @@ int db_rule_shadow(Db* db,
   /* Storage of the simulations in the output file */
   iptr = db->addColumnsByConstant(nbsimu, 0.);
   if (iptr < 0) goto label_end;
-  db->setLocatorsByUID(nbsimu, iptr, ELoc::FACIES);
+  db->setLocatorsByUID(nbsimu, iptr, ELoc::FACIES, 0);
 
   /* Identify the Non conditional simulations at target points */
   for (igrf = 0; igrf < 2; igrf++)

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -1125,11 +1125,12 @@ void Db::setLocatorByUID(int iuid,
                          bool cleanSameLocator)
 {
   if (!isUIDValid(iuid)) return;
-  if (locatorIndex < 0) return;
 
   // Optional clean
 
   if (cleanSameLocator) clearLocators(locatorType);
+
+  if (locatorIndex < 0) locatorIndex = getLocatorNumber(locatorType);
 
   /* Cancel any locator referring to this column */
 

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -205,7 +205,7 @@ int Db::resetFromBox(int nech,
 
   int jcol = 0;
   if (flagAddSampleRank) jcol++;
-  setLocatorsByUID(ndim, jcol, ELoc::X);
+  setLocatorsByUID(ndim, jcol, ELoc::X, 0);
 
   return 0;
 }
@@ -235,7 +235,7 @@ int Db::resetFromOnePoint(const VectorDouble& tab, bool flagAddSampleRank)
 
   int jcol = 0;
   if (flagAddSampleRank) jcol++;
-  setLocatorsByUID(ndim, jcol, ELoc::X);
+  setLocatorsByUID(ndim, jcol, ELoc::X, 0);
 
   return 0;
 }
@@ -341,6 +341,8 @@ int Db::getColIdxByLocator(const ELoc& locatorType, int locatorIndex) const
 
 int Db::getLocatorNumber(const ELoc& locatorType) const
 {
+  int number = locatorType.getValue();
+  if (number < 0) return 0;
   const PtrGeos& p = _p[locatorType.getValue()];
   return p.getLocatorNumber();
 }
@@ -1066,6 +1068,13 @@ void Db::clearLocators(const ELoc& locatorType)
   p.clear();
 }
 
+int Db::_getNextLocator(const ELoc& locatorType) const
+{
+  int number = getLocatorNumber(locatorType);
+
+  return number;
+}
+
 /**
  * Setting the locator for a set of variables designated by their names
  * @param names        Vector of variable names
@@ -1083,6 +1092,8 @@ void Db::setLocators(const VectorString &names,
   if (iuids.empty()) return;
 
   if (cleanSameLocator) clearLocators(locatorType);
+
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
 
   for (unsigned int i = 0; i < iuids.size(); i++)
     setLocatorByUID(iuids[i], locatorType, locatorIndex + i);
@@ -1105,6 +1116,8 @@ void Db::setLocator(const String &name,
 
   if (cleanSameLocator) clearLocators(locatorType);
 
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
+
   for (unsigned int i = 0; i < iuids.size(); i++)
     setLocatorByUID(iuids[i], locatorType, locatorIndex + i);
 }
@@ -1115,9 +1128,10 @@ void Db::setLocator(const String &name,
  * @param locatorType   Type of locator (include ELoc::UNKNOWN)
  * @param locatorIndex  Rank in the Locator (starting from 0)
  * @param cleanSameLocator When TRUE, clean variables with same locator beforehand
- * @remark: At this stage, no check is performed to see if items
- * @remark: are consecutive and all defined
- * @remark: This allow using this function in any order.
+ * @remark: 1) At this stage, no check is performed to see if items
+ * @remark: are consecutive and all defined. This allow using this function in any order.
+ * @remark: Argument 'locatorIndex' can be set to a negative value: in that case,
+ * @remark: the next index of the same 'locatorType' is generated automatically
  */
 void Db::setLocatorByUID(int iuid,
                          const ELoc& locatorType,
@@ -1130,7 +1144,7 @@ void Db::setLocatorByUID(int iuid,
 
   if (cleanSameLocator) clearLocators(locatorType);
 
-  if (locatorIndex < 0) locatorIndex = getLocatorNumber(locatorType);
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
 
   /* Cancel any locator referring to this column */
 
@@ -1195,6 +1209,8 @@ void Db::setLocatorsByUID(int number,
 {
   if (cleanSameLocator) clearLocators(locatorType);
 
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
+
   for (int i = 0; i < number; i++)
     setLocatorByUID(iuid+i, locatorType, locatorIndex + i);
 }
@@ -1206,8 +1222,9 @@ void Db::setLocatorsByUID(const VectorInt& iuids,
 {
   if (cleanSameLocator) clearLocators(locatorType);
 
-  int number = (int) iuids.size();
-  for (int i = 0; i < number; i++)
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
+
+  for (int i = 0, number = (int) iuids.size(); i < number; i++)
     setLocatorByUID(iuids[i], locatorType, locatorIndex + i);
 }
 
@@ -1218,7 +1235,9 @@ void Db::setLocatorsByColIdx(const VectorInt& icols,
 {
   if (cleanSameLocator) clearLocators(locatorType);
 
-  for (int icol = 0; icol < (int) icols.size(); icol++)
+  if (locatorIndex < 0) locatorIndex = _getNextLocator(locatorType);
+
+  for (int icol = 0, ncol = (int) icols.size(); icol < ncol; icol++)
   {
     int iuid = getUIDByColIdx(icol);
     setLocatorByUID(iuid, locatorType, locatorIndex + icol);

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -143,7 +143,7 @@ int DbGrid::reset(const VectorInt& nx,
   {
     int jcol = 0;
     if (flagAddSampleRank) jcol++;
-    setLocatorsByUID(ndim, jcol, ELoc::X);
+    setLocatorsByUID(ndim, jcol, ELoc::X, 0);
     _defineDefaultLocators(number, locatorNames);
   }
 
@@ -220,7 +220,7 @@ int DbGrid::resetCoveringDb(const Db* db,
   // Create the locators
 
   int jcol = 0;
-  setLocatorsByUID(ndim, jcol, ELoc::X);
+  setLocatorsByUID(ndim, jcol, ELoc::X, 0);
 
   return 0;
 }
@@ -289,7 +289,7 @@ int DbGrid::resetFromPolygon(Polygons* polygon,
 
   int jcol = 0;
   if (flagAddSampleRank) jcol++;
-  setLocatorsByUID(ndim, jcol, ELoc::X);
+  setLocatorsByUID(ndim, jcol, ELoc::X, 0);
 
   return 0;
 }
@@ -640,7 +640,7 @@ void DbGrid::_createGridCoordinates(int icol0)
 
   // Set the locators
 
-  setLocatorsByUID(getNDim(), icol0, ELoc::X);
+  setLocatorsByUID(getNDim(), icol0, ELoc::X, 0);
 
   // Generate the vector of coordinates
 

--- a/src/Db/DbHelper.cpp
+++ b/src/Db/DbHelper.cpp
@@ -921,7 +921,7 @@ int DbHelper::dbgrid_filling(DbGrid *dbgrid,
   int iatt_in = dbgrid->getUIDByLocator(ELoc::Z, 0);
   int iatt_out = dbgrid->addColumnsByConstant(1);
   dbgrid->duplicateColumnByUID(iatt_in, iatt_out);
-  dbgrid->setLocatorByUID(iatt_out, ELoc::Z);
+  dbgrid->setLocatorByUID(iatt_out, ELoc::Z, 0);
 
   /* Global variables */
 

--- a/src/Estimation/CalcKriging.cpp
+++ b/src/Estimation/CalcKriging.cpp
@@ -194,7 +194,7 @@ bool CalcKriging::_postprocess()
   }
   else if (_flagDGM)
   {
-    if (!_nameCoord.empty()) getDbin()->setLocators(_nameCoord, ELoc::X);
+    if (!_nameCoord.empty()) getDbin()->setLocators(_nameCoord, ELoc::X, 0);
 
     _renameVariable(2, VectorString(), ELoc::Z, nvar, _iptrVarZ, "varz", 1);
     _renameVariable(2, VectorString(), ELoc::Z, nvar, _iptrStd, "stdev", 1);

--- a/src/Estimation/CalcKrigingFactors.cpp
+++ b/src/Estimation/CalcKrigingFactors.cpp
@@ -36,7 +36,7 @@ bool CalcKrigingFactors::_check()
 {
   // Turn the problem to Monovariate before checking consistency with 'Model'
   getDbin()->clearLocators(ELoc::Z);
-  getDbin()->setLocatorByUID(_iuidFactors[0], ELoc::Z);
+  getDbin()->setLocatorByUID(_iuidFactors[0], ELoc::Z, 0);
 
   if (! ACalcInterpolator::_check()) return false;
 
@@ -130,7 +130,7 @@ bool CalcKrigingFactors::_postprocess()
   /* Free the temporary variables */
   _cleanVariableDb(2);
 
-  getDbin()->setLocatorsByUID(_iuidFactors, ELoc::Z);
+  getDbin()->setLocatorsByUID(_iuidFactors, ELoc::Z, 0);
 
   int nfactor = _getNFactors();
   _renameVariable(2, VectorString(), ELoc::Z, nfactor, _iptrStd, "stdev", 1);
@@ -138,7 +138,7 @@ bool CalcKrigingFactors::_postprocess()
 
   // Centering the information (only when a change of support is defined)
   if (_hasChangeSupport() && ! _nameCoord.empty())
-    getDbin()->setLocators(_nameCoord, ELoc::X);
+    getDbin()->setLocators(_nameCoord, ELoc::X, 0);
 
   return true;
 }
@@ -177,7 +177,7 @@ bool CalcKrigingFactors::_run()
     int jptr_est = (_flagEst) ? _iptrEst + iclass - 1 : -1;
     int jptr_std = (_flagStd) ? _iptrStd + iclass - 1 : -1;
     getDbin()->clearLocators(ELoc::Z);
-    getDbin()->setLocatorByUID(_iuidFactors[iclass - 1], ELoc::Z);
+    getDbin()->setLocatorByUID(_iuidFactors[iclass - 1], ELoc::Z, 0);
     if (ksys.updKrigOptEstim(jptr_est, jptr_std, -1)) return 1;
     if (ksys.updKrigOptIclass(iclass, _getNFactors())) return 1;
 

--- a/src/Simulation/CalcSimuPartition.cpp
+++ b/src/Simulation/CalcSimuPartition.cpp
@@ -83,7 +83,7 @@ bool CalcSimuPartition::_voronoi()
   /* Create the Point Data Base */
 
   Db* dbpoint = Db::createFromSamples(nbpoints, ELoadBy::SAMPLE, coor);
-  dbpoint->setLocatorsByUID(ndim, 0, ELoc::X);
+  dbpoint->setLocatorsByUID(ndim, 0, ELoc::X, 0);
   VectorDouble simpoint(dbpoint->getSampleNumber());
 
   /* Perform the simulation at the seed points */

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -2264,7 +2264,7 @@ bool CalcSimuTurningBands::_postprocess()
   if (_flagDGM)
   {
     if (!_nameCoord.empty())
-      getDbin()->setLocators(_nameCoord, ELoc::X);
+      getDbin()->setLocators(_nameCoord, ELoc::X, 0);
   }
 
   return true;

--- a/src/Variogram/Vario.cpp
+++ b/src/Variogram/Vario.cpp
@@ -422,7 +422,7 @@ int Vario::computeIndic(Db *db,
 
   // Delete the Indicators (created locally)
   _db->deleteColumnsByLocator(ELoc::Z);
-  _db->setLocatorByUID(iatt, ELoc::Z);
+  _db->setLocatorByUID(iatt, ELoc::Z, 0);
 
   return 0;
 }
@@ -2929,7 +2929,7 @@ int Vario::_calculateOnGrid(DbGrid *db)
     iatt_old = db->getUIDByLocator(ELoc::W, 0);
     iadd_new = db->addColumnsByConstant(1, 0.);
     if (iadd_new < 0) return 1;
-    db->setLocatorByUID(iadd_new, ELoc::W);
+    db->setLocatorByUID(iadd_new, ELoc::W, 0);
     maille = db->getCellSize();
     for (int iech = 0; iech < db->getSampleNumber(); iech++)
       db->setLocVariable(ELoc::W, iech, 0, maille);
@@ -2958,7 +2958,7 @@ int Vario::_calculateOnGrid(DbGrid *db)
   if (getCalcul() == ECalcVario::COVARIOGRAM)
   {
     if (iadd_new > 0) db->deleteColumnByUID(iadd_new);
-    if (iatt_old > 0) db->setLocatorByUID(iatt_old, ELoc::W);
+    if (iatt_old > 0) db->setLocatorByUID(iatt_old, ELoc::W, 0);
   }
   return 0;
 }

--- a/tests/cpp/test_AllGibbs.cpp
+++ b/tests/cpp/test_AllGibbs.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
   for (int isimu=0; isimu<nbsimu; isimu++)
   {
     db->clearLocators(ELoc::Z);
-    db->setLocator(names[isimu],ELoc::Z);
+    db->setLocator(names[isimu],ELoc::Z, 0);
     vario.compute(db, ECalcVario::VARIOGRAM);
     (void) vario.dumpToNF(incrementStringVersion("Vario",isimu+1));
   }

--- a/tests/cpp/test_Anam.cpp
+++ b/tests/cpp/test_Anam.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
   // Extracting a subset
   int np = 500;
   Db* data = Db::createSamplingDb(grid, 0., np, {"x1","x2","Y","Z"});
-  data->setLocator("Z", ELoc::Z);
+  data->setLocator("Z", ELoc::Z, 0);
   data->display();
 
   // Gaussian Anamorphosis

--- a/tests/cpp/test_Limits.cpp
+++ b/tests/cpp/test_Limits.cpp
@@ -57,13 +57,13 @@ int main(int argc, char *argv[])
   limits.display();
 
   // Other option
-  grid->setLocator("Simu", ELoc::Z);
+  grid->setLocator("Simu", ELoc::Z, 0);
   limits.toIndicator(grid,"Simu",0);
   dbfmt = DbStringFormat(FLAG_ARRAY, {"Simu", "Indicator.Simu.Mean"});
   grid->display(&dbfmt);
 
   // Convert into Indicators
-  grid->setLocator("Simu", ELoc::Z);
+  grid->setLocator("Simu", ELoc::Z, 0);
   limits.toIndicator(grid,"Simu",1);
   dbfmt = DbStringFormat(FLAG_ARRAY, {"Indicator.Simu.Class*"});
   grid->display(&dbfmt);

--- a/tests/cpp/test_Model.cpp
+++ b/tests/cpp/test_Model.cpp
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
   driftM.display();
 
   // Adding the selection
-  workingDbc->setLocator("Sel", ELoc::SEL);
+  workingDbc->setLocator("Sel", ELoc::SEL, 0);
   message("Covariance Matrix (with selection)\n");
   covM = modelM->evalCovMatrixSymmetric(workingDbc);
   covM.display();
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   driftM.display();
 
   // Adding the variables (heterotopic multivariate)
-  workingDbc->setLocators({"Z*"}, ELoc::Z);
+  workingDbc->setLocators({"Z*"}, ELoc::Z, 0);
   message("Covariance Matrix (with selection & heterotopic multivariate)\n");
   covM = modelM->evalCovMatrixSymmetric(workingDbc);
   covM.display();
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
   driftM.display();
 
   // Adding the variables (heterotopic multivariate & Verr)
-  workingDbc->setLocators({"V*"}, ELoc::V);
+  workingDbc->setLocators({"V*"}, ELoc::V, 0);
   message("Covariance Matrix (with selection & heterotopic multivariate & verr)\n");
   covM = modelM->evalCovMatrixSymmetric(workingDbc);
   covM.display();

--- a/tests/cpp/test_PCA.cpp
+++ b/tests/cpp/test_PCA.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
   // ============
 
   mestitle(0,"Testing MAF");
-  db->setLocator("Simu*", ELoc::Z);
+  db->setLocator("Simu*", ELoc::Z, 0);
   PCA maf;
   maf.maf_compute_interval(db, 0.95, 1.05);
   maf.display();

--- a/tests/cpp/test_PGS.cpp
+++ b/tests/cpp/test_PGS.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
   // Perform a non-conditional simulation on the Db
   error = simpgs(nullptr,db,ruleprop,model1,model2,neighU);
-  db->setLocator(db->getLastName(),ELoc::Z);
+  db->setLocator(db->getLastName(),ELoc::Z, 0);
   (void) db->dumpToNF("simupgs.ascii");
   db->display(&dbfmt);
 

--- a/tests/cpp/test_PGSSPDE.cpp
+++ b/tests/cpp/test_PGSSPDE.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
   VectorString names = generateMultipleNames("Props",nfac);
   for (int ifac = 0; ifac < nfac; ifac++)
     dbprop->addColumnsByConstant(1,props[ifac],names[ifac]);
-  dbprop->setLocators(names,ELoc::P);
+  dbprop->setLocators(names,ELoc::P, 0);
 
   // Creating the Model(s) of the Underlying GRF(s)
   double range1 = 20;

--- a/tests/cpp/test_SPDEDrift.cpp
+++ b/tests/cpp/test_SPDEDrift.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
   filename = ASerializable::getTestData("Scotland","temperatures.ascii");
   Db* temperatures = Db::createFromNF(filename,verbose);
-  temperatures->setLocator("January_temp", ELoc::Z);
+  temperatures->setLocator("January_temp", ELoc::Z, 0);
   temperatures->display();
 
   filename = ASerializable::getTestData("Scotland","grid.ascii");

--- a/tests/cpp/test_csv.cpp
+++ b/tests/cpp/test_csv.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
 
   mydb->setLocator("X", ELoc::X, 0);
   mydb->setLocator("Y", ELoc::X, 1);
-  mydb->setLocator("Zn", ELoc::Z);
+  mydb->setLocator("Zn", ELoc::Z, 0);
   DbStringFormat dbfmt(FLAG_RESUME | FLAG_EXTEND | FLAG_VARS);
   mydb->display(&dbfmt);
 

--- a/tests/cpp/test_kd.cpp
+++ b/tests/cpp/test_kd.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
   // Data extraction
   int np = 500;
   Db* data = Db::createSamplingDb(grid, 0., np, {"x1","x2","Y","Z"});
-  data->setLocator("Z", ELoc::Z);
+  data->setLocator("Z", ELoc::Z, 0);
   data->display(&dbfmt);
 
   // Gaussian Anamorphosis with 10 coefficients
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
 
   // Perform the Point Kriging of the Raw Variable
   data->clearLocators(ELoc::Z);
-  data->setLocator("Z",ELoc::Z);
+  data->setLocator("Z",ELoc::Z, 0);
   data->display();
   (void) kriging(data, blocs, model, neighM, EKrigOpt::POINT,
                  true, true, false, VectorInt(), VectorInt(),
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
                              "Z_PTS*estim", "Z_PTS*stdev",
                              NamingConvention("UC",false));
   blocs->display();
-  data->setLocator("Gauss.Z",ELoc::Z);
+  data->setLocator("Gauss.Z",ELoc::Z, 0);
 
   // ====================== Block Disjunctive Kriging (DGM-1) =====================
 

--- a/tests/cpp/test_krige.cpp
+++ b/tests/cpp/test_krige.cpp
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
   // ====================== Image Neighborhood case ===========================
   // Generate the Image
   (void) simtub(nullptr,image,model);
-  image->setLocator("Simu", ELoc::Z);
+  image->setLocator("Simu", ELoc::Z, 0);
   image->display();
 
   // Modify the Model (for filtering)

--- a/tests/data/testim.cpp
+++ b/tests/data/testim.cpp
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
                       5.,true,true,true))
       messageAbort("gibbs_sampler");
     /* Set the current variable to the conditional expectation */
-    dbin->setLocatorByUID(dbin->getColumnNumber()-1,ELoc::Z);
+    dbin->setLocatorByUID(dbin->getColumnNumber()-1,ELoc::Z, 0);
   }
 
   /* Perform the estimation */

--- a/tests/data/testpgs.cpp
+++ b/tests/data/testpgs.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       iatt_ind = dbin->getColumnNumber();
       Limits limits = Limits(nclass);
       limits.toIndicator(dbin);
-      dbin->setLocatorsByUID(nclass,iatt_ind,ELoc::Z);
+      dbin->setLocatorsByUID(nclass,iatt_ind,ELoc::Z, 0);
       
       /* Calculate the experimental variograms */
       
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
       dbin->clearLocators(ELoc::Z);
       for (ifac=0; ifac<nclass; ifac++)
         dbin->deleteColumnByUID(iatt_ind+ifac);
-      dbin->setLocatorByUID(iatt_z,ELoc::Z);
+      dbin->setLocatorByUID(iatt_z,ELoc::Z, 0);
     }
   }
 

--- a/tests/data/testvar.cpp
+++ b/tests/data/testvar.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     if (simtub(nullptr,dbout,model,nullptr,nbsimu,seed,nbtuba,0))
       messageAbort("Simulations");
     /* Set the current variable to the conditional expectation */
-    dbout->setLocatorByUID(dbout->getColumnNumber()-1,ELoc::Z);
+    dbout->setLocatorByUID(dbout->getColumnNumber()-1,ELoc::Z, 0);
   }
   seed = law_get_random_seed();
   

--- a/tests/inter/testInter_GibbsMMulti.cpp
+++ b/tests/inter/testInter_GibbsMMulti.cpp
@@ -135,7 +135,7 @@ int main()
     for (int isimu = 0; isimu < (int) names.size(); isimu++)
     {
       db->clearLocators(ELoc::Z);
-      db->setLocator(names[isimu], ELoc::Z);
+      db->setLocator(names[isimu], ELoc::Z, 0);
       Vario vario(varioparam);
       vario.compute(db, ECalcVario::VARIOGRAM);
       (void) vario.dumpToNF(incrementStringVersion("Vario", isimu + 1));

--- a/tests/py/test_kriging.py
+++ b/tests/py/test_kriging.py
@@ -46,7 +46,7 @@ def createDbIn(ndat,nvar,percent,ndim=2,selDbin=False,measurement_error=False,nd
     for i in range(ndim):
         db["x" +str(i)] = np.random.uniform(size = ndat)
      
-    db.setLocators(["x*"],gl.ELoc.X)
+    db.setLocators(["x*"],gl.ELoc.X,0)
         
     indIn = np.arange(ndat)
     if selDbin:
@@ -56,7 +56,7 @@ def createDbIn(ndat,nvar,percent,ndim=2,selDbin=False,measurement_error=False,nd
         sel = np.zeros(shape=ndat)
         sel[indIn] = 1
         db["sel"] = sel
-        db.setLocator("sel",gl.ELoc.SEL)
+        db.setLocator("sel",gl.ELoc.SEL, 0)
       
     #Creation of an heterotopic data set
     indList = [] 
@@ -72,7 +72,7 @@ def createDbIn(ndat,nvar,percent,ndim=2,selDbin=False,measurement_error=False,nd
         vect[ind] = np.random.normal(size = len(ind))
         db["z"+str(i)]=vect
           
-    db.setLocators(["z*"],gl.ELoc.Z)
+    db.setLocators(["z*"],gl.ELoc.Z, 0)
     
     indF = []
     
@@ -83,12 +83,12 @@ def createDbIn(ndat,nvar,percent,ndim=2,selDbin=False,measurement_error=False,nd
         for i in range(nvar):
             db["err"+str(i)] = 0.1 * np.random.uniform(size = ndat)
             
-        db.setLocators(["err*"],gl.ELoc.V)
+        db.setLocators(["err*"],gl.ELoc.V, 0)
     
     if ndrift>0:
         for i in range(ndrift):
             db["ff" + str(i)] = np.random.normal(size = ndat)
-        db.setLocator("ff*",gl.ELoc.F)
+        db.setLocator("ff*",gl.ELoc.F, 0)
     
     return db,indF
 
@@ -154,7 +154,7 @@ def test_kriging(ndat,nx,nvar,percent,model,cova,
         sel = np.zeros(shape = target.getSampleNumber())
         sel[indOut] = 1
         target["sel"] = sel
-        target.setLocator("sel",gl.ELoc.SEL)
+        target.setLocator("sel",gl.ELoc.SEL, 0)
                   
     if irf is not None:
         modeln.setDriftIRF(irf)
@@ -162,7 +162,7 @@ def test_kriging(ndat,nx,nvar,percent,model,cova,
     if drift :
         target["ff"] = np.random.normal(size = target.getSampleNumber())
         
-        target.setLocator("ff",gl.ELoc.F)
+        target.setLocator("ff",gl.ELoc.F, 0)
         modeln.addDrift(gl.DriftF(0))
       
     v = np.array([db["x0"],db["x1"]]).T


### PR DESCRIPTION
In this new PR, the functions setLocatorXXX() present a new feature.
When used with 'locatorIndex' negative, the new variable(s) is(are) set to the locator defined by 'locatorType' at the next rank available. This allows ADDING new locators more easily.
This even becomes the new default value for 'locatorIndex' argument.