### PR TITLE
CI: Fix building rgl for publish_doc workflow

### DIFF
--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -50,6 +50,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libpng-dev \
           libnlopt-dev
 
     - name: Setup Python Version


### PR DESCRIPTION
Add missing `libpgn-dev` package to make `rgl` build correctly.

Corresponding Action run: https://github.com/pierre-guillou/gstlearn/actions/runs/12369216682

Pierre