### PR TITLE
Remove spurious obsolete scipy import

### DIFF
--- a/doc/courses/python/03_Graphics.ipynb
+++ b/doc/courses/python/03_Graphics.ipynb
@@ -37,12 +37,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
+      "application/javascript": "\nIPython.OutputArea.prototype._should_scroll = function(lines) {\n    return false;\n}\n",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -61,7 +56,6 @@
     "import gstlearn as gl\n",
     "import gstlearn.plot as gp\n",
     "import gstlearn.document as gdoc\n",
-    "from scipy import ndimage, misc \n",
     "\n",
     "gdoc.setNoScroll()"
    ]
@@ -1774,46 +1768,11 @@
     "fig.decoration(title=\"Overlay test\")\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
scipy.misc will become soon obsolete and generates warning message when imported.
It was imported in 03_Graphics.ipynb but not used in the script.
The importation has been removed to fix the non-reg demo CI.