### PR TITLE
Make some Python dependencies optional

### DIFF
--- a/doc/courses/python/01_gstlearn_start.ipynb
+++ b/doc/courses/python/01_gstlearn_start.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# Uncomment next line for installing last release of gstlearn package (remove '#' character)\n",
-    "#!pip install gstlearn"
+    "#!pip install gstlearn[plot]"
    ]
   },
   {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -232,7 +232,7 @@ endforeach()
 # Add a custom target for python package installation
 # TODO: Do also installation each time setup.py.in or README.md is modified
 add_custom_target(python_install
-  COMMAND ${Python3_EXECUTABLE} -m pip install ${PYTHON_PACKAGE_ROOT_FOLDER}
+  COMMAND ${Python3_EXECUTABLE} -m pip install "${PYTHON_PACKAGE_ROOT_FOLDER}[plot]"
   COMMENT "Installing python package"
   )
  

--- a/python/README.md
+++ b/python/README.md
@@ -32,6 +32,13 @@ For using this Python package you only need Python 3.8 (or higher) (with numpy, 
 pip install gstlearn
 ```
 
+The `gstlearn.plot` Python module requires additional dependencies,
+those can be installed alongside gstlearn with the following command:
+
+``` python
+pip install gstlearn[plot]
+```
+
 ## Usage
 
 We refer the reader to this [course page](https://soft.mines-paristech.fr/gstlearn/courses-latest/python/01_gstlearn_start.html) for an introduction and important information about Python gstlearn package.

--- a/python/modules/plot.py
+++ b/python/modules/plot.py
@@ -21,11 +21,7 @@ import math
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from numpy                   import shape
 from pandas.io               import orc
-from plotly.matplotlylib     import mpltools
 from matplotlib.pyplot       import axes
-
-
-from plotly.validators.layout.scene import aspectratio
 
 #Set of global values
 defaultDims = [[5,5], [8,8]]

--- a/python/modules/plot3D.py
+++ b/python/modules/plot3D.py
@@ -9,11 +9,17 @@
 #                                                                              #
 ################################################################################
 
-import plotly.graph_objects as go
 import numpy                as np
 import gstlearn             as gl
 from numpy import pi
 from matplotlib.animation import adjusted_figsize
+
+try:
+    import plotly.graph_objects as go
+except ModuleNotFoundError as ex:
+    msg = ("Python dependency 'plotly' not found.\n"
+          "To install it alongside gstlearn, please run `pip install gstlearn[plot]'")
+    raise ModuleNotFoundError(msg) from ex
 
 def getCscale():
     cscale = [

--- a/python/modules/proj.py
+++ b/python/modules/proj.py
@@ -14,8 +14,13 @@
 #            => Do not restore without reading this: https://github.com/gstlearn/gstlearn/issues/68
 
 
-import geopandas as gpd
-from shapely.geometry import Polygon, Point
+try:
+    import geopandas as gpd
+    from shapely.geometry import Polygon, Point
+except ModuleNotFoundError as ex:
+    msg = ("Python dependencies 'geopandas' and 'shapely' not found.\n"
+          "To install them alongside gstlearn, please run `pip install gstlearn[plot]'")
+    raise ModuleNotFoundError(msg) from ex
 
 ''' Generate GeometryArray of shapely Point geometries from x, y(, z) coordinates.
     x, y: Data coordinates

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -28,8 +28,14 @@ dependencies = [
     "numpy>=1.24,<@Python3_NumPy_NEXT_MAJOR@",
     "matplotlib",
     "scipy",
-    "plotly",
     "pandas",
+]
+
+[project.optional-dependencies]
+plot = [
+     "geopandas",
+     "plotly",
+     "shapely",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR makes the Python packages `geopandas`, `plotly` and `shapely` optional dependencies of the `gstlearn` Python package.

Now, a `pip install gstlearn` won't install those dependencies. Users that want to use the `gstlearn.plot` module should use `pip install gstlearn[plot]` to force the installation of the dependencies, which have been grouped inside the `plot` optional feature.

Other non-essential Python dependencies can be added to this dependency group or into another one. Tell me if I should include/exclude other packages.

Pierre