### PR TITLE
Last renames before closing the branch

### DIFF
--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -257,8 +257,8 @@ public:
   VectorString identifyNames(const VectorString& names) const;
   /**@}*/
 
-  inline int getUIDMaxNumber() const { return (int) _uidcol.size(); }
-  inline int getColumnNumber() const { return _ncol; }
+  inline int getNUIDMax() const { return (int) _uidcol.size(); }
+  inline int getNColumn() const { return _ncol; }
 
   static int getNEloc();
   int getNSample(bool useSel = false) const;
@@ -477,7 +477,7 @@ public:
   void getSamplesAsSP(std::vector<SpacePoint>& pvec,const ASpaceSharedPtr& space,bool useSel = false) const;
 
   bool   hasLocator(const ELoc& locatorType) const;
-  int    getFromLocatorNumber(const ELoc& locatorType) const;
+  int    getNFromLocator(const ELoc& locatorType) const;
   double getFromLocator(const ELoc& locatorType, int iech, int locatorIndex=0) const;
   void   setFromLocator(const ELoc& locatorType,
                         int iech,
@@ -529,7 +529,7 @@ public:
   void   updLocVariable(const ELoc& loctype, int iech, int item, const EOperator& oper, double value);
   /**@}*/
 
-  int    getZNumber() const;
+  int    getNZValues() const;
   bool   hasZVariable() const;
   double getZVariable(int iech, int item) const;
   void   setZVariable(int iech, int item, double value);

--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -41,10 +41,8 @@ int findFirstNoNullOnCol(int j) const;
 const std::vector<int>& getNPoints() const {return _pointNumbers;}
 const std::vector<int>& getNApexs()  const {return _apexNumbers;}
 
-
-
 protected:
-std::vector<std::vector<const IProj*> >_projs; // NOT TO BE DELETED
+std::vector<std::vector<const IProj*>> _projs; // NOT TO BE DELETED
 
 private:
 int _pointNumber;

--- a/include/Matrix/NF_Triplet.hpp
+++ b/include/Matrix/NF_Triplet.hpp
@@ -46,7 +46,7 @@ public:
   DECLARE_TOTL;
 
   void add(int irow, int icol, double value);
-  int getNumber() const { return (int) _eigenT.size(); }
+  int getNElements() const { return (int) _eigenT.size(); }
   int getNRows()  const { return _nrowmax; }
   int getNCols()  const { return _ncolmax; }
   void force(int nrow, int ncol);

--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -118,7 +118,7 @@ public:
 
 private:
   int _defineGrid(const VectorDouble& cellsize);
-  void _setNumberElementPerCell();
+  void _setNElementPerCell();
   int _getPolarized(const constvectint indg) const;
   int _addWeights(int icas,
                   const constvectint indg0,

--- a/include/Simulation/CalcSimuEden.hpp
+++ b/include/Simulation/CalcSimuEden.hpp
@@ -66,7 +66,7 @@ public:
   void setIndPerm(int indPerm) { _indPerm = indPerm; }
   void setIndPoro(int indPoro) { _indPoro = indPoro; }
   void setSpeeds(const VectorInt &speeds) { _speeds = speeds; }
-  void setNumberMax(double numberMax) { _numberMax = numberMax; }
+  void setNMax(double numberMax) { _numberMax = numberMax; }
   void setShowFluid(bool showFluid) { _showFluid = showFluid; }
   void setVolumeMax(double volumeMax) { _volumeMax = volumeMax; }
 
@@ -94,12 +94,12 @@ private:
   void _statsDefine(void);
   void _statsReset();
   void _statsInit();
-  void _setStatNumber(int ifacies, int ifluid, int value);
+  void _setStatCount(int ifacies, int ifluid, int value);
   void _setStatVolume(int ifacies, int ifluid, double value);
-  void _addStatNumber(int ifacies, int ifluid, int value);
+  void _addStatCount(int ifacies, int ifluid, int value);
   void _addStatVolume(int ifacies, int ifluid, double value);
   void _checkInconsistency(bool verbose);
-  int _getStatNumber(int ifacies, int ifluid) const;
+  int  _getStatCount(int ifacies, int ifluid) const;
   double _getStatVolume(int ifacies, int ifluid) const;
   int _checkMax(double number_max, double volume_max);
   int _fluidModify(Skin *skin, int ipos, int *ref_fluid_loc);

--- a/include/Simulation/CalcSimuFFT.hpp
+++ b/include/Simulation/CalcSimuFFT.hpp
@@ -44,7 +44,7 @@ private:
 
   bool _simulate();
   void _alloc();
-  static int _getOptimalEvenNumber(int number, int largeFactor = 11);
+  static int _getNOptimalEven(int number, int largeFactor = 11);
   static VectorInt _getFactors(int number);
   void _gridDilate();
   bool _checkCorrect(const VectorVectorDouble& xyz,

--- a/include/Stats/Selectivity.hpp
+++ b/include/Stats/Selectivity.hpp
@@ -116,7 +116,7 @@ public:
   int  getAddressQTEst(const ESelectivity& code, int iptr0, int rank=0) const;
   int  getAddressQTStd(const ESelectivity& code, int iptr0, int rank=0) const;
   int  getNQTEst(const ESelectivity& code) const;
-  int  geNQTStd(const ESelectivity& code) const;
+  int  getNQTStd(const ESelectivity& code) const;
   VectorInt getNQTEst() const;
   VectorInt geNQTStd() const;
   void storeInDb(Db *db, int iech0, int iptr, double zestim, double zstdev) const;
@@ -131,7 +131,7 @@ public:
   Table getStats() const;
   Table getAllStats() const { return _stats; }
 
-  const MatrixInt& getNumberQt() const { return _numberQT; }
+  const MatrixInt& getCountQT() const { return _numberQT; }
   const MatrixInt& getRankQt() const { return _rankQT; }
 
 private:

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -705,7 +705,7 @@
     int ncols = mat.getNCols();
 
     NF_Triplet NFT = mat.getMatrixToTriplet();
-    const npy_intp nnz = NFT.getNumber();;
+    const npy_intp nnz = NFT.getNElements();
 
     // Create 1D NumPy arrays for row indices, column indices, and values
     npy_intp dim[1] = {nnz};
@@ -1171,14 +1171,14 @@ def findColumnNames(self, columns):
         names = self.getNameByColIdx(columns)
     
     elif isinstance(columns, slice):
-        Nmax = self.getColumnNumber()
+        Nmax = self.getNColumn()
         names = []
         for i in range(Nmax)[columns]:
             names.append(self.getNameByColIdx(i))
 
     elif is_list_type(columns, (int, np.int_)):
         names = []
-        Nfields = self.getColumnNumber()
+        Nfields = self.getNColumn()
         for i in columns:
             if i >= Nfields:
                 print("Warning: the index {} is out of bounds with {}, this index is ignored".format(i,Nfields))

--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -789,7 +789,7 @@ function (x,i,j,...,drop=TRUE)
   if (length(dots) > 0) args = append(args, dots)
   nargs = length(args)
   nech_abs = db$getNSample()
-  ncol_abs = db$getColumnNumber()
+  ncol_abs = db$getNColumn()
   rows <- NA
   namcols <- NA
 
@@ -844,7 +844,7 @@ function (x,i,j,...,drop=TRUE)
   nargs = length(args)
   
   nech_abs = db$getNSample()
-  ncol_abs = db$getColumnNumber()
+  ncol_abs = db$getNColumn()
   value = as.numeric(unlist(value))
 
   rows <- NA
@@ -990,7 +990,7 @@ setMethod('[<-',  '_p_Table',               setTableitem)
 "Db_toTL" <- function(x)
 {
   names = x$getAllNames()
-  nc = x$getColumnNumber()
+  nc = x$getNColumn()
   vals = NULL
   for (i in seq(0,nc-1)) {
     vals = cbind(vals,x$getColumnsByColIdx(i))

--- a/src/Calculators/ACalcDbToDb.cpp
+++ b/src/Calculators/ACalcDbToDb.cpp
@@ -406,12 +406,12 @@ int ACalcDbToDb::_expandInformation(int mode, const ELoc& locatorType) const
   if (getDbout()->isGrid() && locatorType == ELoc::X)
     ninfo = getDbout()->getNDim();
   else
-    ninfo = getDbout()->getFromLocatorNumber(locatorType);
+    ninfo = getDbout()->getNFromLocator(locatorType);
   if (ninfo <= 0) return 0;
 
   // Check the corresponding number of variables in the Input File
 
-  int ninfoIn = getDbin()->getFromLocatorNumber(locatorType);
+  int ninfoIn = getDbin()->getNFromLocator(locatorType);
   if (ninfo == ninfoIn) return 0;
 
   /* Case when the Output Db is not a grid */

--- a/src/Core/convert.cpp
+++ b/src/Core/convert.cpp
@@ -413,7 +413,7 @@ int db_write_csv(Db *db,
                  bool flagInteger)
 {
   if (db == nullptr) return 1;
-  int ncol = db->getColumnNumber();
+  int ncol = db->getNColumn();
   int ndim = db->getNDim();
   int nech = db->getNSample();
   int nvar = db->getNLoc(ELoc::Z);

--- a/src/Core/db.cpp
+++ b/src/Core/db.cpp
@@ -71,7 +71,7 @@ int get_LOCATOR_NITEM(const Db *db, const ELoc& locatorType)
   if (db == nullptr) return (0);
   if (db->isGrid() && locatorType == ELoc::X)
     return (db->getNDim());
-  return (db->getFromLocatorNumber(locatorType));
+  return (db->getNFromLocator(locatorType));
 }
 
 /****************************************************************************/
@@ -2250,7 +2250,7 @@ label_end:
  *****************************************************************************/
 int db_name_identify(Db* db, const String& string)
 {
-  for (int iatt = 0, natt = db->getUIDMaxNumber(); iatt < natt; iatt++)
+  for (int iatt = 0, natt = db->getNUIDMax(); iatt < natt; iatt++)
   {
     int icol = db->getColIdxByUID(iatt);
     if (string != db->getNameByColIdx(icol)) return iatt;

--- a/src/Core/dbtools.cpp
+++ b/src/Core/dbtools.cpp
@@ -205,7 +205,7 @@ static void st_edit_display(Db *db, int nrdv, int nrds, int ivar, int iech)
 
   (void) gslStrcpy(string, "NA");
   nech = db->getNSample();
-  nvar = db->getColumnNumber();
+  nvar = db->getNColumn();
 
   ivar_deb = ivar - nrdv;
   ivar_fin = ivar + nrdv;
@@ -483,7 +483,7 @@ int db_edit(Db *db, int *flag_valid)
   /* Initializations */
 
   nech = db->getNSample();
-  nvar = db->getColumnNumber();
+  nvar = db->getNColumn();
   ivar = iech = 0;
   nrds = nrdv = incr = 1;
   vmin = vmax = TEST;

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -3058,11 +3058,11 @@ int krigsum(Db *dbin,
     messerr("This procedure requires a monovariate model");
     return 1;
   }
-  if (dbout->getFromLocatorNumber(ELoc::SUM) != 1)
+  if (dbout->getNFromLocator(ELoc::SUM) != 1)
   {
     messerr("This procedure requires one Variable with Locator SUM in the Output Db");
     messerr("The number of such variable is currently equal to %d",
-            dbout->getFromLocatorNumber(ELoc::SUM ));
+            dbout->getNFromLocator(ELoc::SUM ));
     return 1;
   }
 

--- a/src/Core/simtub.cpp
+++ b/src/Core/simtub.cpp
@@ -1763,7 +1763,7 @@ int simtub_constraints(Db* dbin,
 
   /* Implicit loop on the simulations */
 
-  iatt = dbout->getColumnNumber();
+  iatt = dbout->getNColumn();
   nvalid = iter = nbtest = 0;
   nbsimu = nbsimu_min + nbsimu_quant;
   while (nvalid < nbsimu_min && iter < niter_max)

--- a/src/Core/spill.cpp
+++ b/src/Core/spill.cpp
@@ -635,8 +635,8 @@ int spill_point(DbGrid* dbgrid,
     messerr("Spill point is limited to 2-D space");
     return (1);
   }
-  if (ind_depth < 0 || ind_depth > dbgrid->getColumnNumber() ||
-      ind_data  < 0 || ind_data  > dbgrid->getColumnNumber())
+  if (ind_depth < 0 || ind_depth > dbgrid->getNColumn() ||
+      ind_data  < 0 || ind_data  > dbgrid->getNColumn())
   {
     messerr("Error in the ranks of the height (%d) and data (%d) variables",
             ind_depth, ind_data);

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -253,7 +253,7 @@ bool Db::isDimensionIndexValid(int idim) const
  */
 bool Db::isUIDValid(int iuid) const
 {
-  return checkArg("UID Index", iuid, getUIDMaxNumber());
+  return checkArg("UID Index", iuid, getNUIDMax());
 }
 
 /**
@@ -312,7 +312,7 @@ VectorInt Db::getColIdxsByUID(const VectorInt& iuids) const
 int Db::getUIDByColIdx(int icol) const
 {
   if (!isColIdxValid(icol)) return -1;
-  for (int iuid = 0; iuid < getUIDMaxNumber(); iuid++)
+  for (int iuid = 0; iuid < getNUIDMax(); iuid++)
     if (_uidcol[iuid] == icol) return iuid;
   return -1;
 }
@@ -1002,7 +1002,7 @@ bool Db::hasLocator(const ELoc& locatorType) const
   return p.hasLocator();
 }
 
-int Db::getFromLocatorNumber(const ELoc& locatorType) const
+int Db::getNFromLocator(const ELoc& locatorType) const
 {
   const PtrGeos& p = _p[locatorType.getValue()];
   return p.getNLoc();
@@ -1070,15 +1070,15 @@ String Db::_summaryUIDs(void) const
   std::stringstream sstr;
 
   sstr << toTitle(1, "List of unsorted UIDs");
-  sstr << "Maximum number of positions = " << getUIDMaxNumber() << std::endl;
-  sstr << "Number of Columns           = " << getColumnNumber() << std::endl;
+  sstr << "Maximum number of positions = " << getNUIDMax() << std::endl;
+  sstr << "Number of Columns           = " << getNColumn() << std::endl;
 
   /* Loop on the UIDs */
 
-  if (getUIDMaxNumber() <= 0) return sstr.str();
+  if (getNUIDMax() <= 0) return sstr.str();
 
   sstr << "UID = ";
-  for (int iuid = 0; iuid < getUIDMaxNumber(); iuid++)
+  for (int iuid = 0; iuid < getNUIDMax(); iuid++)
     sstr << _uidcol[iuid] << " ";
   sstr << std::endl;
   return sstr.str();
@@ -1285,7 +1285,7 @@ int Db::addColumnsByConstant(int nadd,
                              int nechInit)
 {
   int ncol = _ncol;
-  int nmax = getUIDMaxNumber();
+  int nmax = getNUIDMax();
   int nnew = ncol + nadd;
   if (nadd <= 0) return (-1);
 
@@ -1346,7 +1346,7 @@ int Db::addColumnsRandom(int nadd,
                          int nechInit)
 {
   int ncol = _ncol;
-  int nmax = getUIDMaxNumber();
+  int nmax = getNUIDMax();
   int nnew = ncol + nadd;
   if (nadd <= 0) return (-1);
 
@@ -1895,7 +1895,7 @@ void Db::deleteColumnByUID(int iuid_del)
 {
   int ncol = _ncol;
   int nech = _nech;
-  int nmax = getUIDMaxNumber();
+  int nmax = getNUIDMax();
   int nnew = ncol - 1;
   if (!isUIDValid(iuid_del)) return;
 
@@ -2125,7 +2125,7 @@ VectorString Db::identifyNames(const VectorString& names) const
 
   // Constitute the list of the locator names
   VectorString locnames;
-  for (int j = 0; j < getColumnNumber(); j++)
+  for (int j = 0; j < getNColumn(); j++)
   {
     if (! getLocatorByColIdx(j, &locatorType, &locatorIndex)) continue;
     String local = getLocatorName(locatorType, locatorIndex);
@@ -2308,8 +2308,8 @@ void Db::switchLocator(const ELoc& locatorType_in, const ELoc& locatorType_out)
 {
   PtrGeos& p_in  = _p[locatorType_in.getValue()];
   PtrGeos& p_out = _p[locatorType_out.getValue()];
-  int n_in  = getFromLocatorNumber(locatorType_in);
-  int n_out = getFromLocatorNumber(locatorType_out);
+  int n_in  = getNFromLocator(locatorType_in);
+  int n_out = getNFromLocator(locatorType_out);
 
   /* Move the gradient components into additional variables */
   p_out.resize(n_in + n_out);
@@ -2432,7 +2432,7 @@ int Db::getNLoc(const ELoc& loctype) const
   return p.getNLoc();
 }
 
-int Db::getZNumber() const
+int Db::getNZValues() const
 {
   const PtrGeos& p = _p[ELoc::Z.getValue()];
   return p.getNLoc();
@@ -2470,7 +2470,7 @@ double Db::getZVariable(int iech, int item) const
 VectorDouble Db::getLocVariables(const ELoc& loctype, int iech, int nitemax) const
 {
   VectorDouble vec;
-  int number = getFromLocatorNumber(loctype);
+  int number = getNFromLocator(loctype);
   if (number <= 0) return vec;
   int nitem = (nitemax > 0) ? MIN(nitemax, number) : number;
 
@@ -2497,7 +2497,7 @@ void Db::setLocVariables(const ELoc& loctype,
                          int iech,
                          const VectorDouble& values)
 {
-  int number = getFromLocatorNumber(loctype);
+  int number = getNFromLocator(loctype);
   int size = (int) values.size();
   if (number != size)
   {
@@ -3033,7 +3033,7 @@ String Db::getNameByUID(int iuid) const
 VectorString Db::getNamesByLocator(const ELoc& locatorType) const
 {
   VectorString namelist;
-  int count = getFromLocatorNumber(locatorType);
+  int count = getNFromLocator(locatorType);
   if (count <= 0) return namelist;
   for (int i = 0; i < count; i++)
   {
@@ -3152,7 +3152,7 @@ void Db::setName(const VectorString& list, const String& name)
 void Db::setNameByLocator(const ELoc& locatorType, const String& name)
 {
   VectorString namelist;
-  int count = getFromLocatorNumber(locatorType);
+  int count = getNFromLocator(locatorType);
   if (count <= 0) return;
   for (int i = 0; i < count; i++)
   {
@@ -3175,7 +3175,7 @@ String Db::_summaryString(void) const
     sstr << "File is organized as a set of isolated points" << std::endl;
 
   sstr << "Space dimension              = " << getNDim() << std::endl;
-  sstr << "Number of Columns            = " << getColumnNumber() << std::endl;
+  sstr << "Number of Columns            = " << getNColumn() << std::endl;
   sstr << "Total number of samples      = " << getNSample() << std::endl;
   if (hasLocVariable(ELoc::SEL))
     sstr << "Number of active samples     = " << getNSample(true)
@@ -3212,10 +3212,10 @@ String Db::_summaryVariables(void) const
 {
   std::stringstream sstr;
 
-  if (getColumnNumber() <= 0) return sstr.str();
+  if (getNColumn() <= 0) return sstr.str();
   sstr << toTitle(1, "Variables");
 
-  for (int icol = 0; icol < getColumnNumber(); icol++)
+  for (int icol = 0; icol < getNColumn(); icol++)
   {
     sstr << "Column = " << icol;
     sstr << " - Name = " << getNameByColIdx(icol);
@@ -3236,7 +3236,7 @@ String Db::_summaryStats(VectorInt cols, int mode, int maxNClass) const
 {
   std::stringstream sstr;
 
-  int ncol = (cols.empty()) ? getColumnNumber() : static_cast<int> (cols.size());
+  int ncol = (cols.empty()) ? getNColumn() : static_cast<int> (cols.size());
   if (ncol <= 0) return sstr.str();
 
   sstr << toTitle(1, "Data Base Statistics");
@@ -3306,7 +3306,7 @@ String Db::_summaryArrays(VectorInt cols, bool useSel) const
 {
   std::stringstream sstr;
 
-  int ncol = (cols.empty()) ? getColumnNumber() : static_cast<int> (cols.size());
+  int ncol = (cols.empty()) ? getNColumn() : static_cast<int> (cols.size());
   if (ncol <= 0) return sstr.str();
 
   sstr << toTitle(1, "Data Base Contents");
@@ -4376,7 +4376,7 @@ void Db::_createRank(int icol)
  */
 void Db::_addRank(int nech)
 {
-  if (getColumnNumber() > 0 || getNSample() > 0)
+  if (getNColumn() > 0 || getNSample() > 0)
   {
     messerr("Error: the Db should be empty in order to call _addRank. "
             "Nothing is done");
@@ -4388,7 +4388,7 @@ void Db::_addRank(int nech)
 
 void Db::_defineDefaultNames(int shift, const VectorString& names)
 {
-  int ncol = getColumnNumber() - shift;
+  int ncol = getNColumn() - shift;
   if (!names.empty())
   {
     if ((int)names.size() != ncol)
@@ -4412,7 +4412,7 @@ void Db::_defineDefaultLocators(int shift, const VectorString& locatorNames)
 {
   if (locatorNames.empty()) return;
 
-  int ncol = getColumnNumber() - shift;
+  int ncol = getNColumn() - shift;
   if ((int)locatorNames.size() != ncol)
     my_throw("Error in the dimension of 'locatorNames'");
 
@@ -4430,7 +4430,7 @@ void Db::_defineDefaultLocatorsByNames(int shift, const VectorString& names)
 {
   if (names.empty()) return;
 
-  int ncol = getColumnNumber() - shift;
+  int ncol = getNColumn() - shift;
   if ((int)names.size() != ncol) my_throw("Error in the dimension of 'names'");
 
   ELoc locatorType;
@@ -4531,7 +4531,7 @@ Db* Db::createFromNF(const String& neutralFilename, bool verbose)
 
 bool Db::_serialize(std::ostream& os, bool /*verbose*/) const
 {
-  int ncol              = getColumnNumber();
+  int ncol              = getNColumn();
   VectorString locators = getLocators(true);
   VectorString names    = getName("*");
   std::vector<double> vals;
@@ -4611,7 +4611,7 @@ void Db::_loadData(const ELoadBy& order,
 {
   // Preliminary check
 
-  if (getColumnNumber() <= 0) return;
+  if (getNColumn() <= 0) return;
   int jcol = 0;
 
   // Add the rank (optional)
@@ -4627,7 +4627,7 @@ void Db::_loadData(const ELoadBy& order,
   // Add the input array 'tab' (if provided)
 
   if (tab.empty()) return;
-  int ntab = (flagAddSampleRank) ? getColumnNumber() - 1 : getColumnNumber();
+  int ntab = (flagAddSampleRank) ? getNColumn() - 1 : getNColumn();
   int ecr  = 0;
   for (int icol = 0; icol < ntab; icol++)
   {

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -592,7 +592,7 @@ bool DbGrid::migrateAllVariables(Db *dbin, bool flag_fill, bool flag_inter,
   // Constitute the list of Variables to be migrated
 
   VectorInt icols;
-  for (int icol = 0; icol < dbin->getColumnNumber(); icol++)
+  for (int icol = 0; icol < dbin->getNColumn(); icol++)
   {
     // Skip the rank
     if (flagAddSampleRank && icol == 0) continue;
@@ -609,7 +609,7 @@ bool DbGrid::migrateAllVariables(Db *dbin, bool flag_fill, bool flag_inter,
   if (ncol <= 0) return true;
 
   // Migrate the variables
-  int icolOut = getColumnNumber();
+  int icolOut = getNColumn();
   if (migrateByAttribute(dbin, this, icols, 2, VectorDouble(), flag_fill,
                          flag_inter, flag_ball, NamingConvention(String())))
     return false;

--- a/src/Db/DbHelper.cpp
+++ b/src/Db/DbHelper.cpp
@@ -1310,7 +1310,7 @@ DbGrid* DbHelper::dbgrid_sampling(DbGrid *dbin, const VectorInt &nmult)
   /* Initializations */
 
   dbout = nullptr;
-  ncol = dbin->getColumnNumber();
+  ncol = dbin->getNColumn();
   ndim = dbin->getNDim();
 
   /* Core allocation */

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -2410,13 +2410,13 @@ int KrigingSystem::setKrigOptColCok(const VectorInt& rank_colcok)
   {
     int jvar = _rankColCok[ivar];
     if (IFFFF(jvar)) continue;
-    if (jvar > _dbout->getColumnNumber())
+    if (jvar > _dbout->getNColumn())
     {
       messerr("Error in the Colocation array:");
       messerr("Input variable (#%d): rank of the colocated variable is %d",
               ivar + 1, jvar);
       messerr("But the Output file only contains %d attributes(s)",
-              _dbout->getColumnNumber());
+              _dbout->getNColumn());
       return (1);
     }
   }

--- a/src/LithoRule/RuleProp.cpp
+++ b/src/LithoRule/RuleProp.cpp
@@ -196,7 +196,7 @@ bool RuleProp::_checkConsistency()
     _propcst.clear();
 
     // Check consistency of the number of facies
-    int nfacdb = _dbprop->getFromLocatorNumber(ELoc::P);
+    int nfacdb = _dbprop->getNFromLocator(ELoc::P);
     if (nfacies > 0 && nfacies != nfacdb)
     {
       messerr("Mismatch between:");
@@ -256,7 +256,7 @@ int RuleProp::_getNFacies()
   // Non-stationary case: proportions are provided using Dbprop
   if (_dbprop != nullptr)
   {
-    return _dbprop->getFromLocatorNumber(ELoc::P);
+    return _dbprop->getNFromLocator(ELoc::P);
   }
 
   // Stationary proportions provided by 'propcst'

--- a/src/Matrix/LinkMatrixSparse.cpp
+++ b/src/Matrix/LinkMatrixSparse.cpp
@@ -1408,7 +1408,7 @@ String toStringRange(const String &title, const cs *C)
 
   /* Calculate the extreme values */
 
-  StatResults stats = ut_statistics(NF_T.getNumber(), NF_T.getValues().data());
+  StatResults stats = ut_statistics(NF_T.getNElements(), NF_T.getValues().data());
 
   /* Printout */
 
@@ -1417,7 +1417,7 @@ String toStringRange(const String &title, const cs *C)
   sstr << " Descr: m=" << cs_getnrow(C) << " - n=" << cs_getncol(C) << " - nzmax=" << C->nzmax
   << std::endl;
   sstr << " Range: [" << stats.mini << " ; " << stats.maxi << "] (" << stats.nvalid << " / "
-       << NF_T.getNumber() << ")" << std::endl;
+       << NF_T.getNElements() << ")" << std::endl;
 
   return sstr.str();
 }
@@ -1553,7 +1553,7 @@ cs* cs_extract_submatrix(cs *C,
   /* Fill the new sparse triplet */
 
   NF_Triplet NF_Tout;
-  for (int i = 0, n = NF_T.getNumber(); i < n; i++)
+  for (int i = 0, n = NF_T.getNElements(); i < n; i++)
   {
     int ic = NF_T.getCol(i) - col_from;
     if (ic < 0 || ic >= col_length) continue;
@@ -1604,7 +1604,7 @@ void cs_print_range(const char *title, const cs *C)
 
   /* Calculate the extreme values */
 
-  StatResults stats = ut_statistics(NF_T.getNumber(), NF_T.getValues().data());
+  StatResults stats = ut_statistics(NF_T.getNElements(), NF_T.getValues().data());
 
   /* Printout */
 
@@ -1613,8 +1613,8 @@ void cs_print_range(const char *title, const cs *C)
   else
     message("Sparse matrix\n");
   message(" Descr: m=%d n=%d nnz=%d\n", cs_getnrow(C), cs_getncol(C), C->nzmax);
-  if (NF_T.getNumber() > 0)
-    message(" Range: [%lf ; %lf] (%d/%d)\n", stats.mini, stats.maxi, stats.nvalid, NF_T.getNumber());
+  if (NF_T.getNElements() > 0)
+    message(" Range: [%lf ; %lf] (%d/%d)\n", stats.mini, stats.maxi, stats.nvalid, NF_T.getNElements());
   else
     message(" All terms are set to zero\n");
 }
@@ -3085,7 +3085,7 @@ cs* cs_compress(cs *A)
   NF_Triplet NF_T = csToTriplet(A);
 
   NF_Triplet NF_Tout;
-  for (int i = 0; i < NF_T.getNumber(); i++)
+  for (int i = 0; i < NF_T.getNElements(); i++)
   {
     double value = NF_T.getValue(i);
     if (isZero(value)) continue;
@@ -3111,7 +3111,7 @@ void cs_print_file(const char *radix, int rank, const cs *A)
 
   NF_Triplet NF_T = csToTriplet(A);
 
-  for (int i = 0; i < NF_T.getNumber(); i++)
+  for (int i = 0; i < NF_T.getNElements(); i++)
   {
     fprintf(file, "%10d %10d %20.10lf\n", NF_T.getCol(i), NF_T.getRow(i), NF_T.getValue(i));
   }
@@ -3462,11 +3462,11 @@ cs* cs_glue(const cs* A1, const cs* A2, bool shiftRow, bool shiftCol)
   NF_Triplet T2 = csToTriplet(A2);
 
   // Copy the contents of A1 into triplets
-  for (int i = 0; i < T1.getNumber(); i++)
+  for (int i = 0; i < T1.getNElements(); i++)
     NF_Tout.add(T1.getRow(i), T1.getCol(i), T1.getValue(i));
 
   // Copy the contents of A2 into triplets
-  for (int i = 0; i < T2.getNumber(); i++)
+  for (int i = 0; i < T2.getNElements(); i++)
     NF_Tout.add(T2.getRow(i) + addRow, T2.getCol(i) + addCol, T2.getValue(i));
 
   int row_cur = NF_Tout.getNRows();

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -1496,7 +1496,7 @@ MatrixSparse* MatrixSparse::extractSubmatrixByRanks(const VectorInt &rank_rows,
 
   /* Fill the new sparse triplet */
 
-  for (int i = 0; i < NF_Tin.getNumber(); i++)
+  for (int i = 0; i < NF_Tin.getNElements(); i++)
   {
     old_row = NF_Tin.getRow(i);
     old_col = NF_Tin.getCol(i);
@@ -1556,7 +1556,7 @@ MatrixSparse* MatrixSparse::extractSubmatrixByColor(const VectorInt &colors,
 
   /* Fill the new sparse triplet */
 
-  for (int i = 0; i < NF_Tin.getNumber(); i++)
+  for (int i = 0; i < NF_Tin.getNElements(); i++)
   {
     ir = u_row[NF_Tin.getRow(i)];
     ic = u_col[NF_Tin.getCol(i)];

--- a/src/Matrix/NF_Triplet.cpp
+++ b/src/Matrix/NF_Triplet.cpp
@@ -66,7 +66,7 @@ void NF_Triplet::force(int nrow, int ncol)
 cs* NF_Triplet::buildCsFromTriplet() const
 {
   cs* local = cs_spalloc2(0,0,1,1,1);
-  for (int i = 0, n = getNumber(); i < n; i++)
+  for (int i = 0, n = getNElements(); i < n; i++)
     (void) cs_entry2(local, getRow(i), getCol(i), getValue(i));
   cs* Q = cs_triplet2(local);
   cs_spfree2(local);
@@ -110,25 +110,25 @@ NF_Triplet NF_Triplet::createFromEigen(const Eigen::SparseMatrix<double>& mat, i
 
 int NF_Triplet::getRow(int i) const
 {
-  if (i < 0 || i >= getNumber()) return ITEST;
+  if (i < 0 || i >= getNElements()) return ITEST;
   return _eigenT[i].row();
 }
 
 int NF_Triplet::getCol(int i) const
 {
-  if (i < 0 || i >= getNumber()) return ITEST;
+  if (i < 0 || i >= getNElements()) return ITEST;
   return _eigenT[i].col();
 }
 
 double NF_Triplet::getValue(int i) const
 {
-  if (i < 0 || i >= getNumber()) return TEST;
+  if (i < 0 || i >= getNElements()) return TEST;
   return _eigenT[i].value();
 }
 
 VectorDouble NF_Triplet::getValues() const
 {
-  int n = getNumber();
+  int n = getNElements();
   VectorDouble vec(n);
   for (int i = 0; i< n; i++)
     vec[i] = _eigenT[i].value();
@@ -137,7 +137,7 @@ VectorDouble NF_Triplet::getValues() const
 
 VectorInt NF_Triplet::getRows(bool flag_from_1) const
 {
-  int n = getNumber();
+  int n = getNElements();
   int shift = (flag_from_1) ? 1 : 0;
   VectorInt vec(n);
   for (int i = 0; i < n; i++)
@@ -147,7 +147,7 @@ VectorInt NF_Triplet::getRows(bool flag_from_1) const
 
 VectorInt NF_Triplet::getCols(bool flag_from_1) const
 {
-  int n = getNumber();
+  int n = getNElements();
   int shift = (flag_from_1) ? 1 : 0;
   VectorInt vec(n);
   for (int i = 0; i < n; i++)
@@ -164,7 +164,7 @@ void NF_Triplet::appendInPlace(const NF_Triplet& T2)
   _eigenT.insert( _eigenT.end(), T2._eigenT.begin(), T2._eigenT.end() );
 
   // Update the maxima for rows and columns
-  for (int i = 0, n = T2.getNumber(); i < n; i++)
+  for (int i = 0, n = T2.getNElements(); i < n; i++)
   {
     int irow = T2.getRow(i);
     int icol = T2.getCol(i);

--- a/src/Mesh/MeshETurbo.cpp
+++ b/src/Mesh/MeshETurbo.cpp
@@ -283,7 +283,7 @@ int MeshETurbo::_initFromGridInternal(const VectorDouble& sel,
 
   // Define the number of Elements per Cell
 
-  _setNumberElementPerCell();
+  _setNElementPerCell();
 
   // Set polarization
 
@@ -470,7 +470,7 @@ int MeshETurbo::initFromExtend(const VectorDouble &extendmin,
 
   // Define the number of Elements per Cell
 
-  _setNumberElementPerCell();
+  _setNElementPerCell();
 
   // Set polarization
 
@@ -680,7 +680,7 @@ int MeshETurbo::_defineGrid(const VectorDouble& cellsize)
   return 0;
 }
 
-void MeshETurbo::_setNumberElementPerCell()
+void MeshETurbo::_setNElementPerCell()
 {
   int ndim = getNDim();
 

--- a/src/Simulation/CalcSimuEden.cpp
+++ b/src/Simulation/CalcSimuEden.cpp
@@ -141,7 +141,7 @@ bool CalcSimuEden::_simulate()
       }
       else
       {
-        _addStatNumber(_getFACIES(ipos)-1,ref_fluid-1,1);
+        _addStatCount(_getFACIES(ipos)-1,ref_fluid-1,1);
         _addStatVolume(_getFACIES(ipos)-1,ref_fluid-1,_getPORO(ipos));
         _setFLUID(ipos, ref_fluid);
         _setDATE(ipos, idate);
@@ -513,12 +513,12 @@ void CalcSimuEden::_statsReset()
   for (int ifluid = 0; ifluid < _nfluids; ifluid++)
     for (int ifacies = 0; ifacies < _nfacies; ifacies++)
     {
-      _setStatNumber(ifacies,ifluid,0);
+      _setStatCount(ifacies,ifluid,0);
       _setStatVolume(ifacies,ifluid,0.);
     }
 }
 
-void CalcSimuEden::_setStatNumber(int ifacies, int ifluid, int value)
+void CalcSimuEden::_setStatCount(int ifacies, int ifluid, int value)
 {
   _numbers[ifacies * _nfluids + ifluid] = value;
 }
@@ -526,7 +526,7 @@ void CalcSimuEden::_setStatVolume(int ifacies, int ifluid, double value)
 {
   _volumes[ifacies * _nfluids + ifluid] = value;
 }
-void CalcSimuEden::_addStatNumber(int ifacies, int ifluid, int value)
+void CalcSimuEden::_addStatCount(int ifacies, int ifluid, int value)
 {
   _numbers[ifacies * _nfluids + ifluid] += value;
 }
@@ -534,7 +534,7 @@ void CalcSimuEden::_addStatVolume(int ifacies, int ifluid, double value)
 {
   _volumes[ifacies * _nfluids + ifluid] += value;
 }
-int CalcSimuEden::_getStatNumber(int ifacies, int ifluid) const
+int CalcSimuEden::_getStatCount(int ifacies, int ifluid) const
 {
   return _numbers[ifacies * _nfluids + ifluid];
 }
@@ -659,7 +659,7 @@ void CalcSimuEden::_statsInit()
 
     /* The cell does not belong to the skin: it is already filled */
 
-    _addStatNumber(_getFACIES(lec)-1,_getFLUID(lec)-1,1);
+    _addStatCount(_getFACIES(lec)-1,_getFLUID(lec)-1,1);
     _addStatVolume(_getFACIES(lec)-1,_getFLUID(lec)-1,_getPORO(lec));
   }
 }
@@ -680,7 +680,7 @@ int CalcSimuEden::_checkMax(double number_max, double volume_max)
   for (int ifluid = 0; ifluid < _nfluids; ifluid++)
     for (int ifacies = 0; ifacies < _nfacies; ifacies++)
     {
-      int number = _getStatNumber(ifacies, ifluid);
+      int number = _getStatCount(ifacies, ifluid);
       double volume = _getStatVolume(ifacies, ifluid);
       totnum += number;
       totvol += volume;
@@ -784,7 +784,7 @@ void CalcSimuEden::_statsPrint(const char *title)
   for (int ifluid = 0; ifluid < _nfluids; ifluid++)
     for (int ifacies = 0; ifacies < _nfacies; ifacies++)
     {
-      int number    = _getStatNumber(ifacies, ifluid);
+      int number    = _getStatCount(ifacies, ifluid);
       double volume = _getStatVolume(ifacies, ifluid);
       totnum += number;
       totvol += volume;
@@ -1107,7 +1107,7 @@ int fluid_propagation(DbGrid *dbgrid,
 
   seden.setSpeeds(speeds);
   seden.setShowFluid(show_fluid);
-  seden.setNumberMax(number_max);
+  seden.setNMax(number_max);
   seden.setVolumeMax(volume_max);
 
   // Run the calculator

--- a/src/Simulation/CalcSimuFFT.cpp
+++ b/src/Simulation/CalcSimuFFT.cpp
@@ -111,7 +111,7 @@ void CalcSimuFFT::_alloc()
   {
     if (i < _getNDim())
     {
-      int nval = _getOptimalEvenNumber(_shift[i] + dbgrid->getNX(i));
+      int nval = _getNOptimalEven(_shift[i] + dbgrid->getNX(i));
       _dims[i] = nval;
       _dim2[i] = nval / 2;
     }
@@ -155,7 +155,7 @@ void CalcSimuFFT::_alloc()
  ** \param[in]  largeFactor Maximum value for a Factor
  **
  *****************************************************************************/
-int CalcSimuFFT::_getOptimalEvenNumber(int number, int largeFactor)
+int CalcSimuFFT::_getNOptimalEven(int number, int largeFactor)
 {
   int local = number;
   if ((local % 2) == 1) local++;

--- a/src/Simulation/CalcSimuPartition.cpp
+++ b/src/Simulation/CalcSimuPartition.cpp
@@ -92,7 +92,7 @@ bool CalcSimuPartition::_voronoi()
 
   /* Expand the data values over the grid nodes */
 
-  int iattp = dbpoint->getColumnNumber() - 1;
+  int iattp = dbpoint->getNColumn() - 1;
   if (expandPointToGrid(dbpoint, dbgrid, iattp, -1, 0, -1, -1, -1, -1, 0,
                            VectorDouble(), simgrid)) return 1;
 
@@ -139,7 +139,7 @@ bool CalcSimuPartition::_poisson()
 
   if (simtub(NULL, dbgrid, getModel(), NULL, 1, getSeed(), _parparam.getNbtuba()))
     return false;
-  iattg = dbgrid->getColumnNumber() - 1;
+  iattg = dbgrid->getNColumn() - 1;
 
   /***********************/
   /* Information process */

--- a/src/Stats/Regression.cpp
+++ b/src/Stats/Regression.cpp
@@ -90,14 +90,14 @@ bool _regressionCheck(Db *db1,
   switch (mode)
   {
     case 0:
-      if (icol0 < 0 || icol0 >= db1->getUIDMaxNumber())
+      if (icol0 < 0 || icol0 >= db1->getNUIDMax())
       {
         messerr("The regression requires a valid target variable");
         return false;
       }
       for (int icol = 0; icol < ncol; icol++)
       {
-        if (icols[icol] < 0 || icols[icol] >= db2->getUIDMaxNumber())
+        if (icols[icol] < 0 || icols[icol] >= db2->getNUIDMax())
         {
           messerr("The regression requires a valid auxiliary variable (#%d)",
                   icol + 1);

--- a/src/Stats/Selectivity.cpp
+++ b/src/Stats/Selectivity.cpp
@@ -1134,7 +1134,7 @@ int Selectivity::getNQTEst(const ESelectivity& code) const
   return _numberQT.getValue(code.getValue(), 0);
 }
 
-int Selectivity::geNQTStd(const ESelectivity& code) const
+int Selectivity::getNQTStd(const ESelectivity& code) const
 {
   return _numberQT.getValue(code.getValue(), 1);
 }

--- a/tests/cpp/test_Gibbs.cpp
+++ b/tests/cpp/test_Gibbs.cpp
@@ -328,7 +328,7 @@ int main(int argc, char *argv[])
   (void)simulateSPDE(NULL, dbgrid, model2, nullptr, nsimu, NULL, useCholesky,
                      SPDEParam(), verbose);
 
-  int rank = dbgrid->getColumnNumber();
+  int rank = dbgrid->getNColumn();
   for (int i=0; i<nvertex; i++)
   {
     consmin[i] = MIN(dbgrid->getArray(i,rank-1), dbgrid->getArray(i,rank-2));

--- a/tests/data/testim.cpp
+++ b/tests/data/testim.cpp
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
                       5.,true,true,true))
       messageAbort("gibbs_sampler");
     /* Set the current variable to the conditional expectation */
-    dbin->setLocatorByUID(dbin->getColumnNumber()-1,ELoc::Z, 0);
+    dbin->setLocatorByUID(dbin->getNColumn()-1,ELoc::Z, 0);
   }
 
   /* Perform the estimation */

--- a/tests/data/testpgs.cpp
+++ b/tests/data/testpgs.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
       /* Define the indicators */
 
       nclass   = nfac[i];
-      iatt_ind = dbin->getColumnNumber();
+      iatt_ind = dbin->getNColumn();
       Limits limits = Limits(nclass);
       limits.toIndicator(dbin);
       dbin->setLocatorsByUID(nclass,iatt_ind,ELoc::Z, 0);

--- a/tests/data/testvar.cpp
+++ b/tests/data/testvar.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     if (simtub(nullptr,dbout,model,nullptr,nbsimu,seed,nbtuba,0))
       messageAbort("Simulations");
     /* Set the current variable to the conditional expectation */
-    dbout->setLocatorByUID(dbout->getColumnNumber()-1,ELoc::Z, 0);
+    dbout->setLocatorByUID(dbout->getNColumn()-1,ELoc::Z, 0);
   }
   seed = law_get_random_seed();
   

--- a/tests/py/test_Override.py
+++ b/tests/py/test_Override.py
@@ -53,14 +53,14 @@ def findColumnNames(self, columns):
         names = self.getNameByColIdx(columns)
     
     elif isinstance(columns, slice):
-        Nmax = self.getColumnNumber()
+        Nmax = self.getNColumn()
         names = []
         for i in range(Nmax)[columns]:
             names.append(self.getNameByColIdx(i))
 
     elif is_list_type(columns, (int, np.int_)):
         names = []
-        Nfields = self.getColumnNumber()
+        Nfields = self.getNColumn()
         for i in columns:
             if i >= Nfields:
                 print(f"Warning: the index {i} is out of bounds with {Nfields}, this index is ignored")


### PR DESCRIPTION
This concludes the large set of renaming operations that has been completed.
The principle is to rename getXXXNumber() into getNXXX() (same for setXXX). This has been performed almost systematically in order to reduce the name of the methods and to standardize them.
In few methods, where the term "Number" was relevant, it has been replace by "Count".

When this PR is performed successfully, it can be closed and the branch can be deleted