### PR TITLE
Use addMethods for fixing $dumpToNF known caveheat in R

### DIFF
--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -1266,5 +1266,8 @@ setMethod("plot", signature(x="_p_AAnam"), function(x,y="missing",...) plot.anam
 
 addMethods("Model",c("ModelCovList","ModelGeneric"))
 
+addMethods("Db", c("ASerializable"))
+addMethods("DbGrid", c("ASerializable"))
+
 
 %}


### PR DESCRIPTION
This fixes the #308 issue but only for the grid$dumpToNF() error.
The same issue could occur with other base class and in that case, the same kind of fix must be added in rgstlearn.i.