### PR TITLE
CI: Switch to pixi to handle both Python & native dependencies

### DIFF
--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -35,27 +35,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Setup pixi
+      uses: prefix-dev/setup-pixi@v0.8.2
       with:
-        python-version: ${{env.PYTHON_VERSION}}
-
-    - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy
-        python -m pip install pandas scipy mlxtend
-
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+        run-install: false
 
     - name: Install dependencies
       run: |
-        conda install -c conda-forge boost
-        conda install -c conda-forge eigen
-        conda install -c conda-forge ninja
-        # don't interfere with pre-installed Python
-        rm C:\Miniconda\python.exe
+        pixi init
+        pixi add python==${{env.PYTHON_VERSION}}
+        pixi add pip numpy pandas scipy mlxtend
+        pixi add libboost-devel eigen ninja
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.5
@@ -68,7 +58,7 @@ jobs:
 
     - name: Configure build directory
       run: |
-        cmake `
+        pixi run cmake `
           -B${{ env.BUILD_DIR }} `
           -DBUILD_TESTING=ON `
           -DBUILD_PYTHON=ON
@@ -76,7 +66,6 @@ jobs:
         SCCACHE_GHA_ENABLED: "true"
         CMAKE_CC_COMPILER_LAUNCHER: sccache
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
-        CMAKE_PREFIX_PATH: C:\conda\Library\lib\cmake;C:\conda\Library\share\eigen3\cmake;
 
     - name: Build the package
       run: |


### PR DESCRIPTION
This PR switches the `nonreg-tests_windows_latest_msvc` workflow to use `pixi` instead of `conda` + `pip` to download Python and native `gstlearn` dependencies.

This workflow is the only one currently using `conda`. The latest `conda` release (25.1) seem to break down with the current CI setup, in particular around the `setup-conda` action. Switching to `pixi` fixes this issue.

Pierre