### PR TITLE
Proof of concept for serialization/deserialization with HDF5

### DIFF
--- a/.github/actions/hdf5_static_unix/action.yml
+++ b/.github/actions/hdf5_static_unix/action.yml
@@ -1,0 +1,45 @@
+name: 'HDF5 static Unix'
+description: 'Build & install HDF5 static libraries on Ubuntu & macOS'
+runs:
+  using: "composite"
+  steps:
+
+    - name: Build & install HDF5 static libraries
+      shell: bash
+      run: |
+        curl -OL https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz
+        tar xvfz hdf5-1.14.6.tar.gz
+        cd hdf5-1.14.6
+        mkdir build && cd build
+        # extracted from hdf5's CMakePresets.json
+        cmake \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_TESTING=OFF \
+          -DHDF5_BUILD_EXAMPLES=OFF \
+          -DHDF5_BUILD_HL_LIB=OFF \
+          -DHDF5_BUILD_CPP_LIB=ON \
+          -DHDF_PACKAGE_NAMESPACE=hdf5:: \
+          -DHDF5_INSTALL_MOD_FORTRAN=NO \
+          -DHDF5_BUILD_GENERATORS=ON \
+          -DHDF5_ENABLE_ALL_WARNINGS=ON \
+          -DHDF5_MINGW_STATIC_GCC_LIBS=ON \
+          -DHDF5_ALLOW_EXTERNAL_SUPPORT=TGZ \
+          -DTGZPATH=../temp \
+          -DZLIB_PACKAGE_NAME=zlib \
+          -DZLIB_TGZ_ORIGPATH=https://github.com/madler/zlib/releases/download/v1.3.1 \
+          -DZLIB_TGZ_NAME=zlib-1.3.1.tar.gz \
+          -DLIBAEC_PACKAGE_NAME=libaec \
+          -DLIBAEC_TGZ_ORIGPATH=https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3 \
+          -DLIBAEC_TGZ_NAME=libaec-1.1.3.tar.gz \
+          -DHDF5_PACKAGE_EXTLIBS=ON \
+          -DHDF5_USE_ZLIB_NG=OFF \
+          -DZLIB_USE_LOCALCONTENT=OFF \
+          -DLIBAEC_USE_LOCALCONTENT=OFF \
+          -DHDF5_USE_ZLIB_STATIC=ON \
+          -DHDF5_USE_LIBAEC_STATIC=ON \
+          ..
+        cmake --build . --parallel 3
+        sudo cmake --build . --target install
+      env:
+        CMAKE_BUILD_TYPE: Release
+        CMAKE_INSTALL_PREFIX: /usr/local

--- a/.github/actions/hdf5_static_windows/action.yml
+++ b/.github/actions/hdf5_static_windows/action.yml
@@ -1,0 +1,44 @@
+name: 'HDF5 static Windows'
+description: 'Build & install HDF5 static libraries on Windows'
+runs:
+  using: "composite"
+  steps:
+
+    - name: Build & install HDF5 static libraries
+      shell: bash
+      run: |
+        curl -OL https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz
+        tar xvfz hdf5-1.14.6.tar.gz
+        cd hdf5-1.14.6
+        mkdir build && cd build
+        # extracted from hdf5's CMakePresets.json
+        cmake \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_TESTING=OFF \
+          -DHDF5_BUILD_EXAMPLES=OFF \
+          -DHDF5_BUILD_HL_LIB=OFF \
+          -DHDF5_BUILD_CPP_LIB=ON \
+          -DHDF_PACKAGE_NAMESPACE=hdf5:: \
+          -DHDF5_INSTALL_MOD_FORTRAN=NO \
+          -DHDF5_BUILD_GENERATORS=ON \
+          -DHDF5_ENABLE_ALL_WARNINGS=ON \
+          -DHDF5_MINGW_STATIC_GCC_LIBS=ON \
+          -DHDF5_ALLOW_EXTERNAL_SUPPORT=TGZ \
+          -DTGZPATH=../temp \
+          -DZLIB_PACKAGE_NAME=zlib \
+          -DZLIB_TGZ_ORIGPATH=https://github.com/madler/zlib/releases/download/v1.3.1 \
+          -DZLIB_TGZ_NAME=zlib-1.3.1.tar.gz \
+          -DLIBAEC_PACKAGE_NAME=libaec \
+          -DLIBAEC_TGZ_ORIGPATH=https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3 \
+          -DLIBAEC_TGZ_NAME=libaec-1.1.3.tar.gz \
+          -DHDF5_PACKAGE_EXTLIBS=ON \
+          -DHDF5_USE_ZLIB_NG=OFF \
+          -DZLIB_USE_LOCALCONTENT=OFF \
+          -DLIBAEC_USE_LOCALCONTENT=OFF \
+          -DHDF5_USE_ZLIB_STATIC=ON \
+          -DHDF5_USE_LIBAEC_STATIC=ON \
+          ..
+        cmake --build . --config Release --parallel 3 --target install
+      env:
+        CMAKE_BUILD_TYPE: Release
+        CMAKE_INSTALL_PREFIX: C:\Program Files\HDF5

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -38,6 +38,7 @@ jobs:
         brew install boost
         brew install eigen
         brew install nlopt
+        brew install hdf5
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -45,7 +45,7 @@ jobs:
         pixi init
         pixi add python==${{env.PYTHON_VERSION}}
         pixi add pip numpy pandas scipy mlxtend
-        pixi add libboost-devel eigen ninja
+        pixi add libboost-devel eigen ninja hdf5
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.5
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install packages and execute non-regression tests
       run: |
-        cmake --build ${{env.BUILD_DIR}} --target check
+        pixi run cmake --build ${{env.BUILD_DIR}} --target check
 
     - name: Compress output logs and neutral files
       if: success() || failure()

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -49,6 +49,7 @@ jobs:
         pacman -Sy --noconfirm mingw-w64-x86_64-boost
         pacman -Sy --noconfirm mingw-w64-x86_64-eigen3
         pacman -Sy --noconfirm mingw-w64-x86_64-nlopt
+        pacman -Sy --noconfirm mingw-w64-x86_64-hdf5
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-windows-action@v2
@@ -63,6 +64,7 @@ jobs:
           -DBUILD_TESTING=ON `
           -DBUILD_R=ON `
           -DBUILD_PYTHON=OFF `
+          -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
     - name: Build the package

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -78,26 +78,14 @@ jobs:
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
 
-#    - name : Download and install HDF5
-#      run : |
-#        mkdir ${{env.HDF5_ROOT}}
-#        curl --progress-bar --location --output ${{env.HDF5_ROOT}}/download.tar.gz ${{env.HDF5_URL}}
-#        7z  -o${{env.HDF5_ROOT}} x ${{env.HDF5_ROOT}}/download.tar.gz -y -bd
-#        7z  -o${{env.HDF5_ROOT}} x ${{env.HDF5_ROOT}}/download.tar -y -bd
-#        ls
-#        cd ${{env.HDF5_ROOT}}
-#        ls
-#        cd CMake-${{env.HDF5_VERSION}}
-#        mkdir build
-#        cd build
-#        cmake -DHDF5_GENERATE_HEADERS:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DDEFAULT_API_VERSION:STRING=v110 -DCMAKE_BUILD_TYPE:STRING=Release -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=ON -DHDF5_BUILD_JAVA:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=${{env.PROG_ROOT}}/${{env.HDF5_ROOT}} -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF ../${{env.HDF5_VERSION}}
-#        cmake --build . --target all --config Release -- -j 3
-#        cmake --build . --target install --config Release
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_unix
 
     - name : Configure build directory
       run : |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
           -DPython3_ROOT_DIR="${{env.pythonLocation}}" \

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -54,8 +54,6 @@ jobs:
         sudo apt-get install -yq \
           swig \
           doxygen \
-          libhdf5-dev \
-          libopenmpi-dev \
           libboost-dev \
           libeigen3-dev
 
@@ -73,10 +71,14 @@ jobs:
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
 
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_unix
+
     - name : Configure build directory
       run : |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
           -DBUILD_DOXYGEN=ON

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -90,17 +90,10 @@ jobs:
       env:
         CMAKE_GENERATOR_PLATFORM: ${{ matrix.arch.of }}
 
-#    - name : Download and install HDF5
-#      run: |
-#        mkdir ${{env.HDF5_ROOT}}
-#        curl --progress-bar --location --output ${{env.HDF5_ROOT}}/download.zip ${{env.HDF5_URL}}
-#        7z x ${{env.HDF5_ROOT}}/download.zip
-#        cd CMake-${{env.HDF5_VERSION}}
-#        mkdir build
-#        cd build
-#        cmake -G ${{env.GENERATOR}} -DHDF5_GENERATE_HEADERS:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DDEFAULT_API_VERSION:STRING=v110 -DCMAKE_BUILD_TYPE:STRING=Release -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=ON -DHDF5_BUILD_JAVA:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=${{env.PROG_ROOT}}/${{env.HDF5_ROOT}} -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF ../${{env.HDF5_VERSION}}
-#        cmake --build . --target all --config Release
-#        cmake --build . --target install --config Release
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_windows
+      env:
+        CMAKE_GENERATOR_PLATFORM: ${{ matrix.arch.of }}
 
     - name : Configure build directory
       run : |
@@ -110,6 +103,7 @@ jobs:
           -DBUILD_PYTHON=ON `
           -DBUILD_R=OFF `
           -DPython3_ROOT_DIR="${{env.pythonLocation}}" `
+          -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DBUILD_DOXYGEN=ON
 
     - name : Build the package

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -75,10 +75,14 @@ jobs:
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
 
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_unix
+
     - name : Configure build directory
       run : |
         cmake \
           -B${{ env.BUILD_DIR }} \
+          -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=OFF \
           -DBUILD_R=ON \
           -DBUILD_DOXYGEN=ON \

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -47,8 +47,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -yq \
           doxygen \
-          libhdf5-dev \
-          libopenmpi-dev \
           libboost-dev \
           libeigen3-dev
 
@@ -72,6 +70,9 @@ jobs:
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
 
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_unix
+
     - name : Configure build directory
       run : |
         cmake \
@@ -79,6 +80,7 @@ jobs:
           -DBUILD_PYTHON=OFF \
           -DBUILD_R=ON \
           -DBUILD_DOXYGEN=ON \
+          -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
       env:
         CC: gcc-10

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -78,6 +78,9 @@ jobs:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Visual Studio 17 2022"
 
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_windows
+
     - name : Configure build directory
       run : |
         cmake `
@@ -85,6 +88,7 @@ jobs:
           -DBUILD_PYTHON=OFF `
           -DBUILD_R=ON `
           -DBUILD_DOXYGEN=ON `
+          -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig `
           -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ For **compiling and installing** *gstlearn* C++ library, the following tools mus
 * Boost header files 1.65 or higher
 * Eigen3 header files 3.4 or higher
 * NLopt library 2.7 or higher
+* HDF5 C++ library and header files 1.8 or higher
 * Doxygen [Optional] 1.8.3 or higher with LaTeX and Ghostscripts
-* HDF5 [Optional] C++ library and header files 1.8 or higher
 
 See [required tools installation](#required-tools-installation) instructions below
 
@@ -213,9 +213,9 @@ brew install cmake
 brew install texlive-latex-recommended
 brew install texlive-science
 brew install doxygen
-brew install libboost-all-dev
-brew install libeigen3-dev
-brew install libhdf5-dev
+brew install boost
+brew install eigen
+brew install hdf5
 brew install nlopt
 ```
 
@@ -272,6 +272,18 @@ cd C:\NLopt_src\nlopt
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=C:/NLopt -DBUILD_SHARED_LIBS=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_PYTHON=OFF -DNLOPT_SWIG=OFF -DNLOPT_TESTS=OFF
+cmake --build . --config Release --target install
+```
+
+##### Install HDF5 using CMake
+
+Assume that you have fetched the sources from version 1.14.6 from the [HDF5 GitHub repository](https://github.com/HDFGroup/hdf5) in the following folder: `C:\HDF5_src\hdf5`. Open a command prompt by running `cmd.exe` and execute the following commands (adapt the HDF5 source code path in the first command and the HDF5 version in the INSTALL_PREFIX below):
+
+```
+cd C:\HDF5_src\hdf5
+mkdir build
+cd build
+cmake .. -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF -DHDF5_BUILD_HL_LIB=OFF -DHDF5_BUILD_CPP_LIB=ON -DHDF_PACKAGE_NAMESPACE=hdf5:: -DHDF5_INSTALL_MOD_FORTRAN=NO -DHDF5_BUILD_GENERATORS=ON -DHDF5_ENABLE_ALL_WARNINGS=ON -DHDF5_MINGW_STATIC_GCC_LIBS=ON -DHDF5_ALLOW_EXTERNAL_SUPPORT=TGZ -DTGZPATH=../temp -DZLIB_PACKAGE_NAME=zlib -DZLIB_TGZ_ORIGPATH=https://github.com/madler/zlib/releases/download/v1.3.1 -DZLIB_TGZ_NAME=zlib-1.3.1.tar.gz -DLIBAEC_PACKAGE_NAME=libaec -DLIBAEC_TGZ_ORIGPATH=https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3 -DLIBAEC_TGZ_NAME=libaec-1.1.3.tar.gz -DHDF5_PACKAGE_EXTLIBS=ON -DHDF5_USE_ZLIB_NG=OFF -DZLIB_USE_LOCALCONTENT=OFF -DLIBAEC_USE_LOCALCONTENT=OFF -DHDF5_USE_ZLIB_STATIC=ON -DHDF5_USE_LIBAEC_STATIC=ON
 cmake --build . --config Release --target install
 ```
 
@@ -336,6 +348,7 @@ pacman -Sy mingw-w64-x86_64-texlive-latex-recommended
 pacman -Sy mingw-w64-x86_64-texlive-science
 pacman -Sy mingw-w64-x86_64-doxygen
 pacman -Sy mingw-w64-x86_64-nlopt
+pacman -Sy mingw-w64-x86_64-hdf5
 ````
 
 ### Important Notes

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -101,16 +101,10 @@ else()
 endif()
 
 # Look for HDF5
-if (USE_HDF5)
-  # Use static library for HDF5 under Windows (no more issue with DLL location)
-  if (WIN32)
-    set(HDF5_USE_STATIC_LIBRARIES ON)
-  endif()
-  
-  # Look for HDF5
-  # https://stackoverflow.com/questions/41529774/cmakelists-txt-for-compiling-hdf5
-  find_package(HDF5 REQUIRED COMPONENTS CXX)
-  # TODO : If HDF5 not found, fetch it from the web ?
+# use MODULE to use CMake's FindHDF5.cmake instead of HDF5 config files
+find_package(HDF5 MODULE REQUIRED COMPONENTS C CXX)
+if(NOT HDF5_FOUND)
+  message(FATAL_ERROR "HDF5 not found")
 endif()
 
 # Shared and Static libraries
@@ -179,11 +173,9 @@ foreach(FLAVOR ${FLAVORS})
   target_link_libraries(${FLAVOR} PRIVATE NLopt::nlopt)
 
   # Link to HDF5
-  if (USE_HDF5)
-    # Define _USE_HDF5 macro
-    target_compile_definitions(${FLAVOR} PUBLIC _USE_HDF5) 
-    target_link_libraries(${FLAVOR} PUBLIC hdf5::hdf5_cpp)
-  endif()
+  target_compile_definitions(${FLAVOR} PRIVATE ${HDF5_DEFINITIONS})
+  target_include_directories(${FLAVOR} PRIVATE ${HDF5_INCLUDE_DIRS})
+  target_link_libraries(${FLAVOR} PRIVATE ${HDF5_LIBRARIES})
   
   # Exclude [L]GPL features from Eigen
   #target_compile_definitions(${FLAVOR} PUBLIC EIGEN_MPL2_ONLY) 

--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -10,13 +10,11 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/SerializeNeutralFile.hpp"
 #include "gstlearn_export.hpp"
 #include "geoslib_define.h"
 
 #include "Basic/AStringable.hpp"
-#include "Basic/String.hpp"
-#include "Basic/Utilities.hpp"
-#include "Basic/File.hpp"
 
 #include <iostream>
 #include <stdarg.h>
@@ -92,7 +90,6 @@ protected:
                              const String& title,
                              VectorDouble::iterator& it,
                              int nvalues);
-  static bool _onlyBlanks(char *string);
 
   static bool _tableRead(std::istream &is,
                          const String &string,
@@ -108,180 +105,33 @@ private:
   static String _myPrefixName;
 };
 
-template <typename T>
-bool ASerializable::_recordWrite(std::ostream& os,
-                                 const String& title,
-                                 const T& val)
+template<typename T>
+bool ASerializable::_recordWrite(std::ostream& os, const String& title, const T& val)
 {
-  if (os.good())
-  {
-    if (isNA<T>(val))
-    {
-      if (title.empty())
-        os << STRING_NA << " ";
-      else
-        os << STRING_NA << " # " << title << '\n';
-    }
-    else
-    {
-      int prec = os.precision();
-      os.precision(15);
-      if (title.empty())
-        os << val << " ";
-      else
-        os << val << " # " << title << '\n';
-      os.precision(prec);
-    }
-  }
-  return os.good();
+  return SerializeNeutralFile::recordWrite(os, title, val);
 }
 
-template <typename T>
+template<typename T>
 bool ASerializable::_recordWriteVec(std::ostream& os,
                                     const String& title,
                                     const std::vector<T>& vec)
 {
-  if (os.good())
-  {
-    if (!title.empty())
-      os << "# " << title << '\n';
-
-    int prec = os.precision();
-    os.precision(15);
-    for (auto val: vec)
-    {
-      if (isNA<T>(val))
-        os << STRING_NA << " ";
-      else
-        os << val << " ";
-    }
-    os << '\n';
-    os.precision(prec);
-  }
-  return os.good();
+  return SerializeNeutralFile::recordWriteVec(os, title, vec);
 }
 
-template <typename T>
+template<typename T>
 bool ASerializable::_recordRead(std::istream& is, const String& title, T& val)
 {
-  val = T();
-  if (is.good())
-  {
-    String word;
-    // Skip comment or empty lines
-    while (is.good())
-    {
-      word.clear();
-      is >> word;
-      if (!is.good() && !is.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        return false;
-      }
-      word = trim(word);
-      if (!word.empty())
-      {
-        if (word == STRING_NA) break; // We found NA
-        if (word[0] != '#') break;    // We found something
-        // std::getline(is, word);    // We found comment, eat all the line
-        gslSafeGetline(is, word); // We found comment, eat all the line
-      }
-    }
-
-    if (word == STRING_NA)
-    {
-      // Get NA value
-      val = getNA<T>();
-    }
-    else
-    {
-      // Decode the line
-      std::stringstream sstr(word);
-      sstr >> val;
-      if (!sstr.good() && !sstr.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        val = T();
-        return false;
-      }
-    }
-  }
-  return true;
+  return SerializeNeutralFile::recordRead(is, title, val);
 }
 
-template <typename T>
+template<typename T>
 bool ASerializable::_recordReadVec(std::istream& is,
                                    const String& title,
                                    VectorT<T>& vec,
                                    int nvalues)
 {
-  vec.resize(nvalues);
-  int ecr = 0;
-  if (is.good())
-  {
-    String line;
-
-    // Skip comment or empty lines
-    while (is.good())
-    {
-      // std::getline(is, line);
-      gslSafeGetline(is, line);
-      if (!is.good() && !is.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        return false;
-      }
-      line = trim(line);
-      if (!line.empty() && line[0] != '#') break; // We found something
-    }
-
-    // Decode the line
-    std::stringstream sstr(line);
-    while (sstr.good())
-    {
-      String word;
-      sstr >> word;
-      if (!sstr.good() && !sstr.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        vec.clear();
-        return false;
-      }
-      word = trim(word);
-      if (word.empty()) continue;
-      if (word[0] == '#') break; // We found a comment
-
-      T val;
-      if (word == STRING_NA)
-      {
-        // Get NA value
-        val = getNA<T>();
-      }
-      else
-      {
-        // Decode the value
-        std::stringstream sword(word);
-        sword >> val;
-      }
-      if (ecr > nvalues)
-      {
-        messerr("Too many values read");
-        vec.clear();
-        return false;
-      }
-      vec[ecr++] = val;
-    }
-  }
-
-  // Check the number of value actually read
-  if (nvalues != ecr)
-  {
-    messerr("Reading (%s) was expecting %d terms. %d found", title.c_str(),
-            nvalues, ecr);
-    vec.clear();
-    return false;
-  }
-  return true;
+  return SerializeNeutralFile::recordReadVec(is, title, vec, nvalues);
 }
 
 template<typename T>
@@ -290,69 +140,5 @@ bool ASerializable::_recordReadVecInPlace(std::istream& is,
                                           VectorDouble::iterator& it,
                                           int nvalues)
 {
-  int ecr = 0;
-  if (is.good())
-  {
-    String line;
-
-    // Skip comment or empty lines
-    while (is.good())
-    {
-      // std::getline(is, line);
-      gslSafeGetline(is, line);
-      if (!is.good() && !is.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        return false;
-      }
-      line = trim(line);
-      if (!line.empty() && line[0] != '#') break; // We found something
-    }
-
-    // Decode the line
-    std::stringstream sstr(line);
-    while (sstr.good())
-    {
-      String word;
-      sstr >> word;
-      if (!sstr.good() && !sstr.eof())
-      {
-        messerr("Error while reading %s", title.c_str());
-        return false;
-      }
-      word = trim(word);
-      if (word.empty()) continue;
-      if (word[0] == '#') break; // We found a comment
-
-      T val;
-      if (word == STRING_NA)
-      {
-        // Get NA value
-        val = getNA<T>();
-      }
-      else
-      {
-        // Decode the value
-        std::stringstream sword(word);
-        sword >> val;
-      }
-      if (ecr > nvalues)
-      {
-        messerr("Too many values read");
-        return false;
-      }
-      *it = val;
-      ecr++;
-      it++;
-    }
-  }
-
-  // Check the number of value actually read
-  if (nvalues != ecr)
-  {
-    messerr("Reading (%s) was expecting %d terms. %d found", title.c_str(),
-            nvalues, ecr);
-    return false;
-  }
-  return true;
+  return SerializeNeutralFile::recordReadVecInPlace<T>(is, title, it, nvalues);
 }

--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -20,6 +20,11 @@
 #include <stdarg.h>
 #include <fstream>
 
+namespace H5
+{
+  class Group;
+};
+
 class GSTLEARN_EXPORT ASerializable
 {
 public:
@@ -31,6 +36,7 @@ public:
   bool deserialize(std::istream& is, bool verbose = true);
   bool serialize(std::ostream& os,bool verbose = true) const;
   bool dumpToNF(const String& neutralFilename, bool verbose = false) const;
+  bool dumpToH5(const String& H5Filename, bool verbose = false) const;
 
   static String buildFileName(int status, const String& filename, bool ensureDirExist = false);
 
@@ -55,7 +61,19 @@ public:
 
 protected:
   virtual bool _deserialize(std::istream& is, bool verbose = false) = 0;
+  virtual bool _deserializeH5(H5::Group& /*grp*/, bool /*verbose*/ = false)
+  {
+    // TODO virtual pure
+    messerr("Not implemented yet");
+    return false;
+  }
   virtual bool _serialize(std::ostream& os, bool verbose = false) const = 0;
+  virtual bool _serializeH5(H5::Group& /*grp*/, bool /*verbose*/ = false) const
+  {
+    // TODO virtual pure
+    messerr("Not implemented yet");
+    return false;
+  }
 
   bool _fileOpenWrite(const String& filename,
                       std::ofstream& os,

--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -51,11 +51,11 @@ public:
   static bool createDirectory(const String& dir);
   static String getExecDirectory();
   static String getDirectory(const String& path);
+  virtual String _getNFName() const = 0;
 
 protected:
   virtual bool _deserialize(std::istream& is, bool verbose = false) = 0;
   virtual bool _serialize(std::ostream& os, bool verbose = false) const = 0;
-  virtual String _getNFName() const = 0;
 
   bool _fileOpenWrite(const String& filename,
                       std::ofstream& os,

--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -13,13 +13,14 @@
 #include "gstlearn_export.hpp"
 #include "geoslib_define.h"
 #include "Geometry/Rotation.hpp"
+#include "Basic/ASerializable.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/VectorNumT.hpp"
 
 class GridOld;
 class MatrixSquareGeneral;
 
-class GSTLEARN_EXPORT Grid : public AStringable
+class GSTLEARN_EXPORT Grid: public AStringable, public ASerializable
 {
 
 public:
@@ -162,6 +163,11 @@ public:
                VectorDouble& x0) const;
   int getMirrorIndex(int idim, int ix) const;
   bool isInside(const VectorInt& indices) const;
+
+  /// Interface for ASerializable
+  bool _deserialize(std::istream& is, bool verbose = false) override;
+  bool _serialize(std::ostream& os, bool verbose = false) const override;
+  String _getNFName() const override { return "Grid"; }
 
 private:
   const MatrixSquareGeneral& _getRotMat() const { return _rotation.getMatrixDirect(); }

--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -166,7 +166,9 @@ public:
 
   /// Interface for ASerializable
   bool _deserialize(std::istream& is, bool verbose = false) override;
+  bool _deserializeH5(H5::Group& grp, bool verbose = false) override;
   bool _serialize(std::ostream& os, bool verbose = false) const override;
+  bool _serializeH5(H5::Group& grp, bool verbose = false) const override;
   String _getNFName() const override { return "Grid"; }
 
 private:

--- a/include/Basic/SerializeHDF5.hpp
+++ b/include/Basic/SerializeHDF5.hpp
@@ -1,0 +1,360 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2025) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#pragma once
+
+#include "geoslib_define.h"
+
+#include "Basic/AStringable.hpp"
+#include "Basic/VectorT.hpp"
+
+#include <H5Cpp.h>
+
+#include <optional>
+
+namespace SerializeHDF5
+{
+  /**
+   * @brief Map values to corresponding HDF5 C++ types
+   */
+  inline H5::DataType getHDF5Type([[maybe_unused]] const int a)
+  {
+    return H5::PredType::NATIVE_INT;
+  }
+  inline H5::DataType getHDF5Type([[maybe_unused]] const double a)
+  {
+    return H5::PredType::NATIVE_DOUBLE;
+  }
+  inline H5::DataType getHDF5Type([[maybe_unused]] const long a)
+  {
+    return H5::PredType::NATIVE_LONG;
+  }
+  inline H5::DataType getHDF5Type([[maybe_unused]] const std::string& a)
+  {
+    return H5::StrType {0, H5T_VARIABLE};
+  }
+
+  inline void
+  createAttribute(H5::H5Object& obj, const std::string& key, const std::string& value)
+  {
+    try
+    {
+      const auto strtype = H5::StrType {0, H5T_VARIABLE};
+      const hsize_t dim  = 1;
+      const H5::DataSpace ds {1, &dim};
+      auto attr = obj.createAttribute(key, strtype, ds);
+      attr.write(strtype, value);
+    }
+    catch (H5::AttributeIException& e)
+    {
+      messerr("Could not write attribute %s: %s", key.c_str(), e.getCDetailMsg());
+    }
+  }
+
+  inline std::string readAttribute(const H5::H5Object& obj, const std::string& key)
+  {
+    if (!obj.attrExists(key))
+    {
+      messerr("Could not read attribute %s: attributo does not exist", key.c_str());
+      return {};
+    }
+
+    const auto attr = obj.openAttribute(key);
+    std::string res;
+    attr.read(H5::StrType {0, H5T_VARIABLE}, res);
+    return res;
+  }
+
+  /**
+   * @brief Open HDF5 file in read mode, check metadata
+   */
+  inline H5::H5File fileOpenRead(const String& fname)
+  {
+    H5::H5File file {fname, H5F_ACC_RDONLY};
+
+    if (!file.nameExists("gstlearn metadata"))
+    {
+      messerr("File %s doesn't contain Gstlearn metadata…", fname.c_str());
+      return file;
+    }
+
+    auto metadata      = file.openGroup("gstlearn metadata");
+    const auto version = readAttribute(metadata, "Format version");
+    if (version != "1.0.0")
+    {
+      messerr("File %s has format version %s, expected 1.0.0", fname.c_str(),
+              version.c_str());
+    }
+
+    return file;
+  }
+
+  /**
+   * @brief Open HDF5 file in write mode, write metadata
+   */
+  inline H5::H5File fileOpenWrite(const String& fname)
+  {
+    H5::H5File file {fname, H5F_ACC_TRUNC};
+    auto metadata = file.createGroup("gstlearn metadata");
+    createAttribute(
+      metadata, "Description",
+      "This file is used to serialize gstlearn's internal data structures");
+    createAttribute(metadata, "Format version", "1.0.0");
+    return file;
+  }
+
+  /**
+   * @brief Read a HDF5 DataSet into a generic VectorT
+   *
+   * @param[in] grp HDF5 group containing the variable to read
+   * @param[in] title Name of HDF5 variable to read
+   * @param[out] vec Vector to be filled with HDF5 data (will be resized)
+   * @return true if success
+   */
+  template<typename T>
+  bool readVec(const H5::Group& grp, const String& title, VectorT<T>& vec);
+
+  /**
+   * @brief Read a HDF5 string DataSet into a VectorString
+   *
+   * @param[in] grp HDF5 group containing the string variable to read
+   * @param[in] title Name of HDF5 string variable to read
+   * @param[out] vec VectorString to be filled with HDF5 data (will be resized)
+   * @return true if success
+   */
+  template<>
+  inline bool readVec(const H5::Group& grp, const String& title, VectorString& vec);
+
+  /**
+   * @brief Write a generic VectorT into a HDF5 DataSet
+   *
+   * @param[in,out] grp HDF5 Group containing the variable to write
+   * @param[in] title Name of HDF5 DataSet to write
+   * @param[in] vec Vector to write into HDF5
+   * @return true if success
+   */
+  template<typename T>
+  bool writeVec(H5::Group& grp, const String& title, const VectorT<T>& vec);
+
+  /**
+   * @brief Write a VectorString into a HDF5 string DataSet
+   *
+   * @param[in,out] grp HDF5 Group containing the string variable to write
+   * @param[in] title Name of HDF5 string DataSet to write
+   * @param[in] vec VectorString to write to HDF5
+   * @return true if success
+   */
+  template<>
+  inline bool writeVec(H5::Group& grp, const String& title, const VectorString& vec);
+
+  /**
+   * @brief Extract a group inside a parent group
+   *
+   * @param[in] parent Parent group
+   * @param[in] name Name of the group to find in parent
+   * @return Group if found else nullopt
+   */
+  inline std::optional<H5::Group> getGroup(const H5::Group& parent, const String& name)
+  {
+    if (!parent.nameExists(name) || parent.childObjType(name) != H5O_TYPE_GROUP)
+    {
+      std::string parent_name;
+      parent.getObjName(parent_name);
+      messerr("Cannot find group %s in parent group %s", name.c_str(),
+              parent_name.c_str());
+      return std::nullopt;
+    }
+
+    auto grp = parent.openGroup(name);
+    return grp;
+  }
+
+  /**
+   * @brief Read individual value (primitive type) from group
+   *
+   * @param[in] grp HDF5 Group from which to read value
+   * @param[in] name Value name
+   * @param[out] value Return value
+   * @return True if success
+   */
+  template<typename T>
+  bool readValue(const H5::Group& grp, const String& name, T& value);
+
+  /**
+   * @brief Write individual value (primitive type) to group
+   *
+   * Here we make use of H5::Attributes to store individual values
+   * (e.g.  class members of primitive types). Prefer _createAttribute
+   * for strings.
+   *
+   * @param[in,out] grp HDF5 Group in which to write value
+   * @param[in] name Value name
+   * @param[out] value Value to write
+   * @return True if success
+   */
+  template<typename T>
+  bool writeValue(H5::Group& grp, const String& name, const T& value);
+
+}; // namespace SerializeHDF5
+
+template<typename T>
+bool SerializeHDF5::readVec(const H5::Group& grp, const String& title, VectorT<T>& vec)
+{
+
+  const auto grp_name = grp.getObjName();
+
+  if (!grp.nameExists(title) || grp.childObjType(title) != H5O_TYPE_DATASET)
+  {
+    messerr("Cannot read HDF5 Variable of name %s in group %s", title.c_str(),
+            grp_name.c_str());
+    return false;
+  }
+
+  const auto data = grp.openDataSet(title);
+  const auto ds   = data.getSpace();
+
+  // Assume variable is of dim 1
+  if (ds.getSimpleExtentNdims() != 1)
+  {
+    messerr("HDF5 Variable of name %s in group %s has %d dims, but we expect only 1",
+            title.c_str(), grp_name.c_str(), ds.getSimpleExtentNdims());
+    return false;
+  }
+
+  hsize_t dim {};
+  ds.getSimpleExtentDims(&dim);
+  vec.resize(dim);
+
+  data.read(vec.data(), getHDF5Type(T {}));
+
+  return true;
+}
+
+template<>
+bool SerializeHDF5::readVec(const H5::Group& grp, const String& title, VectorString& vec)
+{
+
+  const auto grp_name = grp.getObjName();
+
+  if (!grp.nameExists(title) || grp.childObjType(title) != H5O_TYPE_DATASET)
+  {
+    messerr("Cannot read HDF5 Variable of name %s in group %s", title.c_str(),
+            grp_name.c_str());
+    return false;
+  }
+
+  const auto data = grp.openDataSet(title);
+  const auto ds   = data.getSpace();
+
+  // Assume variable is of dim 1
+  if (ds.getSimpleExtentNdims() != 1)
+  {
+    messerr(
+      "HDF5 String Variable of name %s in group %s has %d dims, but we expect only 1",
+      title.c_str(), grp_name.c_str(), ds.getSimpleExtentNdims());
+    return false;
+  }
+
+  const auto dim = ds.getSimpleExtentDims(0);
+  vec.resize(dim);
+
+  // Use a vector of char* managed by HDF5 to read string data
+  std::vector<char*> data_ptr(dim);
+  data.read(vec.data(), H5::StrType {0, H5T_VARIABLE});
+
+  // copy char pointers into gstlearn managed string vector
+  for (size_t i = 0; i < data_ptr.size(); ++i)
+  {
+    vec[i] = data_ptr[i];
+  }
+
+  return true;
+}
+
+template<typename T>
+bool SerializeHDF5::writeVec(H5::Group& grp, const String& title, const VectorT<T>& vec)
+{
+  if (vec.empty())
+  {
+    messerr("Cannot write empty vector");
+    return false;
+  }
+
+  hsize_t dim = vec.size();
+  H5::DataSpace ds {1, &dim};
+
+  auto data = grp.createDataSet(title, getHDF5Type(vec[0]), ds);
+  data.write(vec.constData(), getHDF5Type(vec[0]));
+  return true;
+}
+
+template<>
+bool SerializeHDF5::writeVec(H5::Group& grp,
+                             const String& title,
+                             const VectorString& vec)
+{
+  if (vec.empty())
+  {
+    messerr("Cannot write empty vector");
+    return false;
+  }
+
+  // generate a vector of char * to feed HDF5
+  std::vector<const char*> data_ptr(vec.size());
+  for (size_t i = 0; i < vec.size(); ++i)
+  {
+    data_ptr[i] = vec[i].c_str();
+  }
+
+  hsize_t dim = vec.size();
+  H5::DataSpace ds {1, &dim};
+
+  const auto var = grp.createDataSet(title, H5::StrType {0, H5T_VARIABLE}, ds);
+  var.write(data_ptr.data(), H5::StrType {0, H5T_VARIABLE});
+  return true;
+}
+
+template<typename T>
+bool SerializeHDF5::readValue(const H5::Group& grp, const String& name, T& value)
+{
+  const auto grp_name = grp.getObjName();
+
+  if (!grp.attrExists(name))
+  {
+    messerr("Could not read value %s in group %s: attribute does not exist", name,
+            grp_name.data());
+    return false;
+  }
+
+  const auto attr = grp.openAttribute(name);
+  if (attr.getDataType() != getHDF5Type(value))
+  {
+    messerr("Could not read value %s in group %s: mismatch in datatypes", name,
+            grp_name.data());
+    return false;
+  }
+
+  attr.read(getHDF5Type(value), value);
+  return true;
+}
+
+template<typename T>
+bool SerializeHDF5::writeValue(H5::Group& grp, const String& name, const T& value)
+{
+  std::string grp_name;
+  grp.getObjName(grp_name);
+
+  const hsize_t dim = 1;
+  const H5::DataSpace ds {1, &dim};
+  auto attr = grp.createAttribute(name, getHDF5Type(value), ds);
+  attr.write(getHDF5Type(value), value);
+
+  return true;
+}

--- a/include/Basic/SerializeNeutralFile.hpp
+++ b/include/Basic/SerializeNeutralFile.hpp
@@ -1,0 +1,303 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2025) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#pragma once
+
+#include "geoslib_define.h"
+
+#include "Basic/AStringable.hpp"
+#include "Basic/File.hpp"
+#include "Basic/VectorT.hpp"
+#include "Basic/Utilities.hpp"
+
+class ASerializable;
+
+namespace SerializeNeutralFile
+{
+
+  bool fileOpenWrite(const ASerializable& parent,
+                     const String& filename,
+                     std::ofstream& os,
+                     bool verbose = false);
+  bool fileOpenRead(const ASerializable& parent,
+                    const String& filename,
+                    std::ifstream& is,
+                    bool verbose = false);
+
+  bool commentWrite(std::ostream& os, const String& comment);
+  template<typename T>
+  bool recordWrite(std::ostream& os, const String& title, const T& val);
+  template<typename T>
+  bool recordWriteVec(std::ostream& os, const String& title, const std::vector<T>& vec);
+
+  template<typename T>
+  bool recordRead(std::istream& is, const String& title, T& val);
+  template<typename T>
+  bool
+  recordReadVec(std::istream& is, const String& title, VectorT<T>& vec, int nvalues);
+
+  template<typename T>
+  bool recordReadVecInPlace(std::istream& is,
+                            const String& title,
+                            VectorDouble::iterator& it,
+                            int nvalues);
+  bool onlyBlanks(char* string);
+
+  bool tableRead(std::istream& is, const String& string, int ntab, double* tab);
+  bool
+  tableWrite(std::ostream& os, const String& string, int ntab, const VectorDouble& tab);
+
+} // namespace SerializeNeutralFile
+
+template<typename T>
+bool SerializeNeutralFile::recordWrite(std::ostream& os,
+                                       const String& title,
+                                       const T& val)
+{
+  if (os.good())
+  {
+    if (isNA<T>(val))
+    {
+      if (title.empty())
+        os << STRING_NA << " ";
+      else
+        os << STRING_NA << " # " << title << '\n';
+    }
+    else
+    {
+      int prec = os.precision();
+      os.precision(15);
+      if (title.empty())
+        os << val << " ";
+      else
+        os << val << " # " << title << '\n';
+      os.precision(prec);
+    }
+  }
+  return os.good();
+}
+
+template<typename T>
+bool SerializeNeutralFile::recordWriteVec(std::ostream& os,
+                                          const String& title,
+                                          const std::vector<T>& vec)
+{
+  if (os.good())
+  {
+    if (!title.empty()) os << "# " << title << '\n';
+
+    int prec = os.precision();
+    os.precision(15);
+    for (auto val: vec)
+    {
+      if (isNA<T>(val))
+        os << STRING_NA << " ";
+      else
+        os << val << " ";
+    }
+    os << '\n';
+    os.precision(prec);
+  }
+  return os.good();
+}
+
+template<typename T>
+bool SerializeNeutralFile::recordRead(std::istream& is, const String& title, T& val)
+{
+  val = T();
+  if (is.good())
+  {
+    String word;
+    // Skip comment or empty lines
+    while (is.good())
+    {
+      word.clear();
+      is >> word;
+      if (!is.good() && !is.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        return false;
+      }
+      word = trim(word);
+      if (!word.empty())
+      {
+        if (word == STRING_NA) break; // We found NA
+        if (word[0] != '#') break;    // We found something
+        // std::getline(is, word);    // We found comment, eat all the line
+        gslSafeGetline(is, word); // We found comment, eat all the line
+      }
+    }
+
+    if (word == STRING_NA)
+    {
+      // Get NA value
+      val = getNA<T>();
+    }
+    else
+    {
+      // Decode the line
+      std::stringstream sstr(word);
+      sstr >> val;
+      if (!sstr.good() && !sstr.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        val = T();
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+template<typename T>
+bool SerializeNeutralFile::recordReadVec(std::istream& is,
+                                         const String& title,
+                                         VectorT<T>& vec,
+                                         int nvalues)
+{
+  vec.resize(nvalues);
+  int ecr = 0;
+  if (is.good())
+  {
+    String line;
+
+    // Skip comment or empty lines
+    while (is.good())
+    {
+      // std::getline(is, line);
+      gslSafeGetline(is, line);
+      if (!is.good() && !is.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        return false;
+      }
+      line = trim(line);
+      if (!line.empty() && line[0] != '#') break; // We found something
+    }
+
+    // Decode the line
+    std::stringstream sstr(line);
+    while (sstr.good())
+    {
+      String word;
+      sstr >> word;
+      if (!sstr.good() && !sstr.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        vec.clear();
+        return false;
+      }
+      word = trim(word);
+      if (word.empty()) continue;
+      if (word[0] == '#') break; // We found a comment
+
+      T val;
+      if (word == STRING_NA)
+      {
+        // Get NA value
+        val = getNA<T>();
+      }
+      else
+      {
+        // Decode the value
+        std::stringstream sword(word);
+        sword >> val;
+      }
+      if (ecr > nvalues)
+      {
+        messerr("Too many values read");
+        vec.clear();
+        return false;
+      }
+      vec[ecr++] = val;
+    }
+  }
+
+  // Check the number of value actually read
+  if (nvalues != ecr)
+  {
+    messerr("Reading (%s) was expecting %d terms. %d found", title.c_str(), nvalues, ecr);
+    vec.clear();
+    return false;
+  }
+  return true;
+}
+
+template<typename T>
+bool SerializeNeutralFile::recordReadVecInPlace(std::istream& is,
+                                                const String& title,
+                                                VectorDouble::iterator& it,
+                                                int nvalues)
+{
+  int ecr = 0;
+  if (is.good())
+  {
+    String line;
+
+    // Skip comment or empty lines
+    while (is.good())
+    {
+      // std::getline(is, line);
+      gslSafeGetline(is, line);
+      if (!is.good() && !is.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        return false;
+      }
+      line = trim(line);
+      if (!line.empty() && line[0] != '#') break; // We found something
+    }
+
+    // Decode the line
+    std::stringstream sstr(line);
+    while (sstr.good())
+    {
+      String word;
+      sstr >> word;
+      if (!sstr.good() && !sstr.eof())
+      {
+        messerr("Error while reading %s", title.c_str());
+        return false;
+      }
+      word = trim(word);
+      if (word.empty()) continue;
+      if (word[0] == '#') break; // We found a comment
+
+      T val;
+      if (word == STRING_NA)
+      {
+        // Get NA value
+        val = getNA<T>();
+      }
+      else
+      {
+        // Decode the value
+        std::stringstream sword(word);
+        sword >> val;
+      }
+      if (ecr > nvalues)
+      {
+        messerr("Too many values read");
+        return false;
+      }
+      *it = val;
+      ecr++;
+      it++;
+    }
+  }
+
+  // Check the number of value actually read
+  if (nvalues != ecr)
+  {
+    messerr("Reading (%s) was expecting %d terms. %d found", title.c_str(), nvalues, ecr);
+    return false;
+  }
+  return true;
+}

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -889,7 +889,9 @@ public:
 protected:
   /// Interface for ASerializable
   virtual bool _deserialize(std::istream& is, bool verbose = false) override;
+  bool _deserializeH5(H5::Group& grp, bool verbose = false) override;
   virtual bool _serialize(std::ostream& os,bool verbose = false) const override;
+  bool _serializeH5(H5::Group& grp, bool verbose = false) const override;
   String _getNFName() const override { return "Db"; }
 
   void _clear();

--- a/include/Db/DbGrid.hpp
+++ b/include/Db/DbGrid.hpp
@@ -85,6 +85,7 @@ public:
 
   static DbGrid* createFromNF(const String& neutralFilename,
                               bool verbose = true);
+  static DbGrid* createFromH5(const String& H5Filename, bool verbose = true);
   static DbGrid* create(const VectorInt& nx,
                         const VectorDouble& dx = VectorDouble(),
                         const VectorDouble& x0 = VectorDouble(),
@@ -379,7 +380,9 @@ public:
 protected:
   /// Interface for ASerializable
   virtual bool _deserialize(std::istream& is, bool verbose = false) override;
+  bool _deserializeH5(H5::Group& grp, bool verbose = false) override;
   virtual bool _serialize(std::ostream& os, bool verbose = false) const override;
+  bool _serializeH5(H5::Group& grp, bool verbose = false) const override;
   String _getNFName() const override { return "DbGrid"; }
 
 private:

--- a/src/Basic/ASerializable.cpp
+++ b/src/Basic/ASerializable.cpp
@@ -10,6 +10,7 @@
 /******************************************************************************/
 #include "Basic/ASerializable.hpp"
 #include "Basic/AStringable.hpp"
+#include "Basic/SerializeHDF5.hpp"
 #include "Basic/SerializeNeutralFile.hpp"
 #include "Basic/File.hpp"
 #include "Basic/String.hpp"
@@ -89,6 +90,18 @@ bool ASerializable::dumpToNF(const String& neutralFilename, bool verbose) const
     }
     os.close();
   }
+  return ret;
+}
+
+bool ASerializable::dumpToH5(const String& H5Filename, bool verbose) const
+{
+  auto file = SerializeHDF5::fileOpenWrite(H5Filename);
+  bool ret  = _serializeH5(file, verbose);
+  if (!ret)
+  {
+    messerr("Problem writing in the netCDF File.");
+  }
+
   return ret;
 }
 

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -12,6 +12,7 @@
 
 #include "Geometry/Rotation.hpp"
 #include "Matrix/MatrixSquareGeneral.hpp"
+#include "Basic/SerializeHDF5.hpp"
 #include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "geoslib_define.h"
@@ -1316,6 +1317,36 @@ bool Grid::_deserialize(std::istream& is, [[maybe_unused]] bool verbose)
   return ret;
 }
 
+bool Grid::_deserializeH5(H5::Group& grp, [[maybe_unused]] bool verbose)
+{
+  VectorInt nx;
+  VectorDouble x0;
+  VectorDouble dx;
+  VectorDouble angles;
+
+  // Call SerializeHDF5::getGroup to get the subgroup of grp named
+  // "Grid" with some error handling
+  auto gr = SerializeHDF5::getGroup(grp, "Grid");
+  if (!gr)
+  {
+    return false;
+  }
+
+  /* Read the grid characteristics */
+  bool ret = true;
+  // deserialize vector members using SerializeHDF5::readVec
+  // (error handling is done in these methods)
+  ret = ret && SerializeHDF5::readVec(*gr, "NX", nx);
+  ret = ret && SerializeHDF5::readVec(*gr, "X0", x0);
+  ret = ret && SerializeHDF5::readVec(*gr, "DX", dx);
+  ret = ret && SerializeHDF5::readVec(*gr, "ANGLE", angles);
+
+  // reset the Grid
+  resetFromVector(nx, dx, x0, angles);
+
+  return ret;
+}
+
 bool Grid::_serialize(std::ostream& os, [[maybe_unused]] bool verbose) const
 {
   bool ret = true;
@@ -1335,6 +1366,23 @@ bool Grid::_serialize(std::ostream& os, [[maybe_unused]] bool verbose) const
     ret = ret && _recordWrite<double>(os, "", getRotAngle(idim));
     ret = ret && _commentWrite(os, "");
   }
+
+  return ret;
+}
+
+bool Grid::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) const
+{
+  // create a new H5::Group every time we enter a _serialize method
+  // => easier to deserialize
+  auto gr = grp.createGroup("Grid");
+
+  bool ret = true;
+  // serialize vector members using SerializeHDF5::writeVec
+  // (error handling is done in these methods)
+  ret = ret && SerializeHDF5::writeVec(gr, "NX", getNXs());
+  ret = ret && SerializeHDF5::writeVec(gr, "X0", getX0s());
+  ret = ret && SerializeHDF5::writeVec(gr, "DX", getDXs());
+  ret = ret && SerializeHDF5::writeVec(gr, "ANGLE", getRotAngles());
 
   return ret;
 }

--- a/src/Basic/SerializeNeutralFile.cpp
+++ b/src/Basic/SerializeNeutralFile.cpp
@@ -1,0 +1,111 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+
+#include "Basic/ASerializable.hpp"
+#include "Basic/SerializeNeutralFile.hpp"
+
+bool SerializeNeutralFile::fileOpenWrite(const ASerializable& parent,
+                                         const String& filename,
+                                         std::ofstream& os,
+                                         bool verbose)
+{
+  // Close the stream if opened
+  if (os.is_open()) os.close();
+  // Build the multi-platform filename
+  String filepath = ASerializable::buildFileName(2, filename, true);
+  // Open new stream
+  os.open(filepath, std::ios::out | std::ios::trunc);
+  if (!os.is_open())
+  {
+    if (verbose) messerr("Error while opening %s", filepath.c_str());
+    return false;
+  }
+  // Write the file type (class name)
+  os << parent._getNFName() << std::endl;
+  return os.good();
+}
+
+bool SerializeNeutralFile::fileOpenRead(const ASerializable& parent,
+                                        const String& filename,
+                                        std::ifstream& is,
+                                        bool verbose)
+{
+  // Close the stream if opened
+  if (is.is_open()) is.close();
+  // Build the multi-platform filename
+  String filepath = ASerializable::buildFileName(1, filename, true);
+  // Open new stream
+  is.open(filepath, std::ios::in);
+  if (!is.is_open())
+  {
+    if (verbose) messerr("Error while opening %s", filepath.c_str());
+    return false;
+  }
+  // Read and check the file type (class name)
+  String type;
+  is >> type;
+  if (type != parent._getNFName())
+  {
+    if (verbose)
+      messerr("The file %s has the wrong type (read: %s, expected: %s)", filepath.c_str(),
+              type.c_str(), parent._getNFName().c_str());
+    is.close();
+    return false;
+  }
+  return is.good(); // Cannot be "end of file" already
+}
+
+bool SerializeNeutralFile::commentWrite(std::ostream& os, const String& comment)
+{
+  if (os.good())
+  {
+    if (comment.empty())
+      os << std::endl;
+    else
+      os << "# " << comment << std::endl;
+  }
+  return os.good();
+}
+
+bool SerializeNeutralFile::tableWrite(std::ostream& os,
+                                      const String& string,
+                                      int ntab,
+                                      const VectorDouble& tab)
+{
+  bool ret = true;
+  VectorDouble loctab(ntab);
+  for (int i = 0; i < ntab; i++) loctab[i] = tab[i];
+  ret = ret && recordWriteVec<double>(os, string, loctab);
+  return ret;
+}
+
+bool SerializeNeutralFile::tableRead(std::istream& is,
+                                     const String& string,
+                                     int ntab,
+                                     double* tab)
+{
+  bool ret = true;
+  VectorDouble loctab(ntab);
+  ret = ret && recordReadVec<double>(is, string, loctab, ntab);
+  if (!ret) return 1;
+  for (int i = 0; i < ntab; i++) tab[i] = loctab[i];
+  return ret;
+}
+
+bool SerializeNeutralFile::onlyBlanks(char* string)
+{
+  int number = static_cast<int>(strlen(string));
+  for (int i = 0; i < number; i++)
+  {
+    if (string[i] != ' ') return false;
+  }
+  return true;
+}

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -744,42 +744,9 @@ bool DbGrid::isConsistent() const
 
 bool DbGrid::_deserialize(std::istream& is, bool verbose)
 {
-  int ndim = 0;
-  VectorInt nx;
-  VectorString locators;
-  VectorString names;
-  VectorDouble x0;
-  VectorDouble dx;
-  VectorDouble angles;
-  VectorDouble values;
-  VectorDouble allvalues;
-
-  /* Initializations */
-
   bool ret = true;
-  ret = ret && _recordRead<int>(is, "Space Dimension", ndim);
-
-  /* Core allocation */
-
-  nx.resize(ndim);
-  dx.resize(ndim);
-  x0.resize(ndim);
-  angles.resize(ndim);
-
-  /* Read the grid characteristics */
-
-  for (int idim = 0; ret && idim < ndim; idim++)
-  {
-    ret = ret && _recordRead<int>(is, "Grid Number of Nodes", nx[idim]);
-    ret = ret && _recordRead<double>(is, "Grid Origin", x0[idim]);
-    ret = ret && _recordRead<double>(is, "Grid Mesh", dx[idim]);
-    ret = ret && _recordRead<double>(is, "Grid Angles", angles[idim]);
-  }
-
-  // Create the Grid characteristics
-  (void) gridDefine(nx, dx, x0, angles);
-
-  ret && Db::_deserialize(is, verbose);
+  ret      = ret && _grid._deserialize(is, verbose);
+  ret      = ret && Db::_deserialize(is, verbose);
 
   return ret;
 }
@@ -788,25 +755,13 @@ bool DbGrid::_serialize(std::ostream& os, bool verbose) const
 {
   bool ret = true;
 
-  /* Writing the header */
-
-  ret = ret && _recordWrite<int>(os, "Space Dimension", getNDim());
-
   /* Writing the grid characteristics */
 
-  ret = ret && _commentWrite(os, "Grid characteristics (NX,X0,DX,ANGLE)");
-  for (int idim = 0; ret && idim < getNDim(); idim++)
-  {
-    ret = ret && _recordWrite<int>(os, "",  getNX(idim));
-    ret = ret && _recordWrite<double>(os, "", getX0(idim));
-    ret = ret && _recordWrite<double>(os, "", getDX(idim));
-    ret = ret && _recordWrite<double>(os, "", getAngle(idim));
-    ret = ret && _commentWrite(os, "");
-  }
+  ret = ret && _grid._serialize(os, verbose);
 
   /* Writing the tail of the file */
 
-  ret && Db::_serialize(os, verbose);
+  ret = ret && Db::_serialize(os, verbose);
 
   return ret;
 }

--- a/src/all_sources.cmake
+++ b/src/all_sources.cmake
@@ -251,6 +251,7 @@ set(SRC
   Basic/OptCustom.cpp
   Basic/Plane.cpp
   Basic/FFT.cpp
+  Basic/SerializeNeutralFile.cpp
   Basic/PolyLine2D.cpp
   Basic/Convolution.cpp
   Geometry/GeometryHelper.cpp

--- a/tests/cpp/bench_H5.cpp
+++ b/tests/cpp/bench_H5.cpp
@@ -1,0 +1,54 @@
+#include <Basic/Timer.hpp>
+#include <Db/DbGrid.hpp>
+
+int test_NF(const DbGrid& db)
+{
+  Timer tm;
+  db.dumpToNF("dbgrid.nf");
+  auto db2 = std::unique_ptr<DbGrid>(DbGrid::createFromNF("dbgrid.nf"));
+  if (db2 != nullptr)
+  {
+    db2->dumpToNF("dbgrid2.nf");
+  }
+  else
+  {
+    messerr("Cannot deserialize `dbgrid.nf'");
+    return 1;
+  }
+  tm.displayIntervalMilliseconds("Serialize + Deserialize + Serialize Neutral File",
+                                 2500);
+  return 0;
+}
+
+int test_HDF5(const DbGrid& db)
+{
+  Timer tm;
+  db.dumpToH5("dbgrid.h5");
+  auto db2 = std::unique_ptr<DbGrid>(DbGrid::createFromH5("dbgrid.h5"));
+  if (db2 != nullptr)
+  {
+    db2->dumpToH5("dbgrid2.h5");
+  }
+  else
+  {
+    messerr("Cannot deserialize `dbgrid.h5'");
+    return 1;
+  }
+  tm.displayIntervalMilliseconds("Serialize + Deserialize + Serialize HDF5", 80);
+
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  std::stringstream sfn;
+  sfn << gslBaseName(__FILE__) << ".out";
+  StdoutRedirect sr(sfn.str(), argc, argv);
+
+  const VectorInt dims {100, 100, 100};
+  auto db = std::unique_ptr<DbGrid>(DbGrid::create(dims));
+  int ret {};
+  ret += test_NF(*db);
+  ret += test_HDF5(*db);
+  return ret;
+}

--- a/tests/cpp/output/bench_H5.ref
+++ b/tests/cpp/output/bench_H5.ref
@@ -1,0 +1,2 @@
+#NO_DIFF# Serialize + Deserialize + Serialize Neutral File: 2519 ms. (Ref = 2500 ms.)
+#NO_DIFF# Serialize + Deserialize + Serialize HDF5: 83 ms. (Ref = 80 ms.)


### PR DESCRIPTION
This PR implements an alternative serialization backend using HDF5 instead of text files (the Neutral File ad-hoc file format) to serialize gstlearn's data structures.

For now, only `DbGrid`, `Db` and `Grid` implement the new serialization format. A new benchmark test, `bench_H5.cpp` shows a speedup of x30 when comparing the serialization and deserialization of somewhat big `DbGrid`s between the Neutral File format and the new HDF5 one.

The GitHub Actions CI now fetches either HDF5 binaries from OS package managers or builds static libraries from HDF5 sources, in particular for `publish` workflows. Corresponding publish workflow: https://github.com/pierre-guillou/gstlearn/actions/runs/13417788720

Fixes #203.

Enjoy, 
Pierre