### PR TITLE
Enable builds with Address Sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@
 # You can use the following variables:
 #
 #  - DEBUG=1            Build the debug version of the library and tests (default =0)
+#  - ASAN=1             Build with Address Sanitizer
 #  - N_PROC=N           Use more CPUs for building procedure (default =1)
 #  - BUILD_DIR=<path>   Define a specific build directory (default =build[_msys])
 #  - USE_HDF5=0         To remove HDF5 support (default =0)
@@ -108,6 +109,12 @@ ifeq ($(DEBUG), 1)
   BUILD_TYPE = Release
 endif
 
+ifeq ($(ASAN), 1)
+  BUILD_ASAN = ON
+ else
+  BUILD_ASAN = OFF
+endif
+
 ifndef BUILD_DIR
   ifeq ($(OS),Windows_NT)
     # Assume MinGW (via RTools) => so MSYS build folder
@@ -130,7 +137,7 @@ endif
 # Add  "| tee /dev/null" because Ninja prints output in a single line :
 # https://stackoverflow.com/questions/46970462/how-to-enable-multiline-logs-instead-of-single-line-progress-logs
 
-CMAKE_DEFINES := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DUSE_HDF5=$(USE_HDF5)
+CMAKE_DEFINES := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DUSE_HDF5=$(USE_HDF5) -DBUILD_ASAN=$(BUILD_ASAN)
 ifdef SWIG_EXEC
   CMAKE_DEFINES := $(CMAKE_DEFINES) -DSWIG_EXECUTABLE=$(SWIG_EXEC)
 endif

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -38,9 +38,20 @@ else()
   endif()
 endif()
 
-# For sanitizer
-#add_compile_options(-fsanitize=address -O0 -ggdb)
-#add_link_options(-fsanitize=address)
+# Address Sanitizer (GCC/Clang)
+option(BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
+mark_as_advanced(BUILD_ASAN)
+
+if(BUILD_ASAN AND MSVC)
+  message(WARNING "Cannot use BUILD_ASAN option with Microsoft Visual Studio compilers")
+  set(BUILD_ASAN OFF)
+endif()
+
+if(BUILD_ASAN)
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
+
 # For valgrind usage (use Debug)
 #add_compile_options(-O0)
 

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -129,7 +129,7 @@ void MatrixSparse::resetFromVVD(const VectorVectorDouble& tab, bool byCol)
 
 void MatrixSparse::resetFromTriplet(const NF_Triplet& NF_T)
 {
-  delete _csMatrix;
+  cs_free(_csMatrix);
 
   if (isFlagEigen())
   {


### PR DESCRIPTION
This PR exposes a new `BUILD_ASAN` CMake option that enables the Address Sanitizer for the current build directory.
The option is also exposed in the main Makefile through the `ASAN=1` variable (default: 0).

A future PR should enable this option for part of the `nonreg` workflows. Meanwhile, an allocator mismatch (`malloc` vs. `new`) has been detected and fixed in `MatrixSparse`.

Fix #411.
Enjoy,
Pierre