### PR TITLE
Add NO_INTERNET option and fix Tuto_2D.Rmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@
 #  - N_PROC=N           Use more CPUs for building procedure (default =1)
 #  - BUILD_DIR=<path>   Define a specific build directory (default =build[_msys])
 #  - USE_HDF5=0         To remove HDF5 support (default =0)
+#  - NO_INTERNET=0      To prevent python pip from looking for dependencies through Internet
+#                       (useful when there is no Internet available) (default =0)
 #  - TEST=<test-target> Name of the test target to be launched (e.g. test_Model_py or test_simTub)
 #  - EIGEN3_ROOT=<path> Path to Eigen3 library (optional)
 #  - BOOST_ROOT=<path>  Path to Boost library (optional)
@@ -67,6 +69,12 @@
 #
 #  make check N_PROC=2
 #
+
+ifeq ($(NO_INTERNET), 1)
+  NO_INTERNET = ON
+ else
+  NO_INTERNET = OFF 
+endif
 
 ifdef USE_HDF5
   USE_HDF5 = 1
@@ -130,7 +138,7 @@ endif
 # Add  "| tee /dev/null" because Ninja prints output in a single line :
 # https://stackoverflow.com/questions/46970462/how-to-enable-multiline-logs-instead-of-single-line-progress-logs
 
-CMAKE_DEFINES := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DUSE_HDF5=$(USE_HDF5)
+CMAKE_DEFINES := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DUSE_HDF5=$(USE_HDF5) -DNO_INTERNET=$(NO_INTERNET)
 ifdef SWIG_EXEC
   CMAKE_DEFINES := $(CMAKE_DEFINES) -DSWIG_EXECUTABLE=$(SWIG_EXEC)
 endif

--- a/doc/demo/r/Tuto_2D.Rmd
+++ b/doc/demo/r/Tuto_2D.Rmd
@@ -33,17 +33,20 @@ err = OptCst_define(ECst_NTCOL(),6)
 # Reading data
 
 The data are stored in a CSV format in the file called Pollution.dat
+It is loaded from the gstlearn distribution but it can be also downloaded
+from the Internet.
 
 **
 At this stage:
 - it is not possible to pass the list of variable names *c("X","Y")*.
-- to pass the FLAGS for *DbStringFormat* (they are not an ENUM)
+- to pass the FLAGS for *DbStringFormat* (they is no ENUM)
 **
 
 ```{r}
-dlfile = "https://soft.minesparis.psl.eu/gstlearn/data/Pollution/Pollution.dat"
-filepath = "Pollution.dat"
-download.file(dlfile, filepath, quiet=TRUE)
+#dlfile = "https://soft.minesparis.psl.eu/gstlearn/data/Pollution/Pollution.dat"
+#filepath = "Pollution.dat"
+#download.file(dlfile, filepath, quiet=TRUE)
+filepath = loadData("Pollution", "Pollution.dat")
 mydb = Db_createFromCSV(filepath,CSVformat())
 err = mydb$setLocator("X",ELoc_X(),0)
 err = mydb$setLocator("Y",ELoc_X(),1)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -229,7 +229,7 @@ endforeach()
 ######################################
 # INSTALLATION
 
-# By default, python pip look for dependencies from Internet
+# By default, python pip looks for dependencies from Internet
 option(NO_INTERNET "Do not try to connect to Internet" OFF)
 message(STATUS "NO_INTERNET=" ${NO_INTERNET})
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -229,10 +229,20 @@ endforeach()
 ######################################
 # INSTALLATION
 
+# By default, python pip look for dependencies from Internet
+option(NO_INTERNET "Do not try to connect to Internet" OFF)
+message(STATUS "NO_INTERNET=" ${NO_INTERNET})
+
+if (NO_INTERNET)
+  set(NO_INTERNET_ARG "--no-build-isolation")
+else()
+  set(NO_INTERNET_ARG "")
+endif()
+
 # Add a custom target for python package installation
 # TODO: Do also installation each time setup.py.in or README.md is modified
 add_custom_target(python_install
-  COMMAND ${Python3_EXECUTABLE} -m pip install "${PYTHON_PACKAGE_ROOT_FOLDER}[plot]"
+  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot]"
   COMMENT "Installing python package"
   )
  

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -14,9 +14,7 @@ set(SWIG_PACKAGE_DESTINATION_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
 set(GENERATED_FILE1 ${CMAKE_CURRENT_BINARY_DIR}/newobject.i)
 set(GENERATED_FILE2 ${CMAKE_CURRENT_BINARY_DIR}/toString.i)
 
-
-
-# Définition d'une cible qui exécute le script Python une seule fois
+# Execute the "classanalysis" python script only one time
 add_custom_command(
     OUTPUT ${GENERATED_FILE1}
     COMMAND ${Python3_EXECUTABLE} ${PYTHON_SCRIPT} ${FILE_TO_READ}
@@ -26,6 +24,7 @@ add_custom_command(
     VERBATIM
 )
 
+# Execute the "toString" python script only one time
 add_custom_command(
     OUTPUT  ${GENERATED_FILE2}
     COMMAND ${Python3_EXECUTABLE} ${PYTHON_SCRIPT2} 
@@ -35,7 +34,7 @@ add_custom_command(
     VERBATIM
 )
 
-# Création d'une cible dédiée pour la génération du fichier
+# Create one target for both generations
 add_custom_target(generate_output DEPENDS ${GENERATED_FILE1} ${GENERATED_FILE2})
 
 set(CMAKE_SWIG_FLAGS "-I${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
This PR fixes the issue #432 by:
- Adding a NO_INTERNET option to be used when building (and installing) gstlearn python package and when there is no more Internet connection. This option prevents 'pip' from looking at Internet in order to check for dependencies. Such dependencies must have been installed beforehand.
- Replacing the download of the 2D data CSV file by the "loadData" function in the Tuto_2D.Rmd.
Hence, gstlearn developers can continue to work on source code even when there is no more Internet connection.
Enjoy