### PR TITLE
Fix wrapping std::string_views for R

### DIFF
--- a/include/Basic/String.hpp
+++ b/include/Basic/String.hpp
@@ -23,8 +23,10 @@ GSTLEARN_EXPORT void skipBOM(std::ifstream &ins);
 GSTLEARN_EXPORT String toUpper(const std::string_view string);
 GSTLEARN_EXPORT String toLower(const std::string_view string);
 
+#ifndef SWIG
 GSTLEARN_EXPORT void toUpper(String &string);
 GSTLEARN_EXPORT void toLower(String &string);
+#endif // SWIG
 
 GSTLEARN_EXPORT bool matchKeyword(const String &string1,
                                   const String &string2,

--- a/include/Enum/AEnum.hpp
+++ b/include/Enum/AEnum.hpp
@@ -31,7 +31,7 @@ public:
   inline int getValue() const { return _value; }
 
   //! Return the enum description as a string
-  inline const std::string_view& getDescr() const { return _descr; }
+  inline const std::string_view getDescr() const { return _descr; }
 
 #ifndef SWIG
   // Remove this: too much dangerous (implicit casts)

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -548,10 +548,6 @@
   {
     return PyUnicode_FromString(convertFromCpp(value));
   }
-  template <> PyObject* objectFromCpp(const std::string_view& value)
-  {
-    return PyUnicode_FromString(convertFromCpp(String{value}));
-  }
   template <> PyObject* objectFromCpp(const float& value)
   {
     return PyFloat_FromDouble(static_cast<double>(convertFromCpp(value)));

--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -315,6 +315,7 @@
 %typemap(rtypecheck, noblock=1) const int&, int                               { length($arg) == 1 && (is.integer(unlist($arg)) || is.numeric(unlist($arg))) }
 %typemap(rtypecheck, noblock=1) const double&, double                         { length($arg) == 1 &&  is.numeric(unlist($arg)) }
 %typemap(rtypecheck, noblock=1) const String&, String                         { length($arg) == 1 &&  is.character(unlist($arg)) }
+%typemap(rtypecheck, noblock=1) const std::string_view, std::string_view      { length($arg) == 1 &&  is.character(unlist($arg)) }
 %typemap(rtypecheck, noblock=1) const float&, float                           { length($arg) == 1 &&  is.numeric(unlist($arg)) }
 %typemap(rtypecheck, noblock=1) const UChar&, UChar                           { length($arg) == 1 && (is.integer(unlist($arg)) || is.numeric(unlist($arg))) }
 %typemap(rtypecheck, noblock=1) const bool&, bool                             { length($arg) == 1 &&  is.logical(unlist($arg)) }
@@ -389,10 +390,6 @@
   template <> SEXP objectFromCpp(const String& value)
   {
     return Rf_ScalarString(Rf_mkChar(convertFromCpp(value).c_str()));
-  }
-  template <> SEXP objectFromCpp(const std::string_view& value)
-  {
-    return Rf_ScalarString(Rf_mkChar(convertFromCpp(String{value}).c_str()));
   }
   template <> SEXP objectFromCpp(const float& value)
   {
@@ -546,6 +543,9 @@
                      VectorVectorDouble, VectorVectorDouble*, VectorVectorDouble&,
                      VectorVectorFloat,  VectorVectorFloat*,  VectorVectorFloat&
  %{    %}
+
+%typemap(scoerceout) std::string_view, const std::string_view
+%{    %}
 
 //%typemap(scoerceout) MatrixRectangular,     MatrixRectangular*,     MatrixRectangular&,
 //                     MatrixSquareGeneral,   MatrixSquareGeneral*,   MatrixSquareGeneral&,

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -438,11 +438,10 @@
     messerr("Error while converting argument #$argnum of type '$type' in '$symname' function");
   }
 }
-%typemap(in, fragment="ToCpp") std::string_view
+%typemap(in, fragment="ToCpp") std::string_view (String tmp)
 {
   try
   {
-    static String tmp;
     int errcode = convertToCpp($input, tmp);
     $1 = tmp;
     if (!SWIG_IsOK(errcode))
@@ -921,8 +920,6 @@
 %typemap(out, fragment="FromCpp") int*,    const int*,    int&,    const int&,
                                   double*, const double*, double&, const double&,
                                   String*, const String*, String&, const String&,
-                                  std::string_view*, const std::string_view*,
-                                  std::string_view&, const std::string_view&,
                                   float*,  const float*,  float&,  const float&,
                                   UChar*,  const UChar*,  UChar&,  const UChar&,
                                   bool*,   const bool*,   bool&,   const bool&

--- a/tests/r/output/test_Enum.ref
+++ b/tests/r/output/test_Enum.ref
@@ -1,4 +1,5 @@
 [1] "CUBIC"
+[1] "character"
 [1] "Cubic"
 [1] "cubic"
 [1] "CUBIC"

--- a/tests/r/output/test_Enum.ref
+++ b/tests/r/output/test_Enum.ref
@@ -1,0 +1,6 @@
+[1] "CUBIC"
+[1] "Cubic"
+[1] "cubic"
+[1] "CUBIC"
+[1] 4
+[1] "Cubic"

--- a/tests/r/test_Enum.R
+++ b/tests/r/test_Enum.R
@@ -4,6 +4,7 @@ a = ECov_CUBIC()
 
 key = a$getKey()
 key
+class(key)
 
 descr = a$getDescr()
 descr

--- a/tests/r/test_Enum.R
+++ b/tests/r/test_Enum.R
@@ -1,0 +1,17 @@
+suppressWarnings(suppressMessages(library(gstlearn)))
+
+a = ECov_CUBIC()
+
+key = a$getKey()
+key
+
+descr = a$getDescr()
+descr
+toLower(descr)
+toUpper(descr)
+
+val = a$getValue()
+val
+
+b = ECov_fromKey(key)
+b$getDescr()


### PR DESCRIPTION
PR #318 seems to have broken the R wrapper: gstlearn methods returning `std::string_view`s don't work any more. `toLower` and `toUpper` also seem to fail.

This PR fixes the R wrapper by making sure that `std::string_view`s are not exposed in the wrapping languages. 

A new R non-regression test has been added.

Fix #426.

Pierre