### PR TITLE
Replace static global vectors in MeshETurbo, Db with mutable class members

### DIFF
--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -966,4 +966,7 @@ private:
   std::vector<int> _uidcol;   //!< UID to Column
   VectorString _colNames;    //!< Names of the variables
   std::vector<PtrGeos> _p;   //!< Locator characteristics
+
+  /// factor allocations
+  mutable std::vector<int> uids;
 };

--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -158,4 +158,11 @@ private:
   bool  _isPolarized;
   Indirection _meshIndirect;
   Indirection _gridIndirect;
+
+  /// factor allocations
+  mutable std::vector<int> indg;
+  mutable std::vector<int> indices;
+  mutable std::vector<double> lambdas;
+  mutable std::vector<double> rhs;
+  mutable std::vector<int> indgg;
 };

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -651,8 +651,6 @@ void Db::setArrayByUID(const VectorDouble& tab, int iuid)
   }
 }
 
-static std::vector<int> uids;
-
 void Db::getArrayBySample(std::vector<double>& vals, int iech) const
 {
   getAllUIDs(uids);

--- a/src/Mesh/MeshETurbo.cpp
+++ b/src/Mesh/MeshETurbo.cpp
@@ -138,8 +138,6 @@ double MeshETurbo::getMeshSize(int /*imesh*/) const
   return size;
 }
 
-static std::vector<int> indg;
-
 /****************************************************************************/
 /*!
 ** Returns the Apex 'rank' of the Mesh 'imesh'
@@ -485,9 +483,6 @@ int MeshETurbo::initFromExtend(const VectorDouble &extendmin,
   return 0;
 }
 
-static std::vector<int> indices;
-static std::vector<double> lambdas;
-
 bool MeshETurbo::_addElementToTriplet(NF_Triplet& NF_T,
                                       int iech,
                                       const VectorDouble &coor,
@@ -736,9 +731,6 @@ void MeshETurbo::_setNElementPerCell()
   else if (ndim == 3)
     _nPerCell = 6;
 }
-
-static std::vector<double> rhs;
-static std::vector<int> indgg;
 
 /**
  * Return the weights assigned to the corners


### PR DESCRIPTION
This PR replaces the static global `std::vector` variables in `MeshETurbo.cpp` and `Db.cpp` introduced in #287 and #324 with mutable class member variables.

No change observed in the number of memory allocations.

Fix #445.

Pierre