### PR TITLE
Fix VectorVector* typemap in R with a list of 1 vector

### DIFF
--- a/doc/courses/r/01_gstlearn_start.Rmd
+++ b/doc/courses/r/01_gstlearn_start.Rmd
@@ -105,7 +105,7 @@ For people who were using [RGeostats](http://cg.ensmp.fr/rgeostats), here is the
 
 * The objects manipulated through *gstlearn* R package (Database, Variograms, Polygons, etc...) are now **external pointers**.
 
-* If you need to duplicate your objects, a simple assignment (e.g. `db2 = db1`) is not possible. You must use the `clone` method by doing this: `db2 = db1$clone()`. All classes that inherits from `iCloneable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classICloneable.html)).
+* If you need to duplicate your objects, a simple assignment (e.g. `db2 = db1`) is not possible. You must use the `clone` method by doing this: `db2 = db1$clone()`. All classes that inherits from `ICloneable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classICloneable.html)).
 
 * The *gstlearn* objects memory content is not stored in the R workspace anymore. This means that saving the R workspace (`.RData`) is dangerous because it stores only memory pointers that won't be valid when loading the workspace in a future R session.
 

--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -200,10 +200,13 @@
     int size = (int)Rf_length(obj);
     if (size == 1)
     {
-      // Not a vector (or a single value)
       InputVector vec;
+      SEXP item = getElem(obj,0);
       // Try to convert
-      myres = vectorToCpp(obj, vec);
+      if (TYPEOF(item) == NILSXP) 
+        myres = vectorToCpp(obj, vec);
+      else
+        myres = vectorToCpp(item, vec);
       if (SWIG_IsOK(myres))
         vvec.push_back(vec);
     }

--- a/tests/py/output/test_Arguments.ref
+++ b/tests/py/output/test_Arguments.ref
@@ -67,6 +67,16 @@ Testing for VectorVectorDouble :
 
 [[1. 2.]
  [3. 4.]]
+ Testing for VectorVectorInt : 
+[1][1] : 5 
+[2][1] : 6 
+
+[[5 6]]
+Testing for VectorVectorDouble : 
+[1][1] : 5.000000 
+[2][1] : 6.000000 
+
+[[5. 6.]]
 Integer = -1 - Real = -1.100000 - String = NA
 Integer = 2 - Real = -1.100000 - String = NA
 Testing for Integer : 2 

--- a/tests/py/test_Arguments.py
+++ b/tests/py/test_Arguments.py
@@ -70,6 +70,8 @@ print(gl.argumentReturnVectorDouble([1., 2., 3.]))
 print(gl.argumentReturnVectorInt([3,2,8]))
 print(gl.argumentReturnVectorVectorInt([[1,2],[3,4]]))
 print(gl.argumentReturnVectorVectorDouble([[1,2],[3,4]]))
+print(gl.argumentReturnVectorVectorInt([[5,6]]))
+print(gl.argumentReturnVectorVectorDouble([[5,6]]))
 
 # Testing assessors to the elements of a class
 

--- a/tests/r/output/test_Arguments.ref
+++ b/tests/r/output/test_Arguments.ref
@@ -70,6 +70,20 @@ Testing for VectorVectorDouble :
 [[2]]
 [1] 3 4
 
+Testing for VectorVectorInt : 
+[1][1] : 5 
+[2][1] : 6 
+
+[[1]]
+[1] 5 6
+
+Testing for VectorVectorDouble : 
+[1][1] : 5.000000 
+[2][1] : 6.000000 
+
+[[1]]
+[1] 5 6
+
 Integer = -1 - Real = -1.100000 - String = NA
 [1] -1
 Integer = 21 - Real = -1.100000 - String = NA

--- a/tests/r/test_Arguments.R
+++ b/tests/r/test_Arguments.R
@@ -66,6 +66,8 @@ print(argumentReturnVectorDouble(c(1., 2., 3.)))
 print(argumentReturnVectorInt(c(3,2,8)))
 print(argumentReturnVectorVectorInt(list(c(1,2),c(3,4))))
 print(argumentReturnVectorVectorDouble(list(c(1,2),c(3,4))))
+print(argumentReturnVectorVectorInt(list(c(5,6))))
+print(argumentReturnVectorVectorDouble(list(c(5,6))))
 
 # Testing assessors (instead of relevant functions)
 # to access the elements of a class


### PR DESCRIPTION
This branch fixes the issue #438.
Which means that, now, you can call gstlearn functions having VectorVector* argument when the vector only contains one vector. For example, this code in R:

`print(argumentReturnVectorVectorInt(list(c(5,6))))`

... now print the following output:

```
Testing for VectorVectorInt : 
[1][1] : 5 
[2][1] : 6 

[[1]]
[1] 5 6
```

Fix #438