### PR TITLE
Python: Move scipy, pandas to optional dependencies

### DIFF
--- a/doc/courses/python/01_gstlearn_start.ipynb
+++ b/doc/courses/python/01_gstlearn_start.ipynb
@@ -194,7 +194,7 @@
     "\n",
     "* Some classes of the *gstlearn* C++ library have been extended in Python:\n",
     "  * Almost all classes are 'stringable' (those which inherit from `AStringable`, [see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classAStringable.html)), that means that you can type the object name in the Python console prompt and hit 'Enter' key to obtain a detailed description of the object content. The same output text is obtained using the `display` method (e.g. `mygrid.display()`)\n",
-    "  * Some classes have an additional Python method named `toTL` (i.e. 'to Target Language') that permits to convert an object into the corresponding Python type. For example, the instruction `df = mygrid.toTL()` permits to create a pandas `DataFrame` from a `Db` object. In that case, the newly created `DataFrame` will contain all variables from the Db (but locators and grid parameters (for DbGrid) will be lost)\t"
+    "  * Some classes have an additional Python method named `toTL` (i.e. 'to Target Language') that permits to convert an object into the corresponding Python type. For example, the instruction `df = mygrid.toTL()` permits to create a pandas `DataFrame` from a `Db` object. This needs additional Python dependencies that can be installed alongside gstlearn with the `conv` optional dependency group (c.f. README). In that case, the newly created `DataFrame` will contain all variables from the Db (but locators and grid parameters (for DbGrid) will be lost)\t"
    ]
   },
   {

--- a/doc/courses/python/02_Db.ipynb
+++ b/doc/courses/python/02_Db.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dat = gl.Db_fromPanda(datcsv)\n",
+    "dat = gl.Db_fromPandas(datcsv)\n",
     "dat"
    ]
   },

--- a/doc/courses/python/02_Db.ipynb
+++ b/doc/courses/python/02_Db.ipynb
@@ -402,7 +402,7 @@
    "id": "a0250251",
    "metadata": {},
    "source": [
-    "A particular function is available to convert all the data base in an appropriate object of the Target Langage (here Python). A gstlearn *Db* is converted into a *Pandas frame* using **toTL**."
+    "A particular function is available to convert all the data base in an appropriate object of the Target Langage (here Python). A gstlearn *Db* is converted into a *Pandas frame* using **toTL** (needs the `conv` optional dependency group)."
    ]
   },
   {

--- a/include/geoslib_define.h
+++ b/include/geoslib_define.h
@@ -50,7 +50,12 @@ typedef unsigned char UChar;
 // This function must be:
 // - declared in rgstlearn.i or pygstlearn.i
 // - be called as 'classname'_toTL
-#define DECLARE_TOTL inline void toTL() const {};
+#define DECLARE_TOTL                                        \
+  inline void toTL() const                                  \
+  {                                                         \
+    void messerr(const char* format, ...);                  \
+    messerr("Not implemented yet (missing dependencies?)"); \
+  };
 
 // No need to this stuff through SWIG (using target language NAs)
 // => Not really : Using customized SWIG 4.2.0b, TEST is often a default argument value!

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -242,7 +242,7 @@ endif()
 # Add a custom target for python package installation
 # TODO: Do also installation each time setup.py.in or README.md is modified
 add_custom_target(python_install
-  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot]"
+  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot,conv]"
   COMMENT "Installing python package"
   )
  

--- a/python/README.md
+++ b/python/README.md
@@ -39,6 +39,20 @@ those can be installed alongside gstlearn with the following command:
 pip install gstlearn[plot]
 ```
 
+Converting several gstlearn C++ types through `toTL` methods to, e.g.,
+Pandas DataFrames also require additional dependencies. These are
+available through the `conv` optional dependency group:
+
+``` python
+pip install gstlearn[conv]
+```
+
+All optional dependencies can be installed with the following command:
+
+``` python
+pip install gstlearn[all]
+```
+
 ## Usage
 
 We refer the reader to this [course page](https://soft.mines-paristech.fr/gstlearn/courses-latest/python/01_gstlearn_start.html) for an introduction and important information about Python gstlearn package.

--- a/python/modules/conv.py
+++ b/python/modules/conv.py
@@ -29,7 +29,7 @@ def Db_toTL(self, flagLocate=False):
 setattr(gl.Db, "toTL", Db_toTL)
 
 
-def Db_fromPanda(df):
+def Db_fromPandas(df):
     # Create an empty Db
     dat = gl.Db()
     # And import all columns in one a loop using [] operator
@@ -40,7 +40,7 @@ def Db_fromPanda(df):
     return dat
 
 
-gl.Db.fromTL = staticmethod(Db_fromPanda)
+gl.Db.fromTL = staticmethod(Db_fromPandas)
 
 
 def table_toTL(self):

--- a/python/modules/conv.py
+++ b/python/modules/conv.py
@@ -1,0 +1,127 @@
+import gstlearn as gl
+import numpy as np
+
+try:
+    import pandas as pd
+    import scipy.sparse as sc
+except ModuleNotFoundError as ex:
+    msg = (
+        "Python dependencies 'pandas' and 'scipy' not found.\n"
+        "To install them alongside gstlearn, please run `pip install gstlearn[conv]'"
+    )
+    raise ModuleNotFoundError(msg) from ex
+
+
+def Db_toTL(self, flagLocate=False):
+    df = pd.DataFrame(
+        self.getAllColumns().reshape(-1, self.getNSample()).T,
+        columns=self.getAllNames(),
+    )
+
+    if flagLocate:
+        for j, i in enumerate(self.getAllNames()):
+            df[i].locator = self.getLocators()[j]
+    return df
+
+
+# TODO : This below (and all other setattr for toTL) overrides
+# DECLARE_TOTL usage (not needed in python ?)
+setattr(gl.Db, "toTL", Db_toTL)
+
+
+def Db_fromPanda(df):
+    # Create an empty Db
+    dat = gl.Db()
+    # And import all columns in one a loop using [] operator
+    for field in df.columns:
+        mycol = df[field]
+        if mycol.dtype == "float64" or mycol.dtype == "int64":
+            dat[field] = mycol
+    return dat
+
+
+gl.Db.fromTL = staticmethod(Db_fromPanda)
+
+
+def table_toTL(self):
+    # As a Panda Data Frame
+    colnames = self.getColumnNames()
+    rownames = self.getRowNames()
+    if len(colnames) == 0:
+        colnames = None
+    if len(rownames) == 0:
+        rownames = None
+    Anp = pd.DataFrame(
+        self.getValues(False).reshape(self.getNRows(), self.getNCols()),
+        columns=colnames,
+        index=rownames,
+    )
+    return Anp
+
+
+setattr(gl.Table, "toTL", table_toTL)
+
+
+def vario_toTL(self, idir, ivar, jvar):
+    sw = self.getSwVec(idir, ivar, jvar, False)
+    hh = self.getHhVec(idir, ivar, jvar, False)
+    gg = self.getGgVec(idir, ivar, jvar, False, False, False)
+    array = np.vstack((sw, hh, gg)).T
+    colnames = np.array(["sw", "hh", "gg"])
+    return pd.DataFrame(array, columns=colnames)
+
+
+setattr(gl.Vario, "toTL", vario_toTL)
+
+
+def vario_updateFromPanda(self, pf, idir, ivar, jvar):
+    vario = self
+    ndir = vario.getNDir()
+    nvar = vario.getNVar()
+    if idir < 0 or idir >= ndir:
+        return vario
+    if ivar < 0 or ivar >= nvar:
+        return vario
+    if jvar < 0 or jvar >= nvar:
+        return vario
+    nlag = vario.getNLagTotal(idir)
+    if len(pf.index) != nlag:
+        return vario
+
+    vario.setSwVec(idir, ivar, jvar, pf["sw"])
+    vario.setHhVec(idir, ivar, jvar, pf["hh"])
+    vario.setGgVec(idir, ivar, jvar, pf["gg"])
+    return vario
+
+
+setattr(gl.Vario, "updateFromPanda", vario_updateFromPanda)
+
+
+def matrix_toTL(self):
+    if self.isSparse():
+        NF_T = self.getMatrixToTriplet()
+        return Triplet_toTL(NF_T)
+    else:
+        return np.array(self.getValues(False)).reshape(self.getNRows(), self.getNCols())
+
+
+setattr(gl.MatrixRectangular, "toTL", matrix_toTL)
+setattr(gl.MatrixSquareGeneral, "toTL", matrix_toTL)
+setattr(gl.MatrixSquareSymmetric, "toTL", matrix_toTL)
+setattr(gl.MatrixSparse, "toTL", matrix_toTL)
+setattr(gl.ProjMatrix, "toTL", matrix_toTL)
+setattr(gl.PrecisionOpMultiMatrix, "toTL", matrix_toTL)
+setattr(gl.ProjMultiMatrix, "toTL", matrix_toTL)
+
+
+def Triplet_toTL(self):
+    return sc.csc_matrix(
+        (
+            np.array(self.getValues()),
+            (np.array(self.getRows()), np.array(self.getCols())),
+        ),
+        shape=(self.getNRows() + 1, self.getNCols() + 1),
+    )
+
+
+setattr(gl.NF_Triplet, "toTL", Triplet_toTL)

--- a/python/modules/plot.py
+++ b/python/modules/plot.py
@@ -6,11 +6,18 @@
 # License: BSD 3-clause                                                        #
 #                                                                              #
 ################################################################################
-import matplotlib
-import matplotlib.pyplot     as plt
-import matplotlib.patches    as ptc
-import matplotlib.transforms as transform
-import matplotlib.colors     as mcolors
+
+try:
+    import matplotlib
+    import matplotlib.pyplot     as plt
+    import matplotlib.patches    as ptc
+    import matplotlib.transforms as transform
+    import matplotlib.colors     as mcolors
+except ModuleNotFoundError as ex:
+    msg = ("Python dependency 'matplotlib' not found.\n"
+          "To install it alongside gstlearn, please run `pip install gstlearn[plot]'")
+    raise ModuleNotFoundError(msg) from ex
+
 import numpy                 as np
 import numpy.ma              as ma
 import gstlearn              as gl

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -26,8 +26,6 @@ dependencies = [
     # from the oldest supported numpy to the next major version of the
     # numpy install used in building gstlearn
     "numpy>=1.24,<@Python3_NumPy_NEXT_MAJOR@",
-    "scipy",
-    "pandas",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +35,11 @@ plot = [
      "plotly",
      "shapely",
 ]
+conv = [
+     "pandas",
+     "scipy",
+]
+all = ["gstlearn[plot,conv]"]
 
 [project.urls]
 Homepage = "@PROJECT_HOMEPAGE_URL@"


### PR DESCRIPTION
This PR creates a new optional dependency group for the Python package, named `conv`. This group controls the installation of `scipy` and `pandas`, two dependencies of the gstlearn Python package.

A few functions use these dependencies, they have been moved to a separate Python module that is automatically loaded if the dependencies are installed. If not, an error message is displayed within the `toTL` C++ function. This concerns the `Vario`, `Db` and `Table` conversions from/to Pandas Dataframes and several types of gstlearn matrices to NumPy or scipy sparse.

Also, the Python function `Db_fromPanda` has been renamed to `Db_fromPandas` to fix a typo (`pandas` has a trailing 's').

To manage all optional Python dependencies, a third dependency group, `all`, is introduced in this PR. `pip install gstlearn[all]` will install all optional dependencies (`matplotlib`, `scipy`, `geopandas`, etc.).

Closes #442.

Pierre