### PR TITLE
Add %newobject for ::clone methods (to prevent memory leaks)

### DIFF
--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -1059,7 +1059,7 @@
 };
 
 
-// Prevent memory leaks from 'create*' methods
+// Prevent memory leaks from 'create*' anc 'clone' methods
 
 // The following file should contain all 'createFrom*' methods
 %include swig/newobject.i
@@ -1067,6 +1067,8 @@
 %newobject *::create;
 // So bad that the following syntax doesn't work:
 // %newobject *::create*;
+// This is for all 'clone' methods
+%newobject *::clone;
 
 %{
   #include <memory>


### PR DESCRIPTION
Prevent memory leaks after a call to clone method in Python or R. Created object will be garbage collected if not used anymore. To prevent this, the object has to be stored in a variable.