### PR TITLE
Remove shared_ptr inside VectorT

### DIFF
--- a/include/Basic/VectorNumT.hpp
+++ b/include/Basic/VectorNumT.hpp
@@ -88,7 +88,7 @@ T VectorNumT<T>::sum() const
   if (VectorNumT::size() <= 0) return T();
   T sum = 0;
   for (size_type i = 0, n = VectorNumT::size(); i < n; i++)
-    sum += VectorNumT::_v->at(i);
+    sum += VectorNumT::_v.at(i);
   return (sum);
 }
 
@@ -97,7 +97,7 @@ T VectorNumT<T>::maximum() const  // Prevent using max and min keywords (Visual)
 {
   if (VectorNumT::size() <= 0) return 0;
   T mymax = (std::numeric_limits<T>::min)(); // https://stackoverflow.com/a/27443191/3952924
-  for (auto v : *VectorNumT::_v)
+  for (auto v : VectorNumT::_v)
     if (v > mymax) mymax = v;
   return (mymax);
 }
@@ -107,7 +107,7 @@ T VectorNumT<T>::minimum() const  // Prevent using max and min keywords (Visual)
 {
   if (VectorNumT::size() <= 0) return 0;
   T mymin = (std::numeric_limits<T>::max)(); // https://stackoverflow.com/a/27443191/3952924
-  for (auto v : *VectorNumT::_v)
+  for (auto v : VectorNumT::_v)
     if (v < mymin) mymin = v;
   return (mymin);
 }
@@ -117,7 +117,7 @@ double VectorNumT<T>::mean() const
 {
   if (VectorNumT::size() <= 0) return static_cast<T>(NAN);
   double s = static_cast<double>(sum());
-  return (s / static_cast<double>(VectorNumT::_v->size()));
+  return (s / static_cast<double>(VectorNumT::_v.size()));
 }
 
 template <typename T>

--- a/include/Basic/VectorT.hpp
+++ b/include/Basic/VectorT.hpp
@@ -16,7 +16,6 @@
 
 #include <vector>
 #include <sstream>
-#include <memory>
 #include <algorithm>
 #include <cmath>
 
@@ -41,38 +40,39 @@ public:
   typedef typename Vector::const_reverse_iterator   const_reverse_iterator;
 
 public:
-  inline VectorT()                                                    : _v(std::make_shared<Vector>()) { }
-  inline VectorT(const Vector& vec)                                   : _v(std::make_shared<Vector>(vec)) { }
-  inline VectorT(size_type count, const T& value = T())               : _v(std::make_shared<Vector>(count, value)) { }
+  inline VectorT()                                                    : _v() { }
+  inline VectorT(const Vector& vec)                                   : _v(vec) { }
+  inline VectorT(size_type count, const T& value = T())               : _v(count, value) { }
   template< class InputIt >
-  inline VectorT(InputIt first, InputIt last)                         : _v(std::make_shared<Vector>()) { _v->assign(first, last); }
+  inline VectorT(InputIt first, InputIt last)                         : _v() { _v.assign(first, last); }
   inline VectorT(const VectorT& other) = default;
 #ifndef SWIG
-  inline VectorT(std::initializer_list<T> init)                       : _v(std::make_shared<Vector>(init)) { }
+  inline VectorT(std::initializer_list<T> init)                       : _v(init) { }
   inline VectorT(VectorT&& other)                                      noexcept { _v.swap(other._v); }
 #endif
   inline ~VectorT() = default;
 
 #ifndef SWIG
-  inline operator const Vector&() const                               { return *_v; }
+  inline operator const Vector&() const                               { return _v; }
 #endif
 
-  inline Vector& getVector() const                                    { return *_v; }
-  inline Vector* getVectorPtr() const                                 { return _v.get(); }
+  inline Vector& getVector()                                    { return _v; }
+  inline const Vector& getVector() const                                    { return _v; }
+  inline const Vector* getVectorPtr() const                                 { return &_v; }
 
 #ifndef SWIG
-  inline VectorT& operator=(const Vector& vec)                        { _detach(); *_v = vec; return (*this); }
+  inline VectorT& operator=(const Vector& vec)                        { _detach(); _v = vec; return (*this); }
   inline VectorT& operator=(const VectorT& other)                     { _detach(); _v = other._v; return (*this); }
   inline VectorT& operator=(VectorT&& other)                           noexcept { _v.swap(other._v); return (*this); }
-  inline VectorT& operator=(std::initializer_list<T> init)            { _detach(); (*_v) = init; return (*this); }
+  inline VectorT& operator=(std::initializer_list<T> init)            { _detach(); _v = init; return (*this); }
 #endif
 
-  inline bool operator==(const VectorT& other) const                  { return *_v == *other._v; }
-  inline bool operator!=(const VectorT& other) const                  { return *_v != *other._v; }
-  inline bool operator <(const VectorT& other) const                  { return *_v  < *other._v; }
-  inline bool operator<=(const VectorT& other) const                  { return *_v <= *other._v; }
-  inline bool operator >(const VectorT& other) const                  { return *_v  > *other._v; }
-  inline bool operator>=(const VectorT& other) const                  { return *_v >= *other._v; }
+  inline bool operator==(const VectorT& other) const                  { return _v == other._v; }
+  inline bool operator!=(const VectorT& other) const                  { return _v != other._v; }
+  inline bool operator <(const VectorT& other) const                  { return _v  < other._v; }
+  inline bool operator<=(const VectorT& other) const                  { return _v <= other._v; }
+  inline bool operator >(const VectorT& other) const                  { return _v  > other._v; }
+  inline bool operator>=(const VectorT& other) const                  { return _v >= other._v; }
 
   // For SWIG users (size_type is not much appreciated)
   inline const T& getAt(int pos) const;
@@ -86,53 +86,53 @@ public:
   inline T& operator[](size_type pos);
 #endif
 
-  inline T& front()                                                   { _detach(); return _v->front(); }
-  inline const T& front() const                                       { return _v->front(); }
-  inline T& back()                                                    { _detach(); return _v->back(); }
-  inline const T& back() const                                        { return _v->back(); }
-  inline T* data()                                                    { _detach(); return _v->data(); }
-  inline const T* data() const                                        { return _v->data(); }
-  inline const T* constData() const                                   { return _v->data(); }
+  inline T& front()                                                   { _detach(); return _v.front(); }
+  inline const T& front() const                                       { return _v.front(); }
+  inline T& back()                                                    { _detach(); return _v.back(); }
+  inline const T& back() const                                        { return _v.back(); }
+  inline T* data()                                                    { _detach(); return _v.data(); }
+  inline const T* data() const                                        { return _v.data(); }
+  inline const T* constData() const                                   { return _v.data(); }
 
-  inline T* subdata(size_type i = 0)                                  { _detach(); return _v->data() + i; }
-  inline const T* subdata(size_type i = 0) const                      { return _v->data() + i; }
+  inline T* subdata(size_type i = 0)                                  { _detach(); return _v.data() + i; }
+  inline const T* subdata(size_type i = 0) const                      { return _v.data() + i; }
 
-  inline bool empty() const                                           { return _v->empty(); }
-  inline size_type size() const                                       { return _v->size(); }
-  inline void reserve(size_type new_cap)                              { _v->reserve(new_cap); }
-  inline size_type capacity() const                                   { return _v->capacity(); }
-  inline void clear()                                                 { _detach(); _v->clear(); }
+  inline bool empty() const                                           { return _v.empty(); }
+  inline size_type size() const                                       { return _v.size(); }
+  inline void reserve(size_type new_cap)                              { _v.reserve(new_cap); }
+  inline size_type capacity() const                                   { return _v.capacity(); }
+  inline void clear()                                                 { _detach(); _v.clear(); }
 
-  inline void insert(size_type i, const T& value)                     { _detach(); _v->insert(begin() + i, value); }
-  inline void insert(size_type i, size_type count, const T& value)    { _detach(); _v->insert(begin() + i, count, value); }
+  inline void insert(size_type i, const T& value)                     { _detach(); _v.insert(begin() + i, value); }
+  inline void insert(size_type i, size_type count, const T& value)    { _detach(); _v.insert(begin() + i, count, value); }
   inline iterator insert(const_iterator pos,
                          const_iterator first,
-                         const_iterator last )                        { _detach(); return _v->insert(pos, first, last); }
-  inline void remove(size_type i)                                     { _detach(); _v->erase(begin() + i); }
-  inline void remove(size_type i, size_type count)                    { _detach(); _v->erase(begin() + i, begin() + i + count); }
-  inline iterator erase( const_iterator pos )                         { _detach(); return _v->erase(pos); }
-  inline iterator erase( const_iterator first, const_iterator last)   { _detach(); return _v->erase(first, last); }
+                         const_iterator last )                        { _detach(); return _v.insert(pos, first, last); }
+  inline void remove(size_type i)                                     { _detach(); _v.erase(begin() + i); }
+  inline void remove(size_type i, size_type count)                    { _detach(); _v.erase(begin() + i, begin() + i + count); }
+  inline iterator erase( const_iterator pos )                         { _detach(); return _v.erase(pos); }
+  inline iterator erase( const_iterator first, const_iterator last)   { _detach(); return _v.erase(first, last); }
 
-  inline void push_back(const T& value)                               { _detach(); _v->push_back(value); }
-  inline void push_front(const T& value)                              { _detach(); _v->insert(begin(), value); }
+  inline void push_back(const T& value)                               { _detach(); _v.push_back(value); }
+  inline void push_front(const T& value)                              { _detach(); _v.insert(begin(), value); }
 #ifndef SWIG
-  inline void push_back(const T&& value)                              { _detach(); _v->push_back(value); }
-  inline void push_front(const T&& value)                             { _detach(); _v->insert(begin(), value); }
+  inline void push_back(const T&& value)                              { _detach(); _v.push_back(value); }
+  inline void push_front(const T&& value)                             { _detach(); _v.insert(begin(), value); }
 #endif
-  inline void resize(size_type count)                                 { if (count == size()) return; _detach(); _v->resize(count); }
-  inline void resize(size_type count, const T& value)                 { if (count == size()) return; _detach(); _v->resize(count, value); }
+  inline void resize(size_type count)                                 { if (count == size()) return; _detach(); _v.resize(count); }
+  inline void resize(size_type count, const T& value)                 { if (count == size()) return; _detach(); _v.resize(count, value); }
 
-  inline iterator begin()                                             { _detach(); return _v->begin(); }
-  inline const_iterator begin() const                                 { return _v->begin(); }
-  inline const_iterator cbegin() const                                { return _v->cbegin(); }
-  inline iterator end()                                               { _detach(); return _v->end(); }
-  inline const_iterator end() const                                   { return _v->end(); }
-  inline const_iterator cend() const                                  { return _v->cend(); }
+  inline iterator begin()                                             { _detach(); return _v.begin(); }
+  inline const_iterator begin() const                                 { return _v.begin(); }
+  inline const_iterator cbegin() const                                { return _v.cbegin(); }
+  inline iterator end()                                               { _detach(); return _v.end(); }
+  inline const_iterator end() const                                   { return _v.end(); }
+  inline const_iterator cend() const                                  { return _v.cend(); }
 
-  inline reverse_iterator rbegin()                                    { _detach(); return _v->rbegin(); }
-  inline const_reverse_iterator crbegin() const                       { return _v->crbegin(); }
-  inline reverse_iterator rend()                                      { _detach(); return _v->rend(); }
-  inline const_reverse_iterator crend() const                         { return _v->crend(); }
+  inline reverse_iterator rbegin()                                    { _detach(); return _v.rbegin(); }
+  inline const_reverse_iterator crbegin() const                       { return _v.crbegin(); }
+  inline reverse_iterator rend()                                      { _detach(); return _v.rend(); }
+  inline const_reverse_iterator crend() const                         { return _v.crend(); }
 
 #ifndef SWIG
   inline VectorT& operator<<(const T& value);
@@ -146,7 +146,7 @@ public:
   inline void assign(InputIt first, InputIt last)
   {
     _detach();
-    _v->assign(first, last);
+    _v.assign(first, last);
   }
 
   inline String toString(const AStringFormat* strfmt = nullptr) const;
@@ -159,7 +159,7 @@ public:
   inline void toTL() const {};
 
 protected:
-  std::shared_ptr<Vector> _v;
+  Vector _v;
 
 private:
   inline void _detach();
@@ -184,7 +184,7 @@ void VectorT<T>::setAt(int pos, const T& v)
 template <typename T>
 int VectorT<T>::length() const
 {
-  return static_cast<int>(_v->size());
+  return static_cast<int>(_v.size());
 }
 
 template <typename T>
@@ -211,7 +211,7 @@ const T& VectorT<T>::operator[](size_type pos) const
   // Unprotect operator[] ... as in std::vector library
   //  if (pos >= size())
   //    my_throw("VectorT<T>::operator[]: index out of range");
-  return _v->operator[](pos);
+  return _v.operator[](pos);
 }
 
 template<typename T>
@@ -221,7 +221,7 @@ T& VectorT<T>::operator[](size_type pos)
   //  if (pos >= size())
   //    my_throw("VectorT<T>::operator[]: index out of range");
   _detach();
-  return _v->operator[](pos);
+  return _v.operator[](pos);
 }
 #endif
 
@@ -270,9 +270,6 @@ void VectorT<T>::display(const AStringFormat* strfmt) const
 template<typename T>
 void VectorT<T>::_detach()
 {
-  if (_v.use_count() == 1)
-    return;
-  _v = std::make_shared<Vector>(*_v);
 }
 
 #ifndef SWIG

--- a/include/Basic/VectorT.hpp
+++ b/include/Basic/VectorT.hpp
@@ -61,10 +61,10 @@ public:
   inline const Vector* getVectorPtr() const                                 { return &_v; }
 
 #ifndef SWIG
-  inline VectorT& operator=(const Vector& vec)                        { _detach(); _v = vec; return (*this); }
-  inline VectorT& operator=(const VectorT& other)                     { _detach(); _v = other._v; return (*this); }
+  inline VectorT& operator=(const Vector& vec)                        { _v = vec; return (*this); }
+  inline VectorT& operator=(const VectorT& other)                     { _v = other._v; return (*this); }
   inline VectorT& operator=(VectorT&& other)                           noexcept { _v.swap(other._v); return (*this); }
-  inline VectorT& operator=(std::initializer_list<T> init)            { _detach(); _v = init; return (*this); }
+  inline VectorT& operator=(std::initializer_list<T> init)            { _v = init; return (*this); }
 #endif
 
   inline bool operator==(const VectorT& other) const                  { return _v == other._v; }
@@ -86,52 +86,52 @@ public:
   inline T& operator[](size_type pos);
 #endif
 
-  inline T& front()                                                   { _detach(); return _v.front(); }
+  inline T& front()                                                   { return _v.front(); }
   inline const T& front() const                                       { return _v.front(); }
-  inline T& back()                                                    { _detach(); return _v.back(); }
+  inline T& back()                                                    { return _v.back(); }
   inline const T& back() const                                        { return _v.back(); }
-  inline T* data()                                                    { _detach(); return _v.data(); }
+  inline T* data()                                                    { return _v.data(); }
   inline const T* data() const                                        { return _v.data(); }
   inline const T* constData() const                                   { return _v.data(); }
 
-  inline T* subdata(size_type i = 0)                                  { _detach(); return _v.data() + i; }
+  inline T* subdata(size_type i = 0)                                  { return _v.data() + i; }
   inline const T* subdata(size_type i = 0) const                      { return _v.data() + i; }
 
   inline bool empty() const                                           { return _v.empty(); }
   inline size_type size() const                                       { return _v.size(); }
   inline void reserve(size_type new_cap)                              { _v.reserve(new_cap); }
   inline size_type capacity() const                                   { return _v.capacity(); }
-  inline void clear()                                                 { _detach(); _v.clear(); }
+  inline void clear()                                                 { _v.clear(); }
 
-  inline void insert(size_type i, const T& value)                     { _detach(); _v.insert(begin() + i, value); }
-  inline void insert(size_type i, size_type count, const T& value)    { _detach(); _v.insert(begin() + i, count, value); }
+  inline void insert(size_type i, const T& value)                     { _v.insert(begin() + i, value); }
+  inline void insert(size_type i, size_type count, const T& value)    { _v.insert(begin() + i, count, value); }
   inline iterator insert(const_iterator pos,
                          const_iterator first,
-                         const_iterator last )                        { _detach(); return _v.insert(pos, first, last); }
-  inline void remove(size_type i)                                     { _detach(); _v.erase(begin() + i); }
-  inline void remove(size_type i, size_type count)                    { _detach(); _v.erase(begin() + i, begin() + i + count); }
-  inline iterator erase( const_iterator pos )                         { _detach(); return _v.erase(pos); }
-  inline iterator erase( const_iterator first, const_iterator last)   { _detach(); return _v.erase(first, last); }
+                         const_iterator last )                        { return _v.insert(pos, first, last); }
+  inline void remove(size_type i)                                     { _v.erase(begin() + i); }
+  inline void remove(size_type i, size_type count)                    { _v.erase(begin() + i, begin() + i + count); }
+  inline iterator erase( const_iterator pos )                         { return _v.erase(pos); }
+  inline iterator erase( const_iterator first, const_iterator last)   { return _v.erase(first, last); }
 
-  inline void push_back(const T& value)                               { _detach(); _v.push_back(value); }
-  inline void push_front(const T& value)                              { _detach(); _v.insert(begin(), value); }
+  inline void push_back(const T& value)                               { _v.push_back(value); }
+  inline void push_front(const T& value)                              { _v.insert(begin(), value); }
 #ifndef SWIG
-  inline void push_back(const T&& value)                              { _detach(); _v.push_back(value); }
-  inline void push_front(const T&& value)                             { _detach(); _v.insert(begin(), value); }
+  inline void push_back(const T&& value)                              { _v.push_back(value); }
+  inline void push_front(const T&& value)                             { _v.insert(begin(), value); }
 #endif
-  inline void resize(size_type count)                                 { if (count == size()) return; _detach(); _v.resize(count); }
-  inline void resize(size_type count, const T& value)                 { if (count == size()) return; _detach(); _v.resize(count, value); }
+  inline void resize(size_type count)                                 { if (count == size()) return; _v.resize(count); }
+  inline void resize(size_type count, const T& value)                 { if (count == size()) return; _v.resize(count, value); }
 
-  inline iterator begin()                                             { _detach(); return _v.begin(); }
+  inline iterator begin()                                             { return _v.begin(); }
   inline const_iterator begin() const                                 { return _v.begin(); }
   inline const_iterator cbegin() const                                { return _v.cbegin(); }
-  inline iterator end()                                               { _detach(); return _v.end(); }
+  inline iterator end()                                               { return _v.end(); }
   inline const_iterator end() const                                   { return _v.end(); }
   inline const_iterator cend() const                                  { return _v.cend(); }
 
-  inline reverse_iterator rbegin()                                    { _detach(); return _v.rbegin(); }
+  inline reverse_iterator rbegin()                                    { return _v.rbegin(); }
   inline const_reverse_iterator crbegin() const                       { return _v.crbegin(); }
-  inline reverse_iterator rend()                                      { _detach(); return _v.rend(); }
+  inline reverse_iterator rend()                                      { return _v.rend(); }
   inline const_reverse_iterator crend() const                         { return _v.crend(); }
 
 #ifndef SWIG
@@ -145,7 +145,6 @@ public:
   template< class InputIt >
   inline void assign(InputIt first, InputIt last)
   {
-    _detach();
     _v.assign(first, last);
   }
 
@@ -160,9 +159,6 @@ public:
 
 protected:
   Vector _v;
-
-private:
-  inline void _detach();
 };
 
 template <typename T>
@@ -178,7 +174,6 @@ void VectorT<T>::setAt(int pos, const T& v)
 {
   if (pos < 0 || pos >= length())
     my_throw("VectorT<T>::set: index out of range");
-  _detach();
   operator[](pos) = v;
 }
 template <typename T>
@@ -200,7 +195,6 @@ T& VectorT<T>::at(size_type pos)
 {
   if (pos >= size())
     my_throw("VectorT<T>::at: index out of range");
-  _detach();
   return operator[](pos);
 }
 
@@ -220,7 +214,6 @@ T& VectorT<T>::operator[](size_type pos)
   // Unprotect operator[] ... as in std::vector library
   //  if (pos >= size())
   //    my_throw("VectorT<T>::operator[]: index out of range");
-  _detach();
   return _v.operator[](pos);
 }
 #endif
@@ -240,7 +233,6 @@ bool VectorT<T>::contains(const T& value) const
 template <typename T>
 void VectorT<T>::fill(const T& value, size_type size)
 {
-  _detach();
   if (size > 0) resize(size);
   std::fill(begin(), end(), value);
 }
@@ -267,16 +259,10 @@ void VectorT<T>::display(const AStringFormat* strfmt) const
   message_extern(toString(strfmt).c_str());
 }
 
-template<typename T>
-void VectorT<T>::_detach()
-{
-}
-
 #ifndef SWIG
 template <typename T>
 VectorT<T>& VectorT<T>::operator<<(const T& value)
 {
-  _detach();
   push_back(value);
   return (*this);
 }
@@ -284,7 +270,6 @@ VectorT<T>& VectorT<T>::operator<<(const T& value)
 template <typename T>
 VectorT<T>& VectorT<T>::operator<<(const VectorT<T>& v)
 {
-  _detach();
   reserve(size() + v.size());
   std::for_each(v.cbegin(), v.cend(), [&](const T& value)
                 { push_back(value); });

--- a/include/LinearOp/AShiftOp.hpp
+++ b/include/LinearOp/AShiftOp.hpp
@@ -16,6 +16,8 @@
 #include "Basic/VectorNumT.hpp"
 #include "Basic/VectorT.hpp"
 
+#include <memory>
+
 #ifndef SWIG
 
 #include <Eigen/Core>

--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -13,6 +13,8 @@
 #include "gstlearn_export.hpp"
 #include "LinearOp/IProj.hpp"
 
+#include <memory>
+
 class GSTLEARN_EXPORT ProjComposition : public IProj
 {
 public:

--- a/include/Matrix/AMatrixDense.hpp
+++ b/include/Matrix/AMatrixDense.hpp
@@ -16,6 +16,8 @@
 #include "Matrix/AMatrix.hpp"
 #include "Basic/WarningMacro.hpp"
 
+#include <memory>
+
 #ifndef SWIG
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_COND_EXPR_CONSTANT


### PR DESCRIPTION
The `std::shared_ptr` inside `VectorT` has a confusing behavior and a negative effect on performance. This PR removes the `std::shared_ptr` indirection. There are small gains visible in the non-regression tests timings: on Ubuntu, the whole CI step goes from 22min to 13min. This is particularly true for the `bench_Tree` benchmark, whose execution time goes from 350s to 90s on Ubuntu and from 60s to 25s on Windows.

Enjoy,
Pierre