### PR TITLE
Krigopt rearranged

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,9 @@ This file contains the logs between consecutive releases
 
 Release 1.7.0
 =============
-- API functions such as kriging, xvalid, ... are now using KrigOpt argument to carry
-  all the options used while kriging (calcul, ndisc for block, matLC, DGM, ...)
+- Essential modificaiton: API functions such as kriging, xvalid, ... are now using KrigOpt 
+  argument to carry all the options used while kriging (calcul, ndisc for block, matLC, DGM, ...)
+
 - evalCov is now a concrete method of ACov and it calls _eval which is pure virtual and has to be implemented in new covariance classes.
 - eval is renamed evalCov in ACov (the version which takes const SpacePoint& in arguments) 
 - evalCov is renamed evalCorFunc in CovFunc class

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.7.0
 =============
+- API functions such as kriging, xvalid, ... are now using KrigOpt argument to carry
+  all the options used while kriging (calcul, ndisc for block, matLC, DGM, ...)
 - evalCov is now a concrete method of ACov and it calls _eval which is pure virtual and has to be implemented in new covariance classes.
 - eval is renamed evalCov in ACov (the version which takes const SpacePoint& in arguments) 
 - evalCov is renamed evalCorFunc in CovFunc class

--- a/doc/courses/python/05_Kriging.ipynb
+++ b/doc/courses/python/05_Kriging.ipynb
@@ -1002,7 +1002,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/07a_Simulations.ipynb
+++ b/doc/courses/python/07a_Simulations.ipynb
@@ -377,8 +377,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err = gl.kriging(dat, target, model=fitmod, \n",
-    "              neigh = neighU,\n",
+    "err = gl.kriging(dat, target, model=fitmod, neigh = neighU,\n",
     "              namconv=gl.NamingConvention(\"KS\"))"
    ]
   },
@@ -556,8 +555,7 @@
     "target.statisticsBySample(names=[\"Simu.January_temp*\"], opers=[gl.EStatOption.MEAN])\n",
     "\n",
     "## Compute kriging\n",
-    "err = gl.kriging(dat, target, model=model_ED, \n",
-    "              neigh = neighU,\n",
+    "err = gl.kriging(dat, target, model=model_ED, neigh = neighU,\n",
     "              namconv=gl.NamingConvention(\"KED\"))"
    ]
   },

--- a/doc/courses/r/06a_Multivariate.Rmd
+++ b/doc/courses/r/06a_Multivariate.Rmd
@@ -213,8 +213,7 @@ We perform a cross-validation of the fitted model using Ordinary Kriging, and ca
 
 ```{r Cross-validation_Ordinary_kriging, results=FALSE}
 ## Compute cross-validation
-err = xvalid(dat, model=fitmod_raw, 
-             neigh=uniqueNeigh,
+err = xvalid(dat, model=fitmod_raw, neigh=uniqueNeigh,
              namconv=NamingConvention_create(prefix="CV_OK",flag_locator=FALSE))
 ```
 
@@ -329,8 +328,7 @@ movingNeigh = NeighMoving_create(radius = 1000, nmaxi = 10)
 To perform a cross-validation of the bivariate model using co-kriging, we use the  same commands as in the univariate case. Then cross-validation errors are computed for each variable of the multivariate model (hence for both the Temperature and the Elevation in our case).
 
 ```{r Cross-validation_Cokriging, echo=TRUE}
-err = xvalid(dat, model=fitmod2var,
-             neigh=movingNeigh,
+err = xvalid(dat, model=fitmod2var, neigh=movingNeigh,
              namconv=NamingConvention_create(prefix="CV_COK",flag_locator=FALSE))
 ```
 
@@ -635,8 +633,7 @@ dbStatisticsPrint(target, names=c("OK.T*estim", "UK.T*estim"), opers=opers,
 To perform cross-validation using Universal Kriging, we simply call the `xvalid` function with the model we fitted on the residuals. 
 
 ```{r Cross-validation_Universal_Kriging}
-err = xvalid(dat, model=polDriftModel, 
-             neigh=uniqueNeigh,
+err = xvalid(dat, model=polDriftModel, neigh=uniqueNeigh,
              namconv=NamingConvention_create(prefix="CV_UK",flag_locator=FALSE))
 ```
 
@@ -767,8 +764,7 @@ Note that negative Estimates are present when using External Drift.
 To perform a cross-validation, we simply call the `xvalid` function. 
 
 ```{r Cross-Validation_External_Drift}
-err = xvalid(dat, model=EDmodel, 
-             neigh=uniqueNeigh,
+err = xvalid(dat, model=EDmodel, neigh=uniqueNeigh,
              namconv=NamingConvention_create(prefix="CV_KED",flag_locator=FALSE))
 ```
 

--- a/doc/demo/python/Inheritance.ipynb
+++ b/doc/demo/python/Inheritance.ipynb
@@ -198,9 +198,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "kriging-env",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "kriging-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/demo/python/Tuto_BlockKriging.ipynb
+++ b/doc/demo/python/Tuto_BlockKriging.ipynb
@@ -214,7 +214,7 @@
    "outputs": [],
    "source": [
     "node = 155\n",
-    "err = gl.krigtest(data, grid, model, neigh, node, calcul=gl.EKrigOpt.POINT)"
+    "err = gl.krigtest(data, grid, model, neigh, node)"
    ]
   },
   {
@@ -238,7 +238,9 @@
    "outputs": [],
    "source": [
     "ndiscs = [5,5]\n",
-    "err = gl.kriging(data, grid, model, neigh, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs,\n",
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "err = gl.kriging(data, grid, model, neigh, krigopt=krigopt,\n",
     "                namconv=gl.NamingConvention(\"Block_Kriging\"))"
    ]
   },
@@ -327,7 +329,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err = gl.krigtest(data, grid, model, neigh, node, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs)"
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "err = gl.krigtest(data, grid, model, neigh, node, krigopt)"
    ]
   },
   {
@@ -361,7 +365,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err = gl.krigcell(data, grid, model, neigh, ndiscs=ndiscs,\n",
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs, True);\n",
+    "err = gl.krigcell(data, grid, model, neigh, krigopt = krigopt,\n",
     "                  namconv=gl.NamingConvention(\"Irregular_Kriging\"))"
    ]
   },
@@ -450,9 +456,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "err = gl.krigtest(data, grid, model, neigh, node, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs,\n",
-    "                 flagPerCell = True)"
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs, True)\n",
+    "err = gl.krigtest(data, grid, model, neigh, node, krigopt)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/demo/python/Tuto_SuperKriging.ipynb
+++ b/doc/demo/python/Tuto_SuperKriging.ipynb
@@ -30,12 +30,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
+      "application/javascript": "\nIPython.OutputArea.prototype._should_scroll = function(lines) {\n    return false;\n}\n",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -511,18 +506,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "ndiscs = [5,5]\n",
-    "err = gl.kriging(data, grid, model, neigh, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs,\n",
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "err = gl.kriging(data, grid, model, neigh, krigopt=krigopt,\n",
     "                namconv=gl.NamingConvention(\"Block_Kriging\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -598,7 +595,9 @@
    ],
    "source": [
     "if flagDebug:\n",
-    "    err = gl.krigtest(data, grid, model, neigh, node, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs)"
+    "    krigopt = gl.KrigOpt()\n",
+    "    krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "    err = gl.krigtest(data, grid, model, neigh, node, krigopt)"
    ]
   },
   {
@@ -843,11 +842,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "err = gl.kriging(data, grid, model, neighC, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs,\n",
+    "krigopt = gl.KrigOpt()\n",
+    "krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "err = gl.kriging(data, grid, model, neighC, krigopt=krigopt,\n",
     "                 namconv=gl.NamingConvention(\"Super_Kriging\"))"
    ]
   },
@@ -858,7 +859,9 @@
    "outputs": [],
    "source": [
     "if flagDebug:\n",
-    "    err = gl.krigtest(data, grid, model, neighC, node, calcul=gl.EKrigOpt.BLOCK, ndiscs=ndiscs)"
+    "    krigopt = gl.KrigOpt()\n",
+    "    krigopt.setOptionCalcul(gl.EKrigOpt.BLOCK, ndiscs)\n",
+    "    err = gl.krigtest(data, grid, model, neighC, node, krigopt)"
    ]
   },
   {

--- a/doc/demo/python/Tuto_Xvalid.ipynb
+++ b/doc/demo/python/Tuto_Xvalid.ipynb
@@ -333,7 +333,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/doc/demo/r/Tuto_Gibbs.Rmd
+++ b/doc/demo/r/Tuto_Gibbs.Rmd
@@ -591,7 +591,6 @@ for (s in 1:nbsimu) {
    # simple kriging of the Gaussian variable
     err = data$setLocators(s_nm, locatorType = ELoc_Z(), cleanSameLocator = TRUE)
     err = kriging(dbin = data, dbout = grid, model = model, neigh = neigh, 
-                  calcul = EKrigOpt_POINT(),
                   flag_est = TRUE, flag_std = TRUE, flag_varz = FALSE,
                   namconv = NamingConvention("sk"))
     # conditional expectation

--- a/doc/demo/r/Tuto_Kriging_MatLC.Rmd
+++ b/doc/demo/r/Tuto_Kriging_MatLC.Rmd
@@ -413,10 +413,11 @@ if(flag.verbose) {
 # fromTL(matrix(beta, nrow=1, ncol=length(beta)))
 
 # kriging LC variables
-err = data$setLocators(nm_var, ELoc_Z(), cleanSameLocator=TRUE)
+err = data$setLocators(nm_var, ELoc_Z(), cleanSameLocator = TRUE)
+krigopt = KrigOpt()
+krigopt$setMatLC(fromTL(matrix(beta, nrow = 1, ncol = length(beta))))
 err = kriging(data, grd, mod_Z_IRF0, neigh, 
-              matLC = fromTL(matrix(beta, nrow=1, ncol=length(beta))),
-              flag_est = TRUE, flag_std = TRUE,
+              flag_est = TRUE, flag_std = TRUE, krigopt=krigopt,
               namconv = NamingConvention("dOK"))
 
 # statistics
@@ -592,10 +593,11 @@ if(flag.verbose) {
 # fromTL(matrix(beta, nrow=1, ncol=length(beta)))
 
 # kriging LC variables
-err = data$setLocators(nm_var, ELoc_Z(), cleanSameLocator=TRUE)
+err = data$setLocators(nm_var, ELoc_Z(), cleanSameLocator = TRUE)
+krigopt = KrigOpt()
+krigopt$setMatLC(fromTL(matrix(beta, nrow = 1, ncol = length(beta))))
 err = kriging(data, grd, mod_Z_SOS, neigh, 
-              matLC = fromTL(matrix(beta, nrow=1, ncol=length(beta))),
-              flag_est = TRUE, flag_std = TRUE,
+              flag_est = TRUE, flag_std = TRUE, krigopt=krigopt,
               namconv = NamingConvention("dSK"))
 
 # statistics
@@ -651,9 +653,10 @@ if(flag.verbose) {
 }
 
 # kriging LC variables
-err = data$setLocators(paste(nm_var, "miss", sep = "_"), ELoc_Z(), cleanSameLocator=TRUE)
-err = kriging(data, grd, mod_Z_IRF0, neigh, 
-              matLC = fromTL(matrix(beta, nrow=1, ncol=length(beta))),
+err = data$setLocators(paste(nm_var, "miss", sep = "_"), ELoc_Z(), cleanSameLocator = TRUE)
+krigopt = KrigOpt()
+krigopt$setMatLC(fromTL(matrix(beta, nrow = 1, ncol = length(beta))))
+err = kriging(data, grd, mod_Z_IRF0, neigh, krigopt=krigopt,
               flag_est = TRUE, flag_std = TRUE,
               namconv = NamingConvention("dOK_He"))
 
@@ -719,9 +722,10 @@ if(flag.verbose) {
 }
 
 # kriging LC variables
-err = data$setLocators(paste(nm_var, "miss", sep = "_"), ELoc_Z(), cleanSameLocator=TRUE)
-err = kriging(data, grd, mod_Z_SOS, neigh, 
-              matLC = fromTL(matrix(beta, nrow=1, ncol=length(beta))),
+err = data$setLocators(paste(nm_var, "miss", sep = "_"), ELoc_Z(), cleanSameLocator = TRUE)
+krigopt = KrigOpt()
+krigopt$setMatLC(fromTL(matrix(beta, nrow = 1, ncol = length(beta))))
+err = kriging(data, grd, mod_Z_SOS, neigh, krigopt=krigopt,
               flag_est = TRUE, flag_std = TRUE,
               namconv = NamingConvention("dSK_He"))
 

--- a/doc/demo/r/Tuto_NonLinear_Gaussian_Pts.Rmd
+++ b/doc/demo/r/Tuto_NonLinear_Gaussian_Pts.Rmd
@@ -403,7 +403,6 @@ err = model$delDrift(0)
 err = model$setMean(0.)
 data$setLocator("Gaussian.Z", ELoc_Z(), cleanSameLocator=TRUE)
 err = kriging(data, blocs, model, neigh, 
-              calcul = EKrigOpt_POINT(),
               namconv= NamingConvention("G_Pts"))
 
 p = ggplot()
@@ -583,7 +582,7 @@ What is performed? Compute the (simple) kriging of the factors. Simple Kriging i
 ```{r dk_pts_estim, echo=TRUE, eval=TRUE}
 err = krigingFactors(dbin   = data,   # Input data set (a Db structure)
                      dbout  = blocs,  # Output data set (a DbGrid structure)
-                     model  = model, neigh, calcul= EKrigOpt_POINT(),
+                     model  = model, neigh, 
                      namconv = NamingConvention("DK_Pts"))
 blocs$display()
 ```
@@ -668,12 +667,14 @@ $$
 The post-processing is identical using **DisjunctiveKriging**.
 
 ```{r dk_blk_estim, echo=TRUE, eval=TRUE}
-# The number of estimated factors is defined by the number of selected variables 
+# The number of estimated factors is defined by the number of selected variables
 # in the input data base
 ndisc_B = c(5, 5)
+krigopt = KrigOpt()
+krigopt$setOptionCalcul(EKrigOpt_BLOCK(), ndisc_B)
 err = krigingFactors(dbin   = data,   # Input data set (a Db structure)
                      dbout  = blocs,  # Output data set (a DbGrid structure)
-                     model  = model, neigh, calcul= EKrigOpt_BLOCK(), ndisc = ndisc_B,
+                     model  = model, neigh, krigopt = krigopt,
                      namconv = NamingConvention("DK_Blk"))
 blocs$display()
 ```
@@ -713,10 +714,13 @@ XF: factors should be used instead if DK has to be computed.
 # The number of estimated factors is defined by the number of selected variables 
 # in the input data base
 ndisc_P = c(10, 10)
-data$setLocator("Gaussian.Z", ELoc_Z(), cleanSameLocator=TRUE)
+data$setLocator("Gaussian.Z", ELoc_Z(), cleanSameLocator = TRUE)
+krigopt = KrigOpt()
+krigopt$setOptionCalcul(calcul= EKrigOpt_BLOCK(), ndisc = ndisc_P)
 err = kriging(dbin   = data,   # Input data set (a Db structure).
               dbout  = panels, # Output data set (a DbGrid structure)
-              model  = model, neigh, calcul= EKrigOpt_BLOCK(), ndisc = ndisc_P,
+              model  = model, neigh = neigh, 
+              krigopt = krigopt,
               namconv = NamingConvention("DK_Blk"))
 panels$display()
 ```
@@ -777,7 +781,6 @@ err = model_raw$delDrift(0)
 err = model_raw$setMean(mean(data["Z"]))
 data$setLocator("Z", ELoc_Z(), cleanSameLocator=TRUE)
 err = kriging(data, grid, model_raw, neigh, 
-              calcul = EKrigOpt_POINT(),
               namconv= NamingConvention("SK"))
 
 # Conditional expectation
@@ -785,7 +788,6 @@ err = model_Y$delDrift(0)
 err = model_Y$setMean(0.)
 data$setLocator("Gaussian.Z", ELoc_Z(), cleanSameLocator=TRUE)
 err = kriging(data, grid, model_Y, neigh, 
-              calcul = EKrigOpt_POINT(),
               namconv= NamingConvention("SK"))
 err = ConditionalExpectation(db = grid, 
                              anam = anam, 
@@ -800,7 +802,7 @@ grid$setName("CE.Z-stdev", "CE.Z.stdev")
 data$setLocator("F.*", ELoc_Z(), cleanSameLocator=TRUE)
 err = krigingFactors(dbin   = data,   # Input data set (a Db structure)
                      dbout  = grid,  # Ouput data set (a DbGrid structure)
-                     model  = model, neigh, calcul= EKrigOpt_POINT(),
+                     model  = model, neigh, 
                      namconv = NamingConvention("SK"))
 
 ```
@@ -887,7 +889,6 @@ legend("topleft", legend = c("Hermite", "Theoretical"),
 # plot(psi.metal, psi.metal.qc)
 # abline(a = 0, b = 1, col = "red")
 
-
 # generic function to test DK
 compute_DK <- function(psi, name) {
 N   <- length(psi)
@@ -944,9 +945,7 @@ psi <- hermiteCoefMetal(yc = ycuts[1], phi = anam$getPsiHns())
 grid$setName(paste0("DK.Q-estim-", zcuts[1]), "DK.Q1.estim")
 grid$setName(paste0("DK.Q-stdev-", zcuts[1]), "DK.Q1.stdev")
 compute_DK(psi = psi, name = "DK.Q1")
-
 ```
-
 
 ## Scores of the estimators
 

--- a/doc/demo/r/Tuto_Xvalid.Rmd
+++ b/doc/demo/r/Tuto_Xvalid.Rmd
@@ -242,8 +242,11 @@ We perform the cross-validation (using Ordinary Kriging) without the folds: it i
 err = dbin$deleteColumns(names = "*.xval.*")
 
 err = dbin$setLocators("Y", locatorType = ELoc_Z(), cleanSameLocator = TRUE)
-err = xvalid(db = dbin, model = model, neigh = neigh, flag_kfold = FALSE, 
-             flag_xvalid_est = 1, flag_xvalid_std = 1, namconv = NamingConvention("OK.xval.LOO"))
+err = xvalid(
+  db = dbin, model = model, neigh = neigh, flag_kfold = FALSE,
+  flag_xvalid_est = 1, flag_xvalid_std = 1,
+  namconv = NamingConvention("OK.xval.LOO")
+)
 ```
 
 We now perform the same task but with K-Fold option
@@ -251,8 +254,11 @@ We now perform the same task but with K-Fold option
 ```{r}
 err = dbin$setLocators("Y", locatorType = ELoc_Z(), cleanSameLocator = TRUE)
 err = dbin$setLocator("folds", locatorType = ELoc_C(), cleanSameLocator = TRUE)
-err = xvalid(db = dbin, model = model, neigh = neigh, flag_kfold = TRUE, 
-             flag_xvalid_est = 1, flag_xvalid_std = 1, namconv = NamingConvention("OK.xval.kfold"))
+err = xvalid(
+  db = dbin, model = model, neigh = neigh, flag_kfold = TRUE,
+  flag_xvalid_est = 1, flag_xvalid_std = 1,
+  namconv = NamingConvention("OK.xval.kfold")
+)
 ```
 
 ```{r}

--- a/include/Calculators/ACalcInterpolator.hpp
+++ b/include/Calculators/ACalcInterpolator.hpp
@@ -30,9 +30,11 @@ public:
 
   void setModel(ModelGeneric* model) { _model = model; }
   void setNeigh(ANeigh* neigh) { _neigh = neigh; }
+  void setKrigopt(const KrigOpt& krigopt) { _krigopt = krigopt; }
 
   ModelGeneric*  getModel() const { return _model; }
   ANeigh* getNeigh() const { return _neigh; }
+  const KrigOpt& getKrigopt() const { return _krigopt; }
 
   bool hasModel(bool verbose = true) const;
   bool hasNeigh(bool verbose = true) const;
@@ -48,5 +50,6 @@ protected:
 private:
   ModelGeneric*  _model;
   ANeigh* _neigh;
+  KrigOpt _krigopt;
   int _ncova;
 };

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -577,12 +577,14 @@ public:
                                       int item              = -1,
                                       bool useSel           = true,
                                       bool useZ             = true,
-                                      bool useVerr          = false) const;
+                                      bool useVerr          = false,
+                                      bool useExtD          = false) const;
   VectorVectorInt getSampleRanks(const VectorInt& ivars = VectorInt(),
                                  const VectorInt& nbgh  = VectorInt(),
                                  bool useSel            = true,
                                  bool useZ              = true,
-                                 bool useVerr           = false) const;
+                                 bool useVerr           = false,
+                                 bool useExtD           = false) const;
   VectorDouble getValuesByRanks(const VectorVectorInt& sampleRanks,
                                 const VectorDouble& means = VectorDouble(),
                                 bool subtractMean         = true) const;

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -574,7 +574,7 @@ public:
   int          getSelection(int iech) const;
   VectorDouble getSelections(void) const;
   VectorInt getSampleRanksPerVariable(const VectorInt& nbgh = VectorInt(),
-                                      int item              = -1,
+                                      int ivar              = -1,
                                       bool useSel           = true,
                                       bool useZ             = true,
                                       bool useVerr          = false,

--- a/include/Estimation/CalcKriging.hpp
+++ b/include/Estimation/CalcKriging.hpp
@@ -14,8 +14,6 @@
 
 #include "geoslib_define.h"
 
-#include "Enum/EKrigOpt.hpp"
-
 #include "Calculators/ACalcInterpolator.hpp"
 #include "Matrix/MatrixRectangular.hpp"
 #include "Matrix/MatrixSquareSymmetric.hpp"
@@ -58,13 +56,11 @@ public:
   CalcKriging& operator=(const CalcKriging &r) = delete;
   virtual ~CalcKriging();
 
-  void setCalcul(const EKrigOpt& calcul);
   void setPriorCov(const MatrixSquareSymmetric& priorCov) { _priorCov = priorCov; }
   void setPriorMean(const VectorDouble& priorMean) { _priorMean = priorMean; }
   void setFlagBayes(bool flagBayes) { _flagBayes = flagBayes; }
   void setIechSingleTarget(int iechSingleTarget) { _iechSingleTarget = iechSingleTarget; }
   void setVerboseSingleTarget(bool verbose) { _verboseSingleTarget = verbose; }
-  void setFlagPerCell(bool flagPerCell) { _flagPerCell = flagPerCell; }
   void setAnam(AAnam* anam) { _anam = anam; }
   void setFlagGam(bool flagGam) { _flagGam = flagGam; }
   void setFlagXvalidEst(int flagXvalidEst) { _flagXvalidEst = flagXvalidEst; }
@@ -90,8 +86,6 @@ private:
   bool _flagStd;
   bool _flagVarZ;
 
-  EKrigOpt _calcul;
-
   VectorString _nameCoord;
 
   bool _flagBayes;
@@ -100,8 +94,6 @@ private:
 
   int  _iechSingleTarget;
   bool _verboseSingleTarget;
-
-  bool _flagPerCell;
 
   bool _flagGam;
   AAnam* _anam;
@@ -127,13 +119,10 @@ GSTLEARN_EXPORT int kriging(Db* dbin,
                             Db* dbout,
                             ModelGeneric* model,
                             ANeigh* neigh,
-                            const EKrigOpt& calcul          = EKrigOpt::fromKey("POINT"),
                             bool flag_est                   = true,
                             bool flag_std                   = true,
                             bool flag_varz                  = false,
-                            const VectorInt& ndiscs         = VectorInt(),
-                            const VectorInt& rank_colcok    = VectorInt(),
-                            const MatrixRectangular* matLC  = nullptr,
+                            const KrigOpt& krigopt          = KrigOpt(),
                             const NamingConvention& namconv = NamingConvention("Kriging"));
 GSTLEARN_EXPORT int krigcell(Db* dbin,
                              Db* dbout,
@@ -141,8 +130,7 @@ GSTLEARN_EXPORT int krigcell(Db* dbin,
                              ANeigh* neigh,
                              bool flag_est                   = true,
                              bool flag_std                   = true,
-                             const VectorInt& ndiscs         = VectorInt(),
-                             const VectorInt& rank_colcok    = VectorInt(),
+                             const KrigOpt& krigopt          = KrigOpt(),
                              const NamingConvention& namconv = NamingConvention("KrigCell"));
 GSTLEARN_EXPORT int kribayes(Db* dbin,
                              Db* dbout,
@@ -163,11 +151,9 @@ GSTLEARN_EXPORT Krigtest_Res krigtest(Db* dbin,
                                       Db* dbout,
                                       ModelGeneric* model,
                                       ANeigh* neigh,
-                                      int iech0               = 0,
-                                      const EKrigOpt& calcul  = EKrigOpt::fromKey("POINT"),
-                                      const VectorInt& ndiscs = VectorInt(),
-                                      bool flagPerCell        = false,
-                                      bool verbose            = true);
+                                      int iech0              = 0,
+                                      const KrigOpt& krigopt = KrigOpt(),
+                                      bool verbose           = true);
 GSTLEARN_EXPORT int xvalid(Db* db,
                            ModelGeneric* model,
                            ANeigh* neigh,
@@ -175,7 +161,7 @@ GSTLEARN_EXPORT int xvalid(Db* db,
                            int flag_xvalid_est             = 1,
                            int flag_xvalid_std             = 1,
                            int flag_xvalid_varz            = 0,
-                           const VectorInt& rank_colcok    = VectorInt(),
+                           const KrigOpt& krigopt          = KrigOpt(),
                            const NamingConvention& namconv = NamingConvention("Xvalid"));
 GSTLEARN_EXPORT int test_neigh(Db* dbin,
                                Db* dbout,

--- a/include/Estimation/CalcKriging.hpp
+++ b/include/Estimation/CalcKriging.hpp
@@ -59,10 +59,6 @@ public:
   virtual ~CalcKriging();
 
   void setCalcul(const EKrigOpt& calcul);
-  void setMatLC(const MatrixRectangular* matLC) { _matLC = matLC; }
-  void setNdisc(const VectorInt& ndiscs) { _ndiscs = ndiscs; }
-  void setRankColCok(const VectorInt& rankColCok) { _rankColCok = rankColCok; }
-  void setFlagDgm(bool flagDgm) { _flagDGM = flagDgm; }
   void setPriorCov(const MatrixSquareSymmetric& priorCov) { _priorCov = priorCov; }
   void setPriorMean(const VectorDouble& priorMean) { _priorMean = priorMean; }
   void setFlagBayes(bool flagBayes) { _flagBayes = flagBayes; }
@@ -94,12 +90,8 @@ private:
   bool _flagStd;
   bool _flagVarZ;
 
-  EKrigOpt  _calcul;
-  VectorInt _ndiscs;
-  VectorInt _rankColCok;
-  const MatrixRectangular* _matLC;
+  EKrigOpt _calcul;
 
-  bool _flagDGM;
   VectorString _nameCoord;
 
   bool _flagBayes;

--- a/include/Estimation/CalcKrigingFactors.hpp
+++ b/include/Estimation/CalcKrigingFactors.hpp
@@ -15,7 +15,6 @@
 #include "geoslib_define.h"
 
 #include "Calculators/ACalcInterpolator.hpp"
-#include "Enum/EKrigOpt.hpp"
 
 class Db;
 class DbGrid;
@@ -29,8 +28,6 @@ public:
   CalcKrigingFactors& operator=(const CalcKrigingFactors &r) = delete;
   virtual ~CalcKrigingFactors();
 
-  void setCalcul(const EKrigOpt& calcul) { _calcul = calcul; }
-  void setNdisc(const VectorInt& ndiscs) { _ndiscs = ndiscs; }
   void setIuidFactors(const VectorInt& iuidFactors) { _iuidFactors = iuidFactors; }
 
 private:
@@ -48,8 +45,6 @@ private:
   bool _flagEst;
   bool _flagStd;
 
-  EKrigOpt  _calcul;
-  VectorInt _ndiscs;
   VectorString _nameCoord;
 
   int _iptrEst;
@@ -60,12 +55,11 @@ private:
   Model* _modelLocal;
 };
 
-GSTLEARN_EXPORT int krigingFactors(Db *dbin,
-                                   Db *dbout,
-                                   Model *model,
-                                   ANeigh *neigh,
-                                   const EKrigOpt &calcul = EKrigOpt::fromKey("POINT"),
-                                   const VectorInt& ndiscs = VectorInt(),
-                                   bool flag_est = true,
-                                   bool flag_std = true,
-                                   const NamingConvention &namconv = NamingConvention("KD"));
+GSTLEARN_EXPORT int krigingFactors(Db* dbin,
+                                   Db* dbout,
+                                   Model* model,
+                                   ANeigh* neigh,
+                                   bool flag_est                   = true,
+                                   bool flag_std                   = true,
+                                   const KrigOpt& krigopt          = KrigOpt(),
+                                   const NamingConvention& namconv = NamingConvention("KD"));

--- a/include/Estimation/CalcKrigingSimpleCase.hpp
+++ b/include/Estimation/CalcKrigingSimpleCase.hpp
@@ -30,8 +30,6 @@ public:
   CalcKrigingSimpleCase& operator=(const CalcKrigingSimpleCase &r) = delete;
   virtual ~CalcKrigingSimpleCase();
 
-  void setCalcul(const EKrigOpt& calcul);
-
 private:
   virtual bool _check() override;
   virtual bool _preprocess() override;
@@ -45,8 +43,6 @@ private:
   bool _flagEst;
   bool _flagStd;
   bool _flagVarZ;
-
-  EKrigOpt  _calcul;
 
   VectorString _nameCoord;
   int _iechSingleTarget;

--- a/include/Estimation/CalcKrigingSimpleCase.hpp
+++ b/include/Estimation/CalcKrigingSimpleCase.hpp
@@ -12,8 +12,6 @@
 
 #include "gstlearn_export.hpp"
 
-#include "geoslib_define.h"
-
 #include "Enum/EKrigOpt.hpp"
 
 #include "Calculators/ACalcInterpolator.hpp"

--- a/include/Estimation/KrigOpt.hpp
+++ b/include/Estimation/KrigOpt.hpp
@@ -14,10 +14,10 @@
 
 #include "Enum/EKrigOpt.hpp"
 #include "Covariances/CovCalcMode.hpp"
+#include "Matrix/MatrixRectangular.hpp"
 
 class Db;
 class DbGrid;
-class MatrixRectangular;
 class ANeigh;
 class ModelGeneric;
 
@@ -33,10 +33,10 @@ public:
                        Db* dbout               = nullptr,
                        const VectorInt& ndiscs = VectorInt(),
                        bool flag_per_cell      = false);
-  int setKrigingDGM(bool flag_dgm);
   int setRankColCok(const VectorInt& rank_colcok);
   int setMatLC(const MatrixRectangular* matLC, int nvar);
   void setMode(const CovCalcMode* mode);
+  void setKrigingDGM(bool flag_dgm);
 
   const CovCalcMode& getMode() const { return _mode; }
   const EKrigOpt& getCalcul() const { return _calcul; }
@@ -44,21 +44,23 @@ public:
   int getNDisc() const { return _nDiscNumber; }
   const VectorInt& getDiscs() const { return _ndiscs; }
   int getDisc(int idim) const { return _ndiscs[idim]; }
-  bool isFlagCell() const { return _flagPerCell; }
+  bool hasFlagPerCell() const { return _flagPerCell; }
   void blockDiscretize(int iechout, bool flagRandom = false, int seed = 1234546) const;
   VectorDouble getDisc1VD(int idisc) const;
   VectorDouble getDisc2VD(int idisc) const;
   VectorVectorDouble getDisc1VVD() const;
   VectorVectorDouble getDisc2VVD() const;
   const MatrixRectangular* getMatLC() const { return _matLC; }
-  double getMatCLValue(int ivarcl, int ivar) const;
-  bool isMatLC() const { return _matLC != nullptr; }
-  int getNvarCL() const;
+  double getMatLCValue(int ivarcl, int ivar) const;
+  bool hasMatLC() const { return _matLC != nullptr; }
+  int getMatLCNRows() const { return _matLC->getNRows(); }
+  int getNvarLC() const;
   const VectorInt& getRankColcok() const { return _rankColcok; }
   int getRankColcok(int i) const { return _rankColcok[i]; }
   bool hasColcok() const { return _flagColcok; }
+  bool hasFlagDGM() const { return _flagDGM; }
 
-  bool isValid(const Db* dbout, const ANeigh* neigh, const ModelGeneric* model) const;
+  bool isCorrect(const Db* dbout, const ANeigh* neigh, const ModelGeneric* model) const;
   void dumpOptions() const;
 
 private:
@@ -67,7 +69,7 @@ private:
   bool _isValidCalcul(const Db* dbout, const ANeigh* neigh) const;
   bool _isValidColcok(const Db* dbout, const ModelGeneric* model) const;
   bool _isValidMatLC(const ModelGeneric* model) const;
-  bool _isValidDGM(const ModelGeneric* model) const;
+  bool _isValidDGM(const Db* dbout, const ModelGeneric* model) const;
 
 private:
   // General information

--- a/include/Estimation/KrigOpt.hpp
+++ b/include/Estimation/KrigOpt.hpp
@@ -29,19 +29,19 @@ public:
   KrigOpt& operator=(const KrigOpt &m);
   virtual ~KrigOpt();
 
-  int setKrigingOption(const EKrigOpt& calcul  = EKrigOpt::POINT,
-                       Db* dbout               = nullptr,
-                       const VectorInt& ndiscs = VectorInt(),
-                       bool flag_per_cell      = false);
-  int setRankColCok(const VectorInt& rank_colcok);
-  int setMatLC(const MatrixRectangular* matLC, int nvar);
+  int setOptionCalcul(const EKrigOpt& calcul  = EKrigOpt::POINT,
+                      const VectorInt& ndiscs = VectorInt(),
+                      bool flag_per_cell      = false);
+  int setColCok(const VectorInt& rank_colcok);
+  int setMatLC(const MatrixRectangular* matLC);
   void setMode(const CovCalcMode* mode);
-  void setKrigingDGM(bool flag_dgm);
+  void setOptionDGM(bool flag_dgm);
 
   const CovCalcMode& getMode() const { return _mode; }
   const EKrigOpt& getCalcul() const { return _calcul; }
 
   int getNDisc() const { return _nDiscNumber; }
+  bool hasDiscs() const { return ! _ndiscs.empty(); }
   const VectorInt& getDiscs() const { return _ndiscs; }
   int getDisc(int idim) const { return _ndiscs[idim]; }
   bool hasFlagPerCell() const { return _flagPerCell; }
@@ -94,5 +94,5 @@ private:
   // Matrix used for variable combination
   const MatrixRectangular* _matLC; // Pointer not to be deleted
 
-  DbGrid* _dbgrid; // Pointer to the DbGrid (not to be deleted)
+  mutable const DbGrid* _dbgrid; // Pointer to the DbGrid (not to be deleted)
 };

--- a/include/Estimation/KrigingSystem.hpp
+++ b/include/Estimation/KrigingSystem.hpp
@@ -43,9 +43,10 @@ public:
   KrigingSystem(Db* dbin,
                 Db* dbout,
                 const ModelGeneric* model,
-                ANeigh* neigh);
-  KrigingSystem(const KrigingSystem &m) = delete;
-  KrigingSystem& operator=(const KrigingSystem &m) = delete;
+                ANeigh* neigh,
+                const KrigOpt& krigopt = KrigOpt());
+  KrigingSystem(const KrigingSystem& m)            = delete;
+  KrigingSystem& operator=(const KrigingSystem& m) = delete;
   virtual ~KrigingSystem();
 
   int resetData();
@@ -65,7 +66,6 @@ public:
   int setKrigOptDataWeights(int iptrWeights, bool flagSet = true);
   int setKrigOptMatLC(const MatrixRectangular* matLC);
   int setKrigOptFlagSimu(bool flagSimu, int nbsimu = 0, int rankPGS = -1);
-  int setKrigOptDGM(bool flag_dgm);
   int setKrigOptFlagGlobal(bool flag_global);
   int setKrigOptFlagLTerm(bool flag_lterm);
   int setKrigOptAnamophosis(AAnam* anam);
@@ -168,9 +168,6 @@ private:
   bool _flagVarZ;
   bool _flagDataChanged;
 
-  /// Option for Calculation
-  EKrigOpt _calcul;
-
   /// Option for Weights at Data locations
   int  _iptrWeights;
   bool _flagWeights;
@@ -198,16 +195,10 @@ private:
   MatrixRectangular     _postSimu; 
   MatrixSquareSymmetric _varCorrec;
 
-  /// Option for Discrete Gaussian case
-  bool _flagDGM;
-
   /// Option for (Disjunctive) Kriging of Factor
   bool _flagFactorKriging;
   int  _nclasses;
   int  _factorClass;
-
-  /// Option for Estimating the Linear Combination of Variables
-  const MatrixRectangular* _matLC;
 
   /// Option for asking for Z * A-1 * Z
   bool _flagLTerm;
@@ -241,7 +232,6 @@ private:
   mutable SpacePoint _p0_memo;
 
   /// Some local flags defined in order to speed up the process
-  mutable bool _flagNoMatLC;
   mutable bool _flagVerr;
   mutable bool _flagNoStat;
 };

--- a/include/Estimation/KrigingSystem.hpp
+++ b/include/Estimation/KrigingSystem.hpp
@@ -59,12 +59,10 @@ public:
                        bool optionXValidEstim = false,
                        bool optionXValidStdev = false,
                        bool optionXValidVarZ  = false);
-  int setKrigOptColCok(const VectorInt& rank_colcok);
   int setKrigOptBayes(bool flag_bayes,
                       const VectorDouble& prior_mean,
                       const MatrixSquareSymmetric& prior_cov);
   int setKrigOptDataWeights(int iptrWeights, bool flagSet = true);
-  int setKrigOptMatLC(const MatrixRectangular* matLC);
   int setKrigOptFlagSimu(bool flagSimu, int nbsimu = 0, int rankPGS = -1);
   int setKrigOptFlagGlobal(bool flag_global);
   int setKrigOptFlagLTerm(bool flag_lterm);

--- a/include/Estimation/KrigingSystemSimpleCase.hpp
+++ b/include/Estimation/KrigingSystemSimpleCase.hpp
@@ -139,9 +139,6 @@ private:
   bool _flagVarZ;
   bool _flagDataChanged;
 
-  /// Option for Calculation
-  EKrigOpt _calcul;
-
   /// Option for Weights at Data locations
   int  _iptrWeights;
   bool _flagWeights;

--- a/include/Model/ModelOptimLikelihood.hpp
+++ b/include/Model/ModelOptimLikelihood.hpp
@@ -51,8 +51,6 @@ private:
   struct AlgorithmLikelihood
   {
     Model_Part& _modelPart;
-
-    // Part relative to the Experimental variograms
     ModelOptimLikelihood::Db_Part& _dbPart;
   };
 

--- a/src/Calculators/ACalcInterpolator.cpp
+++ b/src/Calculators/ACalcInterpolator.cpp
@@ -21,6 +21,7 @@ ACalcInterpolator::ACalcInterpolator()
   : ACalcDbToDb()
   , _model(nullptr)
   , _neigh(nullptr)
+  , _krigopt()
   , _ncova(0)
 {
 }
@@ -144,9 +145,9 @@ bool ACalcInterpolator::_check()
     }
   }
 
-  /**************************************/
+  /***************************************/
   /* Checking the Validity of the _model */
-  /**************************************/
+  /***************************************/
 
   if (_model != nullptr)
   {
@@ -156,6 +157,12 @@ bool ACalcInterpolator::_check()
       return false;
     }
   }
+
+  /******************************/
+  /* Cross-checking the Krigopt */
+  /******************************/
+
+  if (!_krigopt.isCorrect(getDbout(), _neigh, _model)) return false;
 
   /*********************************/
   /* Calculate the field extension */

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -1578,7 +1578,7 @@ int _krigsim(Db* dbin,
   /* Setting options */
 
   KrigOpt krigopt;
-  krigopt.setKrigingDGM(flag_dgm);
+  krigopt.setOptionDGM(flag_dgm);
 
   KrigingSystem ksys(dbin, dbout, model, neigh, krigopt);
   if (ksys.setKrigOptFlagSimu(true, nbsimu, icase)) return 1;
@@ -4081,9 +4081,10 @@ static int st_declustering_2(Db *db,
                              ANeigh* neigh,
                              int iptr)
 {
-  KrigingSystem ksys(db, db, model, neigh);
+  KrigOpt krigopt;
+  krigopt.setOptionCalcul(EKrigOpt::DRIFT);
+  KrigingSystem ksys(db, db, model, neigh, krigopt);
   if (ksys.setKrigOptDataWeights(iptr,  true)) return 1;
-  if (ksys.setKrigOptCalcul(EKrigOpt::DRIFT)) return 1;
   if (! ksys.isReady()) return 1;
   if (ksys.estimate(0)) return 1;
   ksys.conclusion();
@@ -4137,9 +4138,10 @@ static int st_declustering_3(Db *db,
 
   /* Setting options */
 
-  KrigingSystem ksys(db, dbgrid, model, neigh);
+  KrigOpt krigopt;
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndiscs);
+  KrigingSystem ksys(db, dbgrid, model, neigh, krigopt);
   if (ksys.setKrigOptDataWeights(iptr,  false)) return 1;
-  if (ksys.setKrigOptCalcul(EKrigOpt::BLOCK, ndiscs)) return 1;
   if (! ksys.isReady()) return 1;
 
   /* Loop on the targets to be processed */

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -1577,11 +1577,13 @@ int _krigsim(Db* dbin,
 
   /* Setting options */
 
-  KrigingSystem ksys(dbin, dbout, model, neigh);
+  KrigOpt krigopt;
+  krigopt.setKrigingDGM(flag_dgm);
+
+  KrigingSystem ksys(dbin, dbout, model, neigh, krigopt);
   if (ksys.setKrigOptFlagSimu(true, nbsimu, icase)) return 1;
   if (ksys.updKrigOptEstim(iptr_est, -1, -1, true)) return 1;
   if (ksys.setKrigOptBayes(flag_bayes, dmean, dcov)) return 1;
-  if (ksys.setKrigOptDGM(flag_dgm)) return 1;
   if (! ksys.isReady()) return 1;
 
   /* Loop on the targets to be processed */

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -329,7 +329,7 @@ int ACov::evalCovMat0InPlace(MatrixSquareSymmetric& mat,
     eval0CovMatBiPointInPlace(mat, &mode);
   else
   {
-    if (krigopt.isFlagCell()) krigopt.blockDiscretize(0, true);
+    if (krigopt.hasFlagPerCell()) krigopt.blockDiscretize(0, true);
 
     VectorVectorDouble d1 = krigopt.getDisc1VVD();
     VectorVectorDouble d2 = krigopt.getDisc2VVD();
@@ -340,7 +340,7 @@ int ACov::evalCovMat0InPlace(MatrixSquareSymmetric& mat,
   };
 
   // In case of combined R.H.S., modify the output matrix
-  if (krigopt.isMatLC()) mat = mat.compress0MatLC(*krigopt.getMatLC());
+  if (krigopt.hasMatLC()) mat = mat.compress0MatLC(*krigopt.getMatLC());
 
   return 0;
 }
@@ -1257,7 +1257,7 @@ int ACov::evalCovMatRHSInPlaceFromIdx(MatrixRectangular& mat,
   }
 
   // In case of combined R.H.S., modify the output matrix
-  if (krigopt.isMatLC()) mat = mat.compressMatLC(*krigopt.getMatLC());
+  if (krigopt.hasMatLC()) mat = mat.compressMatLC(*krigopt.getMatLC());
 
   if (cleanOptim) optimizationPostProcess();
   return 0;
@@ -1331,7 +1331,7 @@ int ACov::_evalCovMatRHSInPlaceBlock(MatrixRectangular& mat,
       db2->getSampleAsSPInPlace(p2, iabs2);
 
       // Discretize the block if adapted to the cell dimensions
-      if (krigopt.isFlagCell()) krigopt.blockDiscretize(p2.getIech());
+      if (krigopt.hasFlagPerCell()) krigopt.blockDiscretize(p2.getIech());
 
       // Loop on the discretization points
       for (int idisc = 0; idisc < ndisc; idisc++)

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -3624,7 +3624,7 @@ VectorVectorInt Db::getSampleRanks(const VectorInt& ivars,
   for (int ivar = 0; ivar < nvar; ivar++)
   {
     int jvar    = jvars[ivar];
-    index[ivar] = getRanksActive(nbgh, jvar, useSel, useZ, useVerr, useExtD);
+    index[ivar] = getSampleRanksPerVariable(nbgh, jvar, useSel, useZ, useVerr, useExtD);
   }
   return index;
 }
@@ -3640,12 +3640,12 @@ VectorVectorInt Db::getSampleRanks(const VectorInt& ivars,
  * @param useExtD True if the definition of the External Drift must be checked
  * @return VectorInt 
  */
-VectorInt Db::getRanksActive(const VectorInt& nbgh,
-                             int ivar,
-                             bool useSel,
-                             bool useZ,
-                             bool useVerr,
-                             bool useExtD) const
+VectorInt Db::getSampleRanksPerVariable(const VectorInt& nbgh,
+                                        int ivar,
+                                        bool useSel,
+                                        bool useZ,
+                                        bool useVerr,
+                                        bool useExtD) const
 {
   double value;
   int nech_tot = getNSample();

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -1724,6 +1724,65 @@ int Db::addSelection(const VectorDouble &tab,
 }
 
 /**
+ * @brief Create a selection by testing a target variable against 'lower' and 'upper'
+ * 
+ * @param varname Name of the target variable
+ * @param lower Lower bound (included) or TEST for no lower bound
+ * @param upper Upper bound (included) or TEST for no upper bound
+ * @param name  Name given to the newly created selection
+ * @param selName If defined, the current selection is combined with the existing one
+ * @return int 
+ */
+int Db::addSelectionByVariable(const String& varname,
+                               double lower,
+                               double upper,
+                               const String& name,
+                               const String& selName)
+{
+  VectorDouble var = getColumn(varname, false);
+  if (var.empty())
+  {
+    messerr("The variable '%s' does not exist", varname.c_str());
+    return 1;
+  }
+
+  int nech = getNSample(false);
+  VectorDouble sel(nech);
+  for (int iech = 0; iech < nech; iech++)
+  {
+    double value = var[iech];
+    double answer = 1;
+    if (FFFF(value))
+    {
+      answer = 0;
+    }
+    else
+    {
+      if (! FFFF(lower) && value < lower) answer = 0;
+      if (! FFFF(upper) && value > upper) answer = 0;
+    }
+    sel[iech] = answer;
+  }
+
+  // Intersection with an already existing selection (optional)
+  if (selName != "")
+  {
+    VectorDouble selOld = getColumn(selName, false);
+    if (selOld.empty())
+    {
+      messerr("The previous selection '%s' does not exist", selName.c_str());
+      return 1;
+    }
+    for (int iech = 0; iech < nech; iech++)
+      sel[iech] = sel[iech] * selOld[iech];
+  }
+
+  // Store the newly createed selection
+  int iuid = addColumns(sel, name, ELoc::SEL);
+  return iuid;
+}
+
+/**
  * Add a Selection by considering the input 'ranks' vector which give the ranks
  * of the active samples (starting from 0)
  * @param ranks   Vector of ranks of active samples
@@ -3755,8 +3814,7 @@ VectorDouble Db::getColumnByLocator(const ELoc& locatorType,
  * Returns the contents of one Column identified by its name
  *
  */
-VectorDouble
-Db::getColumn(const String& name, bool useSel, bool flagCompress) const
+VectorDouble Db::getColumn(const String& name, bool useSel, bool flagCompress) const
 {
   VectorInt iuids = _ids(name, true);
   if (iuids.empty()) return VectorDouble();

--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -611,7 +611,7 @@ int DriftList::evalDriftMatByTarget(MatrixRectangular& mat,
     }
 
   // In case of combined R.H.S., modify the output matrix
-  if (krigopt.isMatLC()) mat = mat.compressMatLC(*krigopt.getMatLC(), true);
+  if (krigopt.hasMatLC()) mat = mat.compressMatLC(*krigopt.getMatLC(), true);
   return 0;
 }
 

--- a/src/Estimation/CalcImage.cpp
+++ b/src/Estimation/CalcImage.cpp
@@ -193,7 +193,7 @@ bool CalcImage::_filterImage(DbGrid* dbgrid, const ModelCovList* model)
 
   // We perform a Kriging of the center 'dbaux' in Unique Neighborhood
   NeighUnique* neighU = NeighUnique::create();
-  KrigingSystem ksys(dblocal, target, model, neighU);
+  KrigingSystem ksys(dblocal, target, model, neighU, getKrigopt());
   if (ksys.updKrigOptEstim(iuid, -1, -1, true)) return false;
   if (!ksys.isReady()) return false;
   if (ksys.estimate(0)) return false;

--- a/src/Estimation/CalcKrigingSimpleCase.cpp
+++ b/src/Estimation/CalcKrigingSimpleCase.cpp
@@ -9,13 +9,11 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Basic/VectorNumT.hpp"
-#include "Db/DbGrid.hpp"
 #include "Db/Db.hpp"
 #include "Estimation/CalcKrigingSimpleCase.hpp"
 #include "Enum/EKrigOpt.hpp"
 #include "Estimation/KrigingSystem.hpp"
 #include "Estimation/KrigingSystemSimpleCase.hpp"
-#include "Basic/OptDbg.hpp"
 #include "Model/Model.hpp"
 #include "Neigh/NeighUnique.hpp"
 
@@ -26,7 +24,6 @@ CalcKrigingSimpleCase::CalcKrigingSimpleCase(bool flag_est, bool flag_std, bool 
     _flagEst(flag_est),
     _flagStd(flag_std),
     _flagVarZ(flag_varZ),
-    _calcul(EKrigOpt::POINT),
     _nameCoord(),
     _iechSingleTarget(-1),
     _nbNeigh(5),
@@ -39,11 +36,6 @@ CalcKrigingSimpleCase::CalcKrigingSimpleCase(bool flag_est, bool flag_std, bool 
 
 CalcKrigingSimpleCase::~CalcKrigingSimpleCase()
 {
-}
-
-void CalcKrigingSimpleCase::setCalcul(const EKrigOpt &calcul)
-{
-  _calcul = calcul;
 }
 
 bool CalcKrigingSimpleCase::_check()
@@ -147,7 +139,6 @@ bool CalcKrigingSimpleCase::_run()
 
   KrigingSystemSimpleCase ksys(getDbin(), getDbout(), getModel(), getNeigh());
   if (ksys.updKrigOptEstim(_iptrEst, _iptrStd, _iptrVarZ)) return false;
-  if (ksys.setKrigOptCalcul(_calcul)) return false;
 
   if (!ksys.isReady()) return false;
 

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -44,7 +44,8 @@
 KrigingSystem::KrigingSystem(Db* dbin,
                              Db* dbout,
                              const ModelGeneric* model,
-                             ANeigh* neigh)
+                             ANeigh* neigh,
+                             const KrigOpt& krigopt)
   : _dbin(dbin)
   , _dbout(dbout)
   , _model(nullptr)
@@ -52,7 +53,7 @@ KrigingSystem::KrigingSystem(Db* dbin,
   , _anam(nullptr)
   , _isReady(false)
   , _algebra()
-  , _krigopt()
+  , _krigopt(krigopt)
   , _sampleRanks()
   , _Sigma00()
   , _Sigma()
@@ -69,7 +70,6 @@ KrigingSystem::KrigingSystem(Db* dbin,
   , _flagStd(false)
   , _flagVarZ(false)
   , _flagDataChanged(false)
-  , _calcul(EKrigOpt::POINT)
   , _iptrWeights(-1)
   , _flagWeights(false)
   , _flagSet(true)
@@ -87,11 +87,9 @@ KrigingSystem::KrigingSystem(Db* dbin,
   , _postCov()
   , _postSimu()
   , _varCorrec()
-  , _flagDGM(false)
   , _flagFactorKriging(false)
   , _nclasses(0)
   , _factorClass(0)
-  , _matLC(nullptr)
   , _flagLTerm(false)
   , _flagAnam(false)
   , _flagNeighOnly(false)
@@ -111,7 +109,6 @@ KrigingSystem::KrigingSystem(Db* dbin,
   , _p1()
   , _p2()
   , _p0_memo()
-  , _flagNoMatLC(true)
   , _flagVerr(false)
   , _flagNoStat(false)
 {
@@ -126,7 +123,6 @@ KrigingSystem::KrigingSystem(Db* dbin,
     neigh->reset();
 
   // Define local constants
-  _flagNoMatLC = _matLC == nullptr;
   _flagVerr    = _dbin->hasLocVariable(ELoc::V);
 
   _resetMemoryGeneral();
@@ -190,8 +186,8 @@ int KrigingSystem::_getNVar() const
 
 int KrigingSystem::_getNVarCL() const
 {
-  if (_flagNoMatLC) return _getNVar();
-  return (int)_matLC->getNRows();
+  if (!_krigopt.hasMatLC()) return _getNVar();
+  return _krigopt.getMatLCNRows();
 }
 
 int KrigingSystem::_getNbfl() const
@@ -525,13 +521,13 @@ bool KrigingSystem::isReady()
   if (!_isCorrect()) return false;
 
   // Check the internal class '_krigopt'
-  if (_krigopt.isValid(_dbout, _neigh, _model)) return false;
+  if (!_krigopt.isCorrect(_dbout, _neigh, _model)) return false;
 
   // Define the means of each variable
   _means       = _model->getMeans();
   // Possible adjust the means in case of presence of 'matLC'
   _meansTarget = _means;
-  if (_matLC != nullptr) _meansTarget = _matLC->prodMatVec(_means);
+  if (_krigopt.hasMatLC()) _meansTarget = _krigopt.getMatLC()->prodMatVec(_means);
 
   if ((_neigh != nullptr && _neigh->getType() == ENeigh::UNIQUE) || _flagBayes)
   {
@@ -1088,9 +1084,7 @@ int KrigingSystem::setKrigOptCalcul(const EKrigOpt& calcul,
                                     bool flag_per_cell)
 {
   _isReady = false;
-  _calcul  = calcul;
-  _krigopt.setKrigingOption(calcul, _dbout, ndiscs, flag_per_cell);
-  return 0;
+  return _krigopt.setKrigingOption(calcul, _dbout, ndiscs, flag_per_cell);
 }
 
 /**
@@ -1158,11 +1152,8 @@ int KrigingSystem::setKrigOptXValid(bool flag_xvalid,
  *****************************************************************************/
 int KrigingSystem::setKrigOptColCok(const VectorInt& rank_colcok)
 {
-  if (rank_colcok.empty()) return 0;
-
   _isReady = false;
-  _krigopt.setRankColCok(rank_colcok);
-  return 0;
+  return _krigopt.setRankColCok(rank_colcok);
 }
 
 int KrigingSystem::setKrigOptBayes(bool flag_bayes,
@@ -1225,33 +1216,7 @@ int KrigingSystem::setKrigOptBayes(bool flag_bayes,
  */
 int KrigingSystem::setKrigOptMatLC(const MatrixRectangular* matLC)
 {
-  if (matLC == nullptr) return 0;
-  _isReady = false;
-  int n1 = (int) matLC->getNRows();
-  int n2 = (int) matLC->getNCols();
-
-  if (n1 > _getNVar())
-  {
-    messerr("First dimension of 'matLC' (%d)",(int) n1);
-    messerr("should be smaller than the number of variables in the model (%d)",
-            _getNVar());
-    return 1;
-  }
-  if (n2 != _getNVar())
-  {
-    messerr("Second dimension of 'matLC' (%d)",(int) n2);
-    messerr("should be equal to the number of variables in the model (%d)",
-            _getNVar());
-    return 1;
-  }
-  _matLC = matLC;
-  _flagNoMatLC = false;
-  _resetMemoryGeneral();
-
-  
-  // New style assignment
-  _krigopt.setMatLC(matLC, _getNVar());
-  return 0;
+  return _krigopt.setMatLC(matLC, _getNVar());
 }
 
 int KrigingSystem::setKrigOptFlagSimu(bool flagSimu, int nbsimu, int rankPGS)
@@ -1262,14 +1227,6 @@ int KrigingSystem::setKrigOptFlagSimu(bool flagSimu, int nbsimu, int rankPGS)
  _rankPGS = rankPGS;
  _neigh->setFlagSimu(flagSimu);
  return 0;
-}
-
-
-int KrigingSystem::setKrigOptDGM(bool flag_dgm)
-{
-  _isReady = false;
-  _krigopt.setKrigingDGM(flag_dgm);
-  return 0;
 }
 
 int KrigingSystem::setKrigOptFlagGlobal(bool flag_global)

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -1084,7 +1084,7 @@ int KrigingSystem::setKrigOptCalcul(const EKrigOpt& calcul,
                                     bool flag_per_cell)
 {
   _isReady = false;
-  return _krigopt.setKrigingOption(calcul, _dbout, ndiscs, flag_per_cell);
+  return _krigopt.setOptionCalcul(calcul, ndiscs, flag_per_cell);
 }
 
 /**
@@ -1133,27 +1133,6 @@ int KrigingSystem::setKrigOptXValid(bool flag_xvalid,
   _xvalidStdev = optionXValidStdev;
   _xvalidVarZ  = optionXValidVarZ;
   return 0;
-}
-
-/****************************************************************************/
-/*!
- **  Check the consistency of the Colocation specification
- **
- ** \return  Error return code
- **
- ** \param[in]  rank_colcok   Array of ranks of colocated variables
- **
- ** \remarks The array 'rank_colcok' (if present) must be dimensioned
- ** \remarks to the number of variables in Dbin.
- ** \remarks Each element gives the rank of the colocated variable within Dbout
- ** \remarks or -1 if not colocated
- ** \remarks If the array 'rank_colcok' is absent, colocation option is OFF.
- **
- *****************************************************************************/
-int KrigingSystem::setKrigOptColCok(const VectorInt& rank_colcok)
-{
-  _isReady = false;
-  return _krigopt.setRankColCok(rank_colcok);
 }
 
 int KrigingSystem::setKrigOptBayes(bool flag_bayes,
@@ -1205,18 +1184,6 @@ int KrigingSystem::setKrigOptBayes(bool flag_bayes,
   }
   _flagBayes = flag_bayes;
   return 0;
-}
-
-/**
- * Define the output as Linear Combinations of the Input Variables
- * @param matLC Vector of Vectors of weights (see remarks)
- * @return
- * @remarks The first dimension of 'matLC' is the number of Output variables
- * @remarks The second dimension is the number of input Variables.
- */
-int KrigingSystem::setKrigOptMatLC(const MatrixRectangular* matLC)
-{
-  return _krigopt.setMatLC(matLC, _getNVar());
 }
 
 int KrigingSystem::setKrigOptFlagSimu(bool flagSimu, int nbsimu, int rankPGS)

--- a/src/Estimation/KrigingSystemSimpleCase.cpp
+++ b/src/Estimation/KrigingSystemSimpleCase.cpp
@@ -68,7 +68,6 @@ KrigingSystemSimpleCase::KrigingSystemSimpleCase(Db* dbin,
   , _flagStd(false)
   , _flagVarZ(false)
   , _flagDataChanged(false)
-  , _calcul(EKrigOpt::POINT)
   , _iptrWeights(-1)
   , _flagWeights(false)
   , _flagSet(true)
@@ -616,12 +615,7 @@ int KrigingSystemSimpleCase::setKrigOptDataWeights(int iptrWeights, bool flagSet
 int KrigingSystemSimpleCase::setKrigOptCalcul(const EKrigOpt& calcul)
 {
   _isReady         = false;
-  _calcul          = calcul;
-  bool flagPerCell = false;
-  DbGrid* dbgrid   = dynamic_cast<DbGrid*>(_dbout);
-
-  // New style operation
-  _krigopt.setKrigingOption(calcul, dbgrid, 1, flagPerCell);
+  _krigopt.setOptionCalcul(calcul);
   return 0;
 }
 

--- a/tests/cpp/bench_BlockKrige.cpp
+++ b/tests/cpp/bench_BlockKrige.cpp
@@ -87,7 +87,9 @@ int main(int argc, char* argv[])
   VectorInt ndisc = {3, 3};
   data->display();
   target->display();
-  kriging(data, target, model, neigh, EKrigOpt::BLOCK, true, true, false, ndisc);
+  KrigOpt krigopt;
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc);
+  kriging(data, target, model, neigh, true, true, false, krigopt);
   dbfmt = DbStringFormat::create(FLAG_STATS, {"Kriging.*"});
   target->display(dbfmt);
 

--- a/tests/cpp/bench_CoKrigingMatLC.cpp
+++ b/tests/cpp/bench_CoKrigingMatLC.cpp
@@ -61,7 +61,6 @@ int main(int argc, char* argv[])
   int order = (flagSK) ? -1 : 0;
   Model* model = Model::createFillRandom(ndim, nvar, {ECov::EXPONENTIAL}, 1., order);
   model->display();
-  
 
   // Neighborhood
   ANeigh* neigh;
@@ -77,15 +76,15 @@ int main(int argc, char* argv[])
 
   // Test on Collocated CoKriging in Unique Neighborhood
   mestitle(0, "Without MATLC");
-  kriging(data, target, model, neigh, EKrigOpt::POINT, true, true, false, VectorInt(),
-          VectorInt());
+  kriging(data, target, model, neigh, true, true, false);
   target->display(dbfmt);
 
   mestitle(0, "With MATLC");
   MatrixRectangular* matLC = MatrixRectangular::createFromVD({1, -3.}, 1, nvar);
   matLC->display();
-  kriging(data, target, model, neigh, EKrigOpt::POINT, true, true, false, VectorInt(),
-          VectorInt(), matLC);
+  KrigOpt krigopt;
+  krigopt.setMatLC(matLC);
+  kriging(data, target, model, neigh, true, true, false, krigopt);
   target->display(dbfmt);
 
   // Free pointers

--- a/tests/cpp/bench_ColCok.cpp
+++ b/tests/cpp/bench_ColCok.cpp
@@ -73,9 +73,10 @@ int main(int argc, char* argv[])
   if (debug) OptDbg::setReference(1);
 
   // Test on Collocated CoKriging in Unique Neighborhood
-  VectorInt varColCok = {0, -1, 2};
-  kriging(data, target, model, neigh, EKrigOpt::POINT, true, true, false, VectorInt(),
-          varColCok);
+  VectorInt rank_colcok = {0, -1, 2};
+  KrigOpt krigopt;
+  krigopt.setColCok(rank_colcok);
+  kriging(data, target, model, neigh, true, true, false, krigopt);
   dbfmt = DbStringFormat::create(FLAG_STATS, {"Kriging.*"});
   target->display(dbfmt);
 

--- a/tests/cpp/bench_Kriging3DU.cpp
+++ b/tests/cpp/bench_Kriging3DU.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Enum/ESpaceType.hpp"
 #include "Enum/ECov.hpp"
-#include "Enum/EKrigOpt.hpp"
 
 #include "Space/ASpaceObject.hpp"
 #include "Db/Db.hpp"
@@ -63,7 +62,7 @@ int main(int argc, char *argv[])
   if (verbose) neighU->display();
 
   Timer timer;
-  kriging(data, grid, model, neighU, EKrigOpt::POINT, true, false, false);
+  kriging(data, grid, model, neighU, true, false, false);
   timer.displayIntervalMilliseconds("Kriging in Unique Neighborhood", 2400);
 
   // Produce some statistics for comparison

--- a/tests/cpp/bench_KrigingB.cpp
+++ b/tests/cpp/bench_KrigingB.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Enum/ESpaceType.hpp"
 #include "Enum/ECov.hpp"
-#include "Enum/EKrigOpt.hpp"
 
 #include "Space/ASpaceObject.hpp"
 #include "Db/Db.hpp"
@@ -69,7 +68,7 @@ int main(int argc, char *argv[])
   message("  . Bench width = %lf\n", width);
 
   Timer timer;
-  kriging(data, grid, model, neighB, EKrigOpt::POINT, true, false);
+  kriging(data, grid, model, neighB, true, false);
   timer.displayIntervalMilliseconds("Kriging in Bench Neighborhood", 1800);
   // Produce some stats for comparison
   DbStringFormat* dbfmt = DbStringFormat::create(FLAG_STATS, {"*estim"});

--- a/tests/cpp/bench_KrigingM.cpp
+++ b/tests/cpp/bench_KrigingM.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Enum/ESpaceType.hpp"
 #include "Enum/ECov.hpp"
-#include "Enum/EKrigOpt.hpp"
 
 #include "Space/ASpaceObject.hpp"
 #include "Db/Db.hpp"
@@ -60,7 +59,7 @@ void st_test(Db* grid, Model* model, int nech, int leaf_size, bool verbose)
   }
 
   Timer timer;
-  kriging(data, grid, model, neighM, EKrigOpt::POINT, true, false);
+  kriging(data, grid, model, neighM, true, false);
 
   if (verbose)
     timer.displayIntervalMilliseconds("Kriging in Moving Neighborhood", 1500);

--- a/tests/cpp/bench_KrigingU.cpp
+++ b/tests/cpp/bench_KrigingU.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Enum/ESpaceType.hpp"
 #include "Enum/ECov.hpp"
-#include "Enum/EKrigOpt.hpp"
 
 #include "Space/ASpaceObject.hpp"
 #include "Db/Db.hpp"
@@ -70,7 +69,7 @@ int main(int argc, char *argv[])
   message("- the Unique Neighborhood is required\n");
 
   Timer timer;
-  kriging(data, grid, model, neighU, EKrigOpt::POINT, true, false, false);
+  kriging(data, grid, model, neighU, true, false, false);
   timer.displayIntervalMilliseconds("Kriging in Unique Neighborhood", 700);
 
   // Produce some statistics for comparison

--- a/tests/cpp/template_Kriging.cpp
+++ b/tests/cpp/template_Kriging.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 
   // Perform Kriging using the API
   mestitle(0, "Kriging using API");
-  (void)kriging(dbin, dbout, model, neigh, EKrigOpt::POINT, true, true, true);
+  (void)kriging(dbin, dbout, model, neigh, true, true, true);
   DbStringFormat* dbfmt = DbStringFormat::create(FLAG_ARRAY, {"Kriging*"});
   dbout->display(dbfmt); // Always print the results at all target sites
 

--- a/tests/cpp/test_KD.cpp
+++ b/tests/cpp/test_KD.cpp
@@ -143,9 +143,9 @@ int main(int argc, char *argv[])
 
   // Estimating the Gaussian Variable on the nodes of the Blocks
   data->display();
-  (void) kriging(data, blocs, model, neighM, EKrigOpt::POINT,
-                 true, true, false, VectorInt(), VectorInt(),
-                 nullptr, NamingConvention("G_PTS"));
+  (void) kriging(data, blocs, model, neighM, 
+                 true, true, false, KrigOpt(),
+                 NamingConvention("G_PTS"));
 
   // Calculating the Conditional Expectation
   (void) ConditionalExpectation(blocs, anam, selectivity, "G_PTS*estim",
@@ -167,20 +167,23 @@ int main(int argc, char *argv[])
   data->display();
 
   // Simple Point Kriging over the blocks
-  (void) krigingFactors(data, blocs, model, neighM, EKrigOpt::POINT, VectorInt(),
-                        true, true, NamingConvention("DK_Pts"));
+  (void) krigingFactors(data, blocs, model, neighM,
+                        true, true, KrigOpt(), NamingConvention("DK_Pts"));
   blocs->display();
 
   // Simple Block Kriging over the blocks
   VectorInt ndisc_B = { 5, 5 };
-  (void) krigingFactors(data, blocs, model, neighM, EKrigOpt::BLOCK, ndisc_B,
-                        true, true, NamingConvention("DK_Blk"));
+  KrigOpt krigopt;
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_B);
+  (void)krigingFactors(data, blocs, model, neighM,
+                       true, true, krigopt, NamingConvention("DK_Blk"));
   blocs->display();
 
   // Simple Block Kriging over the panel(s)
   VectorInt ndisc_P = { 10, 10 };
-  (void) krigingFactors(data, panel, model, neighM, EKrigOpt::BLOCK, ndisc_P,
-                        true, true, NamingConvention("DK_Blk"));
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_P);
+  (void) krigingFactors(data, panel, model, neighM, 
+                        true, true, krigopt, NamingConvention("DK_Blk"));
   panel->display();
 
   // ====================== Uniform Conditioning ==================================
@@ -189,9 +192,9 @@ int main(int argc, char *argv[])
   data->clearLocators(ELoc::Z);
   data->setLocator("Z",ELoc::Z, 0);
   data->display();
-  (void) kriging(data, blocs, model, neighM, EKrigOpt::POINT,
-                 true, true, false, VectorInt(), VectorInt(),
-                 nullptr, NamingConvention("Z_PTS"));
+  (void) kriging(data, blocs, model, neighM, 
+                 true, true, false, KrigOpt(), 
+                 NamingConvention("Z_PTS"));
   blocs->display();
 
   // Perform the Uniform Conditioning over Blocks
@@ -226,14 +229,15 @@ int main(int argc, char *argv[])
   model_b1_Y->display();
 
   // Simple Point Kriging over the blocs(s) with Model with Change of Support
-  (void) krigingFactors(data, blocs, model_b1_Y, neighM, EKrigOpt::POINT,
-                        VectorInt(), true, true, NamingConvention("DK_DGM1"));
+  (void) krigingFactors(data, blocs, model_b1_Y, neighM, 
+                        true, true, KrigOpt(), NamingConvention("DK_DGM1"));
   blocs->display();
 
   // Simple Point Kriging over the panel(s) with Model with Change of Support
   VectorInt ndisc_Bc = { nx_B, nx_B };
-  (void) krigingFactors(data, panel, model_b1_Y, neighM, EKrigOpt::BLOCK,
-                        ndisc_Bc, true, true, NamingConvention("DK_DGM1"));
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_Bc);
+  (void) krigingFactors(data, panel, model_b1_Y, neighM, 
+                        true, true, krigopt, NamingConvention("DK_DGM1"));
   panel->display();
 
   // ====================== Block Disjunctive Kriging (DGM-2) =====================
@@ -264,13 +268,14 @@ int main(int argc, char *argv[])
   model_b2_Y->display();
 
   // Simple Point Kriging over the blocs(s) with Model with Change of Support
-  (void) krigingFactors(data, blocs, model_b2_Y, neighM, EKrigOpt::POINT,
-                        VectorInt(), true, true, NamingConvention("DK_DGM2"));
+  (void) krigingFactors(data, blocs, model_b2_Y, neighM, 
+                        true, true, KrigOpt(), NamingConvention("DK_DGM2"));
   blocs->display();
 
   // Simple Point Kriging over the panel(s) with Model with Change of Support
-  (void) krigingFactors(data, panel, model_b2_Y, neighM, EKrigOpt::BLOCK,
-                        ndisc_Bc, true, true, NamingConvention("DK_DGM2"));
+  krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_Bc);
+  (void) krigingFactors(data, panel, model_b2_Y, neighM, 
+                        true, true, krigopt, NamingConvention("DK_DGM2"));
   panel->display();
 
   // ====================== Selectivity Function ==================================

--- a/tests/cpp/test_Krige.cpp
+++ b/tests/cpp/test_Krige.cpp
@@ -205,7 +205,7 @@ int main(int argc, char* argv[])
     message("\n<----- Cross-Validation in Moving Neighborhood ----->\n");
     delete data_res;
     data_res = data->clone();
-    xvalid(data_res, model, neighM, 0, -1, -1, 0);
+    xvalid(data_res, model, neighM, false, -1, -1, 0);
     data_res->display(&dbfmtXvalid);
   }
 
@@ -246,7 +246,7 @@ int main(int argc, char* argv[])
     message("\n<----- Cross-Validation in Unique Neighborhood ----->\n");
     delete data_res;
     data_res = data->clone();
-    xvalid(data_res, model, neighU, 0, -1, -1, 0);
+    xvalid(data_res, model, neighU, false, -1, -1, 0);
     data_res->display(&dbfmtXvalid);
   }
 
@@ -306,7 +306,9 @@ int main(int argc, char* argv[])
     message("\n<----- Block Kriging (fixed size) ----->\n");
     delete grid_res;
     grid_res = grid->clone();
-    kriging(data, grid_res, model, neighU, EKrigOpt::BLOCK, 1, 1, 0, ndiscs);
+    KrigOpt krigopt;
+    krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndiscs);
+    kriging(data, grid_res, model, neighU, 1, 1, 0, krigopt);
     grid_res->display(&dbfmtKriging);
   }
 
@@ -315,7 +317,9 @@ int main(int argc, char* argv[])
     message("\n<----- Block Kriging (variable size) ----->\n");
     delete grid_res;
     grid_res = grid->clone();
-    krigcell(data, grid_res, model, neighU, 1, 1, ndiscs);
+    KrigOpt krigopt;
+    krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndiscs, true);
+    krigcell(data, grid_res, model, neighU, true, true, krigopt);
     grid_res->display(&dbfmtKriging);
   }
 
@@ -429,8 +433,9 @@ int main(int argc, char* argv[])
     grid_res = grid->clone();
     MatrixRectangular* matLC =
       MatrixRectangular::createFromVD({2., 2., 1., 1., 0., 1.}, 2, 3);
-    kriging(data, grid_res, model, neighU, EKrigOpt::POINT, true, true, false,
-            VectorInt(), VectorInt(), matLC);
+    KrigOpt krigopt;
+    krigopt.setMatLC(matLC);
+    kriging(data, grid_res, model, neighU, true, true, false, krigopt);
     grid_res->display(&dbfmtKriging);
   }
 

--- a/tests/data/testim.cpp
+++ b/tests/data/testim.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
         
         /* Cross-validation */
 
-        if (xvalid(dbin,new_model,neigh,0,1,0,0)) messageAbort("xvalid");
+        if (xvalid(dbin,new_model,neigh,false,1,0,0)) messageAbort("xvalid");
         dbfmt.setFlags(true, false, true, true, true);
         dbin->display(&dbfmt);
       }
@@ -215,7 +215,7 @@ int main(int argc, char *argv[])
 
         /* Estimation case */
 
-        if (kriging(dbin,dbout,new_model,neigh,EKrigOpt::POINT,
+        if (kriging(dbin,dbout,new_model,neigh,
                     1,1,0)) messageAbort("kriging");
         dbfmt.setFlags(true, false, true, true, true);
         dbout->display(&dbfmt);

--- a/tests/r/test_Kriging.R
+++ b/tests/r/test_Kriging.R
@@ -197,7 +197,6 @@ performTest = function(ndim, cas, k, nvar,
   #  Perform Kriging using the API
   prefix_1 = paste0(prefix,"_ini")
   err = kriging(dbin = dbin, dbout = dbout, model = model, neigh = neigh,
-                calcul = EKrigOpt_POINT(),
                 flag_est = flag_est, flag_std = flag_std, flag_varz = flag_varz,
                 namconv = NamingConvention(prefix_1))
   if (verbose) {

--- a/tests/rmd/output/Tuto_Kriging_MatLC.out
+++ b/tests/rmd/output/Tuto_Kriging_MatLC.out
@@ -37,6 +37,7 @@ Table: Statistics on the grid for Ordinary Kriging with the LC model
 |OK.Z1.stdev    |  10000|  0.0443|  0.2663|  0.2206|   0.0273|
 |OK-LC.Z1.stdev |  10000|  0.0443|  0.2663|  0.2206|   0.0273|
 |OK-LC.LC.stdev |  10000|  2.1581|  3.9132|  2.7951|   0.2130|
+[1] 0
 
 
 Table: Statistics on the grid for Ordinary Kriging of LC
@@ -73,6 +74,7 @@ Table: Statistics on the grid for Simple Kriging with the LC model
 |SK.Z1.stdev    |  10000|  0.0443|  0.2466|  0.2177|   0.0257|
 |SK-LC.Z1.stdev |  10000|  0.0443|  0.2466|  0.2177|   0.0257|
 |SK-LC.LC.stdev |  10000|  2.1580|  3.8860|  2.7909|   0.2096|
+[1] 0
 
 
 Table: Statistics on the grid for Simple Kriging of LC
@@ -94,6 +96,7 @@ Table: Statistics on the heterotopic data
 |Z1_miss |     40|  0.7668|  1.6995| 1.1455|   0.2535|
 |Z2      |     50|  0.2648|  4.6042| 1.6170|   1.1103|
 |Z2_miss |     26|  0.2648|  4.1471| 1.6766|   1.0977|
+[1] 0
 
 
 Table: Statistics on the grid for Ordinary Kriging with heterotopic data
@@ -105,6 +108,7 @@ Table: Statistics on the grid for Ordinary Kriging with heterotopic data
 |LC.OK.estim     |  10000|  -9.3628|  0.7857| -4.0043|   1.9728|
 |dOK_He.LC.stdev |  10000|   2.2084|  3.9516|  2.9518|   0.2158|
 |dOK.LC.stdev    |  10000|   2.1581|  3.9132|  2.7951|   0.2130|
+[1] 0
 
 
 Table: Statistics on the grid for simple coKriging with heterotopic data

--- a/tests/rmd/output/Tuto_NonLinear_Gaussian_Pts.out
+++ b/tests/rmd/output/Tuto_NonLinear_Gaussian_Pts.out
@@ -304,6 +304,7 @@ Column = 25 - Name = DK_Pts.F.1.stdev - Locator = NA
 Column = 26 - Name = DK_Pts.F.2.stdev - Locator = NA
 Column = 27 - Name = DK_Pts.F.3.stdev - Locator = NA
 NULL
+[1] 0
 
 Data Base Grid Characteristics
 ==============================
@@ -359,6 +360,7 @@ Column = 32 - Name = DK_Blk.F.2.stdev - Locator = NA
 Column = 33 - Name = DK_Blk.F.3.stdev - Locator = NA
 NULL
 NULL
+[1] 0
 
 Data Base Grid Characteristics
 ==============================


### PR DESCRIPTION
This is a major branch as:
- the API interfaces of major functions, such as kriging(), krigcell, xvalid() ... have changed introducing the new common argument which belongs to the class KrigOpt
- - development of the new class KrigOpt() which contains the main kriging options.
The aim of this branch is ti simplify / unify the calls to kriging functionalities, suppressing the overburden created by spurious arguments (seldom used) such as:
_ ECalcul: defines the type of kriging (point, block, drift, ...)
- ndisc, flag_per_cell: used in the Block kriging option
- matLC: to update the contents of output variables in CoKriging case, ...

The main interest of this new class is that we can easily add new options, by modifying this class only .... and not perturbate the already existing versions of all API involving Kriging.