### PR TITLE
Adding RankHandler

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.7.0
 =============
+- adding the new class RankHandler which translates the samples selected in neighborhood search
+into a list of variables / samples useable within a CoKriging system.
 - Essential modification: API functions such as kriging, xvalid, ... are now using KrigOpt 
   argument to carry all the options used while kriging (calcul, ndisc for block, matLC, DGM, ...)
 

--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -90,11 +90,12 @@ public:
                               bool flagAbsolute    = false,
                               const String& string = "");
 
+  static void sequenceInPlace(int n, VectorInt& vec);
   static VectorInt sequence(int number, int ideb = 0, int step = 1);
   static VectorDouble sequence(double valFrom,
                                double valTo,
                                double valStep = 1.,
-                               double ratio = 1.);
+                               double ratio   = 1.);
   static void fill(VectorDouble& vec, double v, int size = 0);
   static void fill(VectorInt& vec, int v, int size = 0);
   static void fill(VectorVectorDouble &vec, double value);

--- a/include/Db/RankHandler.hpp
+++ b/include/Db/RankHandler.hpp
@@ -37,7 +37,6 @@ public:
 
   void defineSampleRanks(const VectorInt& nbgh = VectorInt());
 
-  const VectorInt& getTotalSampleRanks() const { return _nbgh; }
   const VectorInt& getSampleRanks(int ivar) const { return _index[ivar]; }
   const VectorVectorInt& getSampleRanks() const { return _index; }
   const VectorInt& getSampleRanksByVariable(int ivar) const { return _index[ivar]; }

--- a/include/Db/RankHandler.hpp
+++ b/include/Db/RankHandler.hpp
@@ -1,0 +1,73 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#pragma once
+
+#include "gstlearn_export.hpp"
+
+#include "Basic/VectorNumT.hpp"
+
+class Db;
+
+/**
+ * \brief
+ * Class returning the list of sample IDs for a quick search within a Db
+ *
+ * The main functionality of this class is to return the list of samples
+ * per variable, within a given list of elligible sample ranks (neighborhood)
+ */
+class GSTLEARN_EXPORT RankHandler
+{
+public:
+  RankHandler(const Db* db,
+              bool useSel = true,
+              bool useZ   = true,
+              bool useVerr = false,
+              bool useExtD = true);
+  RankHandler(const RankHandler& r);
+  RankHandler& operator=(const RankHandler& r);
+  virtual ~RankHandler();
+
+  void defineSampleRanks(const VectorInt& nbgh = VectorInt());
+
+  const VectorInt& getTotalSampleRanks() const { return _nbgh; }
+  const VectorInt& getSampleRanks(int ivar) const { return _index[ivar]; }
+  const VectorVectorInt& getSampleRanks() const { return _index; }
+  const VectorInt& getSampleRanksByVariable(int ivar) const { return _index[ivar]; }
+  const VectorDouble& getZflatten() const { return _Zflatten; }
+  int getNumber() const;
+  int getCount(int ivar) const;
+  int getTotalCount() const;
+  int identifyVariableRank(int ipos) const;
+  int identifySampleRank(int ipos) const;
+
+  void dump(bool flagFull = false) const;
+
+private:
+  bool _useSel;
+  bool _useZ;
+  bool _useVerr;
+  bool _useExtD;
+
+  int  _nvar;
+  int  _nExtD;
+  int  _iptrSel;
+  VectorInt _iptrZ;
+  VectorInt _iptrVerr;
+  VectorInt _iptrExtD;
+
+  constvectint _nbgh; // Span of internal buffer
+
+  VectorVectorInt _index; // Vector of sample ranks per variable
+  VectorDouble _Zflatten; // Vector of Z values (fpr active samples of target variables)
+
+  const Db* _db;       // Pointer to Db
+  VectorInt _workNbgh; // Vector of ellible sample absolute ranks
+};

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -960,6 +960,12 @@ void VectorHelper::fillUndef(VectorDouble& vec, double repl)
   }
 }
 
+void VectorHelper::sequenceInPlace(int n, VectorInt& vec)
+{
+  vec.resize(n);
+  for (int i = 0; i < n; i++)
+    vec[i] = i;
+}
 /**
  * Create an output vector containing the 'number' consecutive numbers starting from 'ideb'
  *

--- a/src/Db/RankHandler.cpp
+++ b/src/Db/RankHandler.cpp
@@ -1,0 +1,290 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#include "Db/RankHandler.hpp"
+
+#include "Db/Db.hpp"
+#include "Basic/VectorHelper.hpp"
+
+RankHandler::RankHandler(const Db* db,
+                         bool useSel,
+                         bool useZ,
+                         bool useVerr,
+                         bool useExtD)
+  : _useSel(useSel)
+  , _useZ(useZ)
+  , _useVerr(useVerr)
+  , _useExtD(useExtD)
+  , _nvar(0)
+  , _nExtD(0)
+  , _iptrSel(-1)
+  , _iptrZ()
+  , _iptrVerr()
+  , _iptrExtD()
+  , _nbgh()
+  , _index()
+  , _Zflatten()
+  , _db(db)
+  , _workNbgh()
+{
+  _nvar = _db->getNLoc(ELoc::Z);
+  if (_nvar <= 0) _nvar = 1;
+
+  // Prepare the vector of sample ranks per variable
+  _index.resize(_nvar);
+
+  // Column index for selection (if 'useSel' and if present)
+  _iptrSel = (_useSel) ? _db->getColIdxByLocator(ELoc::SEL, 0) : -1;
+
+  // Column indices for variables (if 'useZ' and if present)
+  _iptrZ = VectorInt();
+  if (useZ && _db->hasLocator(ELoc::Z))
+  {
+    _iptrZ.resize(_nvar);
+    for (int ivar = 0; ivar < _nvar; ivar++)
+      _iptrZ[ivar] = _db->getColIdxByLocator(ELoc::Z, ivar);
+  }
+
+  // Column indices for variance of measurement error (if 'useVerr' and if present)
+  _iptrVerr = VectorInt();
+  if (_useVerr && _db->hasLocator(ELoc::V))
+  {
+    _iptrVerr.resize(_nvar);
+    for (int ivar = 0; ivar < _nvar; ivar++)
+      _iptrVerr[ivar] = _db->getColIdxByLocator(ELoc::V, ivar);
+  }
+
+  // Column indices for external drifts (if 'useExtD' and if present)
+  _nExtD = 0;
+  _iptrExtD = VectorInt();
+  if (_useExtD && _db->hasLocator(ELoc::F))
+  {
+    _nExtD = _db->getNLoc(ELoc::F);
+    _iptrExtD.resize(_nExtD);
+    for (int iext = 0; iext < _nExtD; iext++)
+      _iptrExtD[iext] = _db->getColIdxByLocator(ELoc::F, iext);
+  }
+}
+
+RankHandler::RankHandler(const RankHandler& r)
+  : _useSel(r._useSel)
+  , _useZ(r._useZ)
+  , _useVerr(r._useVerr)
+  , _useExtD(r._useExtD)
+  , _nvar(r._nvar)
+  , _nExtD(r._nExtD)
+  , _iptrSel(r._iptrSel)
+  , _iptrZ(r._iptrZ)
+  , _iptrVerr(r._iptrVerr)
+  , _iptrExtD(r._iptrExtD)
+  , _nbgh(r._nbgh)
+  , _index(r._index)
+  , _Zflatten(r._Zflatten)
+  , _db(r._db)
+  , _workNbgh(r._workNbgh)
+{
+}
+
+RankHandler& RankHandler::operator=(const RankHandler& r)
+{
+  if (this != &r)
+  {
+    _useSel   = r._useSel;
+    _useZ     = r._useZ;
+    _useVerr  = r._useVerr;
+    _useExtD  = r._useExtD;
+    _nvar     = r._nvar;
+    _nExtD    = r._nExtD;
+    _iptrSel  = r._iptrSel;
+    _iptrZ    = r._iptrZ;
+    _iptrVerr = r._iptrVerr;
+    _iptrExtD = r._iptrExtD;
+    _nbgh     = r._nbgh;
+    _index    = r._index;
+    _Zflatten = r._Zflatten;
+    _db       = r._db;
+    _workNbgh = r._workNbgh;
+  }
+  return *this;
+}
+
+RankHandler::~RankHandler()
+{
+}
+
+/**
+ * Defines the list of indices 'index' for valid samples for the set of
+ * variables (Z locator)
+ *
+ * @param nbgh Vector giving the ranks of the elligible samples (optional)
+ */
+void RankHandler::defineSampleRanks(const VectorInt& nbgh)
+{
+  // Define the ranks of the samples
+  if (nbgh.empty())
+  {
+    int nech_init = _db->getNSample();
+    VH::sequenceInPlace(nech_init, _workNbgh);
+    _nbgh = _workNbgh;
+  }
+  else
+  {
+    _nbgh = nbgh;
+  }
+  int nech = (int)_nbgh.size();
+
+  double value;
+  _Zflatten.clear();
+
+  // Loop on the variables
+  for (int ivar = 0; ivar < _nvar; ivar++)
+  {
+    VectorInt ranks;
+
+    // Loop on the elligible sample ranks
+    for (int irel = 0; irel < nech; irel++)
+    {
+      int iabs = _nbgh[irel];
+
+      // Check against a possible selection
+      if (_iptrSel >= 0)
+      {
+        value = _db->getValueByColIdx(iabs, _iptrSel);
+        if (value <= 0) continue;
+      }
+ 
+      // Check against validity of the Variance of Measurement Error variable
+      if (!_iptrVerr.empty())
+      {
+        value = _db->getValueByColIdx(iabs, _iptrVerr[ivar]);
+        if (FFFF(value) || value < 0) continue;
+      }
+
+      // Check against the validity of ALL external drifts
+      if (!_iptrExtD.empty())
+      {
+        bool valid = true;
+        for (int iext = 0; iext < _nExtD && valid; iext++)
+        {
+          value = _db->getValueByColIdx(iabs, _iptrExtD[iext]);
+          if (FFFF(value)) valid = false;
+        }
+        if (!valid) continue;
+      }
+
+      // Check against the existence of a target variable
+      if (!_iptrZ.empty())
+      {
+        value = _db->getValueByColIdx(iabs, _iptrZ[ivar]);
+        if (FFFF(value)) continue;
+
+        _Zflatten.push_back(value);
+      }
+
+      // The sample is finally accepted: its ABSOLUTE index is stored
+      ranks.push_back(iabs);
+    }
+
+    // The vector of ranks is stored for the current variable
+    _index[ivar] = ranks;
+  }
+}
+
+/**
+ * @brief Get the number of active samples for a given variable
+ * 
+ * @param ivar Rank of the target variable
+ * @return int 
+ */
+int RankHandler::getCount(int ivar) const
+{
+  if (ivar < 0 || ivar >= _nvar)
+  {
+    messerr("RankHandler::getCount: invalid variable index %d", ivar);
+    return -1;
+  }
+  return (int)_index[ivar].size();
+}
+
+/**
+ * @brief Get the total number of active samples for all variables
+ * 
+ * @return int 
+ */
+int RankHandler::getTotalCount() const
+{
+  int count = 0;
+  for (int ivar = 0; ivar < _nvar; ivar++)
+    count += getCount(ivar);
+  return count;
+}
+
+/**
+ * @brief Return the total number of samples 
+ * 
+ * @return int 
+ */
+int RankHandler::getNumber() const
+{
+  return (int) _nbgh.size();
+}
+
+int RankHandler::identifyVariableRank(int ipos) const
+{
+  int ntotal = 0;
+  for (int ivar = 0; ivar < _nvar; ivar++)
+  {
+    int size = getCount(ivar);
+    if (ipos < ntotal + size)
+      return ivar; // Found the variable
+    ntotal += size;
+  }
+  return -1; // Not found
+}
+
+int RankHandler::identifySampleRank(int ipos) const
+{
+  int ntotal = 0;
+  for (int ivar = 0; ivar < _nvar; ivar++)
+  {
+    int size = getCount(ivar);
+    if (ipos < ntotal + size)
+    {
+      int jpos = ipos - ntotal;
+      return _index[ivar][jpos]; // Found the sample
+    }
+    ntotal += size;
+  }
+  return -1; // Not found
+}
+
+void RankHandler::dump(bool flagFull) const
+{
+  mestitle(0, "Rank Handler");
+  message("Use Selection: %d\n", (int)_useSel);
+  message("Use Z-variable: %d\n", (int)_useZ);
+  message("Use Variance of Measurement Error: %d\n", (int)_useVerr);
+  message("Use External Drift: %d\n", (int)_useExtD);
+  message("\n");
+  message("Number of Variables: %d\n", _nvar);
+  message("Number of External Drifts: %d\n", _nExtD);
+
+  if (! flagFull) return;
+
+  mestitle(1,"Variable and Sample ranks - Variable values");
+  for (int ivar = 0, lec = 0; ivar < _nvar; ivar++)
+  {
+    message("Variable= %d: \n", ivar);
+    int size = getCount(ivar);
+    for (int i = 0; i < size; i++, lec++)
+      message("- Sample= %2d : Variable value= %lf\n", _index[ivar][i], _Zflatten[lec]);
+    message("\n");
+  }
+}

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -1109,7 +1109,7 @@ void MatrixSparse::prodNormDiagVecInPlace(const VectorDouble &vec, int oper_choi
 void MatrixSparse::prodNormMatVecInPlace(const MatrixSparse* a, const VectorDouble& vec, bool transpose)
 {
   if (!_checkLink(getNRows(), getNCols(), transpose, a->getNRows(), a->getNCols(),
-                  false, vec.size(), 1, false)) return;
+                  false, (int) vec.size(), 1, false)) return;
 
   if (isFlagEigen() && a->isFlagEigen())
   {

--- a/src/all_sources.cmake
+++ b/src/all_sources.cmake
@@ -176,6 +176,7 @@ set(SRC
   Db/DbStringFormat.cpp
   Db/PtrGeos.cpp
   Db/DbHelper.cpp
+  Db/RankHandler.cpp
   LinearOp/LogStats.cpp
   LinearOp/CGParam.cpp
   LinearOp/PrecisionOp.cpp

--- a/swig/swig_exp.i
+++ b/swig/swig_exp.i
@@ -309,6 +309,7 @@
 %include Db/DbMeshStandard.hpp
 %include Db/DbStringFormat.hpp
 %include Db/DbHelper.hpp
+%include Db/RankHandler.hpp
 
 %include Anamorphosis/CalcAnamTransform.hpp
 %include Anamorphosis/AAnam.hpp

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -287,6 +287,7 @@
   #include "Db/DbMeshStandard.hpp"
   #include "Db/DbStringFormat.hpp"
   #include "Db/DbHelper.hpp"
+  #include "Db/RankHandler.hpp"
   
   #include "Anamorphosis/CalcAnamTransform.hpp"
   #include "Anamorphosis/AAnam.hpp"

--- a/tests/cpp/output/test_RankHandler.ref
+++ b/tests/cpp/output/test_RankHandler.ref
@@ -1,0 +1,67 @@
+
+Data Base Characteristics
+=========================
+
+Data Base Summary
+-----------------
+File is organized as a set of isolated points
+Space dimension              = 2
+Number of Columns            = 7
+Total number of samples      = 20
+Number of active samples     = 14
+
+Data Base Contents
+------------------
+                 rank       x-1       x-2       sel       z-1       z-2       z-3
+     [  0,]     1.000     0.652     0.703     1.000     0.561     0.111    -0.202
+     [  1,]     2.000     0.483     0.765     1.000       N/A    -0.473    -0.025
+     [  2,]     3.000     0.762     0.345     1.000    -0.084     0.187    -0.683
+     [  3,]     4.000     0.015     0.215     1.000       N/A    -0.869    -1.465
+     [  4,]     5.000     0.557     0.572     1.000    -0.770    -0.661     1.213
+     [  5,]     8.000     0.140     0.952     1.000    -0.116    -0.716     0.789
+     [  6,]     9.000     0.729     0.987     1.000     1.428    -1.008     1.270
+     [  7,]    10.000     0.537     0.687     1.000       N/A     1.027    -0.174
+     [  8,]    11.000     0.408     0.100     1.000       N/A       N/A     1.351
+     [  9,]    13.000     0.336     0.869     1.000    -0.577       N/A    -1.102
+     [ 10,]    14.000     0.300     0.269     1.000     1.023    -0.811    -0.360
+     [ 11,]    15.000     0.470     0.237     1.000     1.713    -0.936     0.443
+     [ 12,]    16.000     0.376     0.936     1.000       N/A     0.312     0.325
+     [ 13,]    18.000     0.150     0.561     1.000    -0.489     0.370    -0.497
+List of ranks for Elligible samples
+         0         8        10        12        13
+Number of elligible samples: 5
+Total count of sample references = 12
+Number of references for Variable 0 = 4
+Number of references for Variable 1 = 3
+Number of references for Variable 2 = 5
+
+Rank Handler
+============
+Use Selection: 1
+Use Z-variable: 1
+Use Variance of Measurement Error: 1
+Use External Drift: 1
+
+Number of Variables: 3
+Number of External Drifts: 0
+
+Variable and Sample ranks - Variable values
+-------------------------------------------
+Variable= 0: 
+- Sample=  0 : Variable value= 0.560644
+- Sample=  8 : Variable value= 1.428061
+- Sample= 12 : Variable value= -0.576756
+- Sample= 13 : Variable value= 1.022651
+
+Variable= 1: 
+- Sample=  0 : Variable value= 0.111160
+- Sample=  8 : Variable value= -1.008487
+- Sample= 13 : Variable value= -0.811086
+
+Variable= 2: 
+- Sample=  0 : Variable value= -0.201679
+- Sample=  8 : Variable value= 1.269695
+- Sample= 10 : Variable value= 1.351290
+- Sample= 12 : Variable value= -1.101517
+- Sample= 13 : Variable value= -0.359538
+

--- a/tests/cpp/test_RankHandler.cpp
+++ b/tests/cpp/test_RankHandler.cpp
@@ -1,0 +1,78 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#include "Basic/Law.hpp"
+#include "Basic/File.hpp"
+#include "Basic/OptCst.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbStringFormat.hpp"
+#include "Db/RankHandler.hpp"
+
+/****************************************************************************/
+/*!
+ ** Main Program
+ **
+ ** This program is meant to check the facility offered by RankHandler class
+ **
+ *****************************************************************************/
+int main(int argc, char *argv[])
+{
+  std::stringstream sfn;
+  sfn << gslBaseName(__FILE__) << ".out";
+  StdoutRedirect sr(sfn.str(), argc, argv);
+
+  ASerializable::setContainerName(true);
+  ASerializable::setPrefixName("TestRkHdl-");
+  int seed = 10355;
+  law_set_random_seed(seed);
+  OptCst::define(ECst::NTROW, -1);
+  OptCst::define(ECst::NTCOL, -1);
+
+  // Creating the Db
+  int ndat = 20;
+  int ndim = 2;
+  int nvar = 3;
+  double selRatio = 0.2;
+  VectorDouble heteroRatio = {0.3, 0.2, 0.1};
+  Db* db = Db::createFillRandom(ndat, ndim, nvar, 0, 0, 0., selRatio, heteroRatio);
+  DbStringFormat* dbfmt = DbStringFormat::create(FLAG_RESUME | FLAG_ARRAY);
+  db->display(dbfmt);
+
+  // Instanciate the RankHandler
+  RankHandler* rkhd = new RankHandler(db, true, true, true, true);
+
+  // Creating the vector of elligible samples
+  // It is constructed so as to involve:
+  // - masked samples
+  // - heterotopic sample
+  // Warning: Db contents should not be mofiied anymore.
+  VectorInt nbgh = {0, 8, 10, 12, 13};
+  VH::dump("List of ranks for Elligible samples", nbgh);
+
+  // Define the Rank Handler for the previous list
+  rkhd->defineSampleRanks(nbgh);
+
+  // Using some features of the RankHandler class
+  message("Number of elligible samples: %d\n", rkhd->getNumber());
+  message("Total count of sample references = %d\n", rkhd->getTotalCount());
+  for (int ivar = 0; ivar < nvar; ivar++)
+    message("Number of references for Variable %d = %d\n", ivar, rkhd->getCount(ivar));
+
+  // Complete dump
+  rkhd->dump(true);
+
+  delete db;
+  delete dbfmt;
+  delete rkhd;
+
+  return 0;
+}
+


### PR DESCRIPTION
A new class has been promoted: RankHandler.
Its task:
Given the list of samples selected by a neighborhood search (which could also be the Unique neighborhood search), defines the list of Variable / Sample information that needs to be considered while establishing the general Co-Kriging system.
In particular, this pre-process takes into account:
- the presence of a selection 
- the presence of heterotopic information
- the definition of a variance of measurement error
- the presence of external drift information.
This new structure stores all the relevant information (and provides a set of accessors) allowing a fast way to handle / construct the covariance matrix (for LHS and / or RHS).
It should place the previous analogue solution provided as a VectorVectorInt as the result of the function Db/getSampleRanks().

Finally a specific tests/cpp has been developed: test_RankHandler.cpp