### PR TITLE
Python: Add request, IPython optional dependencies to package

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -242,7 +242,7 @@ endif()
 # Add a custom target for python package installation
 # TODO: Do also installation each time setup.py.in or README.md is modified
 add_custom_target(python_install
-  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot,conv]"
+  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot,conv,doc]"
   COMMENT "Installing python package"
   )
  

--- a/python/modules/document.py
+++ b/python/modules/document.py
@@ -13,12 +13,19 @@
 
 import urllib.request
 import urllib.error
-import requests
 import os
 import re
 import base64
+
 import gstlearn as gl
-from IPython.display import display, Javascript, Markdown
+
+try:
+    from IPython.display import display, Javascript, Markdown
+    import requests
+except ModuleNotFoundError as ex:
+    msg = ("Python dependencies 'IPython' and 'requests' not found.\n"
+          "To install them alongside gstlearn, please run `pip install gstlearn[doc]'")
+    raise ModuleNotFoundError(msg) from ex
 
 # The various pieces of documentation are supposed to be located
 # at the following URL

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -39,7 +39,11 @@ conv = [
      "pandas",
      "scipy",
 ]
-all = ["gstlearn[plot,conv]"]
+doc = [
+    "requests",
+    "IPython",
+]
+all = ["gstlearn[plot,conv,doc]"]
 
 [project.urls]
 Homepage = "@PROJECT_HOMEPAGE_URL@"


### PR DESCRIPTION
This PR adds `requests` and `IPython` as optional dependencies of gstlearn's Python package. They are required by `document.py`. A new optional dependency group, `doc`, is introduced to contain the two of them.

Pierre