### PR TITLE
Fix bug in Driftist to prevent crash with setMean

### DIFF
--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -131,7 +131,7 @@ void DriftList::delAllDrifts()
   _betaHat.clear();
   _driftCL.clear();
   _mean.resize(0);
-
+  _update();
 }
 
 bool DriftList::isDriftFiltered(int i) const


### PR DESCRIPTION
The _means vector for DriftList class was wrongly resized to 0 size when deleting all drifts. Its length should be fixed to NVariables during the whole life of the DriftList object. 