### PR TITLE
GitHub Actions: Fixes for Q2 2025

### DIFF
--- a/.github/actions/hdf5_static_windows/action.yml
+++ b/.github/actions/hdf5_static_windows/action.yml
@@ -38,7 +38,7 @@ runs:
           -DHDF5_USE_ZLIB_STATIC=ON \
           -DHDF5_USE_LIBAEC_STATIC=ON \
           ..
-        cmake --build . --config Release --parallel 3 --target install
+        cmake --build . --config Release --parallel 3
+        cmake --install . --prefix /c/"Program Files"/HDF5
       env:
         CMAKE_BUILD_TYPE: Release
-        CMAKE_INSTALL_PREFIX: C:\Program Files\HDF5

--- a/.github/actions/nlopt_static_unix/action.yml
+++ b/.github/actions/nlopt_static_unix/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Build & install nlopt static libraries
       shell: bash
       run: |
-        curl -OL https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz
-        tar xvfz v2.7.1.tar.gz
-        cd nlopt-2.7.1
+        curl -OL https://github.com/stevengj/nlopt/archive/v2.10.0.tar.gz
+        tar xvfz v2.10.0.tar.gz
+        cd nlopt-2.10.0
         mkdir build && cd build
         cmake \
           -DBUILD_SHARED_LIBS=OFF \

--- a/.github/actions/nlopt_static_windows/action.yml
+++ b/.github/actions/nlopt_static_windows/action.yml
@@ -7,9 +7,9 @@ runs:
     - name: Build & install nlopt static libraries
       shell: bash
       run: |
-        curl -OL https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz
-        tar xvfz v2.7.1.tar.gz
-        cd nlopt-2.7.1
+        curl -OL https://github.com/stevengj/nlopt/archive/v2.10.0.tar.gz
+        tar xvfz v2.10.0.tar.gz
+        cd nlopt-2.10.0
         mkdir build && cd build
         cmake \
           -DBUILD_SHARED_LIBS=OFF \

--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -63,7 +63,7 @@ jobs:
         python -m pip install scikit-sparse
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -81,7 +81,7 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -71,7 +71,7 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -35,10 +35,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew install llvm
+        brew install bison
         brew install boost
         brew install eigen
         brew install nlopt
         brew install hdf5
+        echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
     - name: Setup Python Version
       uses: actions/setup-python@v5

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -72,7 +72,7 @@ jobs:
         generator: "Unix Makefiles"
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure build directory
       run: |

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -45,7 +45,7 @@ jobs:
         pixi add libboost-devel eigen ninja hdf5
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Set up Visual Studio shell
       uses: egor-tensin/vs-shell@v2

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -49,6 +49,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Setup Python Version

--- a/.github/workflows/publish_data.yml
+++ b/.github/workflows/publish_data.yml
@@ -43,6 +43,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Get project version

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -51,6 +51,7 @@ jobs:
           libboost-dev \
           libeigen3-dev \
           libpng-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Setup Python Version

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -39,6 +39,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Install Python dependencies

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -44,6 +44,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Configure build directory

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -149,7 +149,7 @@ jobs:
       run: brew install llvm
 
     - name: Install Python package
-      run: pip install ./$(ls *.whl)
+      run: pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -132,7 +132,7 @@ jobs:
         python-version: ${{matrix.python.py}}
 
     - name: Install Python package
-      run: pip install ./$(ls *.whl)
+      run: pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -153,7 +153,7 @@ jobs:
         python-version: ${{matrix.python.py}}
 
     - name: Install Python package
-      run: pip install $(ls *.whl)
+      run: pip install "$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         echo '{
           "dependencies": [ "boost-math", "eigen3" ],
-          "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
+          "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
         }' > vcpkg.json
         vcpkg install
       env:

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -52,8 +52,10 @@ jobs:
       run: |
         brew install --formula doxygen
         brew install llvm
+        brew install bison
         brew install boost
         brew install eigen
+        echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         echo '{
           "dependencies": [ "boost-math", "eigen3", "nlopt" ],
-          "builtin-baseline": "bcf3d00d2116056fda0ce47615f6074ffecb7524"
+          "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
         }' > vcpkg.json
         vcpkg install
 

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -91,6 +91,8 @@ jobs:
           -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig `
           -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}
+      env:
+        HDF5_ROOT: "C:/Program Files/HDF5/cmake/"
 
     - name : Build the package and save generated file name in the environment
       run : |

--- a/.github/workflows/publish_references.yml
+++ b/.github/workflows/publish_references.yml
@@ -44,6 +44,7 @@ jobs:
           libopenmpi-dev \
           libboost-dev \
           libeigen3-dev \
+          libhdf5-dev \
           libnlopt-dev
 
     - name: Get project version

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "@PROJECT_DESCRIPTION@"
 readme = "README.md"
-license = {text = 'BSD-3-Clause'}
+license = 'BSD-3-Clause'
 requires-python = '>=3.8'
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -18,7 +18,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Other Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
Several dependencies of gstlearn have been updated at the end of Q1 2025 and it broke down the GitHub Actions workflows. This PR aims at fixing everything:
- CMake has been updated to v4.0 in the runner images. It drops the support of `CMakeLists.txt` with `cmake_minimum_required` < 3.5. In particular, the custom `fabien-ors/swig` and our static builds of NLopt are affected. Swig has been directly updated from v4.2 to v4.3 in `fabien-ors/swig`. NLopt has been updated from v2.7 to v2.10 (Feb 2025) in the relevant actions.
- Swig 4.3 somehow needs a recent bison on macOS, it has been installed with brew. 
- missing installations of system packages of HDF5 have been added to `publish-doc` workflows.
- missing Python optional dependencies are now installed in `publish-python` workflows.
- `pyproject.toml` License keys were incompatible with the latest setuptools.
- the VCPKG baseline had been updated to Feb 2025 (prev. June 2024).
- `sccache` actions were updated following a brownout from GitHub cache (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/).
- the installation prefix for HDF5 in `publish_r_windows` was not properly  taken into account (CMake 4.0 fallout?). This has also been fixed.

Enjoy,
Pierre