### PR TITLE
Create BUILD_DOC cmake variable

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -143,7 +143,7 @@ jobs:
         cmake \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_TESTING=ON \
-          -DBUILD_DOXYGEN=ON \
+          -DBUILD_DOC=ON \
           $GITHUB_WORKSPACE
 
     - name: Use clang-tidy to lint code

--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -21,7 +21,7 @@ env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
   SCCACHE_IDLE_TIMEOUT: 0
 
 jobs:

--- a/.github/workflows/nonreg-tests_macos-latest-one.yml
+++ b/.github/workflows/nonreg-tests_macos-latest-one.yml
@@ -18,7 +18,7 @@ env:
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
   LLVM_ROOT : /opt/homebrew
 
 jobs:

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -22,7 +22,7 @@ env:
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig_430b
   LLVM_ROOT : /opt/homebrew
 
 jobs:

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -22,7 +22,7 @@ env:
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_430b
+  SWIG_ROOT : ${{github.workspace}}/swig
   LLVM_ROOT : /opt/homebrew
 
 jobs:

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -23,7 +23,7 @@ env:
   BUILD_DIR : build
   PYTHON_VERSION : "3.11"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
 
 jobs:
   build:

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -23,7 +23,7 @@ env:
   BUILD_DIR : build
   CMAKE_GENERATOR : "MSYS Makefiles"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}\swig_420b
+  SWIG_ROOT : ${{github.workspace}}\swig
 
 jobs:
 

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -28,7 +28,7 @@ env:
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
 
 jobs:
   build:

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -28,7 +28,7 @@ env:
   PYTHON_VERSION : "3.11"
   NUMPY_VERSION : "1.23.5"
   R_VERSION : "4.3.2"
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
 
 jobs:
   build:

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -53,7 +53,7 @@ jobs:
           -B${{ env.BUILD_DIR }} \
           -DBUILD_PYTHON=OFF \
           -DBUILD_R=OFF \
-          -DBUILD_DOXYGEN=ON
+          -DBUILD_DOC=ON
           
     - name: Build doxygen documentation and save generated folder name in the environment
       id: main_step

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -86,7 +86,7 @@ jobs:
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
           -DPython3_ROOT_DIR="${{env.pythonLocation}}" \
-          -DBUILD_DOXYGEN=ON
+          -DBUILD_DOC=ON
       env:
         CC: ${{matrix.arch.pat}}/opt/llvm/bin/clang
         CXX: ${{matrix.arch.pat}}/opt/llvm/bin/clang++

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -81,7 +81,7 @@ jobs:
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
-          -DBUILD_DOXYGEN=ON
+          -DBUILD_DOC=ON
       env:
         CC: gcc-10
         CXX: g++-10

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -101,7 +101,7 @@ jobs:
           -DBUILD_R=OFF `
           -DPython3_ROOT_DIR="${{env.pythonLocation}}" `
           -DHDF5_USE_STATIC_LIBRARIES=ON `
-          -DBUILD_DOXYGEN=ON
+          -DBUILD_DOC=ON
 
     - name : Build the package
       run : |

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -25,7 +25,7 @@ on:
 env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
 
 jobs:
   build:
@@ -87,7 +87,7 @@ jobs:
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=OFF \
           -DBUILD_R=ON \
-          -DBUILD_DOXYGEN=ON \
+          -DBUILD_DOC=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
       env:
         CC: ${{matrix.arch.pat}}/opt/llvm/bin/clang

--- a/.github/workflows/publish_r_ubuntu.yml
+++ b/.github/workflows/publish_r_ubuntu.yml
@@ -25,7 +25,7 @@ on:
 env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
-  SWIG_ROOT : ${{github.workspace}}/swig_420b
+  SWIG_ROOT : ${{github.workspace}}/swig
 
 jobs:
   build:
@@ -79,7 +79,7 @@ jobs:
           -B${{ env.BUILD_DIR }} \
           -DBUILD_PYTHON=OFF \
           -DBUILD_R=ON \
-          -DBUILD_DOXYGEN=ON \
+          -DBUILD_DOC=ON \
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
       env:

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -27,7 +27,7 @@ env:
   CMAKE_BUILD_TYPE : Release
   BUILD_DIR : build
   CMAKE_GENERATOR : "MSYS Makefiles"
-  SWIG_ROOT : ${{github.workspace}}\swig_420b
+  SWIG_ROOT : ${{github.workspace}}\swig
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
@@ -87,7 +87,7 @@ jobs:
           -B${{ env.BUILD_DIR }} `
           -DBUILD_PYTHON=OFF `
           -DBUILD_R=ON `
-          -DBUILD_DOXYGEN=ON `
+          -DBUILD_DOC=ON `
           -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig `
           -DDoxygen_ROOT=${{env.DOXYGEN_ROOT}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,10 @@ get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 #set(CMAKE_FIND_DEBUG_MODE TRUE)
 
 # Options
-option(BUILD_PYTHON  "Build Python package"        OFF)
-option(BUILD_R       "Build R package"             OFF)
-option(BUILD_TESTING "Build tests"                 OFF)
-option(BUILD_DOXYGEN "Build Doxygen documentation" OFF)
+option(BUILD_PYTHON  "Build Python package"                     OFF)
+option(BUILD_R       "Build R package"                          OFF)
+option(BUILD_TESTING "Build tests"                              OFF)
+option(BUILD_DOC     "Build Doxygen and packages documentation" OFF)
 if (MINGW)
   set(BUILD_PYTHON OFF)
 endif()
@@ -76,7 +76,7 @@ endif()
 message(STATUS "BUILD_PYTHON="  ${BUILD_PYTHON})
 message(STATUS "BUILD_R="       ${BUILD_R})
 message(STATUS "BUILD_TESTING=" ${BUILD_TESTING})
-message(STATUS "BUILD_DOXYGEN=" ${BUILD_DOXYGEN})
+message(STATUS "BUILD_DOC="     ${BUILD_DOC})
 message(STATUS "USE_HDF5="      ${USE_HDF5})
 
 # Create gstlearn cmake file path in the build tree
@@ -93,28 +93,28 @@ add_subdirectory(3rd-party/csparse)
 include(cmake/version.cmake)
 include(cmake/doc.cmake)
 # TODO : Add BUILD_CPP option (not needed for print_version or doxygen targets)
-#if(BUILD_CPP)
+#if (BUILD_CPP)
   include(cmake/cpp.cmake)
   include(cmake/install.cmake)
 #endif()
-if(BUILD_DOXYGEN)
+if (BUILD_DOC)
   include(cmake/doxygen.cmake)
 endif()
 
 ####################################################
 ## PACKAGES
 
-if(BUILD_PYTHON)
+if (BUILD_PYTHON)
   add_subdirectory(python)
   set(SWIG ON)  
 endif()
 
-if(BUILD_R)
+if (BUILD_R)
   add_subdirectory(r)
   set(SWIG ON)
 endif()
 
-if(SWIG)
+if (SWIG)
   add_subdirectory(swig)
 endif()
 
@@ -122,7 +122,7 @@ endif()
 ## TESTING
 
 # Add non-regression test target
-if(BUILD_TESTING)
+if (BUILD_TESTING)
   include(CTest)
   enable_testing()
 

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,16 @@
 # You can use the following variables:
 #
 #  - DEBUG=1            Build the debug version of the library and tests (default =0)
-#  - ASAN=1             Build with Address Sanitizer
 #  - N_PROC=N           Use more CPUs for building procedure (default =1)
 #  - BUILD_DIR=<path>   Define a specific build directory (default =build[_msys])
+#  - BUILD_PYTHON=1     Configure cmake to build python wrapper (default =0, see target python_*)
+#  - BUILD_R=1          Configure cmake to build R wrapper (default =0, see target r_*)
+#  - BUILD_DOC=1        Configure cmake to build documentation (default =1)
+#  - TEST=<test-target> Name of the test target to be launched (e.g. test_Model_py or test_simTub)
+#  - ASAN=1             Build with Address Sanitizer
 #  - USE_HDF5=0         To remove HDF5 support (default =1)
 #  - NO_INTERNET=0      To prevent python pip from looking for dependencies through Internet
 #                       (useful when there is no Internet available) (default =0)
-#  - TEST=<test-target> Name of the test target to be launched (e.g. test_Model_py or test_simTub)
 #  - EIGEN3_ROOT=<path> Path to Eigen3 library (optional)
 #  - BOOST_ROOT=<path>  Path to Boost library (optional)
 #  - NLOPT_ROOT=<path>  Path to NLopt library (optional)
@@ -70,6 +73,15 @@
 #
 #  make check N_PROC=2
 #
+
+ifndef BUILD_DOC
+  BUILD_DOC = 1
+endif
+ifeq ($(BUILD_DOC), 1)
+  BUILD_DOC = ON
+ else
+  BUILD_DOC = OFF 
+endif
 
 ifeq ($(NO_INTERNET), 1)
   NO_INTERNET = ON
@@ -96,16 +108,6 @@ else
   endif
   # Set OS also for Linux or Darwin
   OS := $(shell uname -s)
-endif
-
-ifeq ($(OS),Darwin)
-  ifndef LLVM_ROOT
-	LVM_ROOT = /opt/homebrew
-  endif
-  # Particular clang compiler for supporting OpenMP
-  CC_CXX = CC=$(LLVM_ROOT)/opt/llvm/bin/clang CXX=$(LLVM_ROOT)/opt/llvm/bin/clang++
-else
-  CC_CXX = 
 endif
 
 ifeq ($(DEBUG), 1)
@@ -161,46 +163,34 @@ endif
 all: shared install
 
 cmake:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_TESTING=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_TESTING=ON
 
 cmake-python:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_TESTING=ON -DBUILD_PYTHON=ON -DNO_INTERNET=$(NO_INTERNET)
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_TESTING=ON -DBUILD_PYTHON=ON -DNO_INTERNET=$(NO_INTERNET)
 
 cmake-r:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_TESTING=ON -DBUILD_R=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_TESTING=ON -DBUILD_R=ON
 
 cmake-python-r:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_TESTING=ON -DBUILD_PYTHON=ON -DBUILD_R=ON -DNO_INTERNET=$(NO_INTERNET)
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_TESTING=ON -DBUILD_PYTHON=ON -DBUILD_R=ON -DNO_INTERNET=$(NO_INTERNET)
 
 cmake-doxygen:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOXYGEN=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON
 
 cmake-python-doxygen:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_PYTHON=ON -DBUILD_DOXYGEN=ON -DNO_INTERNET=$(NO_INTERNET)
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON -DNO_INTERNET=$(NO_INTERNET)
 
 cmake-r-doxygen:
-	@$(CC_CXX) cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_R=ON -DBUILD_DOXYGEN=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_R=ON
+
+cmake-python-r-doxygen:
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON              -DBUILD_R=ON         -DBUILD_DOC=ON
 
 print_version: cmake
 	@cmake --build $(BUILD_DIR) --target print_version --
 
-static: cmake
-	@cmake --build $(BUILD_DIR) --target static -- $(N_PROC_OPT)
-
-shared: cmake
-	@cmake --build $(BUILD_DIR) --target shared -- $(N_PROC_OPT)
-
-build_tests: cmake
-	@cmake --build $(BUILD_DIR) --target build_tests -- $(N_PROC_OPT)
-
-doxygen: cmake-doxygen
-	@cmake --build $(BUILD_DIR) --target doxygen -- $(N_PROC_OPT)
-
-install: cmake
-	@cmake --build $(BUILD_DIR) --target install -- $(N_PROC_OPT)
-
-uninstall: 
-	@cmake --build $(BUILD_DIR) --target uninstall -- $(N_PROC_OPT)
+static shared build_tests doxygen install uninstall: cmake-doxygen
+	@cmake --build $(BUILD_DIR) --target $@ -- $(N_PROC_OPT)
 
 
 
@@ -212,19 +202,19 @@ python_doc: cmake-python-doxygen
 python_build: cmake-python
 	@cmake --build $(BUILD_DIR) --target python_build -- $(N_PROC_OPT)
 
-python_install: cmake-python
+python_install: python_build
 	@cmake --build $(BUILD_DIR) --target python_install -- $(N_PROC_OPT)
 
 
 .PHONY: r_doc r_build r_install
 
-r_doc: cmake-r #cmake-r-doxygen
+r_doc: cmake-r-doxygen
 	@cmake --build $(BUILD_DIR) --target r_doc -- $(N_PROC_OPT)
 
-r_build: cmake-r #cmake-r-doxygen
+r_build: cmake-r
 	@cmake --build $(BUILD_DIR) --target r_build -- $(N_PROC_OPT)
 
-r_install: cmake-r #cmake-r-doxygen
+r_install: r_build
 	@cmake --build $(BUILD_DIR) --target r_install -- $(N_PROC_OPT)
 
 
@@ -239,16 +229,16 @@ check_cpp: cmake
 check_py: cmake-python
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_py -- $(N_PROC_OPT)
 
-check_r: cmake-r #cmake-r-doxygen
+check_r: cmake-r
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_r -- $(N_PROC_OPT)
 
-check: cmake-python-r
+check: cmake-python-r-doxygen
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check -- $(N_PROC_OPT)
 
-check_ipynb: cmake-python
+check_ipynb: cmake-python-doxygen
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_ipynb -- $(N_PROC_OPT)
 
-check_rmd: cmake-r #cmake-r-doxygen
+check_rmd: cmake-r-doxygen
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_rmd -- $(N_PROC_OPT)
 
 check_test_cpp: cmake
@@ -257,16 +247,16 @@ check_test_cpp: cmake
 check_test_py: cmake-python
 	@cd $(BUILD_DIR); make prepare_check_py; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
-check_test_r: cmake-r-doxygen
+check_test_r: cmake-r
 	@cd $(BUILD_DIR); make prepare_check_r; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy
 
-build_demos: cmake-python-r
+build_demos: cmake-python-r-doxygen
 	@cmake --build $(BUILD_DIR) --target build_demos -- $(N_PROC_OPT)
 
-build_courses: cmake-python-r
+build_courses: cmake-python-r-doxygen
 	@cmake --build $(BUILD_DIR) --target build_courses -- $(N_PROC_OPT)
 
 .PHONY: scan_build clang_tidy clang_check

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ pacman -Sy mingw-w64-x86_64-hdf5
 
 * If your system distribution repository doesn't provide minimum required versions, please install the tools manually (see provider website)
 * You may need to reconnect to your session after installing some requirements
-* If you plan to generate the documentation, add `-DBUILD_DOXYGEN=ON` to the first cmake command above.
+* If you plan to generate the documentation, add `-DBUILD_DOC=ON` to the first cmake command above.
 * If you don't know how to execute github commands or you experience a 'password authentication' problem, you may [read this](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 * HDF5 support is enabled by default, add `-DUSE_HDF5=OFF` in the first cmake command above to disable it.
 * Currently, **HDF5 is not supported** when compiling *gstlearn* C++ library **under Windows and MacOS**. *gstlearn* won't link against HDF5 and GibbsMMulti::setFlagStoreInternal(false) feature won't be available.
@@ -391,7 +391,7 @@ make uninstall
 The Doxygen HTML documentation is optional (not included in the installation by default). If you want to generate it, execute the command:
 
 ```
-cmake -Bbuild -S. -DBUILD_DOXYGEN=ON
+cmake -Bbuild -S. -DBUILD_DOC=ON
 cmake --build build --target doxygen
 ```
 

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -1,4 +1,4 @@
-if(NOT BUILD_DOXYGEN)
+if (NOT BUILD_DOC)
   return()
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,7 +41,7 @@ add_custom_target(python_doc
 )
 
 # Doxygen is optional
-if (BUILD_DOXYGEN)
+if (BUILD_DOC)
   add_dependencies(python_doc doxygen)
 endif()
 

--- a/python/README.md
+++ b/python/README.md
@@ -280,7 +280,7 @@ cmake --build build --target check_ipynb --config Release
 
 * If your system distribution repository doesn't provide minimum required versions, please install the tools manually (see provider website)
 * You may need to reconnect to your session after installing some requirements
-* If you plan to generate the documentation, add `-DBUILD_DOXYGEN=ON` to the first cmake command above.
+* If you plan to generate the documentation, add `-DBUILD_DOC=ON` to the first cmake command above.
 * If you don't know how to execute github commands, you may [read this](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 * Using Visual Studio on a Windows where MinGW is also installed may need to add `-G "Visual Studio 16 2019"` in the first command (adapt version).
 * The Windows C++ Compiler used must be the same that the one used for compiling Python (Visual C++). Using another compiler than Visual C++ is not supported.

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -163,7 +163,9 @@ target_include_directories(r_build PRIVATE ${R_INCLUDE_DIRS})
 target_link_libraries(r_build PRIVATE ${R_LIBRARIES})
 
 # Tell that we need to generate Rd files before building R package
-add_dependencies(r_build r_doc)
+if (BUILD_DOC)
+  add_dependencies(r_build r_doc)
+endif()
 
 add_dependencies(r_build r_wrap_macro)
 

--- a/r/README.md
+++ b/r/README.md
@@ -280,7 +280,7 @@ make check_r
 * If your system distribution repository doesn't provide minimum required versions, please install the tools manually (see provider website)
 * You may need to reconnect to your session after installing some requirements
 * If you experience the following issue: `Error: ERROR: no permission to install to directory...`, we suggest you to run the `install.packages` command (at least one time). This will create a *personal R library folder* having writing permissions.
-* If you plan to generate the documentation, add `-DBUILD_DOXYGEN=ON` to the first cmake command above. Then users will be able to execute `make doxygen`.
+* If you plan to generate the documentation, add `-DBUILD_DOC=ON` to the first cmake command above. Then users will be able to execute `make doxygen`.
 * If you don't know how to execute github commands or you experience a 'password authentication' problem, you may [read this](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 * Under Windows, using RTools is mandatory for compiling R packages
 * Under Windows, you may need to add `-G "MSYS Makefiles"` to the first cmake command above

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -1061,7 +1061,7 @@
 };
 
 
-// Prevent memory leaks from 'create*' anc 'clone' methods
+// Prevent memory leaks from 'create*' and 'clone' methods
 
 // The following file should contain all 'createFrom*' methods
 %include swig/newobject.i


### PR DESCRIPTION
This PR replaces BUILD_DOXYGEN cmake variable by BUILD_DOC.
The later is more general and offers the possibility to deactivate packages documentation generation.
Thus, roxygen2 dependency is no more mandatory to compile gstlearn if you use -DBUILD_DOC=OFF.