### PR TITLE
Enable parallel compilation by default on Windows

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -38,6 +38,11 @@ else()
   endif()
 endif()
 
+if (MSVC)
+  # Enable parallel compilation automatically.
+  add_compile_options(/MP)
+endif()
+
 # Address Sanitizer (GCC/Clang)
 option(BUILD_ASAN "Build with Address Sanitizer enabled" OFF)
 mark_as_advanced(BUILD_ASAN)


### PR DESCRIPTION
This can also be changed in Visual Studio in the project properties but it has to be done for all projects, and is overridden whenever CMake re-runs.

On Linux we can just use "make -j" which is easier, so this is only done for Windows.