### PR TITLE
Fix a crash in SPDEOp::computeDriftCoeffs()

### DIFF
--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -208,7 +208,7 @@ void SPDEOp::evalInvCov(const constvect inv, vect result) const
 VectorDouble SPDEOp::computeDriftCoeffs(const VectorDouble& Z,
                                         const MatrixDense& drifts) const
 {
-  int xsize = (int)(drifts.size());
+  int xsize = (int)(drifts.getNCols());
   VectorDouble XtInvSigmaZ(xsize);
   MatrixSymmetric XtInvSigmaX(xsize);
   VectorDouble result(xsize);


### PR DESCRIPTION
This code was likely copy-pasted from the old version PrecisionOpMultiConditional where the second argument (drifts) was a VectorVectorDouble. Now it's a matrix so using the total size is wrong.

This commit is part of #505 (but not enough!).