### PR TITLE
Add convenience functions in SPDEOp to access some members

### DIFF
--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -55,9 +55,11 @@ public:
                                   const MatrixDense& drifts) const;
   VectorDouble simCond(const VectorDouble& dat) const;
 
-  const ASimulable* invNoise() const { return _invNoise; }
-  const PrecisionOpMulti* Qsimu() const { return _QSimu; }
-  const ProjMulti* projSimu() const { return _projSimu; }
+  const PrecisionOpMulti* getQKriging() const { return _QKriging; }
+  const ProjMulti* getProjKriging() const { return _projKriging; }
+  const ASimulable* getInvNoise() const { return _invNoise; }
+  const PrecisionOpMulti* getQSimu() const { return _QSimu; }
+  const ProjMulti* getProjSimu() const { return _projSimu; }
 
 #ifndef SWIG
 public:

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -55,6 +55,10 @@ public:
                                   const MatrixDense& drifts) const;
   VectorDouble simCond(const VectorDouble& dat) const;
 
+  const ASimulable* const invNoise() const { return _invNoise; }
+  const PrecisionOpMulti* const Qsimu() const { return _QSimu; }
+  const ProjMulti* const projSimu() const { return _projSimu; }
+
 #ifndef SWIG
 public:
   int kriging(const constvect inv, vect out) const;

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -55,9 +55,9 @@ public:
                                   const MatrixDense& drifts) const;
   VectorDouble simCond(const VectorDouble& dat) const;
 
-  const ASimulable* const invNoise() const { return _invNoise; }
-  const PrecisionOpMulti* const Qsimu() const { return _QSimu; }
-  const ProjMulti* const projSimu() const { return _projSimu; }
+  const ASimulable* invNoise() const { return _invNoise; }
+  const PrecisionOpMulti* Qsimu() const { return _QSimu; }
+  const ProjMulti* projSimu() const { return _projSimu; }
 
 #ifndef SWIG
 public:


### PR DESCRIPTION
I need this to tweak some of `SPDEOp` behaviour, in my case to reimplement `simCond()` to work around the issues with the RNG not being properly reproducible/thread-safe (see #495 and #496).