### PR TITLE
Pluging inverse of cholesky for sparse matrix

### DIFF
--- a/include/LinearOp/ACholesky.hpp
+++ b/include/LinearOp/ACholesky.hpp
@@ -36,7 +36,6 @@ public:
   int solveMatrix(const MatrixDense& b, MatrixDense& x) const;
   bool isReady() const { return _ready; }
 
-
   VectorDouble invLtX(const VectorDouble& vecin) const;
   VectorDouble LtX(const VectorDouble& vecin) const;
   VectorDouble LX(const VectorDouble& vecin) const;

--- a/include/LinearOp/ALinearOp.hpp
+++ b/include/LinearOp/ALinearOp.hpp
@@ -28,12 +28,9 @@ public:
 
   int evalDirect(const VectorDouble& inv, VectorDouble& outv) const;
   VectorDouble evalDirect(const VectorDouble& in) const;
-  virtual void multiplyByValueAndAddDiagonal(double v1 = 1.,double v2 = 0.);
+  virtual void multiplyByValueAndAddDiagonal(double v1 = 1., double v2 = 0.);
   virtual void resetModif();
-  void setUseFactor(bool usefactor)
-  {
-    _usefactor = usefactor;
-  }
+  void setUseFactor(bool usefactor) { _usefactor = usefactor; }
 #ifndef SWIG
 
 public:

--- a/include/LinearOp/ASimulable.hpp
+++ b/include/LinearOp/ASimulable.hpp
@@ -29,7 +29,6 @@ public:
   int addSimulateToDest(const constvect whitenoise, vect outv) const;
 
 protected:
-  virtual int _addSimulateToDest(const constvect whitenoise,
-                                 vect outv) const = 0;
+  virtual int _addSimulateToDest(const constvect whitenoise, vect outv) const = 0;
 #endif
 };

--- a/include/LinearOp/CholeskySparse.hpp
+++ b/include/LinearOp/CholeskySparse.hpp
@@ -56,6 +56,8 @@ public:
 private:
   void _clean();
   int _prepare() const;
+  int _stdevOld(VectorDouble& vcur) const;
+  int _stdevEigen(VectorDouble& vcur) const;
 
 private:
   bool _flagEigen;
@@ -65,5 +67,5 @@ private:
   mutable csn* _N; // Cholesky decomposition (for Old-style Csparse storage)
 
   // Eigen storage
-  mutable Eigen::SimplicialLDLT<Eigen::SparseMatrix<double> > *_factor; // (Eigen library)
+  mutable Eigen::SimplicialLDLT<Eigen::SparseMatrix<double> > *_factor;
 };

--- a/include/LinearOp/CholeskySparseInv.hpp
+++ b/include/LinearOp/CholeskySparseInv.hpp
@@ -1,0 +1,168 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+// Taken from:
+// Simpson, Dan. 2024. “Random C++ Part 2: Sparse Partial Inverses in Eigen.” 
+// September 5, 2024. https://dansblog.netlify.app/posts/2024-05-08-laplace/laplace.html.
+//
+#pragma once
+
+#include <Eigen/SparseCore>
+#include <Eigen/SparseCholesky>
+
+typedef Eigen::SparseMatrix<double>::StorageIndex StorageIndex;
+
+template<typename SpMat>
+class MatchPattern
+{
+  using T = typename SpMat::value_type;
+  StorageIndex* m_outer;
+  StorageIndex* m_inner;
+  T* m_val;
+  StorageIndex m_cols;
+  StorageIndex m_nnz;
+
+public:
+  MatchPattern(const SpMat& A, const SpMat& pattern)
+  {
+    m_cols = pattern.cols();
+    m_nnz  = pattern.nonZeros();
+
+    m_outer = new StorageIndex[m_cols + 1];
+    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer);
+    m_inner = new StorageIndex[m_nnz];
+    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner);
+    m_val = new T[m_nnz];
+
+    T* valptr = m_val;
+    for (int j = 0; j < m_cols; ++j)
+    {
+      typename SpMat::InnerIterator Acol(A, j);
+      for (typename SpMat::InnerIterator pattern_col(pattern, j);
+           pattern_col; ++pattern_col)
+      {
+        while (Acol && (Acol.row() < pattern_col.row()))
+        {
+          ++Acol;
+        }
+        *valptr++ = Acol.value();
+        ++Acol;
+      }
+    }
+  }
+
+  // Specialization for rank-1 matrces A = bc^T
+  MatchPattern(
+    const typename Eigen::Matrix<T, 1, Eigen::Dynamic>& b,
+    const typename Eigen::Matrix<T, 1, Eigen::Dynamic>& c,
+    const SpMat& pattern)
+  {
+    m_cols  = pattern.cols();
+    m_nnz   = pattern.nonZeros();
+    m_outer = new StorageIndex[m_cols + 1];
+    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer);
+    m_inner = new StorageIndex[m_nnz];
+    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner);
+    m_val = new T[m_nnz];
+
+    T* valptr = m_val;
+    for (int j = 0; j < m_cols; ++j)
+    {
+      for (typename SpMat::InnerIterator pattern_col(pattern, j);
+           pattern_col; ++pattern_col)
+      {
+        *valptr++ = b.coeff(pattern_col.row()) * c.coeff(j);
+      }
+    }
+  }
+
+  ~MatchPattern()
+  {
+    delete[] m_inner;
+    delete[] m_outer;
+    delete[] m_val;
+  }
+
+  SpMat operator()()
+  {
+    return Eigen::Map<SpMat>(
+      m_cols,
+      m_cols,
+      m_nnz,
+      m_outer,
+      m_inner,
+      m_val);
+  }
+};
+
+template<typename SpChol, typename SpMat>
+typename SpChol::MatrixType partial_inverse(
+  const SpChol& llt,
+  const SpMat& Q)
+{
+  typedef typename SpMat::ReverseInnerIterator reverse_it;
+  StorageIndex ncols = llt.cols();
+  const SpMat& L     = llt.matrixL();
+  SpMat Qinv         = L.template selfadjointView<Eigen::Lower>();
+
+  for (int i = ncols - 1; i >= 0; --i)
+  {
+    reverse_it QinvcolI(Qinv, i);
+    for (reverse_it LcolI_slow(L, i); LcolI_slow; --LcolI_slow)
+    {
+      // inner sum iterators
+      reverse_it LcolI(L, i);
+      reverse_it QinvcolJ(Qinv, LcolI_slow.row());
+
+      // Initialize Qinv[j,i]
+      QinvcolI.valueRef() = 0.0;
+
+      // Inner-most sum
+      while (LcolI.row() > i)
+      {
+        // First up, sync the iterators
+        while (QinvcolJ && (LcolI.row() < QinvcolJ.row()))
+        {
+          --QinvcolJ;
+        }
+        if (QinvcolJ && (QinvcolJ.row() == LcolI.row()))
+        {
+          QinvcolI.valueRef() -= LcolI.value() * QinvcolJ.value();
+          --QinvcolJ;
+        }
+        --LcolI;
+      }
+      // At this point LcolI is the diagonal value
+      if (i == LcolI_slow.row())
+      {
+        QinvcolI.valueRef() += 1 / LcolI.value();
+        QinvcolI.valueRef() /= LcolI.value();
+      }
+      else
+      {
+        QinvcolI.valueRef() /= LcolI.value();
+        // Set Qinv[i,j] = Qinv[j,i]
+        while (QinvcolJ.row() > i)
+        {
+          --QinvcolJ;
+        }
+        QinvcolJ.valueRef() = QinvcolI.value();
+      }
+      --QinvcolI;
+    }
+  }
+
+  // Undo the permutation
+  Qinv = Qinv.twistedBy(llt.permutationP().inverse());
+
+  // Return the non-zero elements of Qinv corresponding to the non-zero
+  // elements of Q
+  return MatchPattern(Qinv, Q)();
+}

--- a/include/LinearOp/CholeskySparseInv.hpp
+++ b/include/LinearOp/CholeskySparseInv.hpp
@@ -9,7 +9,7 @@
 /*                                                                            */
 /******************************************************************************/
 // Taken from:
-// Simpson, Dan. 2024. “Random C++ Part 2: Sparse Partial Inverses in Eigen.” 
+// Simpson, Dan. 2024. "Random C++ Part 2: Sparse Partial Inverses in Eigen."
 // September 5, 2024. https://dansblog.netlify.app/posts/2024-05-08-laplace/laplace.html.
 //
 #pragma once

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -2359,7 +2359,7 @@ double VectorHelper::innerProduct(const std::vector<double> &veca, const std::ve
 
 double VectorHelper::innerProduct(const constvect veca, const constvect vecb)
 {
-    return innerProduct(veca.data(), vecb.data(), veca.size());
+  return innerProduct(veca.data(), vecb.data(), (int)veca.size());
 }
 
 double VectorHelper::innerProduct(const VectorDouble &veca,

--- a/src/Core/model_auto.cpp
+++ b/src/Core/model_auto.cpp
@@ -735,7 +735,7 @@ static void st_compress_array(const Vario *vario,
   int ecr = 0;
   int ipadir = 0;
   int sizein = (int)tabin.size();
-  int sizeout = tabout.size();
+  int sizeout = (int) tabout.size();
   for (int idir = 0, ndir = vario->getNDir(); idir < ndir; idir++)
     for (int ilag = 0, nlag = vario->getNLag(idir); ilag < nlag; ilag++, ipadir++)
     {

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -1671,7 +1671,7 @@ MatrixSparse* ACov::evalCovMatSparse(const Db* db1,
 
   // Loop on Data
   int icol = 0;
-  for (int ivar2 = 0, nvar2 = (int)index2.size(); ivar2 < nvar2; ivar2++)
+  for (int ivar2 = 0; ivar2 < nvar2; ivar2++)
   {
     const VectorInt& index2i = index2[ivar2];
     const int* ptr2          = index2i.data();
@@ -1681,7 +1681,7 @@ MatrixSparse* ACov::evalCovMatSparse(const Db* db1,
       SpacePoint& p2 = optimizationLoadInPlace(irel2, 2, 2);
 
       int irow = 0;
-      for (int ivar1 = 0, nvar1 = (int)index1.size(); ivar1 < nvar1; ivar1++)
+      for (int ivar1 = 0; ivar1 < nvar1; ivar1++)
       {
         const VectorInt& index1i = index1[ivar1];
         for (const auto iabs1: index1i.getVector())

--- a/src/Covariances/CorMatern.cpp
+++ b/src/Covariances/CorMatern.cpp
@@ -31,8 +31,8 @@ CorMatern::CorMatern(const VectorDouble &ranges,
                      const VectorDouble& params ,
                      bool flagRange)
   : ACov()
-  , _nVar(params.size())
-  , _corRef(CorAniso::createAnisotropic(CovContext(1, ranges.size()),ECov::MATERN, ranges, params[0], angles, flagRange))
+  , _nVar((int) params.size())
+  , _corRef(CorAniso::createAnisotropic(CovContext(1, (int) ranges.size()),ECov::MATERN, ranges, params[0], angles, flagRange))
   , _corMatern(*_corRef)
   , _coeffScales(coeffScales)
   , _params(params)

--- a/src/Covariances/CovAnisoList.cpp
+++ b/src/Covariances/CovAnisoList.cpp
@@ -414,7 +414,7 @@ const CovAnisoList* CovAnisoList::createReduce(const VectorInt& validVars) const
     CovAniso* covs = newcovlist->getCovAniso(is);
     newcovlist->setCov(is, covs->createReduce(validVars));
   }
-  newcovlist->setNVar(validVars.size());
+  newcovlist->setNVar((int) validVars.size());
   return newcovlist;
 }
 

--- a/src/Covariances/CovMatern.cpp
+++ b/src/Covariances/CovMatern.cpp
@@ -22,19 +22,19 @@
 static bool bessel_Old_Style = false;
 
 CovMatern::CovMatern(const CovContext& ctxt)
-: ACovFunc(ECov::MATERN, ctxt)
-  ,_correc(1.)
-  ,_markovCoeffs(VectorDouble())
+  : ACovFunc(ECov::MATERN, ctxt)
+  , _correc(1.)
+  , _markovCoeffs(VectorDouble())
 {
   setParam(1);
   computeMarkovCoeffs(2);
-  //TODO compute blin (rapatrier de PrecisionOp.cpp
+  // TODO compute blin (rapatrier de PrecisionOp.cpp
 }
 
-CovMatern::CovMatern(const CovMatern &r)
-: ACovFunc(r)
-  ,_correc(r._correc)
-  ,_markovCoeffs(r._markovCoeffs)
+CovMatern::CovMatern(const CovMatern& r)
+  : ACovFunc(r)
+  , _correc(r._correc)
+  , _markovCoeffs(r._markovCoeffs)
 {
 }
 

--- a/src/Covariances/TabNoStat.cpp
+++ b/src/Covariances/TabNoStat.cpp
@@ -33,7 +33,7 @@ TabNoStat& TabNoStat::operator=(const TabNoStat& m)
 int TabNoStat::removeElem(const EConsElem& econs, int iv1, int iv2)
 {
   ParamId param(econs, iv1, iv2);
-  int res = _items.erase(param);
+  int res = (int) _items.erase(param);
   updateDescription();
   return res;
 }
@@ -106,7 +106,7 @@ int TabNoStat::addElem(std::shared_ptr<ANoStat>& nostat, const EConsElem& econs,
   if (!isValid(econs))
     return 0;
   ParamId param(econs, iv1, iv2);
-  int res       = _items.count(param);
+  int res       = (int) _items.count(param);
   _items[param] = nostat;
   if (res == 1)
   {

--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -540,7 +540,7 @@ int DriftList::evalDriftMatByRanks(MatrixDense& mat,
   mat.resize(neq, ncols);
   mat.fill(0.);
 
-  for (int ivar = 0, irow = 0, nvar = (int)sampleRanks.size(); ivar < nvar; ivar++)
+  for (int ivar = 0, irow = 0; ivar < nvar; ivar++)
   {
 
     /* Loop on the samples */

--- a/src/Estimation/CalcImage.cpp
+++ b/src/Estimation/CalcImage.cpp
@@ -237,12 +237,12 @@ DbGrid* CalcImage::_buildMarpat(const NeighImage* neigh,
                                 const MatrixDense& wgt,
                                 int optionVerbose)
 {
-  int nbneigh = (int) ranks.size();
-  int ndim = (int) ranks[0].size();
+  int nbneigh = (int)ranks.size();
+  int ndim    = (int)ranks[0].size();
   int nvar    = wgt.getNCols();
   VectorInt nx(ndim);
   for (int i = 0; i < ndim; i++)
-    nx[i] = 2 * neigh->getImageRadius(i)+ 1;
+    nx[i] = 2 * neigh->getImageRadius(i) + 1;
 
   // Create the relevant DbGrid
   DbGrid* dbgrid   = DbGrid::create(nx);

--- a/src/Estimation/CalcImage.cpp
+++ b/src/Estimation/CalcImage.cpp
@@ -218,7 +218,6 @@ bool CalcImage::_filterImage(DbGrid* dbgrid, const ModelCovList* model)
     retcode        = conv.ConvolveFFT(_iattOut, nvar, marpat, means);
     delete marpat;
   }
-
   return (retcode == 0);
 }
 

--- a/src/Estimation/CalcImage.cpp
+++ b/src/Estimation/CalcImage.cpp
@@ -237,8 +237,8 @@ DbGrid* CalcImage::_buildMarpat(const NeighImage* neigh,
                                 const MatrixDense& wgt,
                                 int optionVerbose)
 {
-  int nbneigh = ranks.size();
-  int ndim = ranks[0].size();
+  int nbneigh = (int) ranks.size();
+  int ndim = (int) ranks[0].size();
   int nvar    = wgt.getNCols();
   VectorInt nx(ndim);
   for (int i = 0; i < ndim; i++)

--- a/src/Estimation/KrigingAlgebra.cpp
+++ b/src/Estimation/KrigingAlgebra.cpp
@@ -1454,7 +1454,7 @@ void KrigingAlgebra::dumpWGT() {
   for (int ivar = 0; ivar < _nvar; ivar++)
   {
     if (_nvar > 1) message("Using variable Z%-2d\n", ivar + 1);
-    int nbyvar = (*_sampleRanks)[ivar].size();
+    int nbyvar = (int) (*_sampleRanks)[ivar].size();
     sum.fill(0.);
 
     for (int j = 0; j < nbyvar; j++)

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -743,7 +743,7 @@ int KrigingSystem::_updateForColCokMoving()
   // If the target coincides with a data point, do not do anything
   // (otherwise the new CoKriging system will be regular)
   VectorDouble coor = _dbout->getSampleCoordinates(_iechOut);
-  for (int jech = 0, nech = _nbgh.size(); jech < nech; jech++)
+  for (int jech = 0, nech = (int) _nbgh.size(); jech < nech; jech++)
   {
     int iech          = _nbgh[jech];
     bool flagCoincide = true;

--- a/src/Estimation/Vecchia.cpp
+++ b/src/Estimation/Vecchia.cpp
@@ -55,8 +55,8 @@ Vecchia::~Vecchia()
 int Vecchia::computeLower(const MatrixT<int>& Ranks, bool verbose)
 {
   int ndim     = _model->getNDim();
-  int ntot     = Ranks.getNRows();
-  int nb_neigh = Ranks.getNCols() - 1;
+  int ntot     = (int) Ranks.getNRows();
+  int nb_neigh = (int) Ranks.getNCols() - 1;
   int Ndb1     = _db1->getNSample();
   double varK  = _model->eval0();
   double value;

--- a/src/LinearOp/ProjMultiMatrix.cpp
+++ b/src/LinearOp/ProjMultiMatrix.cpp
@@ -106,7 +106,7 @@ ProjMultiMatrix::~ProjMultiMatrix()
 
 std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<const ProjMatrix*> &vectproj, int nvariable)
 {
-    int nlatent = vectproj.size();
+    int nlatent = (int) vectproj.size();
     std::vector<std::vector<const ProjMatrix*>> result;
 
     

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -179,7 +179,7 @@ void ShiftOpStencil::multiplyByValueAndAddDiagonal(double v1, double v2)
   _weightsSimu = VectorDouble(_weights.size());
   for (int i = 0; i < (int)_weights.size(); i++)
     _weightsSimu[i] = v1 * _weights[i];
-  int center = _relativeShifts.size() / 2;
+  int center = (int) _relativeShifts.size() / 2;
   _weightsSimu[center] += v2;
   _useModifiedShift = true;
 }

--- a/tests/cpp/test_Cholesky.cpp
+++ b/tests/cpp/test_Cholesky.cpp
@@ -154,10 +154,8 @@ int main(int argc, char *argv[])
   (void)MP.invert();
   VectorDouble vecout1b = MP.getDiagonal();
 
-  // We use a Tim Davis sparse matrix cs as long as Qchol
-  // stdev calculation is not available with eigen underlying matrix
   MatrixSparse* M2 = MatrixSparse::createFromTriplet(
-    M->getMatrixToTriplet(), M->getNRows(), M->getNCols(), -1, 0);
+    M->getMatrixToTriplet(), M->getNRows(), M->getNCols(), -1, 1);
   CholeskySparse Qchol(M2);
   Qchol.stdev(vecout2, false);
 


### PR DESCRIPTION
In this branch, the CholeskySparse class has been incremented by the possibility of calculating the inverse of the Cholesky decomposition performed on a Sparse Matrix (using the method 'partial_inverse' of the new class CholeskySparseInv).
Note: This algorithm assumes that the decomposition has been performed in LLT.
However, in its current version, CholeskySparse performs a LDLT decomposition and stores the relevant matrix in its member '_factor'.
This member CANNOT be used directly by 'partial_inverse'. Therefore a second decomposition (using LLT method this time) is performed locally ... simply for the sake of using 'partial_inverse' method as is.

In the future:
- either one can modify ALL the usages of _factor in the class CholeskySparse (as the result of a LLT rather than a LDLT)
- or we consider that the loss of time linked to this second decomposition is not important due to the very limited usage of this function (only used for calculating the variance of estimation error in SPDE for the time being). 
- 