### PR TITLE
Remove roxygen2 from nonreg workflows, disable BUILD_DOC in dev Makefile

### DIFF
--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -68,12 +68,6 @@ jobs:
             'callr'),
             repos='https://cloud.r-project.org/')"
 
-    - name: Install roxygen2
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        packages: roxygen2
-        install-pandoc: false
-
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -58,12 +58,6 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install roxygen2
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        packages: roxygen2
-        install-pandoc: false
-
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -59,12 +59,6 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install roxygen2
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        packages: roxygen2
-        install-pandoc: false
-
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-unix-action@v1
       with:

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -38,12 +38,6 @@ jobs:
       with:
         r-version: ${{env.R_VERSION}}
 
-    - name: Install roxygen2
-      uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        packages: roxygen2
-        install-pandoc: false
-
     - name: Install dependencies
       run: |
         pacman -Sy --noconfirm mingw-w64-x86_64-boost

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@
 #  - BUILD_DIR=<path>   Define a specific build directory (default =build[_msys])
 #  - BUILD_PYTHON=1     Configure cmake to build python wrapper (default =0, see target python_*)
 #  - BUILD_R=1          Configure cmake to build R wrapper (default =0, see target r_*)
-#  - BUILD_DOC=1        Configure cmake to build documentation (default =1)
+#  - BUILD_DOC=1        Configure cmake to build documentation (default =0)
 #  - TEST=<test-target> Name of the test target to be launched (e.g. test_Model_py or test_simTub)
-#  - ASAN=1             Build with Address Sanitizer
+#  - ASAN=1             Build with Address Sanitizer (default =0)
 #  - USE_HDF5=0         To remove HDF5 support (default =1)
-#  - NO_INTERNET=0      To prevent python pip from looking for dependencies through Internet
+#  - NO_INTERNET=1      To prevent python pip from looking for dependencies through Internet
 #                       (useful when there is no Internet available) (default =0)
 #  - EIGEN3_ROOT=<path> Path to Eigen3 library (optional)
 #  - BOOST_ROOT=<path>  Path to Boost library (optional)
@@ -74,9 +74,6 @@
 #  make check N_PROC=2
 #
 
-ifndef BUILD_DOC
-  BUILD_DOC = 1
-endif
 ifeq ($(BUILD_DOC), 1)
   BUILD_DOC = ON
  else


### PR DESCRIPTION
Following #494, this PR removes the installation of roxygen2 in the nonreg workflows. The workflows should run about 30 seconds faster now…

Also, the `BUILD_DOC` variable in the main Makefile has been switched to `OFF`. This means that `python_doc` and `r_doc` won't run except if the variable is explicitly set.

Enjoy,
Pierre