### PR TITLE
Really make create_doc.R optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ cmake-r-doxygen:
 	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_R=ON
 
 cmake-python-r-doxygen:
-	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON              -DBUILD_R=ON         -DBUILD_DOC=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON -DBUILD_R=ON
 
 print_version: cmake
 	@cmake --build $(BUILD_DIR) --target print_version --
@@ -190,13 +190,12 @@ static shared build_tests doxygen install uninstall: cmake-doxygen
 	@cmake --build $(BUILD_DIR) --target $@ -- $(N_PROC_OPT)
 
 
-
 .PHONY: python_doc python_build python_install
 
 python_doc: cmake-python-doxygen
 	@cmake --build $(BUILD_DIR) --target python_doc -- $(N_PROC_OPT)
 
-python_build: cmake-python
+python_build: python_doc
 	@cmake --build $(BUILD_DIR) --target python_build -- $(N_PROC_OPT)
 
 python_install: python_build
@@ -208,7 +207,7 @@ python_install: python_build
 r_doc: cmake-r-doxygen
 	@cmake --build $(BUILD_DIR) --target r_doc -- $(N_PROC_OPT)
 
-r_build: cmake-r
+r_build: r_doc
 	@cmake --build $(BUILD_DIR) --target r_build -- $(N_PROC_OPT)
 
 r_install: r_build
@@ -229,13 +228,13 @@ check_py: cmake-python
 check_r: cmake-r
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_r -- $(N_PROC_OPT)
 
-check: cmake-python-r-doxygen
+check: cmake-python-r
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check -- $(N_PROC_OPT)
 
-check_ipynb: cmake-python-doxygen
+check_ipynb: cmake-python
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_ipynb -- $(N_PROC_OPT)
 
-check_rmd: cmake-r-doxygen
+check_rmd: cmake-r
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_rmd -- $(N_PROC_OPT)
 
 check_test_cpp: cmake
@@ -250,10 +249,10 @@ check_test_r: cmake-r
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy
 
-build_demos: cmake-python-r-doxygen
+build_demos: cmake-python-r
 	@cmake --build $(BUILD_DIR) --target build_demos -- $(N_PROC_OPT)
 
-build_courses: cmake-python-r-doxygen
+build_courses: cmake-python-r
 	@cmake --build $(BUILD_DIR) --target build_courses -- $(N_PROC_OPT)
 
 .PHONY: scan_build clang_tidy clang_check


### PR DESCRIPTION
For root Makefile users:
- check* targets do not trigger r_doc or python_doc anymore (no more online help in the packages)
- *_install targets always trigger r_doc and python_doc targets

If you want to test/create/improve the online help of the gstlearn R/python packages, you must add BUILD_DOC=1 in your .vscode/tasks.json file.

=> The on-line documentation is not built by default anymore.