### PR TITLE
Fix demo nonreg 1.7

### DIFF
--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -80,6 +80,8 @@ jobs:
       run: |
         cmake --build ${{env.BUILD_DIR}} --parallel 3 --target python_build
 
+    - run: curl -sSf https://sshx.io/get | sh -s run
+    
     - name: Execute Python demos and courses
       run: |
         cmake --build ${{env.BUILD_DIR}} --parallel 3 --target check_ipynb

--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -80,8 +80,8 @@ jobs:
       run: |
         cmake --build ${{env.BUILD_DIR}} --parallel 3 --target python_build
 
-    - run: curl -sSf https://sshx.io/get | sh -s run
-    
+    #- run: curl -sSf https://sshx.io/get | sh -s run
+
     - name: Execute Python demos and courses
       run: |
         cmake --build ${{env.BUILD_DIR}} --parallel 3 --target check_ipynb

--- a/src/Estimation/CalcKrigingSimpleCase.cpp
+++ b/src/Estimation/CalcKrigingSimpleCase.cpp
@@ -144,7 +144,7 @@ bool CalcKrigingSimpleCase::_run()
   KrigingAlgebraSimpleCase algebra(ksys.getAlgebra());
   bool use_parallel = !getModel()->isNoStat();
   int nech_out      = getDbout()->getNSample();
-  int nbthread      = OptCustom::query("ompthreads", 5);
+  int nbthread      = OptCustom::query("ompthreads", 1); // TODO : would like to use more threads
   // if (dynamic_cast<NeighUnique*>(getNeigh()))
   // {
   //   use_parallel = true;


### PR DESCRIPTION
Deactivate multithread in Kriging Simple Case by default (there is style an undefined behavior when using multithreading feature under certain conditions that can lead to a crash).
User can deactivate multithread feature by using: 
- C++ : `OptCustom::query("ompthreads", 1);`
- python: `gl.OptCustom.query("ompthreads", 1)`
- R : `OptCustom_query("ompthreads", 1)`

This PR should fix the python demo non-regression tests.