### PR TITLE
Reduce allocations

### DIFF
--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -205,6 +205,10 @@ public:
   static void concatenateInPlace(VectorDouble& veca, const VectorDouble& vecb);
   static VectorDouble power(const VectorDouble& vec, double power);
   static VectorDouble inverse(const VectorDouble& vec);
+#ifndef SWIG
+  static void power(VectorDouble& res, const constvect vec, double power);
+  static void inverse(VectorDouble& res, const constvect vec);
+#endif // !SWIG
 
   static double innerProduct(const VectorDouble &veca, const VectorDouble &vecb, int size = -1);
   static double innerProduct(const double* veca, const double* vecb, int size);

--- a/include/Covariances/CovAniso.hpp
+++ b/include/Covariances/CovAniso.hpp
@@ -160,7 +160,7 @@ public:
   bool getFlagRotation() const { return hasRotation(); }
   double getRange(int idim) const { return getRanges()[idim]; }
   double getScale(int idim) const { return getScales()[idim]; }
-  VectorDouble getAnisoAngles() const { return getCorAniso()->getAniso().getAngles(); }
+  const VectorDouble& getAnisoAngles() const { return getCorAniso()->getAniso().getAngles(); }
   const MatrixSquare& getAnisoRotMat() const { return getCorAniso()->getAniso().getMatrixDirect(); }
   const MatrixSquare& getAnisoInvMat() const { return getCorAniso()->getAniso().getMatrixInverse(); }
   VectorDouble getAnisoCoeffs() const;

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -573,7 +573,8 @@ public:
 
   int getSelection(int iech) const;
   VectorDouble getSelections(void) const;
-  VectorInt getSampleRanksPerVariable(const VectorInt& nbgh = VectorInt(),
+  void getSampleRanksPerVariable(VectorInt &ranks,
+                                      const VectorInt& nbgh = VectorInt(),
                                       int ivar              = -1,
                                       bool useSel           = true,
                                       bool useZ             = true,
@@ -585,7 +586,7 @@ public:
                                  bool useZ              = true,
                                  bool useVerr           = false,
                                  bool useExtD           = true) const;
-  void getSampleRanksInPlace(VectorVectorInt* sampleRanks,
+  void getSampleRanksInPlace(VectorVectorInt& sampleRanks,
                              const VectorInt& ivars = VectorInt(),
                              const VectorInt& nbgh  = VectorInt(),
                              bool useSel            = true,

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -446,7 +446,7 @@ public:
   VectorInt getUIDsByLocator(const ELoc& locatorType) const;
   VectorInt getUIDsByColIdx(const VectorInt& icols) const;
   VectorInt getAllUIDs() const;
-  void getAllUIDs(std::vector<int>& iuids) const;
+  void getAllUIDs(VectorInt& iuids) const;
 
   void copyByUID(int iuidIn, int iuidOut);
   void copyByCol(int icolIn, int icolOut);
@@ -1000,5 +1000,5 @@ private:
   std::vector<PtrGeos> _p;    //!< Locator characteristics
 
   /// factor allocations
-  mutable std::vector<int> uids;
+  mutable VectorInt uids;
 };

--- a/include/Estimation/KrigingAlgebraSimpleCase.hpp
+++ b/include/Estimation/KrigingAlgebraSimpleCase.hpp
@@ -70,7 +70,7 @@ public:
   void dumpAux();
 
   VectorDouble& getEstimation();
-  VectorDouble getStdv();
+  const VectorDouble &getStdv();
   double getVarianceZstar(int i);
   VectorDouble getVarianceZstar();
   const MatrixSymmetric* getStdvMat();
@@ -230,4 +230,6 @@ private:
   bool _dualHasChanged;
   bool _invSigmaHasChanged;
   bool _XtInvSigmaHasChanged;
+
+  VectorDouble _dummy;
 };

--- a/include/Geometry/BiTargetCheckGeometry.hpp
+++ b/include/Geometry/BiTargetCheckGeometry.hpp
@@ -52,6 +52,7 @@ private:
   double _cylrad;
   bool   _flagAsym;
 
+  mutable VectorDouble _delta;
   mutable double _psmin;
   mutable double _dist;
 };

--- a/include/Geometry/Rotation.hpp
+++ b/include/Geometry/Rotation.hpp
@@ -67,4 +67,5 @@ private:
   VectorDouble    _angles;
   MatrixSquare _rotMat;
   MatrixSquare _rotInv;
+  mutable VectorDouble _local;
 };

--- a/include/Geometry/Rotation.hpp
+++ b/include/Geometry/Rotation.hpp
@@ -42,10 +42,6 @@ public:
   void setIdentity();
   void rotateDirect(const VectorDouble& inv, VectorDouble& outv) const;
   void rotateInverse(const VectorDouble& inv, VectorDouble& outv) const;
-#ifndef SWIG
-  void rotateDirect(const std::vector<double>& inv, std::vector<double>& outv) const;
-  void rotateInverse(const std::vector<double>& inv, std::vector<double>& outv) const;
-#endif // SWIG
   bool isIdentity() const { return !_flagRot; }
   bool isSame(const Rotation& rot) const;
 

--- a/include/LinearOp/ShiftOpMatrix.hpp
+++ b/include/LinearOp/ShiftOpMatrix.hpp
@@ -177,7 +177,7 @@ class GSTLEARN_EXPORT ShiftOpMatrix: public AShiftOp
     VectorVectorDouble _LambdaGrad;
     bool _flagNoStatByHH;
     std::vector<double> _detHH;
-
+    mutable VectorDouble _diag;
 
     int _ndim;
   };

--- a/include/Matrix/AMatrix.hpp
+++ b/include/Matrix/AMatrix.hpp
@@ -161,7 +161,7 @@ public:
   /*! Returns the contents of the whole matrix as a VectorDouble */
   VectorDouble getValues(bool byCol = true) const;
   /*! Extract a Diagonal (main or secondary) of this */
-  VectorDouble getDiagonal(int shift = 0) const;
+  const VectorDouble &getDiagonal(int shift = 0) const;
   /*! Checks if a Column is valid (contains a non TEST value) */
   bool isColumnDefined(int icol) const;
   /*! Checks if a Row is valid (contains a non TEST value) */
@@ -285,6 +285,7 @@ protected:
                   bool transpose3 = false) const;
 
 private:
+  mutable VectorDouble _diagonal;
   int  _nRows;
   int  _nCols;
   bool _flagCheckAddress;

--- a/include/Simulation/TurningBandDirection.hpp
+++ b/include/Simulation/TurningBandDirection.hpp
@@ -63,4 +63,7 @@ private:
   double _dyp; /* Increment along Y */
   double _dzp; /* Increment along Z */
   VectorDouble _ang; /* Angles for the line orientation */
+
+  mutable VectorInt _indg;
+  mutable VectorDouble _xyz;
 };

--- a/include/Space/ASpaceObject.hpp
+++ b/include/Space/ASpaceObject.hpp
@@ -48,6 +48,8 @@ public:
   /// Indicate if I am consistent with my current space context
   bool isConsistent() const { return isConsistent(_space); }
 
+  void setSpace(ASpaceSharedPtr &&space) { _space = std::move(space); }
+
   /// Return unitary vector for the current space context
   VectorDouble getUnitaryVector() const;
 

--- a/src/Basic/Rotation.cpp
+++ b/src/Basic/Rotation.cpp
@@ -101,9 +101,9 @@ int Rotation::setAngles(const VectorDouble& angles)
     _angles.resize(_nDim,0.);
     if (_nDim == 2) _angles[1] = 0.;
 
-    VectorDouble local = VectorDouble(_nDim * _nDim);
-    GH::rotationMatrixInPlace(_nDim, _angles, local);
-    _rotMat.setValues(local);
+    _local.resize(_nDim * _nDim);
+    GH::rotationMatrixInPlace(_nDim, _angles, _local);
+    _rotMat.setValues(_local);
     _directToInverse();
     _checkRotForIdentity();
   }

--- a/src/Basic/Rotation.cpp
+++ b/src/Basic/Rotation.cpp
@@ -139,11 +139,6 @@ String Rotation::toString(const AStringFormat* strfmt) const
 
 void Rotation::rotateDirect(const VectorDouble& inv, VectorDouble& outv) const
 {
-  this->rotateDirect(inv.getVector(), outv.getVector());
-}
-
-void Rotation::rotateDirect(const std::vector<double>& inv, std::vector<double>& outv) const
-{
   if (!_flagRot)
     outv = inv;
   else
@@ -151,11 +146,6 @@ void Rotation::rotateDirect(const std::vector<double>& inv, std::vector<double>&
 }
 
 void Rotation::rotateInverse(const VectorDouble& inv, VectorDouble& outv) const
-{
-  this->rotateInverse(inv.getVector(), outv.getVector());
-}
-
-void Rotation::rotateInverse(const std::vector<double>& inv, std::vector<double>& outv) const
 {
   if (!_flagRot)
     outv = inv;

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -1897,32 +1897,36 @@ void VectorHelper::mean1AndMean2ToStdev(const VectorDouble &mean1,
   }
 }
 
-VectorDouble VectorHelper::power(const VectorDouble &vec, double power)
+VectorDouble VectorHelper::power(const VectorDouble& vec, double power)
 {
-  VectorDouble res(vec.size());
-  VectorDouble::iterator it(res.begin());
-  VectorDouble::const_iterator itv(vec.begin());
-  while (it < res.end())
-  {
-    *it = pow(*itv, power);
-    it++;
-    itv++;
-  }
+  VectorDouble res;
+  VectorHelper::power(res, vec, power);
   return res;
 }
 
 VectorDouble VectorHelper::inverse(const VectorDouble& vec)
 {
-  VectorDouble inv(vec.size());
-  VectorDouble::iterator it(inv.begin());
-  VectorDouble::const_iterator itv(vec.begin());
-  while (it < inv.end())
+  VectorDouble res;
+  VectorHelper::inverse(res, vec);
+  return res;
+}
+
+void VectorHelper::power(VectorDouble &res, const constvect vec, double power)
+{
+  res.resize(vec.size());
+  for (size_t i = 0; i < vec.size(); ++i)
   {
-    *it = 1. / *itv;
-    it++;
-    itv++;
+    res[i] = pow(vec[i], power);
   }
-  return inv;
+}
+
+void VectorHelper::inverse(VectorDouble& res, const constvect vec)
+{
+  res.resize(vec.size());
+  for (size_t i = 0; i < vec.size(); ++i)
+  {
+    res[i] = 1.0 / vec[i];
+  }
 }
 
 int VectorHelper::countUndefined(const VectorDouble &vec)

--- a/src/Core/db.cpp
+++ b/src/Core/db.cpp
@@ -736,6 +736,9 @@ int point_to_point(Db* db, const double* coor)
   return (iechmin);
 }
 
+static VectorDouble work1;
+static VectorDouble work2;
+
 /*****************************************************************************/
 /*!
  **  Converts from point coordinates to nearest grid node indices
@@ -763,8 +766,8 @@ int point_to_grid(const DbGrid* db,
                   int* indg)
 {
   int ndim = db->getNDim();
-  VectorDouble work1(ndim);
-  VectorDouble work2(ndim);
+  work1.resize(ndim);
+  work2.resize(ndim);
 
   /* Check if all coordinates are defined */
 

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -708,7 +708,8 @@ void ACov::evalPointToDb(VectorDouble& values,
 {
   SpacePoint p2(getSpace());
 
-  VectorInt index2 = db2->getSampleRanksPerVariable(nbgh2, jvar, useSel);
+  VectorInt index2;
+  db2->getSampleRanksPerVariable(index2, nbgh2, jvar, useSel);
   int nech2        = (int)index2.size();
   if (nech2 != (int)values.size()) values.resize(nech2);
 

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -4510,7 +4510,7 @@ VectorInt Db::getAllUIDs() const
   return iuids;
 }
 
-void Db::getAllUIDs(std::vector<int>& iuids) const
+void Db::getAllUIDs(VectorInt& iuids) const
 {
   iuids.clear();
   for (int i = 0; i < (int)_uidcol.size(); i++)

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -943,7 +943,8 @@ MatrixDense Db::getAllCoordinatesMat(const MatrixDense& box) const
   int nech = getNSample(true);
   int ndim = getNDim();
 
-  VectorInt ranks = getSampleRanksPerVariable();
+  VectorInt ranks;
+  getSampleRanksPerVariable(ranks);
 
   // Suppress some data due to bounds
   int nechValid = 0;
@@ -3650,9 +3651,12 @@ VectorVectorInt Db::getSampleRanks(const VectorInt& ivars,
 {
 
   VectorVectorInt index;
-  getSampleRanksInPlace(&index, ivars, nbgh, useSel, useZ, useVerr, useExtD);
+  getSampleRanksInPlace(index, ivars, nbgh, useSel, useZ, useVerr, useExtD);
   return index;
 }
+
+thread_local VectorInt nbgh_init;
+thread_local VectorInt jvars;
 
 /**
  * Compute the list of indices 'index' for valid samples for the set of
@@ -3676,7 +3680,7 @@ VectorVectorInt Db::getSampleRanks(const VectorInt& ivars,
  * @note: if 'useExtD' is ON, each sample for each variable is tested against
  * @note: all the values of External Drift functions.
  */
-void Db::getSampleRanksInPlace(VectorVectorInt* sampleRanks,
+void Db::getSampleRanksInPlace(VectorVectorInt& sampleRanks,
                                const VectorInt& ivars,
                                const VectorInt& nbgh,
                                bool useSel,
@@ -3684,15 +3688,16 @@ void Db::getSampleRanksInPlace(VectorVectorInt* sampleRanks,
                                bool useVerr,
                                bool useExtD) const
 {
-  VectorInt jvars = ivars;
+  jvars.resize(ivars.size());
+  std::copy(ivars.begin(), ivars.end(), jvars.begin());
   if (jvars.empty()) jvars = VH::sequence(getNLoc(ELoc::Z));
   int nvar = (int)jvars.size();
 
-  sampleRanks->resize(nvar);
+  sampleRanks.resize(nvar);
   for (int ivar = 0; ivar < nvar; ivar++)
   {
     int jvar             = jvars[ivar];
-    (*sampleRanks)[ivar] = getSampleRanksPerVariable(nbgh, jvar, useSel, useZ, useVerr, useExtD);
+    getSampleRanksPerVariable(sampleRanks[ivar], nbgh, jvar, useSel, useZ, useVerr, useExtD);
   }
 }
 
@@ -3707,7 +3712,8 @@ void Db::getSampleRanksInPlace(VectorVectorInt* sampleRanks,
  * @param useExtD True if the definition of the External Drift must be checked
  * @return VectorInt
  */
-VectorInt Db::getSampleRanksPerVariable(const VectorInt& nbgh,
+void Db::getSampleRanksPerVariable(VectorInt &ranks,
+                                        const VectorInt& nbgh,
                                         int ivar,
                                         bool useSel,
                                         bool useZ,
@@ -3718,7 +3724,8 @@ VectorInt Db::getSampleRanksPerVariable(const VectorInt& nbgh,
   int nech_tot = getNSample();
 
   // Create vector of sample ranks to be searched (using input 'nbgh' or not)
-  VectorInt nbgh_init = nbgh;
+  nbgh_init.resize(nbgh.size());
+  std::copy(nbgh.begin(), nbgh.end(), nbgh_init.begin());
   if (nbgh_init.empty()) nbgh_init = VH::sequence(nech_tot);
   int nech_init = (int)nbgh_init.size();
 
@@ -3739,7 +3746,8 @@ VectorInt Db::getSampleRanksPerVariable(const VectorInt& nbgh,
   }
 
   // Constitute the resulting vector of selected sample ranks
-  VectorInt ranks;
+  ranks.clear();
+  ranks.reserve(nech_init);
   for (int irel = 0; irel < nech_init; irel++)
   {
     int iabs = nbgh_init[irel];
@@ -3784,7 +3792,6 @@ VectorInt Db::getSampleRanksPerVariable(const VectorInt& nbgh,
     // The sample is finally accepted: its ABSOLUTE index is stored
     ranks.push_back(iabs);
   }
-  return ranks;
 }
 
 VectorDouble Db::getColumnsActiveAndDefined(const ELoc& locatorType,
@@ -5206,7 +5213,7 @@ int Db::resetReduce(const Db* dbin,
   if (ranksel.empty())
   {
     if (dbin->hasLocVariable(ELoc::SEL))
-      ranksel = dbin->getSampleRanksPerVariable();
+      dbin->getSampleRanksPerVariable(ranksel);
     else
       ranksel = VH::sequence(dbin->getNSample());
   }

--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -629,6 +629,9 @@ VectorDouble DriftList::evalMeanVecByRanks(const Db* db,
   return vec;
 }
 
+thread_local VectorInt viech2(1);
+thread_local VectorInt ivars;
+
 /****************************************************************************/
 /*!
  **  Establish the drift rectangular matrix for a given Db
@@ -647,12 +650,13 @@ int DriftList::evalDriftMatByTargetInPlace(MatrixDense& mat,
                                            int iech2,
                                            const KrigOpt& krigopt) const
 {
-  VectorInt ivars = VH::sequence(getNVar());
+  VH::sequenceInPlace(getNVar(), ivars);
   if (ivars.empty()) return 1;
 
   // Create the sets of Vector of valid sample indices per variable
   // (not masked and defined)
-  const VectorVectorInt &index = db->getSampleRanks(ivars, {iech2}, true, false, false);
+  viech2[0] = iech2;
+  const VectorVectorInt &index = db->getSampleRanks(ivars, viech2, true, false, false);
 
   // Creating the matrix
   int neq = VH::count(index);

--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -652,7 +652,7 @@ int DriftList::evalDriftMatByTargetInPlace(MatrixDense& mat,
 
   // Create the sets of Vector of valid sample indices per variable
   // (not masked and defined)
-  VectorVectorInt index = db->getSampleRanks(ivars, {iech2}, true, false, false);
+  const VectorVectorInt &index = db->getSampleRanks(ivars, {iech2}, true, false, false);
 
   // Creating the matrix
   int neq = VH::count(index);

--- a/src/Estimation/KrigingAlgebraSimpleCase.cpp
+++ b/src/Estimation/KrigingAlgebraSimpleCase.cpp
@@ -653,10 +653,10 @@ bool KrigingAlgebraSimpleCase::_forbiddenWhenDual() const
   return false;
 }
 
-VectorDouble KrigingAlgebraSimpleCase::getStdv()
+const VectorDouble &KrigingAlgebraSimpleCase::getStdv()
 {
-  if (!_forbiddenWhenDual()) return VectorDouble();
-  if (_needStdv()) return VectorDouble();
+  if (!_forbiddenWhenDual()) return _dummy;
+  if (_needStdv()) return _dummy;
   return _Stdv.getDiagonal();
 }
 

--- a/src/Estimation/KrigingSystemSimpleCase.cpp
+++ b/src/Estimation/KrigingSystemSimpleCase.cpp
@@ -311,11 +311,10 @@ void KrigingSystemSimpleCase::_estimateEstim(int status, KrigingAlgebraSimpleCas
  *****************************************************************************/
 void KrigingSystemSimpleCase::_estimateStdv(int status, int iechout, KrigingAlgebraSimpleCase& algebra) const
 {
-  VectorDouble local = algebra.getStdv();
+  const VectorDouble &local = algebra.getStdv();
   if (local.size() <= 0) return;
-  if (status) local.fill(TEST);
   for (int ivarCL = 0; ivarCL < 1; ivarCL++)
-    _dbout->setArray(iechout, _iptrStd + ivarCL, local[ivarCL]);
+    _dbout->setArray(iechout, _iptrStd + ivarCL, status ? TEST : local[ivarCL]);
 }
 
 /****************************************************************************/

--- a/src/Geometry/BiTargetCheckGeometry.cpp
+++ b/src/Geometry/BiTargetCheckGeometry.cpp
@@ -100,7 +100,7 @@ bool BiTargetCheckGeometry::isOK(const SpaceTarget &T1, const SpaceTarget &T2) c
   if (_dist <= 0.) return true;
 
   // Increment between two samples
-  VectorDouble delta = T1.getIncrement(T2);
+  _delta = T1.getIncrement(T2);
 
   // Check if the angle of the pair matches the Calculation direction (up to angular tolerance)
   double dproj = 0.;
@@ -108,8 +108,8 @@ bool BiTargetCheckGeometry::isOK(const SpaceTarget &T1, const SpaceTarget &T2) c
   double dn2 = 0.;
   for (int idim = 0; idim < _ndim; idim++)
   {
-    dproj +=  delta[idim] * _codir[idim];
-    dn1   +=  delta[idim] *  delta[idim];
+    dproj +=  _delta[idim] * _codir[idim];
+    dn1   +=  _delta[idim] *  _delta[idim];
     dn2   += _codir[idim] * _codir[idim];
   }
   double prod = dn1 * dn2;
@@ -128,7 +128,7 @@ bool BiTargetCheckGeometry::isOK(const SpaceTarget &T1, const SpaceTarget &T2) c
   // Check for vertical slicing test
   if (!FFFF(_bench) && _bench > 0.)
   {
-    double dvect = ABS(delta[_ndim-1]);
+    double dvect = ABS(_delta[_ndim-1]);
     if (dvect > _bench) return false;
   }
 

--- a/src/LinearOp/ShiftOpMatrix.cpp
+++ b/src/LinearOp/ShiftOpMatrix.cpp
@@ -491,9 +491,9 @@ void ShiftOpMatrix::_loadHHRegular(MatrixSymmetric &hh, int imesh)
   // Calculate the current HH matrix (using local covariance parameters)
   const MatrixSquare &rotmat = _getCovAniso()->getAnisoInvMat();
 
-  VectorDouble diag = VH::power(_getCovAniso()->getScales(), 2.);
+  VH::power(_diag, _getCovAniso()->getScales(), 2.);
   MatrixSymmetric temp(ndim);
-  temp.setDiagonal(diag);
+  temp.setDiagonal(_diag);
   hh.normMatrix(rotmat, temp);
 
 }

--- a/src/Matrix/AMatrix.cpp
+++ b/src/Matrix/AMatrix.cpp
@@ -1074,15 +1074,16 @@ double AMatrix::compare(const AMatrix& mat) const
   return diff;
 }
 
-VectorDouble AMatrix::getDiagonal(int shift) const
+const VectorDouble &AMatrix::getDiagonal(int shift) const
 {
+  _diagonal.clear();
   if (! isSquare())
   {
     messerr("This function is only valid for Square matrices");
-    return VectorDouble();
+    return this->_diagonal;
   }
 
-  VectorDouble vect;
+  _diagonal.reserve(getNRows());
   for (int rank = 0; rank < getNRows(); rank++)
   {
     int irow = rank;
@@ -1091,9 +1092,9 @@ VectorDouble AMatrix::getDiagonal(int shift) const
     int icol = rank;
     if (shift > 0) icol += shift;
     if (icol < 0 || icol >= getNCols()) continue;
-    vect.push_back(getValue(irow,icol));
+    _diagonal.push_back(getValue(irow,icol));
   }
-  return vect;
+  return _diagonal;
 }
 
 /**

--- a/src/Simulation/SimuSpectral.cpp
+++ b/src/Simulation/SimuSpectral.cpp
@@ -223,7 +223,8 @@ void SimuSpectral::_computeOnRn(Db *dbout, int iuid, bool verbose)
   }
 
   // Loop on the active samples
-  VectorInt ranks = dbout->getSampleRanksPerVariable();
+  VectorInt ranks;
+  dbout->getSampleRanksPerVariable(ranks);
   VectorDouble coor(_ndim);
   for (int jech = 0; jech < nech; jech++)
   {

--- a/src/Simulation/TurningBandDirection.cpp
+++ b/src/Simulation/TurningBandDirection.cpp
@@ -75,17 +75,19 @@ double TurningBandDirection::projectGrid(const DbGrid* db,
                                          int iz) const
 {
   int ndim = 3;
-  VectorInt indg(ndim, 0);
-  VectorDouble xyz(ndim, 0.);
+  _indg.clear();
+  _indg.resize(ndim, 0);
+  _xyz.clear();
+  _xyz.resize(ndim, 0.);
 
-  indg[0] = ix;
-  indg[1] = iy;
-  indg[2] = iz;
-  db->indicesToCoordinateInPlace(indg, xyz);
+  _indg[0] = ix;
+  _indg[1] = iy;
+  _indg[2] = iz;
+  db->indicesToCoordinateInPlace(_indg, _xyz);
 
   double t = 0.;
   for (int idim = 0; idim < db->getNDim(); idim++)
-    t += xyz[idim] * _ang[idim];
+    t += _xyz[idim] * _ang[idim];
   return t;
 }
 

--- a/src/Tree/ball_algorithm.cpp
+++ b/src/Tree/ball_algorithm.cpp
@@ -454,8 +454,13 @@ double manhattan_distance(const double* x1, const double* x2, int n_features)
  */
 double euclidean_distance(const double* x1, const double* x2, int n_features)
 {
-  SpacePoint p1;
-  SpacePoint p2;
+  thread_local SpacePoint p1;
+  thread_local SpacePoint p2;
+  if (p1.getSpace() != getDefaultSpaceSh())
+  {
+    p1.setSpace(getDefaultSpaceSh());
+    p2.setSpace(getDefaultSpaceSh());
+  }
   p1.setCoords(x1, n_features);
   p2.setCoords(x2, n_features);
   return p1.getDistance(p2);


### PR DESCRIPTION
This PR reduces the number of allocations around several data structures of gstlearn, using a variety of techniques: passing heap-allocated data structures by reference instead of returning them, returning const references to member variables instead of copies, factoring allocations in member variables or static / thread_local variables.

Some cleanup has been performed around `std::vector`: since #484, `VectorT` can be used without performance penalty.

Here are a few `heaptrack` figures on a selection of C++ tests:

- `bench_Tree`

|                   | before      | after     |
|-------------------|-------------|-----------|
| Exec time (s)     | 14,867      | 8,646     |
| #Allocations      | 265 260 936 | 8 362 891 |
| #Temp allocations | 128 449 078 | 53        |
| Memory cons (MB)  | 11,3        | 11,3      |


- `test_Simtub`

|                   | before  | after   |
|-------------------|---------|---------|
| Exec time (s)     | 0,202   | 0,200   |
| #Allocations      | 188 034 | 114 047 |
| #Temp allocations | 33 737  | 29 715  |
| Memory cons (MB)  | 0,726   | 0,754   |


- `bench_SimtubNC`

|                   | before | after |
|-------------------|--------|-------|
| Exec time (s)     | 1,183  | 1,204 |
| #Allocations      | 26 668 | 4 669 |
| #Temp allocations | 13 025 | 1 025 |
| Memory cons (MB)  | 3,0    | 3,0   |

- `bench_Vario`

|                   | before     | after      |
|-------------------|------------|------------|
| Exec time (s)     | 4,119      | 3,950      |
| #Allocations      | 19 524 519 | 11 522 327 |
| #Temp allocations | 15 521 726 | 11 520 521 |
| Memory cons (MB)  | 18,0       | 18,0       |

Enjoy,
Pierre

