### PR TITLE
Fix publish workflow due to C++20 std::map::contains

### DIFF
--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -191,7 +191,9 @@ int PrecisionOp::_addSimulateToDest(const constvect whitenoise, vect outv) const
 int PrecisionOp::_preparePoly(const EPowerPT& power,bool force) const
 {
   // Polynomial already exists. Nothing to be done
-  if (_polynomials.contains(power) && !force) return 0;
+  if (_polynomials.find(power) != _polynomials.end() && !force) return 0;
+  // Equivalent instruction (but only for C++ 20)
+  // if (_polynomials.contains(power) && !force) return 0;
 
   // Prepare Polynomial for EPowerPT::ONE
   if (_preparePrecisionPoly() != 0 && !force) return 1;


### PR DESCRIPTION
The function std::map::contains used in PrecisionOp is available with C++ 20+ only. Thus the publish workflow which runs on an old Debian distribution (C++17) fails. `contains` function has been replaced by the classical `find`. 