### PR TITLE
Fix Swig wrapping of HDF5 methods 

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -101,6 +101,12 @@ set(CMAKE_SWIG_FLAGS -keyword) # Use -keyword option to activate kwargs
 # Note: Cannot use -doxygen feature because all documentation is in C++ body files
 # Note: Use -E option for seeing SWIG preprocessor output
 
+# Forward C++ compile definitions to pygstlearn.i
+set_property(
+  SOURCE ${SRC}
+  PROPERTY COMPILE_DEFINITIONS
+           $<TARGET_PROPERTY:${PROJECT_NAME}::shared,COMPILE_DEFINITIONS>)
+
 # SWIG target (generate wrapper & python script then build [so,pyd] library)
 swig_add_library(
   python_build

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -118,6 +118,12 @@ set(CMAKE_SWIG_FLAGS)
 # Note: Cannot use -doxygen feature because all documentation is in C++ body files
 # Note: Use -E option for seeing SWIG preprocessor output
 
+# Forward C++ compile definitions to rgstlearn.i
+set_property(
+  SOURCE ${SRC}
+  PROPERTY COMPILE_DEFINITIONS
+           $<TARGET_PROPERTY:${PROJECT_NAME}::shared,COMPILE_DEFINITIONS>)
+
 # SWIG target (generate wrapper & R script then build [so,dll] library)
 swig_add_library(
   r_build

--- a/tests/py/test_h5.py
+++ b/tests/py/test_h5.py
@@ -1,0 +1,8 @@
+import gstlearn as gl
+
+
+dims = [10, 10, 10]
+db = gl.DbGrid.create(nx=dims)
+db.dumpToH5("dbgrid.h5")
+
+db2 = gl.DbGrid.createFromH5("dbgrid.h5")


### PR DESCRIPTION
This PR fixes the missing HDF5 methods in the Python and R wrappers. Swig was missing the `-DHDF5` compilation flag when analyzing the header files.

A non-regression test has been added (in Python only).

Pierre