### PR TITLE
Reduce allocations 2

### DIFF
--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -70,13 +70,13 @@ public:
 
   void    copyParams(int mode, const Grid& gridaux);
   double  getCoordinate(int rank, int idim, bool flag_rotate=true) const;
-  VectorDouble getCoordinatesByRank(int rank, bool flag_rotate=true) const;
-  VectorDouble getCoordinatesByIndice(const VectorInt &indice,
+  const VectorDouble& getCoordinatesByRank(int rank, bool flag_rotate=true) const;
+  const VectorDouble& getCoordinatesByIndice(const VectorInt &indice,
                                       bool flag_rotate = true,
                                       const VectorInt& shift = VectorInt(),
                                       const VectorDouble& dxsPerCell = VectorDouble()) const;
-  VectorDouble getCoordinatesByCorner(const VectorInt& icorner) const;
-  VectorDouble getCellCoordinatesByCorner(int node,
+  const VectorDouble& getCoordinatesByCorner(const VectorInt& icorner) const;
+  const VectorDouble& getCellCoordinatesByCorner(int node,
                                           const VectorInt& shift = VectorInt(),
                                           const VectorDouble& dxsPerCell = VectorDouble()) const;
 #ifndef SWIG

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -97,7 +97,6 @@ public:
   virtual bool isMesh() const { return false; }
   virtual double getCoordinate(int iech, int idim, bool flag_rotate = true) const;
   virtual void getCoordinatesInPlace(VectorDouble& coor, int iech, bool flag_rotate = true) const;
-  virtual void getCoordinatesInPlace(vect coor, int iech, bool flag_rotate = true) const;
 
   virtual double getUnit(int idim = 0) const;
   virtual int getNDim() const;

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -1003,5 +1003,5 @@ private:
   std::vector<PtrGeos> _p;    //!< Locator characteristics
 
   /// factor allocations
-  mutable VectorInt uids;
+  mutable VectorInt _uids;
 };

--- a/include/Db/DbGrid.hpp
+++ b/include/Db/DbGrid.hpp
@@ -76,7 +76,6 @@ public:
   void getCoordinatesInPlace(VectorDouble& coor,
                              int iech,
                              bool flag_rotate = true) const override;
-  void getCoordinatesInPlace(vect coor, int iech, bool flag_rotate = true) const override;
 
   double getUnit(int idim = 0) const override;
   int getNDim() const override;
@@ -228,18 +227,18 @@ public:
   void setX0(int idim, double value) { _grid.setX0(idim, value); }
   void setDX(int idim, double value) { _grid.setDX(idim, value); }
   VectorDouble getGridAxis(int idim) const { return _grid.getAxis(idim); }
-  VectorDouble getCoordinateFromCorner(const VectorInt& icorner) const
+  const VectorDouble& getCoordinateFromCorner(const VectorInt& icorner) const
   {
     return _grid.getCoordinatesByCorner(icorner);
   }
-  VectorDouble getCoordinatesByIndice(const VectorInt &indice,
+  const VectorDouble& getCoordinatesByIndice(const VectorInt &indice,
                                       bool flag_rotate = true,
                                       const VectorInt& shift = VectorInt(),
                                       const VectorDouble& dxsPerCell = VectorDouble()) const
   {
     return _grid.getCoordinatesByIndice(indice, flag_rotate, shift, dxsPerCell);
   }
-  VectorDouble getCoordinatesPerSample(int iech, bool flag_rotate = true) const
+  const VectorDouble& getCoordinatesPerSample(int iech, bool flag_rotate = true) const
   {
     return _grid.getCoordinatesByRank(iech, flag_rotate);
   }

--- a/include/Geometry/BiTargetCheckDistance.hpp
+++ b/include/Geometry/BiTargetCheckDistance.hpp
@@ -54,7 +54,7 @@ public:
   void setRadius(double radius) { _radius = radius; }
 
   double getDistance() const { return _dist; }
-  VectorDouble getIncr() const { return _movingIncr; }
+  const VectorDouble& getIncr() const { return _movingIncr; }
   double getNormalizedDistance(const VectorDouble& dd) const;
 
 private:

--- a/include/LithoRule/Rule.hpp
+++ b/include/LithoRule/Rule.hpp
@@ -142,6 +142,7 @@ private:
   Node*          _mainNode;
 
   mutable VectorInt _facies;
+  mutable VectorDouble _props;
 };
 
 GSTLEARN_EXPORT void   set_rule_mode(int rule_mode);

--- a/include/LithoRule/Rule.hpp
+++ b/include/LithoRule/Rule.hpp
@@ -103,7 +103,9 @@ public:
   bool isYUsed(int igrf) const;
   VectorInt whichGRFUsed() const;
   double getProportion(int facies);
+#ifndef SWIG
   std::array<double, 4> getThresh(int facies) const;
+#endif
   VectorDouble getThreshFromRectangle(int rect, int *facies);
   int getFaciesFromGaussian(double y1, double y2) const;
 

--- a/include/LithoRule/Rule.hpp
+++ b/include/LithoRule/Rule.hpp
@@ -140,6 +140,8 @@ private:
   mutable int    _flagProp;  /* 1 if proportions are defined; 0 otherwise */
   mutable double _rho;       /* Correlation between GRFs */
   Node*          _mainNode;
+
+  mutable VectorInt _facies;
 };
 
 GSTLEARN_EXPORT void   set_rule_mode(int rule_mode);

--- a/include/LithoRule/Rule.hpp
+++ b/include/LithoRule/Rule.hpp
@@ -103,7 +103,7 @@ public:
   bool isYUsed(int igrf) const;
   VectorInt whichGRFUsed() const;
   double getProportion(int facies);
-  VectorDouble getThresh(int facies) const;
+  std::array<double, 4> getThresh(int facies) const;
   VectorDouble getThreshFromRectangle(int rect, int *facies);
   int getFaciesFromGaussian(double y1, double y2) const;
 

--- a/include/Simulation/BooleanObject.hpp
+++ b/include/Simulation/BooleanObject.hpp
@@ -15,6 +15,8 @@
 
 #include "Basic/AStringable.hpp"
 
+#include <array>
+
 class AShape;
 class Db;
 class DbGrid;
@@ -84,9 +86,9 @@ private:
 private:
   int _mode;                // 1 for Primary; 2 for Secondary object
   const AShape* _token;     // Token to which the Object belongs
-  VectorDouble _center;     // Coordinates of the center of the object
-  VectorDouble _extension;  // Extension of the object
+  std::array<double, 3> _center;     // Coordinates of the center of the object
+  std::array<double, 3> _extension;  // Extension of the object
   double _orientation;      // Orientation angle for the object (degree)
-  VectorDouble _values;     // List of additional arguments
-  VectorVectorDouble _box;  // Bounding Box containing the object
+  std::array<double, 3> _values;     // List of additional arguments
+  std::array<std::array<double, 2>, 3> _box;  // Bounding Box containing the object
 };

--- a/include/Space/ASpace.hpp
+++ b/include/Space/ASpace.hpp
@@ -114,6 +114,10 @@ public:
   VectorDouble getIncrement(const SpacePoint& p1,
                             const SpacePoint& p2,
                             int ispace = -1) const;
+  void getIncrementInPlace(const SpacePoint& p1,
+                           const SpacePoint& p2,
+                           VectorDouble& ptemp,
+                           int ispace = -1) const;
 
   /// Project the coordinates in the given space
   virtual VectorDouble projCoord(const VectorDouble& coord,

--- a/include/Space/ASpace.hpp
+++ b/include/Space/ASpace.hpp
@@ -151,6 +151,7 @@ protected:
                                          int ispace = -1) const = 0;
 
   /// Return the increment vector between two space points
+  /// (prefer the in-place variant below in C++ code)
   virtual VectorDouble _getIncrement(const SpacePoint& p1,
                                      const SpacePoint& p2,
                                      int ispace = -1) const = 0;

--- a/include/Space/ASpaceObject.hpp
+++ b/include/Space/ASpaceObject.hpp
@@ -78,6 +78,10 @@ public:
   VectorDouble getIncrement(const SpacePoint& p1,
                             const SpacePoint& p2,
                             int ispace = 0) const;
+  void getIncrementInPlace(const SpacePoint& p1,
+                           const SpacePoint& p2,
+                           VectorDouble& ptemp,
+                           int ispace = -1) const;
 
 protected:
   /// Modify the Space dimension of an already created item (and create RN space)

--- a/include/Space/SpacePoint.hpp
+++ b/include/Space/SpacePoint.hpp
@@ -56,6 +56,7 @@ public:
   VectorDouble getDistances(const SpacePoint& pt) const;
   /// Return the increment vector between 'this' and another point
   VectorDouble getIncrement(const SpacePoint& pt, int ispace = -1) const;
+  void getIncrementInPlace(VectorDouble &inc, const SpacePoint& pt, int ispace = -1) const;
   /// Fill with TEST values to simulate a missing Space Point
   void setFFFF();
   /// Check if the SpacePoint is actually defined

--- a/include/Space/SpacePoint.hpp
+++ b/include/Space/SpacePoint.hpp
@@ -77,6 +77,7 @@ public:
 protected:
   /// Points coordinates (whatever the space context)
   VectorDouble _coord; // Coordinates (initial or projected)
+  mutable VectorDouble _delta; // Increment results
   mutable int _iech;   // Absolute rank of the sample within the Db
   mutable bool _isProjected; // True if the coordinates are projected
 };

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -359,7 +359,7 @@ double Grid::getCoordinate(int rank, int idim0, bool flag_rotate) const
  * @param dxsPerCell   Vector of variable grid meshes (optional)
  * @return
  */
-VectorDouble Grid::getCoordinatesByIndice(const VectorInt &indice,
+const VectorDouble& Grid::getCoordinatesByIndice(const VectorInt &indice,
                                           bool flag_rotate,
                                           const VectorInt& shift,
                                           const VectorDouble& dxsPerCell) const
@@ -393,7 +393,7 @@ VectorDouble Grid::getCoordinatesByIndice(const VectorInt &indice,
  * @param icorner Vector specifying the corner (0: minimum; 1: maximum). (Dimension: ndim)
  * @return The coordinates of a corner
  */
-VectorDouble Grid::getCoordinatesByCorner(const VectorInt& icorner) const
+const VectorDouble& Grid::getCoordinatesByCorner(const VectorInt& icorner) const
 {
   initThread();
   VH::fill(_iwork0, 0);
@@ -410,7 +410,7 @@ VectorDouble Grid::getCoordinatesByCorner(const VectorInt& icorner) const
  * @param dxsPerCell Vector of variable mesh extensions at target cell
  * @return The coordinates of a cell corner (possibly shifted)
  */
-VectorDouble Grid::getCellCoordinatesByCorner(int node,
+const VectorDouble& Grid::getCellCoordinatesByCorner(int node,
                                               const VectorInt& shift,
                                               const VectorDouble& dxsPerCell) const
 {
@@ -425,7 +425,7 @@ VectorDouble Grid::getCellCoordinatesByCorner(int node,
  * @param flag_rotate TRUE: perform the rotation; FALSE: skip rotation
  * @return Vector of coordinates
  */
-VectorDouble Grid::getCoordinatesByRank(int rank, bool flag_rotate) const
+const VectorDouble& Grid::getCoordinatesByRank(int rank, bool flag_rotate) const
 {
   /* Convert a sample number into grid indices */
   rankToIndice(rank, _iwork0);

--- a/src/Core/thresh.cpp
+++ b/src/Core/thresh.cpp
@@ -399,7 +399,7 @@ int rule_thresh_define_shadow(PropDef *propdef,
   /* Convert the proportions into thresholds */
 
   facloc = (IFFFF(facies)) ? 1 : facies;
-  VectorDouble bounds = rule->getThresh(facloc);
+  auto bounds = rule->getThresh(facloc);
   *t1min = bounds[0];
   *t1max = bounds[1];
   *t2min = bounds[2];
@@ -502,7 +502,7 @@ int rule_thresh_define(PropDef *propdef,
 
   facloc = (IFFFF(facies)) ? 1 :
                              facies;
-  VectorDouble bounds = rule->getThresh(facloc);
+  auto bounds = rule->getThresh(facloc);
   *t1min = bounds[0];
   *t1max = bounds[1];
   *t2min = bounds[2];

--- a/src/Core/variopgs.cpp
+++ b/src/Core/variopgs.cpp
@@ -2857,8 +2857,7 @@ static double st_calcul_stat(Local_Pgs *local_pgs,
 
       /* Get the bounds */
 
-      VectorDouble bounds;
-      bounds = local_pgs->rule->getThresh(ifac1 + 1);
+      auto bounds = local_pgs->rule->getThresh(ifac1 + 1);
       lower[0] = bounds[0];
       upper[0] = bounds[1];
       lower[2] = bounds[2];

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -654,10 +654,10 @@ void Db::setArrayByUID(const VectorDouble& tab, int iuid)
 
 void Db::getArrayBySample(std::vector<double>& vals, int iech) const
 {
-  getAllUIDs(uids);
-  vals.resize(uids.size());
-  for (int iuid = 0; iuid < (int)uids.size(); iuid++)
-    vals[iuid] = getArray(iech, uids[iuid]);
+  getAllUIDs(_uids);
+  vals.resize(_uids.size());
+  for (int iuid = 0; iuid < (int)_uids.size(); iuid++)
+    vals[iuid] = getArray(iech, _uids[iuid]);
 }
 
 void Db::setArrayBySample(int iech, const VectorDouble& vec)

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -854,15 +854,6 @@ void Db::getCoordinatesInPlace(VectorDouble& coor, int iech, bool flag_rotate) c
     coor[idim] = _array[_getAddress(iech, icol)];
   }
 }
-void Db::getCoordinatesInPlace(vect coor, int iech, bool flag_rotate) const
-{
-  DECLARE_UNUSED(flag_rotate);
-  for (int idim = 0, ndim = getNDim(); idim < ndim; idim++)
-  {
-    int icol   = getColIdxByLocator(ELoc::X, idim);
-    coor[idim] = _array[_getAddress(iech, icol)];
-  }
-}
 
 double Db::getDistance1D(int iech, int jech, int idim, bool flagAbs) const
 {

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -744,11 +744,14 @@ VectorVectorDouble Db::getIncrements(const VectorInt& iechs, const VectorInt& je
   tab.resize(ndim);
   for (int idim = 0; idim < ndim; idim++) tab[idim].resize(number);
 
+  VectorDouble vect;
   for (int ip = 0; ip < number; ip++)
   {
     getSampleAsSPInPlace(P1, iechs[ip]);
     getSampleAsSPInPlace(P2, jechs[ip]);
-    VectorDouble vect = P2.getIncrement(P1);
+    vect.clear();
+    vect.resize(ndim);
+    P2.getIncrementInPlace(vect, P1);
 
     for (int idim = 0; idim < ndim; idim++)
       tab[idim][ip] = vect[idim];

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -717,14 +717,8 @@ void DbGrid::initThread() const
 }
 void DbGrid::getCoordinatesInPlace(VectorDouble& coor, int iech, bool flag_rotate) const
 {
-  VectorDouble vec = _grid.getCoordinatesByRank(iech, flag_rotate);
-  vec.resize(getNDim());
-  coor             = vec;
-}
-void DbGrid::getCoordinatesInPlace(vect coor, int iech, bool flag_rotate) const
-{
-  VectorDouble vec = _grid.getCoordinatesByRank(iech, flag_rotate);
-  coor             = vec;
+  const VectorDouble &vec = _grid.getCoordinatesByRank(iech, flag_rotate);
+  std::copy(vec.begin(), vec.begin() + getNDim(), coor.begin());
 }
 
 int DbGrid::getNDim() const

--- a/src/Geometry/BiTargetCheckGeometry.cpp
+++ b/src/Geometry/BiTargetCheckGeometry.cpp
@@ -100,7 +100,8 @@ bool BiTargetCheckGeometry::isOK(const SpaceTarget &T1, const SpaceTarget &T2) c
   if (_dist <= 0.) return true;
 
   // Increment between two samples
-  _delta = T1.getIncrement(T2);
+  _delta.resize(T1.getNDim());
+  T1.getIncrementInPlace(_delta, T2);
 
   // Check if the angle of the pair matches the Calculation direction (up to angular tolerance)
   double dproj = 0.;

--- a/src/LithoRule/Rule.cpp
+++ b/src/LithoRule/Rule.cpp
@@ -621,16 +621,19 @@ int Rule::setProportions(const VectorDouble& proportions) const
 
   // Set the proportions when the input argument is left empty
 
-  VectorDouble props = proportions;
-  if (props.empty())
+  _props.resize(proportions.size());
+  if (_props.empty())
   {
     int nfacies = getNFacies();
-    props = VectorDouble(nfacies, 1. / (double) nfacies);
+    _props.clear();
+    _props.resize(nfacies, 1. / (double) nfacies);
+  } else {
+    std::copy(proportions.begin(), proportions.end(), _props.begin());
   }
 
   /* Set the proportions */
 
-  if (_mainNode->proportionDefine(props)) return 1;
+  if (_mainNode->proportionDefine(_props)) return 1;
   _flagProp = 1;
 
   /* Calculate the cumulative proportions */

--- a/src/LithoRule/Rule.cpp
+++ b/src/LithoRule/Rule.cpp
@@ -552,19 +552,20 @@ double Rule::getProportion(int facies)
  * @param facies Rank of the target facies (starting from 1)
  * @return The vector of bounds organized as [t1min, t1max, t2min, t2max]
  */
-VectorDouble Rule::getThresh(int facies) const
+std::array<double, 4> Rule::getThresh(int facies) const
 {
   int fac_ret;
   int rank = 0;
   double t1min, t1max, t2min, t2max;
 
   if (!_mainNode->getThresh(1, facies, &rank, &fac_ret, &t1min, &t1max, &t2min,
-                            &t2max)) return VectorDouble();
-  VectorDouble bounds(4);
-  bounds[0] = t1min;
-  bounds[1] = t1max;
-  bounds[2] = t2min;
-  bounds[3] = t2max;
+                            &t2max)) return {};
+  std::array<double, 4> bounds{
+    t1min,
+    t1max,
+    t2min,
+    t2max,
+  };
   return bounds;
 }
 

--- a/src/LithoRule/Rule.cpp
+++ b/src/LithoRule/Rule.cpp
@@ -417,18 +417,18 @@ int Rule::statistics(int  verbose,
   /* Check that the facies are defined */
 
   nfac = (*nfac_tot);
-  VectorInt facies = VectorInt(nfac);
-  for (ifac=0; ifac<nfac; ifac++) facies[ifac] = 0;
-  if (_mainNode->isValid(facies)) return 1;
+  _facies.clear();
+  _facies.resize(nfac);
+  if (_mainNode->isValid(_facies)) return 1;
 
   /* Check that the first consecutive facies are defined */
 
   ntot = 0;
   for (ifac=0; ifac<nfac; ifac++)
-    if (facies[ifac] > 0) ntot = ifac + 1;
+    if (_facies[ifac] > 0) ntot = ifac + 1;
   for (ifac=0; ifac<nfac; ifac++)
   {
-    if (facies[ifac] <= 0)
+    if (_facies[ifac] <= 0)
     {
       messerr("The facies (%d) is not defined",ifac+1);
       return(1);

--- a/src/Neigh/NeighMoving.cpp
+++ b/src/Neigh/NeighMoving.cpp
@@ -602,7 +602,7 @@ int NeighMoving::_moving(int iech_out, VectorInt& ranks, double eps)
 
     if (getFlagSector())
     {
-      VectorDouble incr = _biPtDist->getIncr();
+      const VectorDouble& incr = _biPtDist->getIncr();
       isect             = _movingSectorDefine(incr[0], incr[1]);
     }
 

--- a/src/Simulation/BooleanObject.cpp
+++ b/src/Simulation/BooleanObject.cpp
@@ -27,7 +27,7 @@ BooleanObject::BooleanObject(const AShape* ashape)
       _extension({0.,0.,0.,}),
       _orientation(0.),
       _values({0.,0.,0.}),
-      _box({{0.,0.},{0.,0.},{0.,0.}})
+      _box()
 {
 }
 
@@ -72,8 +72,8 @@ String BooleanObject::toString(const AStringFormat* /*strfmt*/) const
   else
     sstr << "Secondary Object" << std::endl;
   sstr << "- Type        = " << _token->getType().getDescr() << std::endl;
-  sstr << "- Center      = " << VH::toStringAsVD(_center);
-  sstr << "- Extension   = " << VH::toStringAsVD(_extension);
+  sstr << "- Center      = " << VH::toStringAsSpan(_center);
+  sstr << "- Extension   = " << VH::toStringAsSpan(_extension);
   sstr << "- Orientation = " << _orientation << std::endl;
 
   return sstr.str();
@@ -81,7 +81,6 @@ String BooleanObject::toString(const AStringFormat* /*strfmt*/) const
 
 void BooleanObject::setCenter(const VectorDouble& center)
 {
-  _center.resize(3,0.);
   for (int idim = 0; idim < (int) center.size(); idim++)
     _center[idim] = center[idim];
 }
@@ -91,8 +90,8 @@ VectorDouble BooleanObject::getValues() const
   VectorDouble tab;
   tab.push_back((double) _mode);
   tab.push_back((double) _token->getType().getValue());
-  tab.insert(tab.end(), _center.begin(), _center.end());
-  tab.insert(tab.end(), _extension.begin(), _extension.end());
+  for (const auto c : _center) tab.push_back(c);
+  for (const auto e : _extension) tab.push_back(e);
   tab.push_back(_orientation);
   return tab;
 }

--- a/src/Space/ASpace.cpp
+++ b/src/Space/ASpace.cpp
@@ -240,6 +240,21 @@ VectorDouble ASpace::getIncrement(const SpacePoint& p1,
   return _getIncrement(p1, p2, ispace);
 }
 
+void ASpace::getIncrementInPlace(const SpacePoint& p1,
+                                 const SpacePoint& p2,
+                                 VectorDouble& ptemp,
+                                 int ispace) const
+{
+  if (p1.getNDim() != p2.getNDim())
+  /// TODO : test tensor size
+  {
+    std::cout << "Error: Inconsistent point dimensions. Return empty vector."
+              << std::endl;
+    ptemp.clear();
+  }
+  _getIncrementInPlace(p1, p2, ptemp, ispace);
+}
+
 VectorDouble ASpace::projCoord(const VectorDouble& coord, int ispace) const
 {
   if (ispace < 0 || ispace >= (int)getNComponents()) return coord;

--- a/src/Space/ASpaceObject.cpp
+++ b/src/Space/ASpaceObject.cpp
@@ -97,6 +97,14 @@ VectorDouble ASpaceObject::getIncrement(const SpacePoint& p1,
   return (_space->getIncrement(p1, p2, ispace));
 }
 
+void ASpaceObject::getIncrementInPlace(const SpacePoint& p1,
+                                       const SpacePoint& p2,
+                                       VectorDouble& ptemp,
+                                       int ispace) const
+{
+  _space->getIncrementInPlace(p1, p2, ptemp, ispace);
+}
+
 /**
  * Modify the Space dimension of an already created item
  * (To be used only during creation ... in particular when reading NF)

--- a/src/Space/SpaceComposite.cpp
+++ b/src/Space/SpaceComposite.cpp
@@ -239,16 +239,20 @@ void SpaceComposite::_getIncrementInPlace(const SpacePoint& p1,
                                           int ispace) const
 {
   ptemp.clear();
+  VectorDouble inc;
   if (ispace < 0 || ispace >= (int)getNComponents())
   {
     for (const auto& sp: _comps)
     {
-      VectorDouble inc = sp->getIncrement(p1, p2);
+      inc.clear();
+      inc.resize(sp->getNDim());
+      sp->getIncrementInPlace(p1, p2, inc);
       ptemp.insert(ptemp.begin(), inc.begin(), inc.end());
     }
   }
   else
   {
-    ptemp = _comps[ispace]->getIncrement(p1, p2);
+    ptemp.resize(_comps[ispace]->getNDim());
+    _comps[ispace]->getIncrementInPlace(p1, p2, ptemp);
   }
 }

--- a/src/Space/SpacePoint.cpp
+++ b/src/Space/SpacePoint.cpp
@@ -144,6 +144,11 @@ VectorDouble SpacePoint::getIncrement(const SpacePoint& pt, int ispace) const
   return ASpaceObject::getIncrement(*this, pt, ispace);
 }
 
+void SpacePoint::getIncrementInPlace(VectorDouble& inc, const SpacePoint& pt, int ispace) const
+{
+  ASpaceObject::getIncrementInPlace(*this, pt, inc, ispace);
+}
+
 String SpacePoint::toString(const AStringFormat* /*strfmt*/) const
 {
   return VH::toStringAsSpan(constvect(_coord.data(),getNDim()));

--- a/src/Space/SpacePoint.cpp
+++ b/src/Space/SpacePoint.cpp
@@ -172,11 +172,13 @@ double SpacePoint::getCosineToDirection(const SpacePoint &T2,
   double cosdir = 0.;
   double dn1 = 0.;
   double dn2 = 0.;
-  VectorDouble delta = getIncrement(T2);
+  _delta.clear();
+  _delta.resize(getNDim());
+  getIncrementInPlace(_delta, T2);
   for (int idim = 0; idim < (int)getNDim(); idim++)
   {
-    cosdir += delta[idim] * codir[idim];
-    dn1 += delta[idim] * delta[idim];
+    cosdir += _delta[idim] * codir[idim];
+    dn1 += _delta[idim] * _delta[idim];
     dn2 += codir[idim] * codir[idim];
   }
   double prod = dn1 * dn2;
@@ -191,12 +193,14 @@ double SpacePoint::getOrthogonalDistance(const SpacePoint &P2,
   double dn2 = 0.;
   double v = 0.;
   double dproj = 0.;
-  VectorDouble delta = getIncrement(P2);
+  _delta.clear();
+  _delta.resize(getNDim());
+  getIncrementInPlace(_delta, P2);
   for (int idim = 0; idim < (int)getNDim(); idim++)
   {
-    dproj += delta[idim] * codir[idim];
+    dproj += _delta[idim] * codir[idim];
     dn1 += codir[idim] * codir[idim];
-    dn2 += delta[idim] * delta[idim];
+    dn2 += _delta[idim] * _delta[idim];
   }
   if (dn1 > 0.) v = sqrt(dn2 - dproj * dproj / dn1);
   return (v);

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -1060,6 +1060,15 @@
   }
 };
 
+%extend Rule {
+  // Don't return std::array to wrapping languages
+  VectorDouble getThresh(int facies) const
+  {
+    const auto thresh = $self->getThresh(facies);
+    return VectorDouble{thresh.begin(), thresh.end()};
+  }
+};
+
 
 // Prevent memory leaks from 'create*' and 'clone' methods
 


### PR DESCRIPTION
As a follow-up to #531, this PR factors more allocations in several gstlearn benchmarks.

Several transformations were used: adding and calling in-place methods, replacing fixed-size heap allocations with stack-allocated `std::array`, moving local variables to class members, returning `const` references instead of copies.

Here are some results extracted with `time` and `heaptrack`:

- `bench_Vario`

|                   | before     | after |
|-------------------|------------|-------|
| Exec time (s)     | 4.5        | 2.9   |
| #Allocations      | 11 527 300 | 8 300 |
| #Temp allocations | 11 520 527 | 1 532 |
| Memory cons (MB)  | 18,5       | 18,5  |

- `bench_VGrid`

|                   | before    | after |
|-------------------|-----------|-------|
| Exec time (s)     | 0.6       | 0.4   |
| #Allocations      | 2 387 601 | 5 601 |
| #Temp allocations | 2 382 099 | 99    |
| Memory cons (MB)  | 19,7      | 19,7  |

- `bench_KrigingM`

|                   | before     | after     |
|-------------------|------------|-----------|
| Exec time (s)     | 3.6        | 3.5       |
| #Allocations      | 19 111 913 | 5 348 267 |
| #Temp allocations | 8 546 346  | 277 931   |
| Memory cons (MB)  | 105,4      | 105,4     |

Enjoy,
Pierre
