### PR TITLE
Hotfix for v1.7.2: Fix memleak in Python Swig wrapper

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,10 @@ This file contains the logs between consecutive releases
 ********************************************************
 # Make last version consistent with CMakeLists.txt
 
+Release 1.7.2
+=============
+- Fix memory leak in Python Swig wrapper
+
 Release 1.7.1
 =============
 - Fix HDF5 serialization missing in Python, R wrappers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Define project here
 project(gstlearn
-        VERSION      1.7.1 # Make it consistent with CHANGES
+        VERSION      1.7.2 # Make it consistent with CHANGES
         DESCRIPTION  "Geostatistics & Machine Learning toolbox"
         HOMEPAGE_URL "https://gstlearn.org"
         LANGUAGES    C CXX) # Enable C language for third party libraries

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -75,6 +75,7 @@
         PyObject* item = PySequence_GetItem(obj, i);
         if (!PyNumber_Check(item))
           return SWIG_TypeError;
+        Py_DECREF(item);
       }
       return SWIG_OK;
     }
@@ -90,6 +91,7 @@
         PyObject* item = PySequence_GetItem(obj, i);
         if (!PyUnicode_Check(item))
           return SWIG_TypeError;
+        Py_DECREF(item);
       }
       return SWIG_OK;
     }
@@ -231,6 +233,7 @@
         myres = convertToCpp(item, value);
         if (SWIG_IsOK(myres))
           vec.push_back(value);
+        Py_DECREF(item);
       }
     }
     // else size is zero (empty vector)
@@ -271,6 +274,7 @@
         myres = vectorToCpp(item, vec);
         if (SWIG_IsOK(myres))
           vvec.push_back(vec);
+        Py_DECREF(item);
       }
     }
     // else size is zero (empty vector)
@@ -307,6 +311,7 @@
         myres = vectorToCpp(item, vec);
         if (SWIG_IsOK(myres))
           vvec.push_back(vec);
+        Py_DECREF(item);
       }
     }
     // Convert VVD to Matrix


### PR DESCRIPTION
Cherry-pick from #527 into v1.7.