### PR TITLE
Fix check_test_r and check_test_py for ipynb and Rmd tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,10 +241,10 @@ check_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 check_test_py: cmake-python
-	@cd $(BUILD_DIR); make prepare_check_py; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 check_test_r: cmake-r
-	@cd $(BUILD_DIR); make prepare_check_r; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy

--- a/tests/ipynb/CMakeLists.txt
+++ b/tests/ipynb/CMakeLists.txt
@@ -38,14 +38,20 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 
+# Create the output directory for logs
+add_custom_target(prepare_check_ipynb
+                  COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}")
+
+# Add dependency for prepare_check_ipynb
+add_dependencies(prepare_check_ipynb python_install)
+
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_ipynb
-                  COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
                   COMMAND ${MY_CTEST_COMMAND})
 
 # Add dependency for check_ipynb
-add_dependencies(check_ipynb python_install)
+add_dependencies(check_ipynb prepare_check_ipynb)
 
 # Jupyter notebook script test runner path
 cmake_path(APPEND CMAKE_SOURCE_DIR python run_test_ipynb.py

--- a/tests/r/CMakeLists.txt
+++ b/tests/r/CMakeLists.txt
@@ -26,7 +26,6 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 
-
 # Create the output directory for logs
 add_custom_target(prepare_check_r
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}")

--- a/tests/rmd/CMakeLists.txt
+++ b/tests/rmd/CMakeLists.txt
@@ -32,14 +32,20 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 
+# Create the output directory for logs
+add_custom_target(prepare_check_rmd
+                  COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}")
+
+# Add dependency for prepare_check_rmd
+add_dependencies(prepare_check_rmd r_install)
+
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_rmd
-                  COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
                   COMMAND ${MY_CTEST_COMMAND})
 
 # Add dependency for check_rmd
-add_dependencies(check_rmd r_install)
+add_dependencies(check_rmd prepare_check_rmd)
 
 # Rmd script test runner path
 cmake_path(APPEND CMAKE_SOURCE_DIR r run_test_rmd.R


### PR DESCRIPTION
Improve the special targets (Makefile users only) check_test_r and check_test_py that permit to execute only one non-regression test. Output folders for storing logs were not created for ipynb and Rmd tests.