### PR TITLE
Prevent from calling std::map::contains (only c++20)

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -138,6 +138,9 @@ target_link_libraries(python_build
 # Link to NumPy
 target_link_libraries(python_build PUBLIC Python3::NumPy)
 
+# TODO: to prevent Warning 473, I tried -DSWIG_DIRECTOR_NORTTI below, but it didn't work
+# Source: https://stackoverflow.com/questions/55139832/swig-binding-a-method-returning-a-reference-to-a-pointer-of-a-director-class
+
 # Transmit the fact that we are linking to static ${PROJECT_NAME} library
 set(COMP_FLAGS "-D${PROJECT_NAME_UP}_STATIC_DEFINE")
 if (MSVC)

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -223,7 +223,10 @@ void PrecisionOp::setPolynomialFromPoly(APolynomial* polynomial)
 
 int PrecisionOp::_prepareChebychev(const EPowerPT& power) const
 {
-  if (_cova == nullptr && _polynomials.contains(EPowerPT::ONE)) return 1;
+  // Polynomial already exists. Nothing to be done
+  if (_cova == nullptr && _polynomials.find(EPowerPT::ONE) != _polynomials.end()) return 1;
+  // Equivalent instruction (but only for C++ 20)
+  //if (_cova == nullptr && _polynomials.contains(EPowerPT::ONE)) return 1;
   if (_shiftOp == nullptr) return 1;
 
   double b = _shiftOp->getMaxEigenValue();


### PR DESCRIPTION
The method std::map::contains is C++20 only.
This method should not be used while we build gstlearn packages using C++17.