### PR TITLE
Use uv to manage Python venv in tests

### DIFF
--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -44,23 +44,24 @@ jobs:
           libpng-dev \
           pandoc
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy
-        python -m pip install jupyter
-        python -m pip install notebook==6.1.6
-        python -m pip install matplotlib
-        python -m pip install plotly
-        python -m pip install pandas
-        python -m pip install scipy
-        python -m pip install dash
-        python -m pip install scikit-sparse
+        uv pip install --upgrade pip
+        uv pip install numpy
+        uv pip install jupyter
+        uv pip install notebook==6.1.6
+        uv pip install matplotlib
+        uv pip install plotly
+        uv pip install pandas
+        uv pip install scipy
+        uv pip install dash
+        uv pip install scikit-sparse
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -43,16 +43,16 @@ jobs:
         brew install hdf5
         echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
 
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy
-        python -m pip install pandas scipy mlxtend
+        uv pip install numpy
+        uv pip install pandas scipy mlxtend
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -44,16 +44,16 @@ jobs:
           libeigen3-dev \
           libnlopt-dev
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
 
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy
-        python -m pip install pandas scipy mlxtend
+        uv pip install numpy
+        uv pip install pandas scipy mlxtend
 
     - name: Setup R Version
       uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -24,6 +24,7 @@ env:
   CMAKE_GENERATOR : Ninja
   PYTHON_VERSION : "3.13"
   GSTLEARN_OUTPUT_DIR: ${{ github.workspace }}\build\gstlearn_dir
+  CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
 
@@ -33,17 +34,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup pixi
-      uses: prefix-dev/setup-pixi@v0.8.2
-      with:
-        run-install: false
-
     - name: Install dependencies
       run: |
-        pixi init
-        pixi add python==${{env.PYTHON_VERSION}}
-        pixi add pip numpy pandas scipy mlxtend
-        pixi add libboost-devel eigen ninja hdf5 nlopt
+        echo '{
+          "dependencies": [ "boost-math", "eigen3" ],
+          "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+        }' > vcpkg.json
+        vcpkg install
+
+    - name: Build & install nlopt static libraries
+      uses: ./.github/actions/nlopt_static_windows
+      env:
+        CMAKE_GENERATOR: "Visual Studio 17 2022"
+
+    - name: Build & install HDF5 static libraries
+      uses: ./.github/actions/hdf5_static_windows
+      env:
+        CMAKE_GENERATOR: "Visual Studio 17 2022"
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
+
+    - name: Install python dependencies
+      run: |
+        uv pip install numpy
+        uv pip install pandas scipy mlxtend
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
@@ -53,8 +71,9 @@ jobs:
 
     - name: Configure build directory
       run: |
-        pixi run cmake `
+        cmake `
           -B${{ env.BUILD_DIR }} `
+          -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DBUILD_TESTING=ON `
           -DBUILD_PYTHON=ON
       env:
@@ -68,7 +87,7 @@ jobs:
 
     - name: Install packages and execute non-regression tests
       run: |
-        pixi run cmake --build ${{env.BUILD_DIR}} --target check
+        cmake --build ${{env.BUILD_DIR}} --target check
 
     - name: Compress output logs and neutral files
       if: success() || failure()

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy twine build
+        python -m pip install numpy twine build uv
 
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install numpy
+        python -m pip install numpy uv
 
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -25,14 +25,14 @@ on:
 env:
   BUILD_TYPE : Release
   BUILD_DIR : build
-  CMAKE_GENERATOR : "Visual Studio 16 2019"
+  CMAKE_GENERATOR : "Visual Studio 17 2022"
   DOXYGEN_ROOT : ${{github.workspace}}\doxygen
   DOXYGEN_VERSION : "1.9.8"
   CMAKE_TOOLCHAIN_FILE : C:\vcpkg\scripts\buildsystems\vcpkg.cmake
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         # Python version
@@ -125,7 +125,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         python: [

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -75,6 +75,7 @@ jobs:
         python -m pip install numpy
         python -m pip install build
         python -m pip install twine
+        python -m pip install uv
 
     - name: Install Doxygen under windows
       uses: fabien-ors/install-doxygen-windows-action@v1

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -247,8 +247,10 @@ endforeach()
 option(NO_INTERNET "Do not try to connect to Internet" OFF)
 message(STATUS "NO_INTERNET=" ${NO_INTERNET})
 
+find_program(UV NAMES uv REQUIRED DOC "Python package and project manager")
+
 if (NO_INTERNET)
-  set(NO_INTERNET_ARG "--no-build-isolation")
+  set(NO_INTERNET_ARG "--offline")
 else()
   set(NO_INTERNET_ARG "")
 endif()
@@ -256,10 +258,19 @@ endif()
 # Add a custom target for python package installation
 # TODO: Do also installation each time setup.py.in or README.md is modified
 add_custom_target(python_install
-  COMMAND ${Python3_EXECUTABLE} -m pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot,conv,doc]"
+  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "${PYTHON_PACKAGE_ROOT_FOLDER}[plot,conv,doc]"
   COMMENT "Installing python package"
   )
  
 # Tell to CMake that python package must be built before installation [python_doc is optional]
 
 add_dependencies(python_install python_build)
+
+if(NOT DEFINED ENV{VIRTUAL_ENV})
+  add_custom_target(python_create_venv
+    COMMAND ${UV} venv
+    COMMENT "Creating a new venv with uv"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+  add_dependencies(python_install python_create_venv)
+endif()

--- a/python/run_test_py.py
+++ b/python/run_test_py.py
@@ -3,7 +3,6 @@ import sys
 import os
 
 # This script retrieve the standard output of a python test script (argv[1]) and print it into a log file saved in the given directory (argv[2])
-python_exe = os.path.realpath(sys.executable)
 test_script = sys.argv[1]
 out_dir = sys.argv[2]
 test_name = os.path.splitext(os.path.basename(test_script))[0] # No extension
@@ -11,7 +10,7 @@ test_output = os.path.join(out_dir, test_name + ".out")
 
 # Retrieve all standard outputs (C, python, etc..) and print to log file
 # Use unbuffered (-u) output for "printing" on the fly
-str_output = subprocess.check_output([python_exe, "-u", test_script], encoding='utf-8')
+str_output = subprocess.check_output(["uv", "run", "python", "-u", test_script], encoding='utf-8')
 with open(test_output, "w+", encoding='utf8') as output:
   output.write(str_output)
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -134,4 +134,5 @@ endforeach(TARGET_EXE ${TARGETS_EXE})
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_cpp
   COMMAND ${MY_CTEST_COMMAND} DEPENDS ${TARGETS_EXE}
+  JOB_POOL console
 )

--- a/tests/ipynb/CMakeLists.txt
+++ b/tests/ipynb/CMakeLists.txt
@@ -48,7 +48,9 @@ add_dependencies(prepare_check_ipynb python_install)
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_ipynb
-                  COMMAND ${MY_CTEST_COMMAND})
+  COMMAND ${MY_CTEST_COMMAND}
+  JOB_POOL console
+)
 
 # Add dependency for check_ipynb
 add_dependencies(check_ipynb prepare_check_ipynb)

--- a/tests/py/CMakeLists.txt
+++ b/tests/py/CMakeLists.txt
@@ -34,7 +34,9 @@ add_dependencies(prepare_check_py python_install)
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_py
-                  COMMAND ${MY_CTEST_COMMAND})
+  COMMAND ${MY_CTEST_COMMAND}
+  JOB_POOL console
+)
 
 # Add dependency for check_py
 add_dependencies(check_py prepare_check_py)

--- a/tests/r/CMakeLists.txt
+++ b/tests/r/CMakeLists.txt
@@ -36,7 +36,9 @@ add_dependencies(prepare_check_r r_install)
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_r
-                  COMMAND ${MY_CTEST_COMMAND})
+  COMMAND ${MY_CTEST_COMMAND}
+  JOB_POOL console
+)
 
 # Add dependency for check_r
 add_dependencies(check_r prepare_check_r)

--- a/tests/rmd/CMakeLists.txt
+++ b/tests/rmd/CMakeLists.txt
@@ -42,7 +42,9 @@ add_dependencies(prepare_check_rmd r_install)
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_rmd
-                  COMMAND ${MY_CTEST_COMMAND})
+  COMMAND ${MY_CTEST_COMMAND}
+  JOB_POOL console
+)
 
 # Add dependency for check_rmd
 add_dependencies(check_rmd prepare_check_rmd)


### PR DESCRIPTION
This PR replaces the use of `pip` in the `python_install` and `check_py` CMake targets with `uv` (https://docs.astral.sh/uv/). `uv` will create a venv on the fly if none is detected (environment variable `VIRTUAL_ENV`) and the gstlearn wheel will be installed in it. 

Nonreg workflows have been updated to use `uv` instead of `pip`. Due to the use of `find_program` in CMake, publish workflows also need `uv` to be present (although not called).

Due to incompatibilities between pixi environments and `uv` venvs, the nonreg Python windows workflows switches back to using vcpkg to build static libraries of NLOpt and HDF5, similarly to the corresponding publish workflow.

In addition, due to the deprecation of the `windows-2019` runner image (https://github.com/actions/runner-images/issues/12045), the `publish_python_windows` workflow has been updated to `windows-2022`.

Also, the `JOB_POOL console` instruction has been added to CMake `custom_targets` to make Ninja's output unbuffered.

Fixes #532.

Enjoy,
Pierre