### PR TITLE
Don't call ASerializable::buildFileName in csv_table_read

### DIFF
--- a/src/Core/convert.cpp
+++ b/src/Core/convert.cpp
@@ -532,10 +532,9 @@ int csv_table_read(const String &filename,
   String na_string = csvfmt.getNaString();
 
   String line;
-  String filepath = ASerializable::buildFileName(1, filename, true);
   // Open new stream
   std::ifstream file;
-  file.open(filepath, std::ios::in);
+  file.open(filename, std::ios::in);
 
 //  std::ifstream file(filename.c_str());
   if (!file.is_open())


### PR DESCRIPTION
Avoid calling `ASerializable::buildFileName` in `csv_table_read()`. No need to handle containers and prefixes when loading a CSV file.

Fix #567.

Pierre