### PR TITLE
Cosmetics for coverage, README and gitignore

### DIFF
--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -20,7 +20,7 @@ jobs:
         # Double quote for version is needed otherwise 3.10 => 3.1
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2019, windows-2022, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
         exclude:
           - os: macos-14
             python: "3.9"

--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -20,7 +20,7 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.0]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2019, windows-2022, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
         exclude:
           - os: ubuntu-22.04
             r_version: 4.2.3  # ggpubr install fails

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build*
 python/doc/documentation.i
 tests/data/*/*.out
 __pycache__
+.venv
 .ipynb_checkpoints
 ./*.ascii
 .project

--- a/doc/dev/sandbox/test_Graphics.py
+++ b/doc/dev/sandbox/test_Graphics.py
@@ -40,7 +40,7 @@ if draw_grid:
 	ecr = 1
 	for i in range(2):
 		for j in range(2):
-			ax = gp.grid(grid,"Simu."+str(ecr),ax=axs[j,i],flagLegend=False)
+			ax = gp.raster(grid,"Simu."+str(ecr),ax=axs[j,i],flagLegend=False)
 			ecr = ecr + 1
 #	cbar = fig.colorbar(im,ax=axs[0:,:],location='right',shrink=0.5)
 	plt.show()

--- a/python/README.md
+++ b/python/README.md
@@ -73,8 +73,8 @@ mygrid = gl.DbGrid.create([nx,ny],[1,1])
 var = np.random.randn(nx * ny)
 mygrid.addColumns(var, "var1", gl.ELoc.Z)
 # Display the field
-ax = gp.grid(mygrid)
-ax.decoration(title="Gaussian random field")
+gp.raster(mygrid)
+gp.decoration(title="Gaussian random field")
 plt.show()
 ```
 


### PR DESCRIPTION
- Add .venv folder to gitignore
- Replace git runner Windows 2019 by Windows 2025 in coverage workflows
- Replace gp.grid by gp.raster in README and sandbox