### PR TITLE
Fix publish due to reference_wrapper for R under windows 2022

### DIFF
--- a/include/Basic/ListParams.hpp
+++ b/include/Basic/ListParams.hpp
@@ -7,6 +7,7 @@
 #include "Basic/AStringFormat.hpp"
 #include "Basic/ParamInfo.hpp"
 #include <vector>
+#include <functional>
 
 class GSTLEARN_EXPORT ListParams: public AStringable
 {


### PR DESCRIPTION
The include file <functional> in ListParams.hpp is mandatory for the platform.