### PR TITLE
CMake improvements for tests procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,10 +249,10 @@ check_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); CTEST_OUTPUT_ON_FAILURE=1 ctest -R '^$(TEST)$$'
 
 check_test_py: cmake-python
-	@cd $(BUILD_DIR); make python_install; make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest '^$(TEST)$$'
+	@cd $(BUILD_DIR); make python_install; make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest -R '^$(TEST)$$'
 
 check_test_r: cmake-r
-	@cd $(BUILD_DIR); make r_install; make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest '^$(TEST)$$'
+	@cd $(BUILD_DIR); make r_install; make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest -R '^$(TEST)$$'
 
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy

--- a/Makefile
+++ b/Makefile
@@ -246,13 +246,13 @@ check_rmd: cmake-r
 	@CTEST_OUTPUT_ON_FAILURE=1 cmake --build $(BUILD_DIR) --target check_rmd -- $(N_PROC_OPT)
 
 check_test_cpp: cmake
-	@cd $(BUILD_DIR); make $(TEST); CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make $(TEST); CTEST_OUTPUT_ON_FAILURE=1 ctest -R '^$(TEST)$$'
 
 check_test_py: cmake-python
-	@cd $(BUILD_DIR); make python_install; make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make python_install; make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest '^$(TEST)$$'
 
 check_test_r: cmake-r
-	@cd $(BUILD_DIR); make r_install; make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make r_install; make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest '^$(TEST)$$'
 
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@
 #  - USE_HDF5=0         To remove HDF5 support (default =1)
 #  - NO_INTERNET=1      To prevent python pip from looking for dependencies through Internet
 #                       (useful when there is no Internet available) (default =0)
+#  - NO_BYTE_COMPILE=1  To prevent R from byte-compiling the R package during the installation
+#                       (useful to accelerate installation process) (default =0) 
 #  - EIGEN3_ROOT=<path> Path to Eigen3 library (optional)
 #  - BOOST_ROOT=<path>  Path to Boost library (optional)
 #  - NLOPT_ROOT=<path>  Path to NLopt library (optional)
@@ -84,6 +86,12 @@ ifeq ($(NO_INTERNET), 1)
   NO_INTERNET = ON
  else
   NO_INTERNET = OFF 
+endif
+
+ifeq ($(NO_BYTE_COMPILE), 1)
+  NO_BYTE_COMPILE = ON
+ else
+  NO_BYTE_COMPILE = OFF
 endif
 
 ifeq ($(USE_HDF5), 0)
@@ -166,10 +174,10 @@ cmake-python:
 	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_PYTHON=ON -DNO_INTERNET=$(NO_INTERNET)
 
 cmake-r:
-	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_R=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_R=ON -DNO_BYTE_COMPILE=$(NO_BYTE_COMPILE)
 
 cmake-python-r:
-	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_PYTHON=ON -DBUILD_R=ON -DNO_INTERNET=$(NO_INTERNET)
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=$(BUILD_DOC) -DBUILD_PYTHON=ON -DBUILD_R=ON -DNO_INTERNET=$(NO_INTERNET) -DNO_BYTE_COMPILE=$(NO_BYTE_COMPILE)
 
 cmake-doxygen:
 	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON
@@ -178,10 +186,10 @@ cmake-python-doxygen:
 	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON -DNO_INTERNET=$(NO_INTERNET)
 
 cmake-r-doxygen:
-	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_R=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_R=ON -DNO_BYTE_COMPILE=$(NO_BYTE_COMPILE)
 
 cmake-python-r-doxygen:
-	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON -DBUILD_R=ON
+	@cmake -B$(BUILD_DIR) -S. $(GENERATOR) $(CMAKE_DEFINES) -DBUILD_DOC=ON -DBUILD_PYTHON=ON -DBUILD_R=ON -DNO_INTERNET=$(NO_INTERNET) -DNO_BYTE_COMPILE=$(NO_BYTE_COMPILE)
 
 print_version: cmake
 	@cmake --build $(BUILD_DIR) --target print_version --

--- a/Makefile
+++ b/Makefile
@@ -249,10 +249,10 @@ check_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 check_test_py: cmake-python
-	@cd $(BUILD_DIR); make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make python_install; make prepare_check_py; make prepare_check_ipynb; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 check_test_r: cmake-r
-	@cd $(BUILD_DIR); make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
+	@cd $(BUILD_DIR); make r_install; make prepare_check_r; make prepare_check_rmd; CTEST_OUTPUT_ON_FAILURE=1 ctest -R $(TEST)
 
 dump_test_cpp: cmake
 	@cd $(BUILD_DIR); make $(TEST); "tests/cpp/$(BUILD_TYPE)/$(TEST)" dummy

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -256,13 +256,22 @@ else()
     set(DST_ARCHIVE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}.tar.gz")
   endif()
 endif()
+set(R_FLAGS "")
+
+# By default, byte-compile the R package
+option(NO_BYTE_COMPILE "Do not byte-compile the R package" OFF)
+message(STATUS "NO_BYTE_COMPILE=" ${NO_BYTE_COMPILE})
+
+if (NO_BYTE_COMPILE)
+  set(R_FLAGS ${R_FLAGS} --no-byte-compile)
+endif()
+
 add_custom_target(r_install
   # Empty Makevars (compilation already done by r_build target) - only 64 bits (no multi arch)
   COMMAND ${CMAKE_COMMAND} -E touch ${R_PACKAGE_SRC_FOLDER}/Makevars
   COMMAND ${CMAKE_COMMAND} -E touch ${R_PACKAGE_SRC_FOLDER}/Makevars.win
   COMMAND ${CMAKE_COMMAND} -E touch ${R_PACKAGE_SRC_FOLDER}/Makevars.ucrt
-  COMMAND ${R_EXECUTABLE} CMD INSTALL --build --no-multiarch ${R_PACKAGE_DESTINATION_FOLDER}
-#  COMMAND ${R_EXECUTABLE} CMD INSTALL --no-multiarch --no-byte-compile ${R_PACKAGE_DESTINATION_FOLDER}
+  COMMAND ${R_EXECUTABLE} CMD INSTALL --build --no-multiarch ${R_FLAGS} ${R_PACKAGE_DESTINATION_FOLDER}
   COMMAND ${CMAKE_COMMAND} -E copy ${ARCHIVE_FILE_NAME} ${R_PACKAGE_ROOT_FOLDER}/${DST_ARCHIVE_FILE_NAME}
   COMMENT "Installing R package"
   VERBATIM

--- a/tests/ipynb/CMakeLists.txt
+++ b/tests/ipynb/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_ipynb
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} jupyter notebook dash scikit-sparse) // Add here required python packages for ipynb tests
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} jupyter notebook dash scikit-sparse) # Add here required python packages for ipynb tests
 
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition

--- a/tests/ipynb/CMakeLists.txt
+++ b/tests/ipynb/CMakeLists.txt
@@ -41,10 +41,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_ipynb
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} jupyter notebook dash scikit-sparse)
-
-# Add dependency for prepare_check_ipynb
-add_dependencies(prepare_check_ipynb python_install)
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} jupyter notebook dash scikit-sparse) // Add here required python packages for ipynb tests
 
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
@@ -54,7 +51,7 @@ add_custom_target(check_ipynb
 )
 
 # Add dependency for check_ipynb
-add_dependencies(check_ipynb prepare_check_ipynb)
+add_dependencies(check_ipynb prepare_check_ipynb python_install)
 
 # Jupyter notebook script test runner path
 cmake_path(APPEND CMAKE_SOURCE_DIR python run_test_ipynb.py

--- a/tests/ipynb/CMakeLists.txt
+++ b/tests/ipynb/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_ipynb
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} jupyter notebook dash scikit-sparse) # Add here required python packages for ipynb tests
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} notebook dash scikit-sparse) # Add here required python packages for ipynb tests
 
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition

--- a/tests/py/CMakeLists.txt
+++ b/tests/py/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_py
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "mlxtend") // Add here required package for python tests
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "mlxtend") # Add here required package for python tests
 
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition

--- a/tests/py/CMakeLists.txt
+++ b/tests/py/CMakeLists.txt
@@ -27,10 +27,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_py
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "mlxtend")
-
-# Add dependency for prepare_check_py
-add_dependencies(prepare_check_py python_install)
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "mlxtend") // Add here required package for python tests
 
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
@@ -40,7 +37,7 @@ add_custom_target(check_py
 )
 
 # Add dependency for check_py
-add_dependencies(check_py prepare_check_py)
+add_dependencies(check_py prepare_check_py python_install)
 
 # Look for Python3 (needed here because Python3_EXECUTABLE not populated everywhere)
 find_package(Python3 REQUIRED)

--- a/tests/py/CMakeLists.txt
+++ b/tests/py/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Create the output directory for logs
 add_custom_target(prepare_check_py
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} "mlxtend") # Add here required package for python tests
+                  COMMAND ${UV} pip install ${NO_INTERNET_ARG} mlxtend) # Add here required package for python tests
 
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition

--- a/tests/r/CMakeLists.txt
+++ b/tests/r/CMakeLists.txt
@@ -30,9 +30,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 add_custom_target(prepare_check_r
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}")
 
-# Add dependency for prepare_check_r
-add_dependencies(prepare_check_r r_install)
-
 # Create the main target
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_r
@@ -41,7 +38,7 @@ add_custom_target(check_r
 )
 
 # Add dependency for check_r
-add_dependencies(check_r prepare_check_r)
+add_dependencies(check_r prepare_check_r r_install)
 
 # Display test output in case of failure
 set(CTEST_OUTPUT_ON_FAILURE ON)

--- a/tests/rmd/CMakeLists.txt
+++ b/tests/rmd/CMakeLists.txt
@@ -36,9 +36,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 add_custom_target(prepare_check_rmd
                   COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}")
 
-# Add dependency for prepare_check_rmd
-add_dependencies(prepare_check_rmd r_install)
-
 # Create the target and the output directory for logs
 # Look parent CMakeLists for MY_CTEST_COMMAND definition
 add_custom_target(check_rmd
@@ -47,7 +44,7 @@ add_custom_target(check_rmd
 )
 
 # Add dependency for check_rmd
-add_dependencies(check_rmd prepare_check_rmd)
+add_dependencies(check_rmd prepare_check_rmd r_install)
 
 # Rmd script test runner path
 cmake_path(APPEND CMAKE_SOURCE_DIR r run_test_rmd.R


### PR DESCRIPTION
Three things in this PR:
- New NO_BYTE_COMPILE CMake option : to prevent R from byte-compiling the R package during the installation procedure (quicker). Byte-compilation is active by default (R package runs more rapidly)
- Improvement of Makefile targets check_test_r and check_test_py (execute only one CTest) to prevent from installing the [R / Python] package twice.
- Now, one-test Makefile targets really execute only one test (no more regex matching)