### PR TITLE
HDF5 Serialization fixes

### DIFF
--- a/include/Basic/SerializeHDF5.hpp
+++ b/include/Basic/SerializeHDF5.hpp
@@ -350,7 +350,7 @@ bool SerializeHDF5::readValue(const H5::Group& grp, const String& name, T& value
     return false;
   }
 
-  attr.read(getHDF5Type(value), value);
+  attr.read(getHDF5Type(value), &value);
   return true;
 }
 
@@ -363,7 +363,7 @@ bool SerializeHDF5::writeValue(H5::Group& grp, const String& name, const T& valu
   const hsize_t dim = 1;
   const H5::DataSpace ds {1, &dim};
   auto attr = grp.createAttribute(name, getHDF5Type(value), ds);
-  attr.write(getHDF5Type(value), value);
+  attr.write(getHDF5Type(value), &value);
 
   return true;
 }

--- a/include/Basic/SerializeHDF5.hpp
+++ b/include/Basic/SerializeHDF5.hpp
@@ -14,6 +14,7 @@
 
 #include "geoslib_define.h"
 
+#include "Basic/ASerializable.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/VectorT.hpp"
 
@@ -79,11 +80,14 @@ namespace SerializeHDF5
    */
   inline H5::H5File fileOpenRead(const String& fname)
   {
-    H5::H5File file {fname, H5F_ACC_RDONLY};
+    // Build the multi-platform filename
+    const auto filepath = ASerializable::buildFileName(1, fname, true);
+
+    H5::H5File file {filepath, H5F_ACC_RDONLY};
 
     if (!file.nameExists("gstlearn metadata"))
     {
-      messerr("File %s doesn't contain Gstlearn metadata…", fname.c_str());
+      messerr("File %s doesn't contain Gstlearn metadata…", filepath.c_str());
       return file;
     }
 
@@ -91,7 +95,7 @@ namespace SerializeHDF5
     const auto version = readAttribute(metadata, "Format version");
     if (version != "1.0.0")
     {
-      messerr("File %s has format version %s, expected 1.0.0", fname.c_str(),
+      messerr("File %s has format version %s, expected 1.0.0", filepath.c_str(),
               version.c_str());
     }
 
@@ -103,7 +107,10 @@ namespace SerializeHDF5
    */
   inline H5::H5File fileOpenWrite(const String& fname)
   {
-    H5::H5File file {fname, H5F_ACC_TRUNC};
+    // Build the multi-platform filename
+    const auto filepath = ASerializable::buildFileName(2, fname, true);
+
+    H5::H5File file {filepath, H5F_ACC_TRUNC};
     auto metadata = file.createGroup("gstlearn metadata");
     createAttribute(
       metadata, "Description",


### PR DESCRIPTION
This PR contains a few fixes around the HDF5 Serialization scheme:
- generated files now follow the "gstlearn_dir" / take into account the `GSTLEARN_OUTPUT_DIR` env var and
- Db columns are now extracted in the order of their original Db container (previously they were sorted in alphabetical order of the column name).

Pierre