### PR TITLE
Reordering the include list in CPP files

### DIFF
--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -9,35 +9,34 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/ACov.hpp"
+#include "Basic/AException.hpp"
+#include "Basic/AStringable.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/ListParams.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovContext.hpp"
-#include "Enum/ECalcMember.hpp"
-#include "Enum/EKrigOpt.hpp"
-#include "Matrix/MatrixSquare.hpp"
-#include "Matrix/MatrixDense.hpp"
-#include "Matrix/MatrixSparse.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
-#include "Matrix/NF_Triplet.hpp"
-#include "Db/Db.hpp"
-#include "Geometry/GeometryHelper.hpp"
-#include "Db/DbGrid.hpp"
-#include "Basic/AException.hpp"
-#include "Basic/ListParams.hpp"
-#include "Basic/AStringable.hpp"
-#include "Basic/VectorNumT.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/Law.hpp"
-#include "Space/ASpace.hpp"
-#include "Space/SpacePoint.hpp"
-#include "geoslib_define.h"
 #include "Covariances/NoStatArray.hpp"
 #include "Covariances/NoStatFunctional.hpp"
-#include "Variogram/Vario.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Enum/ECalcMember.hpp"
+#include "Enum/EKrigOpt.hpp"
 #include "Estimation/KrigOpt.hpp"
-
+#include "Geometry/GeometryHelper.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixSparse.hpp"
+#include "Matrix/MatrixSquare.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
+#include "Matrix/NF_Triplet.hpp"
+#include "Space/ASpace.hpp"
+#include "Space/SpacePoint.hpp"
+#include "Variogram/Vario.hpp"
+#include "geoslib_define.h"
 #include <cstddef>
-#include <vector>
 #include <math.h>
+#include <vector>
 
 namespace gstlrn 
 {
@@ -103,14 +102,14 @@ double ACov::evalCov(const SpacePoint& p1,
 }
 
 std::vector<double> ACov::evalCovGrad(const SpacePoint& p1,
-                         const SpacePoint& p2,
-                         int ivar,
-                         int jvar,
-                         const CovCalcMode* mode)
+                                      const SpacePoint& p2,
+                                      int ivar,
+                                      int jvar,
+                                      const CovCalcMode* mode)
 {
   std::vector<covmaptype> gradFuncs;
   auto listParams = std::make_shared<ListParams>();
-  appendParams(*listParams,&gradFuncs);
+  appendParams(*listParams, &gradFuncs);
   listParams->updateDispatch();
   updateCov();
   VectorDouble res(gradFuncs.size());

--- a/src/Covariances/ACovFunc.cpp
+++ b/src/Covariances/ACovFunc.cpp
@@ -9,39 +9,38 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/ACovFunc.hpp"
-#include "Basic/Utilities.hpp"
 #include "Basic/AException.hpp"
 #include "Basic/FFT.hpp"
-
+#include "Basic/Utilities.hpp"
 #include <math.h>
 
 namespace gstlrn
 {
 ACovFunc::ACovFunc(const ECov& type, const CovContext& ctxt)
-: AStringable(),
-  _type(type),
-  _ctxt(ctxt),
-  _param(TEST)
+  : AStringable()
+  , _type(type)
+  , _ctxt(ctxt)
+  , _param(TEST)
 {
   if (!isConsistent())
-    my_throw ("Cannot create such covariance function in that context");
+    my_throw("Cannot create such covariance function in that context");
 }
 
-ACovFunc::ACovFunc(const ACovFunc &r)
-: AStringable(r),
-  _type(r._type),
-  _ctxt(r._ctxt),
-  _param(r._param)
+ACovFunc::ACovFunc(const ACovFunc& r)
+  : AStringable(r)
+  , _type(r._type)
+  , _ctxt(r._ctxt)
+  , _param(r._param)
 {
 }
 
-ACovFunc& ACovFunc::operator=(const ACovFunc &r)
+ACovFunc& ACovFunc::operator=(const ACovFunc& r)
 {
   if (this != &r)
   {
     AStringable::operator=(r);
-    _type = r._type;
-    _ctxt = r._ctxt;
+    _type  = r._type;
+    _ctxt  = r._ctxt;
     _param = r._param;
   }
   return *this;
@@ -54,7 +53,7 @@ ACovFunc::~ACovFunc()
 void ACovFunc::setParam(double param)
 {
   /// TODO : Do not throw in setter. Check range and build the error message here.
-  if (! hasParam()) return;
+  if (!hasParam()) return;
   double max = getParMax();
   if (param < 0. || (!FFFF(max) && param > max))
     my_throw("Wrong third parameter value");
@@ -92,7 +91,7 @@ VectorDouble ACovFunc::evalSpectrumOnSphere(int n, double scale) const
 VectorDouble ACovFunc::evalCovVec(const VectorDouble& vech) const
 {
   VectorDouble vec;
-  for (const auto& h : vech)
+  for (const auto& h: vech)
     vec.push_back(evalCorFunc(h));
   return vec;
 }
@@ -100,7 +99,7 @@ VectorDouble ACovFunc::evalCovDerivativeVec(int degree,
                                             const VectorDouble& vech) const
 {
   VectorDouble vec;
-  for (const auto& i : vech)
+  for (const auto& i: vech)
     vec.push_back(evalCovDerivative(degree, i));
   return vec;
 }
@@ -126,7 +125,7 @@ bool ACovFunc::isConsistent() const
   unsigned int maxndim = getMaxNDim();
   if (maxndim <= 0.) return true;
   if (maxndim >= _ctxt.getNDim()) return true;
-    /// TODO : Test irfDegree vs getMinOrder in CovElem because zonal anisotropies
+  /// TODO : Test irfDegree vs getMinOrder in CovElem because zonal anisotropies
   return false;
 }
 
@@ -138,21 +137,21 @@ bool ACovFunc::hasInt2D() const
 {
   return (getMaxNDim() >= 2 && getMinOrder() <= 0);
 }
- /**
-  * Calculate covariance derivatives, i.e.
-  * - Degree 1: C^1(r) / r
-  * - degree 2: C^2(r)
-  * - Degree 3: C^3(r)
-  * - Degree 4: C^4(r)
-  * @param degree Level of derivation
-  * @param h Normalized distance
-  * @return
-  */
+/**
+ * Calculate covariance derivatives, i.e.
+ * - Degree 1: C^1(r) / r
+ * - degree 2: C^2(r)
+ * - Degree 3: C^3(r)
+ * - Degree 4: C^4(r)
+ * @param degree Level of derivation
+ * @param h Normalized distance
+ * @return
+ */
 double ACovFunc::_evaluateCovDerivative(int degree, double h) const
 {
   DECLARE_UNUSED(degree);
   DECLARE_UNUSED(h);
-  if (! hasCovDerivative())
+  if (!hasCovDerivative())
   {
     messerr("This covariance does not allow Derivative calculations");
     return TEST;
@@ -165,7 +164,7 @@ double ACovFunc::_evaluateCovDerivative(int degree, double h) const
 void ACovFunc::setMarkovCoeffs(const VectorDouble& coeffs)
 {
   DECLARE_UNUSED(coeffs);
-  if (! hasMarkovCoeffs())
+  if (!hasMarkovCoeffs())
   {
     messerr("This covariance is not known to be Markovian");
   }
@@ -176,10 +175,10 @@ void ACovFunc::setMarkovCoeffs(const VectorDouble& coeffs)
 
 VectorDouble ACovFunc::getMarkovCoeffs() const
 {
-  if (! hasMarkovCoeffs())
+  if (!hasMarkovCoeffs())
   {
-      messerr("This covariance is not known to be Markovian");
-      return VectorDouble();
+    messerr("This covariance is not known to be Markovian");
+    return VectorDouble();
   }
   messerr("This covariance should have a method giving the Markov coefficients");
   messerr("But getMarkovCoeffs has not been coded");
@@ -189,10 +188,10 @@ VectorDouble ACovFunc::getMarkovCoeffs() const
 double ACovFunc::evaluateSpectrum(double freq) const
 {
   DECLARE_UNUSED(freq);
-  if (! hasSpectrumOnRn())
+  if (!hasSpectrumOnRn())
   {
-      messerr("This covariance does not allow spectrum calculations");
-      return TEST;
+    messerr("This covariance does not allow spectrum calculations");
+    return TEST;
   }
   messerr("This covariance should have a method giving the spectrum");
   messerr("But evaluateSpectrum has not been coded");
@@ -217,13 +216,13 @@ double ACovFunc::_evaluateCovOnSphere(double alpha,
   else
   {
     double calpha = cos(alpha);
-    double u0 = 1.;
-    double u2 = 0.;
-    double u1 = calpha;
+    double u0     = 1.;
+    double u2     = 0.;
+    double u1     = calpha;
     for (int i = 1; i < (degree + 2); i++)
     {
       u2 = 1. / (i + 1) * ((2 * i + 1) * calpha * u1 - i * u0);
-      s += u0 * spectrum[i-1];
+      s += u0 * spectrum[i - 1];
       u0 = u1;
       u1 = u2;
     }
@@ -248,40 +247,40 @@ VectorDouble ACovFunc::_evaluateSpectrumOnSphere(int n, double scale) const
 Array ACovFunc::_evalCovFFT(const VectorDouble& hmax, int N) const
 {
   N *= 2;
-  int ndim = (int) hmax.size();
+  int ndim = (int)hmax.size();
   VectorInt nxs(ndim);
   for (int idim = 0; idim < ndim; idim++)
-    nxs[idim] = N ;
+    nxs[idim] = N;
   Array array(nxs);
 
-  int ntotal = (int) pow(N, ndim);
+  int ntotal = (int)pow(N, ndim);
   VectorDouble a(ndim);
   double coeff = 0;
-  double prod = 1.;
+  double prod  = 1.;
 
-  for(int idim = 0; idim < ndim; idim++)
+  for (int idim = 0; idim < ndim; idim++)
   {
-    coeff = 1. / (2. * hmax[idim]);
-    a[idim]=    GV_PI * (N-1) / (hmax[idim]);
+    coeff   = 1. / (2. * hmax[idim]);
+    a[idim] = GV_PI * (N - 1) / (hmax[idim]);
     prod *= coeff;
   }
 
-  VectorDouble Re(ntotal,0.);
-  VectorDouble Im(ntotal,0.);
-  VectorInt    indices(ndim);
+  VectorDouble Re(ntotal, 0.);
+  VectorDouble Im(ntotal, 0.);
+  VectorInt indices(ndim);
 
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
+    array.rankToIndice(iad, indices);
 
     double s = 0.;
     for (int idim = 0; idim < ndim; idim++)
     {
-      double temp = a[idim] * ((double) indices[idim] / (N - 1) - 0.5);
+      double temp = a[idim] * ((double)indices[idim] / (N - 1) - 0.5);
       s += temp * temp;
     }
     Re[iad] = prod * evaluateSpectrum(s);
-    array.setValue(indices,Re[iad]);
+    array.setValue(indices, Re[iad]);
   }
 
   FFTn(ndim, nxs, Re, Im);
@@ -290,33 +289,32 @@ Array ACovFunc::_evalCovFFT(const VectorDouble& hmax, int N) const
 
   VectorInt nxs2(ndim);
   for (int idim = 0; idim < ndim; idim++)
-    nxs2[idim] = N/2 ;
+    nxs2[idim] = N / 2;
   Array result(nxs2);
   VectorInt newIndices(ndim);
 
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
-    for (int idim = 0;  idim < ndim; idim++)
+    array.rankToIndice(iad, indices);
+    for (int idim = 0; idim < ndim; idim++)
     {
-      int odd = indices[idim] % 2;
-      int s = 1 - 2 * odd;
-      newIndices[idim] = nxs[idim]/2 + s * (indices[idim]/2 + odd);
+      int odd          = indices[idim] % 2;
+      int s            = 1 - 2 * odd;
+      newIndices[idim] = nxs[idim] / 2 + s * (indices[idim] / 2 + odd);
       Re[iad] *= s;
-
     }
-    array.setValue(newIndices,Re[iad]);
+    array.setValue(newIndices, Re[iad]);
   }
 
   bool cont;
   int iadr = 0;
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
+    array.rankToIndice(iad, indices);
     cont = true;
-    for (int idim = 0;  idim < ndim; idim++)
+    for (int idim = 0; idim < ndim; idim++)
     {
-      if (indices[idim]<(nxs2[idim]/2) || indices[idim] >= (3 * nxs2[idim]/2 ))
+      if (indices[idim] < (nxs2[idim] / 2) || indices[idim] >= (3 * nxs2[idim] / 2))
       {
         cont = false;
         continue;
@@ -324,25 +322,25 @@ Array ACovFunc::_evalCovFFT(const VectorDouble& hmax, int N) const
     }
     if (cont)
     {
-      result.rankToIndice(iadr++,newIndices);
-      result.setValue(newIndices,array.getValue(indices));
+      result.rankToIndice(iadr++, newIndices);
+      result.setValue(newIndices, array.getValue(indices));
     }
   }
   return result;
 }
 
-void ACovFunc::computeCorrec(int ndim) 
+void ACovFunc::computeCorrec(int ndim)
 {
-  if (! hasSpectrumOnRn()) return;
-  int N = (int) pow(2,8);
+  if (!hasSpectrumOnRn()) return;
+  int N = (int)pow(2, 8);
   VectorInt Nv(ndim);
   VectorDouble hmax(ndim);
-  for (int idim = 0; idim<ndim; idim++)
+  for (int idim = 0; idim < ndim; idim++)
   {
     hmax[idim] = 3 * getScadef();
-    Nv[idim] = N/2;
+    Nv[idim]   = N / 2;
   }
-  Array res = _evalCovFFT(hmax,N);
+  Array res     = _evalCovFFT(hmax, N);
   double correc = res.getValue(Nv);
   setCorrec(correc);
 }

--- a/src/Covariances/ACovGradient.cpp
+++ b/src/Covariances/ACovGradient.cpp
@@ -9,32 +9,31 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/ACovGradient.hpp"
-
 #include <math.h>
 
 namespace gstlrn
 {
 
 ACovGradient::ACovGradient(const ECov& type, const CovContext& ctxt)
-    : CovAniso(type, ctxt)
+  : CovAniso(type, ctxt)
 {
 }
 
-ACovGradient::ACovGradient(const ACovGradient &r)
-    : CovAniso(r)
+ACovGradient::ACovGradient(const ACovGradient& r)
+  : CovAniso(r)
 {
 }
 
-ACovGradient::ACovGradient(const CovAniso &r)
-    : CovAniso(r)
+ACovGradient::ACovGradient(const CovAniso& r)
+  : CovAniso(r)
 {
 }
 
-ACovGradient& ACovGradient::operator=(const ACovGradient &r)
+ACovGradient& ACovGradient::operator=(const ACovGradient& r)
 {
   if (this != &r)
   {
-    CovAniso::operator =(r);
+    CovAniso::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/ANoStat.cpp
+++ b/src/Covariances/ANoStat.cpp
@@ -1,111 +1,115 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/ANoStat.hpp"
 #include "Basic/VectorNumT.hpp"
-#include "Mesh/AMesh.hpp"
 #include "Db/Db.hpp"
+#include "Mesh/AMesh.hpp"
 #include "geoslib_define.h"
 
 namespace gstlrn
 {   
 ANoStat::ANoStat()
 {
-
 }
 
 ANoStat::~ANoStat()
 {
-
 }
 
-double ANoStat::getValueOnDb(int iech,int icas) const
+double ANoStat::getValueOnDb(int iech, int icas) const
 {
-    if (icas == 1)
-      return getValueOnDbIn(iech);
-    if (icas == 2)
-      return getValueOnDbOut(iech);
-    return TEST;
+  if (icas == 1)
+    return getValueOnDbIn(iech);
+  if (icas == 2)
+    return getValueOnDbOut(iech);
+  return TEST;
 }
 
-double ANoStat::getValueOnMesh(int iapex,bool center) const
+double ANoStat::getValueOnMesh(int iapex, bool center) const
 {
-    if (center)
-        return getValueOnMeshByMesh(iapex);
-    return getValueOnMeshByApex(iapex);
+  if (center)
+    return getValueOnMeshByMesh(iapex);
+  return getValueOnMeshByApex(iapex);
 }
 
-
-bool ANoStat::getValuesOnDb(int icas1, int iech1, double* val1,
-                            int icas2, int iech2, double* val2) const
+bool ANoStat::getValuesOnDb(int icas1, int iech1, double* val1, int icas2, int iech2, double* val2) const
 {
-    *val1 = getValueOnDb(iech1,icas1);
-    *val2 = getValueOnDb(iech2,icas2);    
-    if (FFFF(*val1) && FFFF(*val2)) return false;
-    
-    if (FFFF(*val1)) *val1 = *val2;
-    if (FFFF(*val2)) *val2 = *val1;
+  *val1 = getValueOnDb(iech1, icas1);
+  *val2 = getValueOnDb(iech2, icas2);
+  if (FFFF(*val1) && FFFF(*val2)) return false;
 
-    return *val1 != *val2;                    
+  if (FFFF(*val1)) *val1 = *val2;
+  if (FFFF(*val2)) *val2 = *val1;
+
+  return *val1 != *val2;
 }
 
 double ANoStat::getValueOnDbOut(int iech) const
 {
-    return _tabdbout[iech];
+  return _tabdbout[iech];
 }
 
-double  ANoStat::getValueOnDbIn(int iech) const
+double ANoStat::getValueOnDbIn(int iech) const
 {
-    return _tabdbin[iech];
+  return _tabdbin[iech];
 }
 
 double ANoStat::getValueOnMeshByMesh(int imesh) const
 {
-    return _tabmesh[imesh];
-
+  return _tabmesh[imesh];
 }
 
 String ANoStat::toString(const AStringFormat* strfmt) const
 {
-    DECLARE_UNUSED(strfmt)
-    std::stringstream sstr;
-    return sstr.str();
+  DECLARE_UNUSED(strfmt)
+  std::stringstream sstr;
+  return sstr.str();
 }
 
 double ANoStat::getValueOnMeshByApex(int iapex) const
 {
-    return  _tabvertices[iapex];
+  return _tabvertices[iapex];
 }
 
-void ANoStat::informField(const VectorVectorDouble & coords, VectorDouble& tab, bool verbose)
+void ANoStat::informField(const VectorVectorDouble& coords, VectorDouble& tab, bool verbose)
 {
-    tab.resize(coords[0].size());
-    _informField(coords, tab, verbose);
+  tab.resize(coords[0].size());
+  _informField(coords, tab, verbose);
 }
 
-
-void ANoStat::informMeshByMesh(const AMesh* amesh,bool verbose) 
+void ANoStat::informMeshByMesh(const AMesh* amesh, bool verbose)
 {
-    VectorVectorDouble coords = amesh->getAllCenterCoordinates();
-    informField(coords,_tabmesh, verbose);
+  VectorVectorDouble coords = amesh->getAllCenterCoordinates();
+  informField(coords, _tabmesh, verbose);
 }
 
 void ANoStat::informMeshByApex(const AMesh* amesh, bool verbose)
 {
-    VectorVectorDouble coords = amesh->getAllCoordinates();
-    informField(coords,_tabvertices, verbose);
+  VectorVectorDouble coords = amesh->getAllCoordinates();
+  informField(coords, _tabvertices, verbose);
 }
-  
+
 void ANoStat::informDbIn(const Db* dbin, bool verbose)
 {
-    _informDb(dbin,_tabdbin, verbose);
+  _informDb(dbin, _tabdbin, verbose);
 }
 
 void ANoStat::informDbOout(const Db* dbout, bool verbose)
 {
-    _informDb(dbout,_tabdbout, verbose);
+  _informDb(dbout, _tabdbout, verbose);
 }
 
-void ANoStat::_informDb(const Db* db, VectorDouble &res, bool verbose)
+void ANoStat::_informDb(const Db* db, VectorDouble& res, bool verbose)
 {
-    VectorVectorDouble coords = db->getAllCoordinates(false);
-    informField(coords, res, verbose);
+  VectorVectorDouble coords = db->getAllCoordinates(false);
+  informField(coords, res, verbose);
 }
 }

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -8,37 +8,39 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Covariances/CorAniso.hpp"
+
 #include "Arrays/Array.hpp"
+#include "Basic/AException.hpp"
 #include "Basic/AFunctional.hpp"
 #include "Basic/AStringFormat.hpp"
+#include "Basic/AStringable.hpp"
+#include "Basic/FFT.hpp"
 #include "Basic/ListParams.hpp"
 #include "Basic/ParamInfo.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "Covariances/ACov.hpp"
-#include "Covariances/TabNoStatCovAniso.hpp"
-#include "Db/Db.hpp"
-#include "Covariances/NoStatArray.hpp"
-#include "Covariances/CorAniso.hpp"
+#include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovFactory.hpp"
 #include "Covariances/CovGradientNumerical.hpp"
-#include "Covariances/CovCalcMode.hpp"
+#include "Covariances/NoStatArray.hpp"
+#include "Covariances/TabNoStatCovAniso.hpp"
+#include "Db/Db.hpp"
 #include "Enum/EConsElem.hpp"
+#include "Geometry/GeometryHelper.hpp"
 #include "Matrix/MatrixSquare.hpp"
-#include "Basic/AStringable.hpp"
-#include "Basic/AException.hpp"
-#include "Basic/VectorNumT.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/FFT.hpp"
-#include "Basic/Utilities.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
 #include "Space/ASpace.hpp"
 #include "Space/ASpaceObject.hpp"
 #include "Space/SpacePoint.hpp"
 #include "Space/SpaceSN.hpp"
-#include "Geometry/GeometryHelper.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
+
 #include "geoslib_define.h"
 #include <algorithm>
-#include <math.h>
 #include <functional>
+#include <math.h>
 #include <vector>
 
 static int NWGT[4]      = {2, 3, 4, 5};
@@ -55,7 +57,7 @@ struct DerivCache
   mutable const SpacePoint* cachedP1ptr = nullptr;
   mutable const SpacePoint* cachedP2ptr = nullptr;
   mutable SpacePoint cachedP1;
-  mutable SpacePoint cachedP2 ;
+  mutable SpacePoint cachedP2;
   mutable double deriv               = 0.0;
   mutable std::vector<double> angles = {};
   mutable bool isInitialized         = false;
@@ -90,11 +92,11 @@ struct DerivCache
 
     if (!useCache)
     {
-      deriv    = cor->evalDerivativeBasis(p1, p2, ivar, jvar, mode);
+      deriv       = cor->evalDerivativeBasis(p1, p2, ivar, jvar, mode);
       cachedP1ptr = &p1;
       cachedP2ptr = &p2;
-      cachedP1 = p1; // copy to cachedP1
-      cachedP2 = p2; // copy to cachedP2
+      cachedP1    = p1; // copy to cachedP1
+      cachedP2    = p2; // copy to cachedP2
     }
     return deriv;
   }

--- a/src/Covariances/CorGneiting.cpp
+++ b/src/Covariances/CorGneiting.cpp
@@ -44,8 +44,8 @@ CorGneiting::CorGneiting(const CorAniso* covS, const CorAniso* covTemp, double s
   space->addSpaceComponent(covTemp->getSpace());
   _ctxt.setSpace(space);
 
-  int nvar = covS->getNVar();
-  CovContext ctxt    = CovContext(nvar, space);
+  int nvar        = covS->getNVar();
+  CovContext ctxt = CovContext(nvar, space);
   setContext(ctxt);
 }
 
@@ -56,7 +56,6 @@ CorGneiting::CorGneiting(const CorGneiting& r)
   , _separability(r._separability)
   , _covSCopy(*r._covS)
 {
-
 }
 
 CorGneiting& CorGneiting::operator=(const CorGneiting& r)

--- a/src/Covariances/CorMatern.cpp
+++ b/src/Covariances/CorMatern.cpp
@@ -8,19 +8,18 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-
 #include "Covariances/CorMatern.hpp"
 #include "Basic/AStringable.hpp"
+#include "Basic/MathFunc.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/CorAniso.hpp"
+#include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
 #include "Space/ASpace.hpp"
 #include "Space/SpaceComposite.hpp"
 #include "Space/SpacePoint.hpp"
-#include "Covariances/CovCalcMode.hpp"
 #include "geoslib_define.h"
-#include "Basic/MathFunc.hpp"
 
 #include <cmath>
 #include <vector>
@@ -33,8 +32,8 @@ CorMatern::CorMatern(const VectorDouble &ranges,
                      const VectorDouble& params ,
                      bool flagRange)
   : ACov()
-  , _nVar((int) params.size())
-  , _corRef(CorAniso::createAnisotropic(CovContext(1, (int) ranges.size()),ECov::MATERN, ranges, params[0], angles, flagRange))
+  , _nVar((int)params.size())
+  , _corRef(CorAniso::createAnisotropic(CovContext(1, (int)ranges.size()), ECov::MATERN, ranges, params[0], angles, flagRange))
   , _corMatern(*_corRef)
   , _coeffScales(coeffScales)
   , _params(params)
@@ -45,10 +44,10 @@ CorMatern::CorMatern(const VectorDouble &ranges,
   {
     messerr("CorMatern: inconsistent size between coeffScales and params");
     messerr("CorMatern: coeffScales size = %d, params size = %d", _coeffScales.size(), _nVar);
-    _nVar = 0;
-    _corMax = MatrixSymmetric(0);
+    _nVar        = 0;
+    _corMax      = MatrixSymmetric(0);
     _coeffScales = VectorDouble();
-    _params = VectorDouble();
+    _params      = VectorDouble();
     return;
   }
   _coeffScales.push_front(1.);
@@ -59,19 +58,19 @@ CorMatern::CorMatern(const VectorDouble &ranges,
     _corMax.setValue(ivar, ivar, 1.);
     for (int jvar = ivar + 1; jvar < _nVar; jvar++)
     {
-      double scalei = _coeffScales[ivar];
-      double scalej = _coeffScales[jvar];
-      double scaleij = computeScale(ivar,jvar);
-      double nui = _params[ivar];
-      double nuj = _params[jvar];
-      double nuij = computeParam(ivar,jvar);
-      double gni =  exp(loggamma(nui));
-      double gnj =  exp(loggamma(nuj));
-      double gnij = exp(loggamma(nuij));
-      double ratioi = gni / pow(scalei, 2. * nui);
-      double ratioj = gnj / pow(scalej, 2. * nuj);
+      double scalei  = _coeffScales[ivar];
+      double scalej  = _coeffScales[jvar];
+      double scaleij = computeScale(ivar, jvar);
+      double nui     = _params[ivar];
+      double nuj     = _params[jvar];
+      double nuij    = computeParam(ivar, jvar);
+      double gni     = exp(loggamma(nui));
+      double gnj     = exp(loggamma(nuj));
+      double gnij    = exp(loggamma(nuij));
+      double ratioi  = gni / pow(scalei, 2. * nui);
+      double ratioj  = gnj / pow(scalej, 2. * nuj);
       double ratioij = gnij / pow(scaleij, 2. * nuij);
-      double val = ratioij / sqrt(ratioi * ratioj);
+      double val     = ratioij / sqrt(ratioi * ratioj);
       _corMax.setValue(ivar, jvar, val);
     }
   }
@@ -80,13 +79,13 @@ CorMatern::CorMatern(const VectorDouble &ranges,
 CorMatern::CorMatern(const CorMatern& r)
   : ACov(r)
   , _corMatern(r._corMatern)
-{   
-    _nVar = r._nVar;
-    _corRef = r._corRef;
-    _coeffScales = r._coeffScales;
-    _params = r._params;
-    _corMax = r._corMax;
-    _angles = r._angles;
+{
+  _nVar        = r._nVar;
+  _corRef      = r._corRef;
+  _coeffScales = r._coeffScales;
+  _params      = r._params;
+  _corMax      = r._corMax;
+  _angles      = r._angles;
 }
 
 CorMatern& CorMatern::operator=(const CorMatern& r)
@@ -94,27 +93,27 @@ CorMatern& CorMatern::operator=(const CorMatern& r)
   if (this != &r)
   {
     ACov::operator=(r);
-    _nVar = r._nVar;
-    _corMatern = r._corMatern;
+    _nVar        = r._nVar;
+    _corMatern   = r._corMatern;
     _coeffScales = r._coeffScales;
-    _params = r._params;
-    _corMax = r._corMax;
-    _angles = r._angles;
+    _params      = r._params;
+    _corMax      = r._corMax;
+    _angles      = r._angles;
   }
   return *this;
 }
 
 double CorMatern::computeScale(int ivar, int jvar) const
-{ 
-    if (ivar == jvar)
-    {
-        return  _coeffScales[ivar];
-    }
-    double ci2 =  _coeffScales[ivar] * _coeffScales[ivar];
-    double cj2 =  _coeffScales[jvar] * _coeffScales[jvar];
-   
-    return sqrt( 0.5 * (ci2+ cj2));
-} 
+{
+  if (ivar == jvar)
+  {
+    return _coeffScales[ivar];
+  }
+  double ci2 = _coeffScales[ivar] * _coeffScales[ivar];
+  double cj2 = _coeffScales[jvar] * _coeffScales[jvar];
+
+  return sqrt(0.5 * (ci2 + cj2));
+}
 
 double CorMatern::computeParam(int ivar, int jvar) const
 {
@@ -124,7 +123,7 @@ double CorMatern::computeParam(int ivar, int jvar) const
   }
 
   return 0.5 * (_params[ivar] + _params[jvar]);
-} 
+}
 
 CorMatern::~CorMatern()
 {
@@ -156,7 +155,7 @@ double CorMatern::_eval(const SpacePoint& p1,
                         int jvar,
                         const CovCalcMode* mode) const
 {
-    _corMatern.setParam(computeParam(ivar, jvar));
+  _corMatern.setParam(computeParam(ivar, jvar));
 
     VectorDouble scales = _corRef->getScales();
   

--- a/src/Covariances/CovAniso.cpp
+++ b/src/Covariances/CovAniso.cpp
@@ -32,6 +32,7 @@
 
 #include <functional>
 #include <math.h>
+#include <math.h>
 #include <ostream>
 
 namespace gstlrn

--- a/src/Covariances/CovAnisoList.cpp
+++ b/src/Covariances/CovAnisoList.cpp
@@ -9,23 +9,22 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovAnisoList.hpp"
-#include "Basic/ParamInfo.hpp"
-#include "Enum/EModelProperty.hpp"
-
+#include "Anamorphosis/AnamHermite.hpp"
 #include "Basic/ListParams.hpp"
-#include "Covariances/CovCalcMode.hpp"
-#include "Covariances/CovContext.hpp"
-#include "Covariances/CovList.hpp"
-#include "Space/ASpace.hpp"
+#include "Basic/ParamInfo.hpp"
 #include "Basic/Utilities.hpp"
 #include "Covariances/CovAniso.hpp"
+#include "Covariances/CovCalcMode.hpp"
+#include "Covariances/CovContext.hpp"
 #include "Covariances/CovFactory.hpp"
-#include "Covariances/CovLMGradient.hpp"
+#include "Covariances/CovLMCAnamorphosis.hpp"
 #include "Covariances/CovLMCConvolution.hpp"
 #include "Covariances/CovLMCTapering.hpp"
-#include "Covariances/CovLMCAnamorphosis.hpp"
+#include "Covariances/CovLMGradient.hpp"
+#include "Covariances/CovList.hpp"
 #include "Db/Db.hpp"
-#include "Anamorphosis/AnamHermite.hpp"
+#include "Enum/EModelProperty.hpp"
+#include "Space/ASpace.hpp"
 #include "geoslib_define.h"
 
 #include <cstddef>

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -8,7 +8,6 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-
 #include "Covariances/CovBase.hpp"
 #include "Basic/ListParams.hpp"
 #include "Basic/Iterators.hpp"
@@ -16,12 +15,12 @@
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/ACov.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Covariances/NoStatArray.hpp"
 #include "Covariances/TabNoStatSills.hpp"
+#include "Db/Db.hpp"
 #include "LinearOp/CholeskyDense.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
-#include "Db/Db.hpp"
-#include "Covariances/NoStatArray.hpp"
 #include "Space/SpacePoint.hpp"
 #include "geoslib_define.h"
 #include <cstddef>

--- a/src/Covariances/CovBesselJ.cpp
+++ b/src/Covariances/CovBesselJ.cpp
@@ -9,9 +9,9 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovBesselJ.hpp"
+#include "Basic/MathFunc.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "Basic/MathFunc.hpp"
 
 #include <math.h>
 
@@ -21,21 +21,21 @@ namespace gstlrn
 {
 
 CovBesselJ::CovBesselJ(const CovContext& ctxt)
-: ACovFunc(ECov::BESSELJ, ctxt)
+  : ACovFunc(ECov::BESSELJ, ctxt)
 {
   setParam(1);
 }
 
-CovBesselJ::CovBesselJ(const CovBesselJ &r)
-: ACovFunc(r)
+CovBesselJ::CovBesselJ(const CovBesselJ& r)
+  : ACovFunc(r)
 {
 }
 
-CovBesselJ& CovBesselJ::operator=(const CovBesselJ &r)
+CovBesselJ& CovBesselJ::operator=(const CovBesselJ& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -48,9 +48,9 @@ double CovBesselJ::_evaluateCov(double h) const
 {
   static double TAB[MAXTAB];
 
-  double cov = 0.;
+  double cov   = 0.;
   double third = getParam();
-  int nb = (int) floor(third);
+  int nb       = (int)floor(third);
   double alpha = third - nb;
   if (third <= 0 || nb >= MAXTAB) return (cov);
   double coeff = (h > 0) ? pow(h / 2., third) : 1.;
@@ -69,7 +69,7 @@ String CovBesselJ::getFormula() const
   return "C(h)=2^\\alpha\\Gamma(\\alpha+1) \\frac{ J_\\alpha\\left( \\frac{h}{a_t} \\right) } {\\left( \\frac{h}{a_t} \\right)^\\alpha}";
 }
 
-double CovBesselJ::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovBesselJ::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.cosineOne(t0);
 }

--- a/src/Covariances/CovCalcMode.cpp
+++ b/src/Covariances/CovCalcMode.cpp
@@ -33,22 +33,22 @@ CovCalcMode::CovCalcMode(const CovCalcMode& r)
 {
 }
 
-CovCalcMode& CovCalcMode::operator=(const CovCalcMode &r)
+CovCalcMode& CovCalcMode::operator=(const CovCalcMode& r)
 {
   if (this != &r)
   {
     AStringable::operator=(r);
-    _member        = r._member;
-    _asVario       = r._asVario;
-    _unitary       = r._unitary;
-    _orderVario    = r._orderVario;
+    _member     = r._member;
+    _asVario    = r._asVario;
+    _unitary    = r._unitary;
+    _orderVario = r._orderVario;
   }
   return *this;
 }
 
 CovCalcMode::~CovCalcMode() {}
 
-CovCalcMode* CovCalcMode::create(const ECalcMember &member,
+CovCalcMode* CovCalcMode::create(const ECalcMember& member,
                                  bool asVario,
                                  bool unitary,
                                  int orderVario)

--- a/src/Covariances/CovCauchy.cpp
+++ b/src/Covariances/CovCauchy.cpp
@@ -16,21 +16,21 @@
 namespace gstlrn
 {
 CovCauchy::CovCauchy(const CovContext& ctxt)
-: ACovFunc(ECov::CAUCHY, ctxt)
+  : ACovFunc(ECov::CAUCHY, ctxt)
 {
   setParam(1);
 }
 
-CovCauchy::CovCauchy(const CovCauchy &r)
-: ACovFunc(r)
+CovCauchy::CovCauchy(const CovCauchy& r)
+  : ACovFunc(r)
 {
 }
 
-CovCauchy& CovCauchy::operator=(const CovCauchy &r)
+CovCauchy& CovCauchy::operator=(const CovCauchy& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovContext.cpp
+++ b/src/Covariances/CovContext.cpp
@@ -9,13 +9,13 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovContext.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Basic/VectorNumT.hpp"
+#include "Db/Db.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
 #include "Space/ASpace.hpp"
 #include "Space/SpaceRN.hpp"
-#include "Basic/VectorNumT.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "Variogram/Vario.hpp"
-#include "Db/Db.hpp"
 
 namespace gstlrn
 {
@@ -27,10 +27,10 @@ namespace gstlrn
  */
 CovContext::CovContext(int nvar, const ASpaceSharedPtr& space)
 
-    : ASpaceObject(space),
-      _nVar(nvar),
-      _field(TEST),
-      _covar0()
+  : ASpaceObject(space)
+  , _nVar(nvar)
+  , _field(TEST)
+  , _covar0()
 {
   _update();
 }
@@ -44,20 +44,20 @@ CovContext::CovContext(int nvar, const ASpaceSharedPtr& space)
  */
 CovContext::CovContext(int nvar,
                        int ndim,
-                       const VectorDouble &covar0)
-    : ASpaceObject(SpaceRN::create(ndim)),
-      _nVar(nvar),
-      _field(TEST),
-      _covar0(covar0)
+                       const VectorDouble& covar0)
+  : ASpaceObject(SpaceRN::create(ndim))
+  , _nVar(nvar)
+  , _field(TEST)
+  , _covar0(covar0)
 {
   _update();
 }
 
-CovContext::CovContext(const Db *db, const ASpaceSharedPtr& space)
-    : ASpaceObject(space),
-      _nVar(0),
-      _field(TEST),
-      _covar0()
+CovContext::CovContext(const Db* db, const ASpaceSharedPtr& space)
+  : ASpaceObject(space)
+  , _nVar(0)
+  , _field(TEST)
+  , _covar0()
 {
   /// TODO : check Db dimension vs provided space
   _nVar = db->getNLoc(ELoc::Z);
@@ -66,33 +66,33 @@ CovContext::CovContext(const Db *db, const ASpaceSharedPtr& space)
   _update();
 }
 
-CovContext::CovContext(const Vario *vario, const ASpaceSharedPtr& space)
-    : ASpaceObject(space),
-      _nVar(0),
-      _field(TEST),
-      _covar0()
+CovContext::CovContext(const Vario* vario, const ASpaceSharedPtr& space)
+  : ASpaceObject(space)
+  , _nVar(0)
+  , _field(TEST)
+  , _covar0()
 {
   /// TODO : check vario dimension vs provided space
-  _nVar = vario->getNVar();
+  _nVar  = vario->getNVar();
   _field = vario->getHmax();
   _update();
 }
 
-CovContext::CovContext(const CovContext &r)
-    : ASpaceObject(r),
-      _nVar(r._nVar),
-      _field(r._field),
-      _covar0(r._covar0)
+CovContext::CovContext(const CovContext& r)
+  : ASpaceObject(r)
+  , _nVar(r._nVar)
+  , _field(r._field)
+  , _covar0(r._covar0)
 {
 }
 
-CovContext& CovContext::operator=(const CovContext &r)
+CovContext& CovContext::operator=(const CovContext& r)
 {
   if (this != &r)
   {
-    ASpaceObject::operator =(r);
-    _nVar = r._nVar;
-    _field = r._field;
+    ASpaceObject::operator=(r);
+    _nVar   = r._nVar;
+    _field  = r._field;
     _covar0 = r._covar0;
   }
   return *this;
@@ -106,10 +106,10 @@ String CovContext::toString(const AStringFormat* strfmt) const
 {
   std::stringstream sstr;
   sstr << ASpaceObject::toString(strfmt);
-  sstr << "Nb Variables       = "       << _nVar << std::endl;
-  if (! FFFF(_field))
-    sstr << "Field Size         = "       << _field << std::endl;
-  sstr << "Covariance (0)     = "       << VH::toStringAsVD(_covar0);
+  sstr << "Nb Variables       = " << _nVar << std::endl;
+  if (!FFFF(_field))
+    sstr << "Field Size         = " << _field << std::endl;
+  sstr << "Covariance (0)     = " << VH::toStringAsVD(_covar0);
   return sstr.str();
 }
 
@@ -132,16 +132,15 @@ bool CovContext::isConsistent(const ASpace* space) const
  * @param r Secondary CovContext to be compared with this
  * @return
  */
-bool CovContext::isEqual(const CovContext &r) const
+bool CovContext::isEqual(const CovContext& r) const
 {
   return (_nVar == r.getNVar() && _space->isEqual(r.getSpace().get()));
 }
 
-
 double CovContext::getCovar0(int ivar, int jvar) const
 {
   int rank = _getIndex(ivar, jvar);
-  if (rank < 0 || rank >= (int) _covar0.size())
+  if (rank < 0 || rank >= (int)_covar0.size())
     my_throw("Invalid argument in _setCovar0");
   return _covar0[rank];
 }
@@ -159,7 +158,7 @@ void CovContext::setCovar0s(const VectorDouble& covar0)
 void CovContext::setCovar0(int ivar, int jvar, double covar0)
 {
   int rank = _getIndex(ivar, jvar);
-  if (rank < 0 || rank >= (int) _covar0.size())
+  if (rank < 0 || rank >= (int)_covar0.size())
     my_throw("Invalid argument in _setCovar0");
   _covar0[rank] = covar0;
 }
@@ -171,7 +170,7 @@ int CovContext::_getIndex(int ivar, int jvar) const
 
 void CovContext::_update()
 {
-  if (_nVar * _nVar != (int) _covar0.size())
+  if (_nVar * _nVar != (int)_covar0.size())
   {
     MatrixSymmetric Id(_nVar);
     Id.setIdentity();
@@ -187,7 +186,7 @@ void CovContext::_update()
  */
 void CovContext::copyCovContext(const CovContext& ctxt, bool severe)
 {
-  if (severe  && ctxt._nVar != _nVar)
+  if (severe && ctxt._nVar != _nVar)
   {
     messerr("The update of a CovContext does not allow modifying the number of variables (old=%d -> New=%d)",
             _nVar, ctxt._nVar);
@@ -200,15 +199,15 @@ void CovContext::copyCovContext(const CovContext& ctxt, bool severe)
   _update();
 }
 
-const CovContext* CovContext::createReduce(const VectorInt &validVars) const
+const CovContext* CovContext::createReduce(const VectorInt& validVars) const
 {
   int ecr, lec;
-  int nvar = (int) validVars.size();
+  int nvar = (int)validVars.size();
   int ndim = getNDim();
   VectorBool valids(_nVar, false);
   for (int ivar = 0; ivar < nvar; ivar++) valids[validVars[ivar]] = true;
 
-  VectorDouble covar0(nvar * nvar,0);
+  VectorDouble covar0(nvar * nvar, 0);
   ecr = 0;
   lec = 0;
   for (int ivar = 0; ivar < _nVar; ivar++)

--- a/src/Covariances/CovCosExp.cpp
+++ b/src/Covariances/CovCosExp.cpp
@@ -9,28 +9,27 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovCosExp.hpp"
-
-#include "math.h"
 #include "Covariances/CovContext.hpp"
+#include "math.h"
 
 namespace gstlrn
 {
 CovCosExp::CovCosExp(const CovContext& ctxt)
-: ACovFunc(ECov::COSEXP, ctxt)
+  : ACovFunc(ECov::COSEXP, ctxt)
 {
   setParam(1);
 }
 
-CovCosExp::CovCosExp(const CovCosExp &r)
-: ACovFunc(r)
+CovCosExp::CovCosExp(const CovCosExp& r)
+  : ACovFunc(r)
 {
 }
 
-CovCosExp& CovCosExp::operator=(const CovCosExp &r)
+CovCosExp& CovCosExp::operator=(const CovCosExp& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -48,7 +47,7 @@ double CovCosExp::_evaluateCov(double h) const
 {
   double cov = 1.;
   if (h > 100) return (0.);
-  cov = exp(-h);
+  cov       = exp(-h);
   double h2 = h / getParam();
   cov *= cos(2. * GV_PI * h2);
   return (cov);

--- a/src/Covariances/CovCosinus.cpp
+++ b/src/Covariances/CovCosinus.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovCosinus.hpp"
-
-#include <math.h>
 #include "Covariances/CovContext.hpp"
+#include <math.h>
 
 namespace gstlrn
 {
 CovCosinus::CovCosinus(const CovContext& ctxt)
-: ACovFunc(ECov::COSINUS, ctxt)
+  : ACovFunc(ECov::COSINUS, ctxt)
 {
 }
 
-CovCosinus::CovCosinus(const CovCosinus &r)
-: ACovFunc(r)
+CovCosinus::CovCosinus(const CovCosinus& r)
+  : ACovFunc(r)
 {
 }
 
-CovCosinus& CovCosinus::operator=(const CovCosinus &r)
+CovCosinus& CovCosinus::operator=(const CovCosinus& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovCubic.cpp
+++ b/src/Covariances/CovCubic.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovCubic.hpp"
-
-#include "Simulation/TurningBandOperate.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovCubic::CovCubic(const CovContext& ctxt)
-: ACovFunc(ECov::CUBIC, ctxt)
+  : ACovFunc(ECov::CUBIC, ctxt)
 {
 }
 
-CovCubic::CovCubic(const CovCubic &r)
-: ACovFunc(r)
+CovCubic::CovCubic(const CovCubic& r)
+  : ACovFunc(r)
 {
 }
 
-CovCubic& CovCubic::operator=(const CovCubic &r)
+CovCubic& CovCubic::operator=(const CovCubic& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -41,7 +40,7 @@ CovCubic::~CovCubic()
 double CovCubic::_evaluateCov(double h) const
 {
   double cov = 0.;
-  double h2 = h * h;
+  double h2  = h * h;
   if (h < 1) cov = 1. - h2 * (7. + h * (-8.75 + h2 * (3.5 - 0.75 * h2)));
   cov = MAX(0., cov);
   return (cov);
@@ -52,7 +51,7 @@ double CovCubic::_evaluateCovDerivative(int degree, double h) const
   double h2, res;
 
   res = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h2 >= 1) return res;
 
   switch (degree)
@@ -73,7 +72,7 @@ String CovCubic::getFormula() const
   return "C(h)=1 - h^2 * \\left(7 + h * \\left(-8.75 + h^2 * \\left(3.5 - 0.75 * h^2 \\right) \\right) \\right)";
 }
 
-double CovCubic::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovCubic::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.shotNoiseCubicOne(t0);
 }

--- a/src/Covariances/CovDiffusionAdvection.cpp
+++ b/src/Covariances/CovDiffusionAdvection.cpp
@@ -9,17 +9,16 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovDiffusionAdvection.hpp"
-#include "Covariances/CovAniso.hpp"
-#include "Basic/FFT.hpp"
 #include "Basic/AException.hpp"
-
+#include "Basic/FFT.hpp"
+#include "Covariances/CovAniso.hpp"
 #include <cmath>
 #include <complex>
 
 namespace gstlrn
 {
 CovDiffusionAdvection::CovDiffusionAdvection()
-:   _markovL(nullptr)
+  : _markovL(nullptr)
   , _markovR(nullptr)
   , _scaleTime(1.)
   , _vel(VectorDouble())
@@ -32,11 +31,10 @@ CovDiffusionAdvection::CovDiffusionAdvection()
   , _markovRdefined(false)
   , _markovLdefined(false)
 {
-
 }
 
 CovDiffusionAdvection::CovDiffusionAdvection(const CovDiffusionAdvection& r)
-:   _markovL(r._markovL->clone())
+  : _markovL(r._markovL->clone())
   , _markovR(r._markovR->clone())
   , _scaleTime(r._scaleTime)
   , _vel(r._vel)
@@ -48,8 +46,6 @@ CovDiffusionAdvection::CovDiffusionAdvection(const CovDiffusionAdvection& r)
   , _markovRdefined(r._markovRdefined)
   , _markovLdefined(r._markovLdefined)
 {
-
-
 }
 
 CovDiffusionAdvection& CovDiffusionAdvection::operator=(const CovDiffusionAdvection& r)
@@ -67,8 +63,8 @@ CovDiffusionAdvection& CovDiffusionAdvection::operator=(const CovDiffusionAdvect
     _destroyMarkovR = true;
     _markovRdefined = r._markovRdefined;
     _markovLdefined = r._markovLdefined;
-   }
-   return *this;
+  }
+  return *this;
 }
 
 CovDiffusionAdvection::~CovDiffusionAdvection()
@@ -80,10 +76,9 @@ CovDiffusionAdvection::~CovDiffusionAdvection()
     delete _markovR;
 }
 
-
 CovDiffusionAdvection* CovDiffusionAdvection::create(CovAniso* markovL,
-                                                     CovAniso* markovR ,
-                                                     double scaleTime ,
+                                                     CovAniso* markovR,
+                                                     double scaleTime,
                                                      VectorDouble vel,
                                                      double sigma2)
 {
@@ -98,58 +93,56 @@ CovDiffusionAdvection* CovDiffusionAdvection::create(CovAniso* markovL,
   return cov;
 }
 
-
 void CovDiffusionAdvection::_init()
 {
-  if (_markovL == nullptr && _markovR==nullptr)
+  if (_markovL == nullptr && _markovR == nullptr)
   {
     my_throw("At least one of the covariances has to be defined to make a valid advection diffusion equation!");
   }
 
-  const CovAniso* cova =  _markovL == nullptr? _markovR : _markovL;
+  const CovAniso* cova = _markovL == nullptr ? _markovR : _markovL;
 
   double correcR = 1.;
   double correcL = 1.;
 
-  _ctxt = cova->getContext();
+  _ctxt    = cova->getContext();
   int ndim = cova->getNDim();
 
-  VectorDouble temp(ndim,1.);
+  VectorDouble temp(ndim, 1.);
   if (_markovL == nullptr)
   {
 
-    _markovL = CovAniso::createAnisotropic(_ctxt,ECov::MARKOV,temp ,1.,1.,temp,false);
+    _markovL        = CovAniso::createAnisotropic(_ctxt, ECov::MARKOV, temp, 1., 1., temp, false);
     _destroyMarkovL = true;
     _markovLdefined = false;
-    correcL = 1.;
+    correcL         = 1.;
   }
   else
   {
     _markovLdefined = true;
-    correcL = _markovL->getCorrec();
+    correcL         = _markovL->getCorrec();
   }
   if (_markovR == nullptr)
   {
-     _markovR = CovAniso::createAnisotropic(_ctxt,ECov::MARKOV,temp ,1.,1.,temp,false);
-     _destroyMarkovR = true;
-     _markovRdefined = false;
-     correcR = 1.;
+    _markovR        = CovAniso::createAnisotropic(_ctxt, ECov::MARKOV, temp, 1., 1., temp, false);
+    _destroyMarkovR = true;
+    _markovRdefined = false;
+    correcR         = 1.;
   }
   else
   {
     _markovRdefined = true;
-    correcR = _markovR->getCorrec();
+    correcR         = _markovR->getCorrec();
   }
 
-    _computeSpatialTrace();
+  _computeSpatialTrace();
 
-   _globalCorrec = _spatialTrace->getFullCorrec()/(correcR * correcL);
-
+  _globalCorrec = _spatialTrace->getFullCorrec() / (correcR * correcL);
 }
 
 void CovDiffusionAdvection::_computeSpatialTrace()
 {
-   delete _spatialTrace;
+  delete _spatialTrace;
 
   VectorDouble scales;
   VectorDouble angles;
@@ -164,30 +157,29 @@ void CovDiffusionAdvection::_computeSpatialTrace()
     angles = _markovR->getAnisoAngles();
   }
 
-   _spatialTrace = CovAniso::createAnisotropic(_ctxt,ECov::MARKOV, scales, _sigma2,1.,angles,false);
+  _spatialTrace = CovAniso::createAnisotropic(_ctxt, ECov::MARKOV, scales, _sigma2, 1., angles, false);
 
-   VectorDouble coeffsL = _markovL->getMarkovCoeffs();
-   VectorDouble coeffsR = _markovR->getMarkovCoeffs();
-   int degree = ((int) coeffsL.size() + (int) coeffsR.size() - 2);
-   VectorDouble coeffs;
-   coeffs.resize(degree + 1,0.);
+  VectorDouble coeffsL = _markovL->getMarkovCoeffs();
+  VectorDouble coeffsR = _markovR->getMarkovCoeffs();
+  int degree           = ((int)coeffsL.size() + (int)coeffsR.size() - 2);
+  VectorDouble coeffs;
+  coeffs.resize(degree + 1, 0.);
 
-   for(int i = 0; i<(int)coeffsR.size();i++)
-     for(int j = 0; j<(int)coeffsL.size();j++)
-     {
-       coeffs[i+j] += coeffsR[i] * coeffsL[j];
-     }
+  for (int i = 0; i < (int)coeffsR.size(); i++)
+    for (int j = 0; j < (int)coeffsL.size(); j++)
+    {
+      coeffs[i + j] += coeffsR[i] * coeffsL[j];
+    }
 
-    _spatialTrace->setMarkovCoeffs(coeffs);
+  _spatialTrace->setMarkovCoeffs(coeffs);
 }
-
 
 std::complex<double> CovDiffusionAdvection::evalSpatialSpectrum(VectorDouble freq, double time) const
 {
 
   double velinner = 0.;
 
-  for(int i = 0; i<(int) freq.size();i++)
+  for (int i = 0; i < (int)freq.size(); i++)
   {
     velinner += _vel[i] * freq[i];
   }
@@ -195,19 +187,18 @@ std::complex<double> CovDiffusionAdvection::evalSpatialSpectrum(VectorDouble fre
   double s1 = 1.;
 
   if (_markovLdefined)
-    s1 = 1./(_markovL->evalSpectrum(freq));
-
+    s1 = 1. / (_markovL->evalSpectrum(freq));
 
   double s2 = 1.;
 
   if (_markovRdefined)
-    s2 = 1./(_markovR->evalSpectrum(freq));
+    s2 = 1. / (_markovR->evalSpectrum(freq));
 
-  //std::complex<double> temp = _scaleTime * (-1i * velinner * time - abs(time * s1));
+  // std::complex<double> temp = _scaleTime * (-1i * velinner * time - abs(time * s1));
   std::complex<double> a(-_scaleTime * abs(time * s1), -_scaleTime * velinner * time);
   std::complex<double> temp = a;
 
-  double ratio =  _sigma2 / (_globalCorrec * s1 * s2 );
+  double ratio = _sigma2 / (_globalCorrec * s1 * s2);
   return ratio * exp(temp);
 }
 
@@ -215,8 +206,8 @@ Array CovDiffusionAdvection::evalCovFFT(const VectorDouble& hmax, double time, i
 {
   std::function<std::complex<double>(VectorDouble, double)> funcSpectrum;
   funcSpectrum = [this](VectorDouble freq, double time)
-         { return evalSpatialSpectrum(freq, time);};
+  { return evalSpatialSpectrum(freq, time); };
 
- return evalCovFFTTimeSlice(hmax, time, N, funcSpectrum);
+  return evalCovFFTTimeSlice(hmax, time, N, funcSpectrum);
 }
 }

--- a/src/Covariances/CovExponential.cpp
+++ b/src/Covariances/CovExponential.cpp
@@ -9,13 +9,11 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovExponential.hpp"
-
-#include "Covariances/CovContext.hpp"
-#include "Simulation/TurningBandOperate.hpp"
-#include "Matrix/MatrixDense.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/VectorHelper.hpp"
-
+#include "Covariances/CovContext.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 #include "math.h"
 
 namespace gstlrn
@@ -29,20 +27,19 @@ double CovExponential::getScadef() const
   return (2.995732);
 }
 
-
 String CovExponential::getFormula() const
 {
   return "C(h)=exp \\left( -\\frac{h}{a_t} \\right)";
 }
 
-double CovExponential::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovExponential::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.spectralOne(t0);
 }
 
 MatrixDense CovExponential::simulateSpectralOmega(int nb) const
 {
-  int ndim = getContext().getNDim();
+  int ndim     = getContext().getNDim();
   double param = 0.5;
   MatrixDense mat(nb, ndim);
 
@@ -66,24 +63,23 @@ double CovExponential::_evaluateCovOnSphere(double alpha,
 
 VectorDouble CovExponential::_evaluateSpectrumOnSphere(int n, double scale) const
 {
-  double nu = scale * getScadef();
-  double nu2 = nu * nu;
+  double nu    = scale * getScadef();
+  double nu2   = nu * nu;
   double expnu = exp(-nu * GV_PI);
 
-  VectorDouble sp(1+n, 0.);
+  VectorDouble sp(1 + n, 0.);
   int k;
 
-  k = 0;
+  k     = 0;
   sp[k] = 1. / 2. * (1. + expnu) / (1. + nu2);
-  k = 1;
+  k     = 1;
   sp[k] = 3. / 2. * (1. - expnu) / (4. + nu2);
 
-  while(1)
+  while (1)
   {
     k++;
     if (k >= n + 1) break;
-    sp[k] = (2. * k + 1.) / (2. * k - 3.) * (nu2 + (k - 2.) * (k - 2.))
-        / (nu2 + (k + 1.) * (k + 1.)) * sp[k - 2];
+    sp[k] = (2. * k + 1.) / (2. * k - 3.) * (nu2 + (k - 2.) * (k - 2.)) / (nu2 + (k + 1.) * (k + 1.)) * sp[k - 2];
   }
 
   VH::normalize(sp, 1);

--- a/src/Covariances/CovFactory.cpp
+++ b/src/Covariances/CovFactory.cpp
@@ -9,26 +9,30 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovFactory.hpp"
-#include "Basic/String.hpp"
 #include "Basic/AException.hpp"
+#include "Basic/String.hpp"
 #include "Covariances/CovBesselJ.hpp"
-#include "Covariances/CovMatern.hpp"
 #include "Covariances/CovCauchy.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Covariances/CovCosExp.hpp"
 #include "Covariances/CovCosinus.hpp"
 #include "Covariances/CovCubic.hpp"
 #include "Covariances/CovExponential.hpp"
-#include "Covariances/CovGamma.hpp"
-#include "Covariances/CovGaussian.hpp"
 #include "Covariances/CovGC1.hpp"
 #include "Covariances/CovGC3.hpp"
 #include "Covariances/CovGC5.hpp"
 #include "Covariances/CovGCspline.hpp"
 #include "Covariances/CovGCspline2.hpp"
+#include "Covariances/CovGamma.hpp"
+#include "Covariances/CovGaussian.hpp"
+#include "Covariances/CovGeometric.hpp"
 #include "Covariances/CovLinear.hpp"
+#include "Covariances/CovLinearSph.hpp"
+#include "Covariances/CovMarkov.hpp"
+#include "Covariances/CovMatern.hpp"
 #include "Covariances/CovNugget.hpp"
 #include "Covariances/CovPenta.hpp"
+#include "Covariances/CovPoisson.hpp"
 #include "Covariances/CovPower.hpp"
 #include "Covariances/CovReg1D.hpp"
 #include "Covariances/CovSincard.hpp"
@@ -39,11 +43,6 @@
 #include "Covariances/CovWendland0.hpp"
 #include "Covariances/CovWendland1.hpp"
 #include "Covariances/CovWendland2.hpp"
-#include "Covariances/CovMarkov.hpp"
-#include "Covariances/CovGeometric.hpp"
-#include "Covariances/CovPoisson.hpp"
-#include "Covariances/CovLinearSph.hpp"
-
 #include <cctype>
 
 namespace gstlrn
@@ -51,44 +50,44 @@ namespace gstlrn
 bool _isValid(ACovFunc* cova, const CovContext& ctxt)
 {
   return (int)cova->getMaxNDim() <= 0 ||
-           (int)ctxt.getNDim() <= (int)cova->getMaxNDim();
+         (int)ctxt.getNDim() <= (int)cova->getMaxNDim();
 }
 
 ACovFunc* CovFactory::createCovFunc(const ECov& type, const CovContext& ctxt)
 {
-  switch(type.toEnum())
+  switch (type.toEnum())
   {
-    case ECov::E_NUGGET:      return new CovNugget(ctxt);
+    case ECov::E_NUGGET: return new CovNugget(ctxt);
     case ECov::E_EXPONENTIAL: return new CovExponential(ctxt);
-    case ECov::E_SPHERICAL:   return new CovSpherical(ctxt);
-    case ECov::E_GAUSSIAN:    return new CovGaussian(ctxt);
-    case ECov::E_CUBIC:       return new CovCubic(ctxt);
-    case ECov::E_SINCARD:     return new CovSincard(ctxt);
-    case ECov::E_BESSELJ:     return new CovBesselJ(ctxt);
-    case ECov::E_MATERN:      return new CovMatern(ctxt);
-    case ECov::E_GAMMA:       return new CovGamma(ctxt);
-    case ECov::E_CAUCHY:      return new CovCauchy(ctxt);
-    case ECov::E_STABLE:      return new CovStable(ctxt);
-    case ECov::E_LINEAR:      return new CovLinear(ctxt);
-    case ECov::E_POWER:       return new CovPower(ctxt);
-    case ECov::E_ORDER1_GC:   return new CovGC1(ctxt);
-    case ECov::E_SPLINE_GC:   return new CovGCspline(ctxt);
-    case ECov::E_SPLINE2_GC:  return new CovGCspline2(ctxt);
-    case ECov::E_ORDER3_GC:   return new CovGC3(ctxt);
-    case ECov::E_ORDER5_GC:   return new CovGC5(ctxt);
-    case ECov::E_COSINUS:     return new CovCosinus(ctxt);
-    case ECov::E_TRIANGLE:    return new CovTriangle(ctxt);
-    case ECov::E_COSEXP:      return new CovCosExp(ctxt);
-    case ECov::E_REG1D:       return new CovReg1D(ctxt);
-    case ECov::E_PENTA:       return new CovPenta(ctxt);
-    case ECov::E_STORKEY:     return new CovStorkey(ctxt);
-    case ECov::E_WENDLAND0:   return new CovWendland0(ctxt);
-    case ECov::E_WENDLAND1:   return new CovWendland1(ctxt);
-    case ECov::E_WENDLAND2:   return new CovWendland2(ctxt);
-    case ECov::E_MARKOV:      return new CovMarkov(ctxt);
-    case ECov::E_GEOMETRIC:   return new CovGeometric(ctxt);
-    case ECov::E_POISSON:     return new CovPoisson(ctxt);
-    case ECov::E_LINEARSPH:   return new CovLinearSph(ctxt);
+    case ECov::E_SPHERICAL: return new CovSpherical(ctxt);
+    case ECov::E_GAUSSIAN: return new CovGaussian(ctxt);
+    case ECov::E_CUBIC: return new CovCubic(ctxt);
+    case ECov::E_SINCARD: return new CovSincard(ctxt);
+    case ECov::E_BESSELJ: return new CovBesselJ(ctxt);
+    case ECov::E_MATERN: return new CovMatern(ctxt);
+    case ECov::E_GAMMA: return new CovGamma(ctxt);
+    case ECov::E_CAUCHY: return new CovCauchy(ctxt);
+    case ECov::E_STABLE: return new CovStable(ctxt);
+    case ECov::E_LINEAR: return new CovLinear(ctxt);
+    case ECov::E_POWER: return new CovPower(ctxt);
+    case ECov::E_ORDER1_GC: return new CovGC1(ctxt);
+    case ECov::E_SPLINE_GC: return new CovGCspline(ctxt);
+    case ECov::E_SPLINE2_GC: return new CovGCspline2(ctxt);
+    case ECov::E_ORDER3_GC: return new CovGC3(ctxt);
+    case ECov::E_ORDER5_GC: return new CovGC5(ctxt);
+    case ECov::E_COSINUS: return new CovCosinus(ctxt);
+    case ECov::E_TRIANGLE: return new CovTriangle(ctxt);
+    case ECov::E_COSEXP: return new CovCosExp(ctxt);
+    case ECov::E_REG1D: return new CovReg1D(ctxt);
+    case ECov::E_PENTA: return new CovPenta(ctxt);
+    case ECov::E_STORKEY: return new CovStorkey(ctxt);
+    case ECov::E_WENDLAND0: return new CovWendland0(ctxt);
+    case ECov::E_WENDLAND1: return new CovWendland1(ctxt);
+    case ECov::E_WENDLAND2: return new CovWendland2(ctxt);
+    case ECov::E_MARKOV: return new CovMarkov(ctxt);
+    case ECov::E_GEOMETRIC: return new CovGeometric(ctxt);
+    case ECov::E_POISSON: return new CovPoisson(ctxt);
+    case ECov::E_LINEARSPH: return new CovLinearSph(ctxt);
     default: break;
   }
   return nullptr;
@@ -96,43 +95,43 @@ ACovFunc* CovFactory::createCovFunc(const ECov& type, const CovContext& ctxt)
 
 ACovFunc* CovFactory::duplicateCovFunc(const ACovFunc& cov)
 {
-  switch(cov.getType().toEnum())
+  switch (cov.getType().toEnum())
   {
     // Warning : if a crash with "bad cast" occurs, please check the type of your CovFunc
-    case ECov::E_NUGGET:      return new CovNugget(     dynamic_cast<const CovNugget&>     (cov));
+    case ECov::E_NUGGET: return new CovNugget(dynamic_cast<const CovNugget&>(cov));
     case ECov::E_EXPONENTIAL: return new CovExponential(dynamic_cast<const CovExponential&>(cov));
-    case ECov::E_SPHERICAL:   return new CovSpherical(  dynamic_cast<const CovSpherical&>  (cov));
-    case ECov::E_GAUSSIAN:    return new CovGaussian(   dynamic_cast<const CovGaussian&>   (cov));
-    case ECov::E_CUBIC:       return new CovCubic(      dynamic_cast<const CovCubic&>      (cov));
-    case ECov::E_SINCARD:     return new CovSincard(    dynamic_cast<const CovSincard&>    (cov));
-    case ECov::E_BESSELJ:     return new CovBesselJ(    dynamic_cast<const CovBesselJ&>    (cov));
-    case ECov::E_MATERN:      return new CovMatern(     dynamic_cast<const CovMatern&>     (cov));
-    case ECov::E_GAMMA:       return new CovGamma(      dynamic_cast<const CovGamma&>      (cov));
-    case ECov::E_CAUCHY:      return new CovCauchy(     dynamic_cast<const CovCauchy&>     (cov));
-    case ECov::E_STABLE:      return new CovStable(     dynamic_cast<const CovStable&>     (cov));
-    case ECov::E_LINEAR:      return new CovLinear(     dynamic_cast<const CovLinear&>     (cov));
-    case ECov::E_POWER:       return new CovPower(      dynamic_cast<const CovPower&>      (cov));
-    case ECov::E_ORDER1_GC:   return new CovGC1(        dynamic_cast<const CovGC1&>        (cov));
-    case ECov::E_SPLINE_GC:   return new CovGCspline(   dynamic_cast<const CovGCspline&>   (cov));
-    case ECov::E_ORDER3_GC:   return new CovGC3(        dynamic_cast<const CovGC3&>        (cov));
-    case ECov::E_ORDER5_GC:   return new CovGC5(        dynamic_cast<const CovGC5&>        (cov));
-    case ECov::E_COSINUS:     return new CovCosinus(    dynamic_cast<const CovCosinus&>    (cov));
-    case ECov::E_TRIANGLE:    return new CovTriangle(   dynamic_cast<const CovTriangle&>   (cov));
-    case ECov::E_COSEXP:      return new CovCosExp(     dynamic_cast<const CovCosExp&>     (cov));
-    case ECov::E_REG1D:       return new CovReg1D(      dynamic_cast<const CovReg1D&>      (cov));
-    case ECov::E_PENTA:       return new CovPenta(      dynamic_cast<const CovPenta&>      (cov));
-    case ECov::E_SPLINE2_GC:  return new CovGCspline2(  dynamic_cast<const CovGCspline2&>  (cov));
-    case ECov::E_STORKEY:     return new CovStorkey(    dynamic_cast<const CovStorkey&>    (cov));
-    case ECov::E_WENDLAND0:   return new CovWendland0(  dynamic_cast<const CovWendland0&>  (cov));
-    case ECov::E_WENDLAND1:   return new CovWendland1(  dynamic_cast<const CovWendland1&>  (cov));
-    case ECov::E_WENDLAND2:   return new CovWendland2(  dynamic_cast<const CovWendland2&>  (cov));
-    case ECov::E_MARKOV:      return new CovMarkov(     dynamic_cast<const CovMarkov&>     (cov));
-    case ECov::E_POISSON:     return new CovPoisson(    dynamic_cast<const CovPoisson&>    (cov));
-    case ECov::E_GEOMETRIC:   return new CovGeometric(  dynamic_cast<const CovGeometric&>  (cov));
-    case ECov::E_LINEARSPH:   return new CovLinearSph(  dynamic_cast<const CovLinearSph&>  (cov));
+    case ECov::E_SPHERICAL: return new CovSpherical(dynamic_cast<const CovSpherical&>(cov));
+    case ECov::E_GAUSSIAN: return new CovGaussian(dynamic_cast<const CovGaussian&>(cov));
+    case ECov::E_CUBIC: return new CovCubic(dynamic_cast<const CovCubic&>(cov));
+    case ECov::E_SINCARD: return new CovSincard(dynamic_cast<const CovSincard&>(cov));
+    case ECov::E_BESSELJ: return new CovBesselJ(dynamic_cast<const CovBesselJ&>(cov));
+    case ECov::E_MATERN: return new CovMatern(dynamic_cast<const CovMatern&>(cov));
+    case ECov::E_GAMMA: return new CovGamma(dynamic_cast<const CovGamma&>(cov));
+    case ECov::E_CAUCHY: return new CovCauchy(dynamic_cast<const CovCauchy&>(cov));
+    case ECov::E_STABLE: return new CovStable(dynamic_cast<const CovStable&>(cov));
+    case ECov::E_LINEAR: return new CovLinear(dynamic_cast<const CovLinear&>(cov));
+    case ECov::E_POWER: return new CovPower(dynamic_cast<const CovPower&>(cov));
+    case ECov::E_ORDER1_GC: return new CovGC1(dynamic_cast<const CovGC1&>(cov));
+    case ECov::E_SPLINE_GC: return new CovGCspline(dynamic_cast<const CovGCspline&>(cov));
+    case ECov::E_ORDER3_GC: return new CovGC3(dynamic_cast<const CovGC3&>(cov));
+    case ECov::E_ORDER5_GC: return new CovGC5(dynamic_cast<const CovGC5&>(cov));
+    case ECov::E_COSINUS: return new CovCosinus(dynamic_cast<const CovCosinus&>(cov));
+    case ECov::E_TRIANGLE: return new CovTriangle(dynamic_cast<const CovTriangle&>(cov));
+    case ECov::E_COSEXP: return new CovCosExp(dynamic_cast<const CovCosExp&>(cov));
+    case ECov::E_REG1D: return new CovReg1D(dynamic_cast<const CovReg1D&>(cov));
+    case ECov::E_PENTA: return new CovPenta(dynamic_cast<const CovPenta&>(cov));
+    case ECov::E_SPLINE2_GC: return new CovGCspline2(dynamic_cast<const CovGCspline2&>(cov));
+    case ECov::E_STORKEY: return new CovStorkey(dynamic_cast<const CovStorkey&>(cov));
+    case ECov::E_WENDLAND0: return new CovWendland0(dynamic_cast<const CovWendland0&>(cov));
+    case ECov::E_WENDLAND1: return new CovWendland1(dynamic_cast<const CovWendland1&>(cov));
+    case ECov::E_WENDLAND2: return new CovWendland2(dynamic_cast<const CovWendland2&>(cov));
+    case ECov::E_MARKOV: return new CovMarkov(dynamic_cast<const CovMarkov&>(cov));
+    case ECov::E_POISSON: return new CovPoisson(dynamic_cast<const CovPoisson&>(cov));
+    case ECov::E_GEOMETRIC: return new CovGeometric(dynamic_cast<const CovGeometric&>(cov));
+    case ECov::E_LINEARSPH: return new CovLinearSph(dynamic_cast<const CovLinearSph&>(cov));
     default: break;
   }
-  my_throw ("Covariance function not yet implemented!");
+  my_throw("Covariance function not yet implemented!");
 }
 
 /**
@@ -204,8 +203,8 @@ ECov CovFactory::identifyCovariance(const String& cov_name,
     if (*it != ECov::UNKNOWN && *it != ECov::FUNCTION)
     {
       ACovFunc* cova = createCovFunc(*it, ctxt);
-      String cn = toUpper(cov_name);
-      String ccn = toUpper(cova->getCovName());
+      String cn      = toUpper(cov_name);
+      String ccn     = toUpper(cova->getCovName());
       delete cova;
       if (cn == ccn)
         return *it;
@@ -217,10 +216,10 @@ ECov CovFactory::identifyCovariance(const String& cov_name,
   return ECov::UNKNOWN;
 }
 
-double CovFactory::getScaleFactor(const ECov &type, double param)
+double CovFactory::getScaleFactor(const ECov& type, double param)
 {
   CovContext ctxt = CovContext(1, 1);
-  ACovFunc *cova = CovFactory::createCovFunc(type, ctxt);
+  ACovFunc* cova  = CovFactory::createCovFunc(type, ctxt);
   cova->setParam(param);
   double scadef = cova->getScadef();
   delete cova;

--- a/src/Covariances/CovGC1.cpp
+++ b/src/Covariances/CovGC1.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGC1.hpp"
-
-#include "Simulation/TurningBandOperate.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovGC1::CovGC1(const CovContext& ctxt)
-: ACovFunc(ECov::ORDER1_GC, ctxt)
+  : ACovFunc(ECov::ORDER1_GC, ctxt)
 {
 }
 
-CovGC1::CovGC1(const CovGC1 &r)
-: ACovFunc(r)
+CovGC1::CovGC1(const CovGC1& r)
+  : ACovFunc(r)
 {
 }
 
-CovGC1& CovGC1::operator=(const CovGC1 &r)
+CovGC1& CovGC1::operator=(const CovGC1& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -54,7 +53,7 @@ double CovGC1::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovGC1::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovGC1::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.IRFProcessOne(t0);
 }

--- a/src/Covariances/CovGC3.cpp
+++ b/src/Covariances/CovGC3.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGC3.hpp"
-
-#include "Simulation/TurningBandOperate.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovGC3::CovGC3(const CovContext& ctxt)
-: ACovFunc(ECov::ORDER3_GC, ctxt)
+  : ACovFunc(ECov::ORDER3_GC, ctxt)
 {
 }
 
-CovGC3::CovGC3(const CovGC3 &r)
-: ACovFunc(r)
+CovGC3::CovGC3(const CovGC3& r)
+  : ACovFunc(r)
 {
 }
 
-CovGC3& CovGC3::operator=(const CovGC3 &r)
+CovGC3& CovGC3::operator=(const CovGC3& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -57,7 +56,7 @@ double CovGC3::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovGC3::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovGC3::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.IRFProcessOne(t0);
 }

--- a/src/Covariances/CovGC5.cpp
+++ b/src/Covariances/CovGC5.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGC5.hpp"
-
-#include "Simulation/TurningBandOperate.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovGC5::CovGC5(const CovContext& ctxt)
-: ACovFunc(ECov::ORDER5_GC, ctxt)
+  : ACovFunc(ECov::ORDER5_GC, ctxt)
 {
 }
 
-CovGC5::CovGC5(const CovGC5 &r)
-: ACovFunc(r)
+CovGC5::CovGC5(const CovGC5& r)
+  : ACovFunc(r)
 {
 }
 
-CovGC5& CovGC5::operator=(const CovGC5 &r)
+CovGC5& CovGC5::operator=(const CovGC5& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -41,8 +40,8 @@ CovGC5::~CovGC5()
 double CovGC5::_evaluateCov(double h) const
 {
   double cov;
-  double r = getContext().getField();
-  int ndim = getContext().getNDim();
+  double r  = getContext().getField();
+  int ndim  = getContext().getNDim();
   double h2 = h * h;
   double r2 = r * r;
   double h4 = h2 * h2;
@@ -51,15 +50,14 @@ double CovGC5::_evaluateCov(double h) const
   if (ndim == 1)
     cov = h4 * (h - 5. * r) + r3 * (20. * h2 - 16. * r2);
   else if (ndim == 2)
-    cov = h4 * (h - 225. * GV_PI * r / 128.)
-        + r3 * (75. * GV_PI * h2 / 8. - 15. * GV_PI * r2);
+    cov = h4 * (h - 225. * GV_PI * r / 128.) + r3 * (75. * GV_PI * h2 / 8. - 15. * GV_PI * r2);
   else
     cov = h4 * (h - 6. * r) + r3 * (40. * h2 - 96. * r2);
 
   return (-cov);
 }
 
-double CovGC5::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovGC5::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.IRFProcessOne(t0);
 }

--- a/src/Covariances/CovGCspline.cpp
+++ b/src/Covariances/CovGCspline.cpp
@@ -11,26 +11,25 @@
 #include "Covariances/CovGCspline.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-
 #include <math.h>
 
 namespace gstlrn
 {
 CovGCspline::CovGCspline(const CovContext& ctxt)
-: ACovFunc(ECov::SPLINE_GC, ctxt)
+  : ACovFunc(ECov::SPLINE_GC, ctxt)
 {
 }
 
-CovGCspline::CovGCspline(const CovGCspline &r)
-: ACovFunc(r)
+CovGCspline::CovGCspline(const CovGCspline& r)
+  : ACovFunc(r)
 {
 }
 
-CovGCspline& CovGCspline::operator=(const CovGCspline &r)
+CovGCspline& CovGCspline::operator=(const CovGCspline& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -41,10 +40,10 @@ CovGCspline::~CovGCspline()
 
 double CovGCspline::_evaluateCov(double h) const
 {
-  int ndim = getContext().getNDim();
-  double r = getContext().getField();
-  double r2 = r * r;
-  double h2 = h * h;
+  int ndim      = getContext().getNDim();
+  double r      = getContext().getField();
+  double r2     = r * r;
+  double h2     = h * h;
   double logval = (r < 10.e-5 || h < r * 10.e-5) ? 0. : log(h / r);
 
   // Code for the first 3 Space dimensions
@@ -59,7 +58,7 @@ double CovGCspline::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovGCspline::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovGCspline::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.cosineOne(t0);
 }

--- a/src/Covariances/CovGCspline2.cpp
+++ b/src/Covariances/CovGCspline2.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGCspline2.hpp"
-
-#include <math.h>
 #include "Covariances/CovContext.hpp"
+#include <math.h>
 
 namespace gstlrn
 {
 CovGCspline2::CovGCspline2(const CovContext& ctxt)
-: ACovFunc(ECov::SPLINE2_GC, ctxt)
+  : ACovFunc(ECov::SPLINE2_GC, ctxt)
 {
 }
 
-CovGCspline2::CovGCspline2(const CovGCspline2 &r)
-: ACovFunc(r)
+CovGCspline2::CovGCspline2(const CovGCspline2& r)
+  : ACovFunc(r)
 {
 }
 
-CovGCspline2& CovGCspline2::operator=(const CovGCspline2 &r)
+CovGCspline2& CovGCspline2::operator=(const CovGCspline2& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -44,18 +43,18 @@ double CovGCspline2::_evaluateCov(double h) const
   double A = (7. - 10. * B) / 12.;
   double C = (-7. - 2. * B) / 12.;
 
-  double h2 = h * h;
+  double h2     = h * h;
   double logval = (h < 10.e-5) ? 0. : log(h);
-  double cov = A + h2 * (B + h2 * (C + logval));
+  double cov    = A + h2 * (B + h2 * (C + logval));
 
   return (cov);
 }
 
 double CovGCspline2::_evaluateCovDerivative(int degree, double h) const
 {
-  double B = 1.;
-  double C = (-7. - 2. * B) / 12.;
-  double h2 = h * h;
+  double B      = 1.;
+  double C      = (-7. - 2. * B) / 12.;
+  double h2     = h * h;
   double logval = (h < 10.e-5) ? 0. : log(h);
 
   double cov = 0.;

--- a/src/Covariances/CovGamma.cpp
+++ b/src/Covariances/CovGamma.cpp
@@ -9,28 +9,27 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGamma.hpp"
-
-#include "math.h"
 #include "Covariances/CovContext.hpp"
+#include "math.h"
 
 namespace gstlrn
 {
 CovGamma::CovGamma(const CovContext& ctxt)
-: ACovFunc(ECov::GAMMA, ctxt)
+  : ACovFunc(ECov::GAMMA, ctxt)
 {
   setParam(1);
 }
 
-CovGamma::CovGamma(const CovGamma &r)
-: ACovFunc(r)
+CovGamma::CovGamma(const CovGamma& r)
+  : ACovFunc(r)
 {
 }
 
-CovGamma& CovGamma::operator=(const CovGamma &r)
+CovGamma& CovGamma::operator=(const CovGamma& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -43,7 +42,7 @@ double CovGamma::getScadef() const
 {
   double param = getParam();
   if (param < 0.05) param = 1.; // This test is too avoid passing too small number to next line
-  double scadef = pow(20.,1. / param) - 1.;
+  double scadef = pow(20., 1. / param) - 1.;
   return (scadef);
 }
 

--- a/src/Covariances/CovGaussian.cpp
+++ b/src/Covariances/CovGaussian.cpp
@@ -9,30 +9,29 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGaussian.hpp"
-#include "Covariances/CovContext.hpp"
-#include "Simulation/TurningBandOperate.hpp"
-#include "Matrix/MatrixDense.hpp"
 #include "Basic/Law.hpp"
-
+#include "Covariances/CovContext.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 #include "math.h"
 
 namespace gstlrn
 {
 CovGaussian::CovGaussian(const CovContext& ctxt)
-: ACovFunc(ECov::GAUSSIAN, ctxt)
+  : ACovFunc(ECov::GAUSSIAN, ctxt)
 {
 }
 
-CovGaussian::CovGaussian(const CovGaussian &r)
-: ACovFunc(r)
+CovGaussian::CovGaussian(const CovGaussian& r)
+  : ACovFunc(r)
 {
 }
 
-CovGaussian& CovGaussian::operator=(const CovGaussian &r)
+CovGaussian& CovGaussian::operator=(const CovGaussian& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -62,7 +61,7 @@ double CovGaussian::_evaluateCovDerivative(int degree, double h) const
   double cov = 0.;
   switch (degree)
   {
-    case 1:   // First order derivative
+    case 1: // First order derivative
       cov = 2. * exp(-r2);
       break;
 
@@ -76,7 +75,7 @@ double CovGaussian::_evaluateCovDerivative(int degree, double h) const
 
     case 4: // Fourth order derivative
       double r4 = r2 * r2;
-      cov = 8. * exp(-r2) * (6. - 15. * r2 + r4);
+      cov       = 8. * exp(-r2) * (6. - 15. * r2 + r4);
       break;
   }
   return (cov);
@@ -87,7 +86,7 @@ String CovGaussian::getFormula() const
   return "C(h)=1-\\frac{7h^2}{a^2}+\\frac{35h^3}{4a^3}-\\frac{7h^5}{2a^5}-\\frac{3h^7}{4a^7}";
 }
 
-double CovGaussian::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovGaussian::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.cosineOne(t0);
 }

--- a/src/Covariances/CovGeometric.cpp
+++ b/src/Covariances/CovGeometric.cpp
@@ -9,29 +9,28 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGeometric.hpp"
-
-#include "math.h"
 #include "Basic/VectorHelper.hpp"
 #include "Covariances/CovContext.hpp"
+#include "math.h"
 
 namespace gstlrn
 {
 CovGeometric::CovGeometric(const CovContext& ctxt)
-: ACovFunc(ECov::GEOMETRIC, ctxt)
+  : ACovFunc(ECov::GEOMETRIC, ctxt)
 {
   setParam(1);
 }
 
-CovGeometric::CovGeometric(const CovGeometric &r)
-: ACovFunc(r)
+CovGeometric::CovGeometric(const CovGeometric& r)
+  : ACovFunc(r)
 {
 }
 
-CovGeometric& CovGeometric::operator=(const CovGeometric &r)
+CovGeometric& CovGeometric::operator=(const CovGeometric& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -52,7 +51,7 @@ double CovGeometric::_evaluateCovOnSphere(double alpha,
 VectorDouble CovGeometric::_evaluateSpectrumOnSphere(int n, double scale) const
 {
   double rho = scale;
-  VectorDouble sp(1+n, 0.);
+  VectorDouble sp(1 + n, 0.);
 
   double rhoprod = 1.;
   for (int k = 0; k <= n; k++)

--- a/src/Covariances/CovGradientFunctional.cpp
+++ b/src/Covariances/CovGradientFunctional.cpp
@@ -9,37 +9,36 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovGradientFunctional.hpp"
-#include "Basic/VectorNumT.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "Space/ASpace.hpp"
-
 #include <math.h>
 
-#define TR(i,j) (Tr[3 * (i) + (j)])
+#define TR(i, j) (Tr[3 * (i) + (j)])
 
 namespace gstlrn
 {
 CovGradientFunctional::CovGradientFunctional(const ECov& type,
                                              const CovContext& ctxt)
-    : ACovGradient(type, ctxt)
+  : ACovGradient(type, ctxt)
 {
 }
 
-CovGradientFunctional::CovGradientFunctional(const CovGradientFunctional &r)
-    : ACovGradient(r)
+CovGradientFunctional::CovGradientFunctional(const CovGradientFunctional& r)
+  : ACovGradient(r)
 {
 }
 
-CovGradientFunctional::CovGradientFunctional(const CovAniso &r)
-    : ACovGradient(r)
+CovGradientFunctional::CovGradientFunctional(const CovAniso& r)
+  : ACovGradient(r)
 {
 }
 
-CovGradientFunctional& CovGradientFunctional::operator=(const CovGradientFunctional &r)
+CovGradientFunctional& CovGradientFunctional::operator=(const CovGradientFunctional& r)
 {
   if (this != &r)
   {
-    ACovGradient::operator =(r);
+    ACovGradient::operator=(r);
   }
   return *this;
 }
@@ -62,7 +61,7 @@ void CovGradientFunctional::_calculateTrTtr(const VectorDouble& d,
 {
   int ndim = getContext().getNDim();
 
-  VectorDouble h(3,0.);
+  VectorDouble h(3, 0.);
   VectorDouble Tr(9, 0.);
 
   VH::fill(u, 0.);
@@ -70,21 +69,21 @@ void CovGradientFunctional::_calculateTrTtr(const VectorDouble& d,
 
   // Matrix Tr = diag(coeffs) . R
 
-  for (int i=0; i<3; i++)
-    for (int j=0; j<3; j++)
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
     {
       if (i >= ndim || j >= ndim) continue;
-      TR(i,j) = getAniso().getRotation().getMatrixDirect().getValue(i,j) / getScale(i);
+      TR(i, j) = getAniso().getRotation().getMatrixDirect().getValue(i, j) / getScale(i);
     }
 
   // Calculate the t(Tr) %*% Tr matrix
 
   int ecr = 0;
-  for (int i=0; i<3; i++)
-    for (int j=0; j<3; j++)
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
     {
       double prod = 0.;
-      for (int k=0; k<3; k++) prod += TR(k,i) * TR(k,j);
+      for (int k = 0; k < 3; k++) prod += TR(k, i) * TR(k, j);
       trttr[ecr++] = prod;
     }
 
@@ -97,7 +96,7 @@ void CovGradientFunctional::_calculateTrTtr(const VectorDouble& d,
   u[0] = Tr[0] * h[0] + Tr[3] * h[1] + Tr[6] * h[2];
   u[1] = Tr[1] * h[0] + Tr[4] * h[1] + Tr[7] * h[2];
   u[2] = Tr[2] * h[0] + Tr[5] * h[1] + Tr[8] * h[2];
- }
+}
 
 /**
  * Evaluates the covariance and gradient components
@@ -129,23 +128,23 @@ void CovGradientFunctional::evalZAndGradients(const SpacePoint& p1,
                                               const CovCalcMode* /*mode*/,
                                               bool flagGrad) const
 {
-  VectorDouble d(3),trttr(9),u(3);
+  VectorDouble d(3), trttr(9), u(3);
 
   // Calculate the isotropic distance
 
-  double h = getSpace()->getDistance(p1, p2, getAniso());
+  double h        = getSpace()->getDistance(p1, p2, getAniso());
   VectorDouble d1 = VH::subtract(p1.getCoords(), p2.getCoords());
-  for (int i=0; i < 3; i++)
-    d[i] = (i < (int) d1.size()) ? d1[i] : 0.;
+  for (int i = 0; i < 3; i++)
+    d[i] = (i < (int)d1.size()) ? d1[i] : 0.;
 
   //  Calculate the covariance
 
-  double covar = getSill(0,0) * getCorFunc()->evalCorFunc(h);
+  double covar = getSill(0, 0) * getCorFunc()->evalCorFunc(h);
   covVal += covar;
   if (getCorFunc()->getType() == ECov::NUGGET) return;
 
   _calculateTrTtr(d, u, trttr);
-  double dcovsr = getSill(0,0) * getCorFunc()->evalCovDerivative(1,h);
+  double dcovsr = getSill(0, 0) * getCorFunc()->evalCovDerivative(1, h);
 
   //  Case where distance is null
 
@@ -171,15 +170,15 @@ void CovGradientFunctional::evalZAndGradients(const SpacePoint& p1,
 
     if (flagGrad)
     {
-      double d2cov = getSill(0,0) * getCorFunc()->evalCovDerivative(2,h);
-      double a = (dcovsr - d2cov) / (h * h);
+      double d2cov = getSill(0, 0) * getCorFunc()->evalCovDerivative(2, h);
+      double a     = (dcovsr - d2cov) / (h * h);
       if (getAniso().isIsotropic())
       {
 
         //  Isotropic case
 
         double b = dcovsr * trttr[0];
-        int ecr = 0;
+        int ecr  = 0;
         for (int i = 0; i < 3; i++)
           for (int j = 0; j < 3; j++)
           {

--- a/src/Covariances/CovGradientNumerical.cpp
+++ b/src/Covariances/CovGradientNumerical.cpp
@@ -8,36 +8,35 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Covariances/CovFactory.hpp"
 #include "Covariances/CovGradientNumerical.hpp"
-#include "Covariances/CovContext.hpp"
 #include "Basic/VectorNumT.hpp"
-
+#include "Covariances/CovContext.hpp"
+#include "Covariances/CovFactory.hpp"
 #include <math.h>
 
-#define TR(i,j)                (Tr[(i) * 3 + (j)])
+#define TR(i, j) (Tr[(i) * 3 + (j)])
 
 namespace gstlrn
 {
 CovGradientNumerical::CovGradientNumerical(const ECov& type,
                                            double ballRadius,
                                            const CovContext& ctxt)
-    : ACovGradient(type, ctxt),
-      _ballRadius(ballRadius)
+  : ACovGradient(type, ctxt)
+  , _ballRadius(ballRadius)
 {
 }
 
-CovGradientNumerical::CovGradientNumerical(const CovGradientNumerical &r)
-    : ACovGradient(r),
-      _ballRadius(r._ballRadius)
+CovGradientNumerical::CovGradientNumerical(const CovGradientNumerical& r)
+  : ACovGradient(r)
+  , _ballRadius(r._ballRadius)
 {
 }
 
-CovGradientNumerical& CovGradientNumerical::operator=(const CovGradientNumerical &r)
+CovGradientNumerical& CovGradientNumerical::operator=(const CovGradientNumerical& r)
 {
   if (this != &r)
   {
-    ACovGradient::operator =(r);
+    ACovGradient::operator=(r);
     _ballRadius = r._ballRadius;
   }
   return *this;
@@ -68,11 +67,11 @@ double CovGradientNumerical::_evalZGrad(int ivar,
   VectorDouble vec(ndim, 0);
 
   vec[idim] = _ballRadius / 2.;
-  paux = p2;
+  paux      = p2;
   paux.move(vec);
   double covp0 = ACovGradient::_eval(p1, paux, ivar, jvar, mode);
-  vec[idim] = -_ballRadius / 2.;
-  paux = p2;
+  vec[idim]    = -_ballRadius / 2.;
+  paux         = p2;
   paux.move(vec);
   double covm0 = ACovGradient::_eval(p1, paux, ivar, jvar, mode);
 
@@ -96,23 +95,23 @@ double CovGradientNumerical::_evalGradGrad(int ivar,
   if (idim != jdim)
   {
     vec[idim] = -_ballRadius / 2.;
-    vec[jdim] =  _ballRadius / 2.;
-    paux = p2;
+    vec[jdim] = _ballRadius / 2.;
+    paux      = p2;
     paux.move(vec);
     double covmp = ACovGradient::evalCov(p1, paux, ivar, jvar, mode);
-    vec[idim] = -_ballRadius / 2.;
-    vec[jdim] = -_ballRadius / 2.;
-    paux = p2;
+    vec[idim]    = -_ballRadius / 2.;
+    vec[jdim]    = -_ballRadius / 2.;
+    paux         = p2;
     paux.move(vec);
     double covmm = ACovGradient::_eval(p1, paux, ivar, jvar, mode);
-    vec[idim] =  _ballRadius / 2.;
-    vec[jdim] = -_ballRadius / 2.;
-    paux = p2;
+    vec[idim]    = _ballRadius / 2.;
+    vec[jdim]    = -_ballRadius / 2.;
+    paux         = p2;
     paux.move(vec);
     double covpm = ACovGradient::_eval(p1, paux, ivar, jvar, mode);
-    vec[idim] = _ballRadius / 2.;
-    vec[jdim] = _ballRadius / 2.;
-    paux = p2;
+    vec[idim]    = _ballRadius / 2.;
+    vec[jdim]    = _ballRadius / 2.;
+    paux         = p2;
     paux.move(vec);
     double covpp = ACovGradient::_eval(p1, paux, ivar, jvar, mode);
 
@@ -121,21 +120,21 @@ double CovGradientNumerical::_evalGradGrad(int ivar,
   else
   {
     vec[idim] = _ballRadius;
-    paux = p2;
+    paux      = p2;
     paux.move(vec);
     double cov2m = ACovGradient::evalCov(p1, paux, ivar, jvar, mode);
-    vec[idim] = -_ballRadius;
-    paux = p2;
+    vec[idim]    = -_ballRadius;
+    paux         = p2;
     paux.move(vec);
     double cov2p = ACovGradient::evalCov(p1, paux, ivar, jvar, mode);
-    vec[idim] = 0;
-    paux = p2;
+    vec[idim]    = 0;
+    paux         = p2;
     paux.move(vec);
     double cov00 = ACovGradient::evalCov(p1, paux, ivar, jvar, mode);
 
-    cov = -2. * (cov2p - 2.*cov00 + cov2m) / (_ballRadius * _ballRadius);
+    cov = -2. * (cov2p - 2. * cov00 + cov2m) / (_ballRadius * _ballRadius);
   }
-  return(cov);
+  return (cov);
 }
 
 /**
@@ -169,14 +168,14 @@ void CovGradientNumerical::evalZAndGradients(const SpacePoint& p1,
 {
   //  Calculate the covariance
 
-  double covar = _evalZZ(0,0,p1,p2,mode);
+  double covar = _evalZZ(0, 0, p1, p2, mode);
   covVal += covar;
   if (getCorFunc()->getType() == ECov::NUGGET) return;
 
   //  Calculate covariance between point and gradient
 
   for (int i = 0; i < 3; i++)
-    covGp[i] += _evalZGrad(0,0,i,p1,p2,mode);
+    covGp[i] += _evalZGrad(0, 0, i, p1, p2, mode);
 
   //  Calculate the covariance between gradient and gradient
 
@@ -220,7 +219,7 @@ double CovGradientNumerical::_eval(const SpacePoint& p1,
     int idim = ivar - 1;
     int jdim = jvar - 1;
     if (ivar == 0)
-      cov = - _evalZGrad(0, 0, jdim, p1, p2, mode);
+      cov = -_evalZGrad(0, 0, jdim, p1, p2, mode);
     else if (jvar == 0)
       cov = _evalZGrad(0, 0, idim, p1, p2, mode);
     else
@@ -228,7 +227,7 @@ double CovGradientNumerical::_eval(const SpacePoint& p1,
       if (jdim == idim)
         cov = _evalGradGrad(0, 0, idim, jdim, p1, p2, mode);
       else
-        cov = - _evalGradGrad(0, 0, idim, jdim, p1, p2, mode);
+        cov = -_evalGradGrad(0, 0, idim, jdim, p1, p2, mode);
     }
   }
   return cov;

--- a/src/Covariances/CovHelper.cpp
+++ b/src/Covariances/CovHelper.cpp
@@ -8,11 +8,10 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Simulation/CalcSimuTurningBands.hpp"
 #include "Covariances/CovHelper.hpp"
+#include "Basic/VectorT.hpp"
 #include "Covariances/ACovFunc.hpp"
 #include "Covariances/CovFactory.hpp"
-#include "Basic/VectorT.hpp"
 #include "Enum/ECov.hpp"
 
 namespace gstlrn
@@ -25,11 +24,11 @@ bool _isSelected(ACovFunc *cov,
                  bool flagSimuSpectral)
 {
   if (cov == nullptr) return false;
-  if (ndim > (int) cov->getMaxNDim()) return false;
+  if (ndim > (int)cov->getMaxNDim()) return false;
   if (minorder < cov->getMinOrder()) return false;
-  if (hasrange && ! cov->hasRange()) return false;
-  if (flagSimtub && ! cov->isValidForTurningBand()) return false;
-  if (flagSimuSpectral && ! cov->isValidForSpectral()) return false;
+  if (hasrange && !cov->hasRange()) return false;
+  if (flagSimtub && !cov->isValidForTurningBand()) return false;
+  if (flagSimuSpectral && !cov->isValidForSpectral()) return false;
   return true;
 }
 
@@ -42,8 +41,8 @@ bool _isSelected(ACovFunc *cov,
  * @param flagSimtub Check that the Covariance can be simulated using Turning Band Method
  * @param flagSimuSpectral Check if the Covariance can be simulated using the Spectral Method
  */
-VectorString CovHelper::getAllCovariances(int  ndim,
-                                          int  minorder,
+VectorString CovHelper::getAllCovariances(int ndim,
+                                          int minorder,
                                           bool hasrange,
                                           bool flagSimtub,
                                           bool flagSimuSpectral)
@@ -51,18 +50,18 @@ VectorString CovHelper::getAllCovariances(int  ndim,
   VectorString vs;
 
   // Create the Context (using Space Dimension)
-  const CovContext ctxt = CovContext(1,ndim);
+  const CovContext ctxt = CovContext(1, ndim);
 
   // Loop on the basic structures
   auto it = ECov::getIterator();
   while (it.hasNext())
   {
     const ECov& covType = ECov::fromKey(it.getKey());
-    ACovFunc* cov = CovFactory::createCovFunc(covType, ctxt);
+    ACovFunc* cov       = CovFactory::createCovFunc(covType, ctxt);
 
     // Check if the covariance is valid
     if (_isSelected(cov, ndim, minorder, hasrange, flagSimtub, flagSimuSpectral))
-      vs.push_back(String{it.getKey()});
+      vs.push_back(String {it.getKey()});
 
     delete cov;
     it.toNext();

--- a/src/Covariances/CovLMCAnamorphosis.cpp
+++ b/src/Covariances/CovLMCAnamorphosis.cpp
@@ -8,21 +8,19 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Covariances/CovLMCAnamorphosis.hpp"
+#include "Anamorphosis/AAnam.hpp"
+#include "Anamorphosis/AnamDiscreteDD.hpp"
+#include "Anamorphosis/AnamDiscreteIR.hpp"
+#include "Anamorphosis/AnamHermite.hpp"
+#include "Covariances/CovAniso.hpp"
 #include "Covariances/CovAnisoList.hpp"
+#include "Covariances/CovCalcMode.hpp"
+#include "Covariances/CovFactory.hpp"
 #include "Enum/EAnam.hpp"
 #include "Enum/ECalcMember.hpp"
-
-#include "Space/ASpace.hpp"
 #include "Model/Model.hpp"
-#include "Covariances/CovLMCAnamorphosis.hpp"
-#include "Covariances/CovAniso.hpp"
-#include "Covariances/CovFactory.hpp"
-#include "Covariances/CovCalcMode.hpp"
-#include "Anamorphosis/AAnam.hpp"
-#include "Anamorphosis/AnamHermite.hpp"
-#include "Anamorphosis/AnamDiscreteIR.hpp"
-#include "Anamorphosis/AnamDiscreteDD.hpp"
-
+#include "Space/ASpace.hpp"
 #include <math.h>
 
 namespace gstlrn

--- a/src/Covariances/CovLMCConvolution.cpp
+++ b/src/Covariances/CovLMCConvolution.cpp
@@ -8,64 +8,62 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Covariances/CovContext.hpp"
-#include "Enum/EConvDir.hpp"
-#include "Enum/EConvType.hpp"
-
-#include "Space/ASpace.hpp"
-#include "Model/Model.hpp"
 #include "Covariances/CovLMCConvolution.hpp"
 #include "Covariances/CovAniso.hpp"
+#include "Covariances/CovContext.hpp"
 #include "Covariances/CovFactory.hpp"
+#include "Enum/EConvDir.hpp"
+#include "Enum/EConvType.hpp"
 #include "Matrix/MatrixDense.hpp"
-
+#include "Model/Model.hpp"
+#include "Space/ASpace.hpp"
 #include <math.h>
 
 namespace gstlrn
 {
 CovLMCConvolution::CovLMCConvolution(const EConvType& conv_type,
-                                     const EConvDir&  conv_dir,
+                                     const EConvDir& conv_dir,
                                      double conv_range,
                                      int conv_ndisc,
                                      const CovContext& ctxt)
-    : CovAnisoList(ctxt),
-      _convType(conv_type),
-      _convDir(conv_dir),
-      _convDiscNumber(conv_ndisc),
-      _convRange(conv_range),
-      _convNumber(0),
-      _convIncr(),
-      _convWeight()
+  : CovAnisoList(ctxt)
+  , _convType(conv_type)
+  , _convDir(conv_dir)
+  , _convDiscNumber(conv_ndisc)
+  , _convRange(conv_range)
+  , _convNumber(0)
+  , _convIncr()
+  , _convWeight()
 {
   init(conv_type, conv_dir, conv_range, conv_ndisc);
 }
 
-CovLMCConvolution::CovLMCConvolution(const CovLMCConvolution &r)
-    : CovAnisoList(r),
-      _convType(r._convType),
-      _convDir(r._convDir),
-      _convDiscNumber(r._convDiscNumber),
-      _convRange(r._convRange),
-      _convNumber(r._convNumber),
-      _convIncr(r._convIncr),
-      _convWeight(r._convWeight)
+CovLMCConvolution::CovLMCConvolution(const CovLMCConvolution& r)
+  : CovAnisoList(r)
+  , _convType(r._convType)
+  , _convDir(r._convDir)
+  , _convDiscNumber(r._convDiscNumber)
+  , _convRange(r._convRange)
+  , _convNumber(r._convNumber)
+  , _convIncr(r._convIncr)
+  , _convWeight(r._convWeight)
 {
 }
 
-CovLMCConvolution& CovLMCConvolution::operator=(const CovLMCConvolution &r)
+CovLMCConvolution& CovLMCConvolution::operator=(const CovLMCConvolution& r)
 {
   if (this != &r)
   {
     CovAnisoList::operator=(r);
-    _convType = r._convType;
-    _convDir = r._convDir;
+    _convType       = r._convType;
+    _convDir        = r._convDir;
     _convDiscNumber = r._convDiscNumber;
-    _convRange = r._convRange;
-    _convNumber = r._convNumber;
-    _convIncr = r._convIncr;
-    _convWeight = r._convWeight;
+    _convRange      = r._convRange;
+    _convNumber     = r._convNumber;
+    _convIncr       = r._convIncr;
+    _convWeight     = r._convWeight;
   }
-{
+  {
   }
   return *this;
 }
@@ -75,11 +73,11 @@ CovLMCConvolution::~CovLMCConvolution()
 }
 
 int CovLMCConvolution::init(const EConvType& conv_type,
-                            const EConvDir&  conv_idir,
+                            const EConvDir& conv_idir,
                             double conv_range,
                             int conv_ndisc)
 {
-  for (auto &e: _covs)
+  for (auto& e: _covs)
   {
     ((CovAniso*)e.get())->setOptimEnabled(false);
   }
@@ -96,11 +94,11 @@ int CovLMCConvolution::init(const EConvType& conv_type,
 
   /* Load the CovLMCConvolution parameters */
 
-  int ndim = getNDim();
-  _convType = conv_type;
-  _convDir  = conv_idir;
+  int ndim        = getNDim();
+  _convType       = conv_type;
+  _convDir        = conv_idir;
   _convDiscNumber = conv_ndisc;
-  _convRange = conv_range;
+  _convRange      = conv_range;
   double diameter = _convRange * D_CONV(_convType.getValue()).convScale;
 
   /* Calculate the discretization points */
@@ -144,11 +142,11 @@ int CovLMCConvolution::init(const EConvType& conv_type,
   for (int i = 0; i < 3; i++)
     _convNumber *= 2 * navail[i] + 1;
 
-  _convIncr = MatrixDense(ndim,_convNumber);
+  _convIncr = MatrixDense(ndim, _convNumber);
   _convWeight.resize(_convNumber);
 
   double delta, weight;
-  int ecr = 0;
+  int ecr      = 0;
   double total = 0.;
   for (int ix = -navail[0]; ix <= navail[0]; ix++)
     for (int iy = -navail[1]; iy <= navail[1]; iy++)
@@ -164,14 +162,14 @@ int CovLMCConvolution::init(const EConvType& conv_type,
         }
         if (ndim >= 2)
         {
-          delta = diameter * iy / (2 * conv_ndisc + 1);
+          delta  = diameter * iy / (2 * conv_ndisc + 1);
           weight = D_CONV(_convType.getValue()).convFunc(delta);
           _convIncr.setValue(1, ecr, delta);
           local *= weight;
         }
         if (ndim >= 3)
         {
-          delta = diameter * iz / (2 * conv_ndisc + 1);
+          delta  = diameter * iz / (2 * conv_ndisc + 1);
           weight = D_CONV(_convType.getValue()).convFunc(delta);
           _convIncr.setValue(2, ecr, delta);
           local *= weight;
@@ -191,49 +189,48 @@ int CovLMCConvolution::init(const EConvType& conv_type,
 Def_Convolution& D_CONV(int rank)
 {
   static Def_Convolution DEF_CONVS[] =
-  {
-   {"Uniform"     , 1.,       _conv_uniform     },
-   {"Exponential" , 2.995732, _conv_exponential },
-   {"Gaussian"    , 1.730818, _conv_gaussian    },
-   {"Sincard"     , 20.371,   _conv_sincard     }
-  };
+    {
+      {"Uniform", 1., _conv_uniform},
+      {"Exponential", 2.995732, _conv_exponential},
+      {"Gaussian", 1.730818, _conv_gaussian},
+      {"Sincard", 20.371, _conv_sincard}};
   return DEF_CONVS[rank];
 }
 
 double _conv_uniform(double /* v */)
 {
   double dp = 1.;
-  return(dp);
+  return (dp);
 }
 
 double _conv_exponential(double v)
 {
   double dp = exp(-v);
-  return(dp);
+  return (dp);
 }
 
 double _conv_gaussian(double v)
 {
-  double dp = exp(-v*v/2.);
-  return(dp);
+  double dp = exp(-v * v / 2.);
+  return (dp);
 }
 
 double _conv_sincard(double v)
 {
-  double dp,v2,dv;
+  double dp, v2, dv;
 
-  v = GV_PI * v;
+  v  = GV_PI * v;
   v2 = v * v;
   if (v < 1.0e-10)
   {
-    dp = 1. - v2/3;
+    dp = 1. - v2 / 3;
   }
   else
   {
     dv = sin(v) / v;
     dp = dv * dv;
   }
-  return(dp);
+  return (dp);
 }
 
 String CovLMCConvolution::toString(const AStringFormat* strfmt) const
@@ -243,7 +240,7 @@ String CovLMCConvolution::toString(const AStringFormat* strfmt) const
   sstr << CovAnisoList::toString(strfmt);
 
   sstr << "Convolution type      = " << _convType.getDescr() << std::endl;
-  sstr << "Convolution direction = " << _convDir.getDescr()   << std::endl;
+  sstr << "Convolution direction = " << _convDir.getDescr() << std::endl;
   sstr << "Nb. discretization    = " << _convDiscNumber << std::endl;
   sstr << "Convolution Scale     = " << _convRange << std::endl;
 
@@ -293,8 +290,8 @@ double CovLMCConvolution::_eval(const SpacePoint& p1,
   }
 
   double cov = 0.;
-  p11 = p1;
-  p22 = p2;
+  p11        = p1;
+  p22        = p2;
   for (int i1 = 0; i1 < _convNumber; i1++)
   {
     double w1 = _convWeight[i1];
@@ -315,8 +312,8 @@ double CovLMCConvolution::_eval(const SpacePoint& p1,
   if (asVario)
   {
     double cov0 = 0.;
-    p11 = p1;
-    p22 = p1;
+    p11         = p1;
+    p22         = p1;
     for (int i1 = 0; i1 < _convNumber; i1++)
     {
       double w1 = _convWeight[i1];
@@ -335,7 +332,7 @@ double CovLMCConvolution::_eval(const SpacePoint& p1,
         cov0 += covloc * w1 * w2;
       }
     }
-    cov = cov0 -cov;
+    cov = cov0 - cov;
   }
   return cov;
 }

--- a/src/Covariances/CovLMCTapering.cpp
+++ b/src/Covariances/CovLMCTapering.cpp
@@ -8,14 +8,13 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Enum/ETape.hpp"
-#include "Space/ASpace.hpp"
-#include "Model/Model.hpp"
-#include "Covariances/CovAniso.hpp"
-#include "Covariances/CovFactory.hpp"
-#include "Covariances/CovAnisoList.hpp"
 #include "Covariances/CovLMCTapering.hpp"
-
+#include "Covariances/CovAniso.hpp"
+#include "Covariances/CovAnisoList.hpp"
+#include "Covariances/CovFactory.hpp"
+#include "Enum/ETape.hpp"
+#include "Model/Model.hpp"
+#include "Space/ASpace.hpp"
 #include <math.h>
 
 namespace gstlrn
@@ -37,12 +36,12 @@ CovLMCTapering::CovLMCTapering(const CovLMCTapering& r)
 {
 }
 
-CovLMCTapering& CovLMCTapering::operator=(const CovLMCTapering &r)
+CovLMCTapering& CovLMCTapering::operator=(const CovLMCTapering& r)
 {
   if (this != &r)
   {
     CovAnisoList::operator=(r);
-    _tapeType = r._tapeType;
+    _tapeType  = r._tapeType;
     _tapeRange = r._tapeRange;
   }
   return *this;
@@ -54,7 +53,7 @@ CovLMCTapering::~CovLMCTapering()
 
 int CovLMCTapering::init(const ETape& tapetype, double taperange)
 {
-  for (auto &e: _covs)
+  for (auto& e: _covs)
   {
     ((CovAniso*)e.get())->setOptimEnabled(false);
   }
@@ -68,8 +67,8 @@ int CovLMCTapering::init(const ETape& tapetype, double taperange)
 
   /* Load the tapering parameters */
 
-  _tapeType    = tapetype;
-  _tapeRange   = taperange;
+  _tapeType  = tapetype;
+  _tapeRange = taperange;
 
   return 0;
 }
@@ -77,15 +76,14 @@ int CovLMCTapering::init(const ETape& tapetype, double taperange)
 Def_Tapering& D_TAPE(int rank)
 {
   static Def_Tapering DEF_TAPES[] =
-  {
-   {"Spherical"    , 3, _tape_spherical },
-   {"Cubic"        , 3, _tape_cubic     },
-   {"Triangle"     , 1, _tape_triangle  },
-   {"Pentamodel"   , 3, _tape_penta     },
-   {"Storkey"      , 1, _tape_storkey   },
-   {"Wendland1"    , 3, _tape_wendland1 },
-   {"Wendland2"    , 3, _tape_wendland2 }
-  };
+    {
+      {"Spherical", 3, _tape_spherical},
+      {"Cubic", 3, _tape_cubic},
+      {"Triangle", 1, _tape_triangle},
+      {"Pentamodel", 3, _tape_penta},
+      {"Storkey", 1, _tape_storkey},
+      {"Wendland1", 3, _tape_wendland1},
+      {"Wendland2", 3, _tape_wendland2}};
   return DEF_TAPES[rank];
 }
 
@@ -103,7 +101,7 @@ double _tape_cubic(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1) cov = 1. - h2 * (7. + h * (-8.75 + h2 * (3.5 - 0.75 * h2)));
   cov = MAX(0., cov);
 
@@ -123,13 +121,9 @@ double _tape_penta(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1)
-    cov = 1.
-        - h2 * (22. / 3.
-            - h2 * (33.
-                - h * (77. / 2.
-                    - h2 * (33. / 2. - h2 * (11. / 2. - 5. / 6. * h2)))));
+    cov = 1. - h2 * (22. / 3. - h2 * (33. - h * (77. / 2. - h2 * (33. / 2. - h2 * (11. / 2. - 5. / 6. * h2)))));
 
   return (cov);
 }
@@ -141,8 +135,7 @@ double _tape_storkey(double h)
   cov = 0.;
   pi2 = 2. * GV_PI;
   if (h < 1)
-    cov = (2. * (1. - h) * (1. + cos(pi2 * h) / 2.) + 3 / pi2 * sin(pi2 * h))
-        / 3.;
+    cov = (2. * (1. - h) * (1. + cos(pi2 * h) / 2.) + 3 / pi2 * sin(pi2 * h)) / 3.;
 
   return (cov);
 }
@@ -152,7 +145,7 @@ double _tape_wendland1(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1) cov = 1 - h2 * (10 - h * (20 - h * (15 - h * 4)));
   return (cov);
 }
@@ -162,12 +155,9 @@ double _tape_wendland2(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1)
-    cov = 1
-        - h2 * ((28. / 3.)
-            - h2 * (70
-                - h * ((448. / 3.) - h * (140 - h * (64 - h * (35. / 3.))))));
+    cov = 1 - h2 * ((28. / 3.) - h2 * (70 - h * ((448. / 3.) - h * (140 - h * (64 - h * (35. / 3.))))));
   return (cov);
 }
 
@@ -198,8 +188,8 @@ double CovLMCTapering::_eval(const SpacePoint& p1,
 {
   // The calculation flag 'as.Vario' must be treated here rather than relying on calculation
   // performed in generic 'eval' method
-  double cov = 0.;
-  double cov0 = 0.;
+  double cov   = 0.;
+  double cov0  = 0.;
   bool asVario = false;
   if (mode == nullptr)
   {
@@ -210,7 +200,7 @@ double CovLMCTapering::_eval(const SpacePoint& p1,
     CovCalcMode modeloc(*mode);
     asVario = mode->getAsVario();
     modeloc.setAsVario(false);
-    cov = CovAnisoList::_eval(p1, p2, ivar, jvar, &modeloc);
+    cov  = CovAnisoList::_eval(p1, p2, ivar, jvar, &modeloc);
     cov0 = CovAnisoList::_eval(p1, p1, ivar, jvar, &modeloc); // or eval0 if stationary
   }
 

--- a/src/Covariances/CovLMGradient.cpp
+++ b/src/Covariances/CovLMGradient.cpp
@@ -8,34 +8,33 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Space/ASpace.hpp"
-#include "Space/SpacePoint.hpp"
 #include "Covariances/CovLMGradient.hpp"
 #include "Covariances/CovAnisoList.hpp"
 #include "Covariances/CovGradientFunctional.hpp"
+#include "Space/ASpace.hpp"
+#include "Space/SpacePoint.hpp"
 
 namespace gstlrn
 {
 CovLMGradient::CovLMGradient(const CovContext& ctxt)
-: CovAnisoList(ctxt)
+  : CovAnisoList(ctxt)
 {
   setOptimEnabled(false);
 }
 
-
-CovLMGradient::CovLMGradient(const CovLMGradient &r)
-: CovAnisoList(r)
+CovLMGradient::CovLMGradient(const CovLMGradient& r)
+  : CovAnisoList(r)
 {
   setOptimEnabled(false);
 }
 
 CovLMGradient::CovLMGradient(const CovAnisoList& r)
-    : CovAnisoList(r.getContext())
+  : CovAnisoList(r.getContext())
 {
   setOptimEnabled(false);
-  for (int icov = r.getNCov()-1; icov >= 0; icov--)
+  for (int icov = r.getNCov() - 1; icov >= 0; icov--)
   {
-    const CovAniso *cov = r.getCovAniso(icov);
+    const CovAniso* cov = r.getCovAniso(icov);
     if (!cov->hasCovDerivative())
     {
       messerr("The covariance %s is not compatible with Gradients",
@@ -47,13 +46,13 @@ CovLMGradient::CovLMGradient(const CovAnisoList& r)
       addCov(newcov);
     }
   }
-  for (auto &e: _covs)
+  for (auto& e: _covs)
   {
     ((CovAniso*)e.get())->setOptimEnabled(false);
   }
 }
 
-CovLMGradient& CovLMGradient::operator=(const CovLMGradient &r)
+CovLMGradient& CovLMGradient::operator=(const CovLMGradient& r)
 {
   if (this != &r)
   {

--- a/src/Covariances/CovLinear.cpp
+++ b/src/Covariances/CovLinear.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovLinear.hpp"
-
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovLinear::CovLinear(const CovContext& ctxt)
-: ACovFunc(ECov::LINEAR, ctxt)
+  : ACovFunc(ECov::LINEAR, ctxt)
 {
 }
 
-CovLinear::CovLinear(const CovLinear &r)
-: ACovFunc(r)
+CovLinear::CovLinear(const CovLinear& r)
+  : ACovFunc(r)
 {
 }
 
-CovLinear& CovLinear::operator=(const CovLinear &r)
+CovLinear& CovLinear::operator=(const CovLinear& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -55,7 +54,7 @@ double CovLinear::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovLinear::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovLinear::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.IRFProcessOne(t0);
 }

--- a/src/Covariances/CovLinearSph.cpp
+++ b/src/Covariances/CovLinearSph.cpp
@@ -9,12 +9,9 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovLinearSph.hpp"
-
-#include "math.h"
 #include "Basic/VectorHelper.hpp"
-#include "Basic/MathFunc.hpp"
-#include "Basic/Law.hpp"
 #include "Covariances/CovContext.hpp"
+#include "math.h"
 
 namespace gstlrn
 {
@@ -24,16 +21,16 @@ CovLinearSph::CovLinearSph(const CovContext &ctxt)
   setParam(1);
 }
 
-CovLinearSph::CovLinearSph(const CovLinearSph &r)
-: ACovFunc(r)
+CovLinearSph::CovLinearSph(const CovLinearSph& r)
+  : ACovFunc(r)
 {
 }
 
-CovLinearSph& CovLinearSph::operator=(const CovLinearSph &r)
+CovLinearSph& CovLinearSph::operator=(const CovLinearSph& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -63,7 +60,7 @@ VectorDouble CovLinearSph::_evaluateSpectrumOnSphere(int n, double scale) const
     k += 2;
     if (k >= n + 1) break;
     double v = (k - 2.) / (k + 1.);
-    sp[k] = (2. * k + 1.) / (2. * k - 3.) * v * v * sp[k - 2];
+    sp[k]    = (2. * k + 1.) / (2. * k - 3.) * v * v * sp[k - 2];
   }
 
   VH::normalize(sp, 1);

--- a/src/Covariances/CovList.cpp
+++ b/src/Covariances/CovList.cpp
@@ -11,6 +11,7 @@
 #include "Covariances/CovList.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/Iterators.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/ACov.hpp"
 #include "Covariances/CovBase.hpp"

--- a/src/Covariances/CovList.cpp
+++ b/src/Covariances/CovList.cpp
@@ -16,18 +16,15 @@
 #include "Covariances/CovBase.hpp"
 #include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovContext.hpp"
-#include "Enum/ECalcMember.hpp"
-#include "Space/ASpace.hpp"
 #include "Covariances/CovFactory.hpp"
 #include "Covariances/CovLMGradient.hpp"
 #include "Db/Db.hpp"
-#include "Space/SpacePoint.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Model/ModelFitSillsVario.hpp"
+#include "Enum/ECalcMember.hpp"
 #include "Model/ModelFitSillsVMap.hpp"
-
+#include "Model/ModelFitSillsVario.hpp"
+#include "Space/ASpace.hpp"
+#include "Space/SpacePoint.hpp"
 #include "geoslib_define.h"
-
 #include <math.h>
 #include <memory>
 #include <vector>
@@ -47,7 +44,6 @@ CovList::CovList(const CovContext& ctxt)
 {
   _updateLists();
 }
-
 
 CovList::CovList(const CovList& r)
   : ACov(r)
@@ -539,18 +535,18 @@ void CovList::appendParams(ListParams& listParams,
 
 void CovList::initParams(const MatrixSymmetric& vars, double href)
 {
-  int ncov = getNCov();
+  int ncov                         = getNCov();
   MatrixSymmetric varsPerStructure = vars;
   LowerTriangularRange itRange(getNVar());
   for (const auto& [ivar, jvar]: itRange)
-      varsPerStructure.setValue(ivar, jvar, vars.getValue(ivar, jvar) / ncov);
+    varsPerStructure.setValue(ivar, jvar, vars.getValue(ivar, jvar) / ncov);
 
-  int jcov = 0;
-  int ntotal = getNCovNuggetExcluded();
+  int jcov      = 0;
+  int ntotal    = getNCovNuggetExcluded();
   double hlocal = href / ntotal / 2;
   for (int icov = 0, ncov = getNCov(); icov < ncov; icov++)
   {
-    if (getCovType(icov) != ECov::NUGGET) 
+    if (getCovType(icov) != ECov::NUGGET)
       jcov++;
     CovBase* cov = getCovModify(icov);
     cov->initParams(varsPerStructure, hlocal * jcov);

--- a/src/Covariances/CovMarkov.cpp
+++ b/src/Covariances/CovMarkov.cpp
@@ -10,8 +10,6 @@
 /******************************************************************************/
 #include "Covariances/CovMarkov.hpp"
 #include "Covariances/CovContext.hpp"
-#include "Basic/MathFunc.hpp"
-
 #include "math.h"
 
 #define MAXTAB 100
@@ -27,20 +25,20 @@ CovMarkov::CovMarkov(const CovContext &ctxt)
   _markovCoeffs.push_back(1.);
 }
 
-CovMarkov::CovMarkov(const CovMarkov &r)
-  : ACovFunc(r),
-    _markovCoeffs(r._markovCoeffs),
-    _correc(r._correc)
+CovMarkov::CovMarkov(const CovMarkov& r)
+  : ACovFunc(r)
+  , _markovCoeffs(r._markovCoeffs)
+  , _correc(r._correc)
 {
 }
 
-CovMarkov& CovMarkov::operator=(const CovMarkov &r)
+CovMarkov& CovMarkov::operator=(const CovMarkov& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
     _markovCoeffs = r._markovCoeffs;
-    _correc = r._correc;
+    _correc       = r._correc;
   }
   return *this;
 }
@@ -61,52 +59,50 @@ String CovMarkov::getFormula() const
 
 VectorDouble CovMarkov::_evaluateSpectrumOnSphere(int n, double scale) const
 {
-  auto sp = _evaluateSpectrumOnSphereWithoutNormalization(n,scale);
-  VH::normalize(sp,1);
+  auto sp = _evaluateSpectrumOnSphereWithoutNormalization(n, scale);
+  VH::normalize(sp, 1);
   return sp;
 }
 
 VectorDouble CovMarkov::_evaluateSpectrumOnSphereWithoutNormalization(int n, double scale) const
 {
-  VectorDouble sp(1+n, 0.);
+  VectorDouble sp(1 + n, 0.);
 
   for (int j = 0; j < (int)sp.size(); j++)
   {
-    double nnp1 = scale * scale * (double) j * ((double) j + 1.);
-    double s = 0.;
+    double nnp1 = scale * scale * (double)j * ((double)j + 1.);
+    double s    = 0.;
     for (int i = 0; i < (int)_markovCoeffs.size(); i++)
     {
-      s += _markovCoeffs[i] * pow(nnp1,i);
+      s += _markovCoeffs[i] * pow(nnp1, i);
     }
     sp[j] = (2. * j + 1.) / (4 * GV_PI * s);
   }
   return sp;
-
 }
 
-double CovMarkov::normalizeOnSphere(int n, double scale) const 
-{ 
-  auto sp = _evaluateSpectrumOnSphereWithoutNormalization(n,scale);
+double CovMarkov::normalizeOnSphere(int n, double scale) const
+{
+  auto sp  = _evaluateSpectrumOnSphereWithoutNormalization(n, scale);
   double s = 0.;
-  for (auto &e : sp)
+  for (auto& e: sp)
   {
     s += e;
   }
   return s;
 }
 
-
 double CovMarkov::evaluateSpectrum(double freq) const
 {
   double s = 0.;
-  int n = (int)_markovCoeffs.size();
+  int n    = (int)_markovCoeffs.size();
   if (n == 0)
   {
     return TEST;
   }
   for (int i = 0; i < n; i++)
   {
-    s += _markovCoeffs[i] * pow(freq,i);
+    s += _markovCoeffs[i] * pow(freq, i);
   }
   return 1. /  s;
 }

--- a/src/Covariances/CovMatern.cpp
+++ b/src/Covariances/CovMatern.cpp
@@ -9,13 +9,12 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovMatern.hpp"
-#include "Covariances/CovContext.hpp"
-#include "Simulation/TurningBandOperate.hpp"
-#include "Matrix/MatrixDense.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
 #include "Basic/Utilities.hpp"
-
+#include "Covariances/CovContext.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 #include "math.h"
 
 #define MAXTAB 100
@@ -40,11 +39,11 @@ CovMatern::CovMatern(const CovMatern& r)
 {
 }
 
-CovMatern& CovMatern::operator=(const CovMatern &r)
+CovMatern& CovMatern::operator=(const CovMatern& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -65,25 +64,22 @@ double CovMatern::_evaluateCov(double h) const
     return _oldMatern(h);
   }
   return _newMatern(h);
- 
 }
-
 
 double CovMatern::_newMatern(double h) const
 {
   if (h == 0) return 1;
   double third = getParam();
-  return 2. * pow(h / 2., third) * _besselK(getParam(),h) / exp(loggamma(third));
+  return 2. * pow(h / 2., third) * _besselK(getParam(), h) / exp(loggamma(third));
 }
-
 
 double CovMatern::_evaluateCovDerivative(double h) const
 {
   if (h == 0) return 1;
-  double nu = getParam();
-  double ratio = pow(2., 1. - nu)  / exp(loggamma(nu));
+  double nu    = getParam();
+  double ratio = pow(2., 1. - nu) / exp(loggamma(nu));
   double term1 = nu * pow(h, nu - 1) * _besselK(nu, h);
-  double term2 = 0.5 * pow (h, nu) * ( _besselK(nu - 1,h) + _besselK(nu + 1,h));
+  double term2 = 0.5 * pow(h, nu) * (_besselK(nu - 1, h) + _besselK(nu + 1, h));
   return ratio * (term1 - term2);
 }
 
@@ -91,7 +87,7 @@ double CovMatern::_besselK(double nu, double h)
 {
 #if defined(__APPLE__)
   double TAB[MAXTAB];
-  int nb = (int) floor(nu);
+  int nb = (int)floor(nu);
   if (nu <= 0 || nb >= MAXTAB) return (0.);
   double alpha = nu - nb;
   if (besselk(h, alpha, nb + 1, TAB) < nb + 1) return 0.;
@@ -101,17 +97,16 @@ double CovMatern::_besselK(double nu, double h)
 #endif
 }
 
-
 double CovMatern::_oldMatern(double h) const
-{ 
+{
   double TAB[MAXTAB];
-  double cov = 0.;
+  double cov   = 0.;
   double third = getParam();
-  int nb = (int) floor(third);
+  int nb       = (int)floor(third);
   double alpha = third - nb;
   if (third <= 0 || nb >= MAXTAB) return (0.);
   double coeff = (h > 0) ? pow(h / 2., third) : 1.;
-  cov = 1.;
+  cov          = 1.;
   if (h > 0)
   {
     if (besselk(h, alpha, nb + 1, TAB) < nb + 1) return 0.;
@@ -127,18 +122,18 @@ String CovMatern::getFormula() const
 
 double CovMatern::evaluateSpectrum(double freq) const
 {
-  int ndim = getContext().getNDim();
-  double alpha = (double) ndim / 2. + getParam();
-  return 1. /  pow(1. + freq, alpha);
+  int ndim     = getContext().getNDim();
+  double alpha = (double)ndim / 2. + getParam();
+  return 1. / pow(1. + freq, alpha);
 }
 
 void CovMatern::computeMarkovCoeffs(int ndim)
 {
-  double param = getParam();
-  double ndims2 = ((double) ndim) / 2.;
-  double alpha = param + ndims2;
-  int p = getClosestInteger(alpha);
-  int ndimp = p + 1;
+  double param  = getParam();
+  double ndims2 = ((double)ndim) / 2.;
+  double alpha  = param + ndims2;
+  int p         = getClosestInteger(alpha);
+  int ndimp     = p + 1;
   _markovCoeffs.resize(ndimp);
   for (int i = 0; i < ndimp; i++)
   {
@@ -150,19 +145,19 @@ void CovMatern::computeMarkovCoeffs(int ndim)
 void CovMatern::computeCorrec(int ndim)
 {
   double g0, ndims2, gammap, gammaa;
-  ndims2 = ((double) ndim) / 2.;
-  gammap = exp(loggamma(getParam()));
-  gammaa = exp(loggamma(getParam() + ndims2));
-  g0 = pow(4. * GV_PI, ndims2);
+  ndims2  = ((double)ndim) / 2.;
+  gammap  = exp(loggamma(getParam()));
+  gammaa  = exp(loggamma(getParam() + ndims2));
+  g0      = pow(4. * GV_PI, ndims2);
   _correc = gammap / (g0 * gammaa);
 }
 
-VectorDouble CovMatern::getMarkovCoeffs()const
+VectorDouble CovMatern::getMarkovCoeffs() const
 {
   return _markovCoeffs;
 }
 
-double CovMatern::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovMatern::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   if (getParam() > 0.5)
     return operTB.cosineOne(t0);
@@ -171,7 +166,7 @@ double CovMatern::simulateTurningBand(double t0, TurningBandOperate &operTB) con
 
 MatrixDense CovMatern::simulateSpectralOmega(int nb) const
 {
-  int ndim = getContext().getNDim();
+  int ndim     = getContext().getNDim();
   double param = getParam();
   MatrixDense mat(nb, ndim);
 
@@ -187,15 +182,15 @@ MatrixDense CovMatern::simulateSpectralOmega(int nb) const
 VectorDouble CovMatern::_evaluateSpectrumOnSphere(int n, double scale) const
 {
   double scale2 = scale * scale;
-  double mu = getParam();
-  double alpha = mu + 1.;
+  double mu     = getParam();
+  double alpha  = mu + 1.;
 
-  VectorDouble sp(1+n, 0.);
+  VectorDouble sp(1 + n, 0.);
 
   for (int k = 0; k <= n; k++)
     sp[k] = (2. * k + 1.) / (4. * GV_PI) / pow(1. + scale2 * k * (k + 1.), alpha);
 
-  VH::normalize(sp,1);
+  VH::normalize(sp, 1);
   return sp;
 }
 

--- a/src/Covariances/CovNugget.cpp
+++ b/src/Covariances/CovNugget.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovNugget.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovNugget::CovNugget(const CovContext& ctxt)
-: ACovFunc(ECov::NUGGET, ctxt)
+  : ACovFunc(ECov::NUGGET, ctxt)
 {
 }
 
-CovNugget::CovNugget(const CovNugget &r)
-: ACovFunc(r)
+CovNugget::CovNugget(const CovNugget& r)
+  : ACovFunc(r)
 {
 }
 
-CovNugget& CovNugget::operator=(const CovNugget &r)
+CovNugget& CovNugget::operator=(const CovNugget& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovPenta.cpp
+++ b/src/Covariances/CovPenta.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovPenta.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovPenta::CovPenta(const CovContext& ctxt)
-: ACovFunc(ECov::PENTA, ctxt)
+  : ACovFunc(ECov::PENTA, ctxt)
 {
 }
 
-CovPenta::CovPenta(const CovPenta &r)
-: ACovFunc(r)
+CovPenta::CovPenta(const CovPenta& r)
+  : ACovFunc(r)
 {
 }
 
-CovPenta& CovPenta::operator=(const CovPenta &r)
+CovPenta& CovPenta::operator=(const CovPenta& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovPoisson.cpp
+++ b/src/Covariances/CovPoisson.cpp
@@ -9,31 +9,30 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovPoisson.hpp"
-
-#include "math.h"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/MathFunc.hpp"
 #include "Basic/Law.hpp"
+#include "Basic/MathFunc.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Covariances/CovContext.hpp"
+#include "math.h"
 
 namespace gstlrn
 {
 CovPoisson::CovPoisson(const CovContext& ctxt)
-: ACovFunc(ECov::POISSON, ctxt)
+  : ACovFunc(ECov::POISSON, ctxt)
 {
   setParam(1);
 }
 
-CovPoisson::CovPoisson(const CovPoisson &r)
-: ACovFunc(r)
+CovPoisson::CovPoisson(const CovPoisson& r)
+  : ACovFunc(r)
 {
 }
 
-CovPoisson& CovPoisson::operator=(const CovPoisson &r)
+CovPoisson& CovPoisson::operator=(const CovPoisson& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -56,8 +55,8 @@ double CovPoisson::_evaluateCovOnSphere(double alpha,
 VectorDouble CovPoisson::_evaluateSpectrumOnSphere(int n, double scale) const
 {
   DECLARE_UNUSED(scale);
-  double lambda = getParam();
-  VectorInt x = VH::sequence(n+1);
+  double lambda   = getParam();
+  VectorInt x     = VH::sequence(n + 1);
   VectorDouble sp = law_df_poisson_vec(x, lambda);
   VH::normalize(sp, 1);
 

--- a/src/Covariances/CovPower.cpp
+++ b/src/Covariances/CovPower.cpp
@@ -9,31 +9,29 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovPower.hpp"
+#include "Basic/MathFunc.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "Basic/Law.hpp"
-#include "Basic/MathFunc.hpp"
-
 #include <math.h>
 
 namespace gstlrn
 {
 CovPower::CovPower(const CovContext& ctxt)
-: ACovFunc(ECov::POWER, ctxt)
+  : ACovFunc(ECov::POWER, ctxt)
 {
   setParam(1);
 }
 
-CovPower::CovPower(const CovPower &r)
-: ACovFunc(r)
+CovPower::CovPower(const CovPower& r)
+  : ACovFunc(r)
 {
 }
 
-CovPower& CovPower::operator=(const CovPower &r)
+CovPower& CovPower::operator=(const CovPower& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -46,11 +44,11 @@ double CovPower::_evaluateCov(double h) const
 {
   double a;
 
-  int ndim = getContext().getNDim();
+  int ndim     = getContext().getNDim();
   double alpha = getParam();
-  double r = getContext().getField();
-  double ra = pow(r, alpha);
-  double g1 = loggamma((alpha + 1.) / 2.) + loggamma(1. - alpha / 2.);
+  double r     = getContext().getField();
+  double ra    = pow(r, alpha);
+  double g1    = loggamma((alpha + 1.) / 2.) + loggamma(1. - alpha / 2.);
 
   if (ndim == 1)
     a = exp(g1) * ra / sqrt(GV_PI);
@@ -64,7 +62,7 @@ double CovPower::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovPower::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovPower::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.cosineOne(t0);
 }

--- a/src/Covariances/CovProportional.cpp
+++ b/src/Covariances/CovProportional.cpp
@@ -8,7 +8,6 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-
 #include "Covariances/CovProportional.hpp"
 #include "Basic/AStringable.hpp"
 #include "Covariances/ACov.hpp"
@@ -17,9 +16,8 @@
 
 namespace gstlrn
 {
-CovProportional::CovProportional(ACov* cor,
-                const MatrixSymmetric &sill)
-: CovBase(cor,sill)
+CovProportional::CovProportional(ACov* cor, const MatrixSymmetric& sill)
+  : CovBase(cor, sill)
 {
   _ctxt.setNVar(sill.getNCols());
   _workMat.resize(_ctxt.getNVar(), _ctxt.getNVar());
@@ -27,20 +25,20 @@ CovProportional::CovProportional(ACov* cor,
   if (cor != nullptr)
     if (cor->getNVar() != 1)
     {
-        messerr("Correlation function should have only 1 variable");
-        messerr("You should use CovBase instead of CovProportional");
-        messerr("Undefined behaviour");
-        return;
+      messerr("Correlation function should have only 1 variable");
+      messerr("You should use CovBase instead of CovProportional");
+      messerr("Undefined behaviour");
+      return;
     }
 }
 
-CovProportional::CovProportional(const CovProportional &r)
-: CovBase(r)
+CovProportional::CovProportional(const CovProportional& r)
+  : CovBase(r)
 {
   _workMat = r._workMat;
 }
 
-CovProportional& CovProportional::operator=(const CovProportional &r)
+CovProportional& CovProportional::operator=(const CovProportional& r)
 {
   if (this != &r)
   {
@@ -52,7 +50,6 @@ CovProportional& CovProportional::operator=(const CovProportional &r)
 
 CovProportional::~CovProportional()
 {
-
 }
 
 void CovProportional::setCor(ACov* cor)
@@ -65,12 +62,11 @@ void CovProportional::setCor(ACov* cor)
   CovBase::setCor(cor);
 }
 
-
-double CovProportional::_eval(const SpacePoint& p1, 
-  const SpacePoint& p2,
-  int ivar, 
-  int jvar, 
-  const CovCalcMode* mode) const
+double CovProportional::_eval(const SpacePoint& p1,
+                              const SpacePoint& p2,
+                              int ivar,
+                              int jvar,
+                              const CovCalcMode* mode) const
 {
 return _sillCur.getValue(ivar,jvar) * getCor()->evalCov(p1, p2,0, 0, mode);
 }

--- a/src/Covariances/CovReg1D.cpp
+++ b/src/Covariances/CovReg1D.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovReg1D.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovReg1D::CovReg1D(const CovContext& ctxt)
-: ACovFunc(ECov::REG1D, ctxt)
+  : ACovFunc(ECov::REG1D, ctxt)
 {
 }
 
-CovReg1D::CovReg1D(const CovReg1D &r)
-: ACovFunc(r)
+CovReg1D::CovReg1D(const CovReg1D& r)
+  : ACovFunc(r)
 {
 }
 
-CovReg1D& CovReg1D::operator=(const CovReg1D &r)
+CovReg1D& CovReg1D::operator=(const CovReg1D& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovSincard.cpp
+++ b/src/Covariances/CovSincard.cpp
@@ -11,27 +11,25 @@
 #include "Covariances/CovSincard.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "Basic/Law.hpp"
-
 #include "math.h"
 
 namespace gstlrn
 {
 CovSincard::CovSincard(const CovContext& ctxt)
-: ACovFunc(ECov::SINCARD, ctxt)
+  : ACovFunc(ECov::SINCARD, ctxt)
 {
 }
 
-CovSincard::CovSincard(const CovSincard &r)
-: ACovFunc(r)
+CovSincard::CovSincard(const CovSincard& r)
+  : ACovFunc(r)
 {
 }
 
-CovSincard& CovSincard::operator=(const CovSincard &r)
+CovSincard& CovSincard::operator=(const CovSincard& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -48,7 +46,7 @@ double CovSincard::getScadef() const
 double CovSincard::_evaluateCov(double h) const
 {
   static double MIN_SIN = 1.e-5;
-  double cov = 1.;
+  double cov            = 1.;
   if (h > MIN_SIN) cov = sin(h) / h;
   return (cov);
 }
@@ -58,7 +56,7 @@ String CovSincard::getFormula() const
   return "C(h)=\\frac{sin(\\frac{h}{a})}{\\frac{h}{a}}";
 }
 
-double CovSincard::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovSincard::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.cosineOne(t0);
 }

--- a/src/Covariances/CovSpherical.cpp
+++ b/src/Covariances/CovSpherical.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovSpherical.hpp"
-
-#include "Simulation/TurningBandOperate.hpp"
 #include "Covariances/CovContext.hpp"
+#include "Simulation/TurningBandOperate.hpp"
 
 namespace gstlrn
 {
 CovSpherical::CovSpherical(const CovContext& ctxt)
-: ACovFunc(ECov::SPHERICAL, ctxt)
+  : ACovFunc(ECov::SPHERICAL, ctxt)
 {
 }
 
-CovSpherical::CovSpherical(const CovSpherical &r)
-: ACovFunc(r)
+CovSpherical::CovSpherical(const CovSpherical& r)
+  : ACovFunc(r)
 {
 }
 
-CovSpherical& CovSpherical::operator=(const CovSpherical &r)
+CovSpherical& CovSpherical::operator=(const CovSpherical& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -57,7 +56,7 @@ String CovSpherical::getFormula() const
   return "C(h)=1-\\frac{3}{2}\\left(\\frac{h}{a}\\right)+ \\frac{1}{2}\\left(\\frac{h}{a}\\right)^3";
 }
 
-double CovSpherical::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovSpherical::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   return operTB.shotNoiseAffineOne(t0);
 }

--- a/src/Covariances/CovStable.cpp
+++ b/src/Covariances/CovStable.cpp
@@ -9,30 +9,28 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovStable.hpp"
-
-#include <math.h>
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "Basic/Law.hpp"
+#include <math.h>
 
 namespace gstlrn
 {
 CovStable::CovStable(const CovContext& ctxt)
-: ACovFunc(ECov::STABLE, ctxt)
+  : ACovFunc(ECov::STABLE, ctxt)
 {
   setParam(1);
 }
 
-CovStable::CovStable(const CovStable &r)
-: ACovFunc(r)
+CovStable::CovStable(const CovStable& r)
+  : ACovFunc(r)
 {
 }
 
-CovStable& CovStable::operator=(const CovStable &r)
+CovStable& CovStable::operator=(const CovStable& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -54,7 +52,7 @@ double CovStable::_evaluateCov(double h) const
   return (cov);
 }
 
-double CovStable::simulateTurningBand(double t0, TurningBandOperate &operTB) const
+double CovStable::simulateTurningBand(double t0, TurningBandOperate& operTB) const
 {
   if (getParam() > 1)
     return operTB.cosineOne(t0);

--- a/src/Covariances/CovStorkey.cpp
+++ b/src/Covariances/CovStorkey.cpp
@@ -9,27 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovStorkey.hpp"
-
-#include <math.h>
 #include "Covariances/CovContext.hpp"
+#include <math.h>
 
 namespace gstlrn
 {
 CovStorkey::CovStorkey(const CovContext& ctxt)
-: ACovFunc(ECov::STORKEY, ctxt)
+  : ACovFunc(ECov::STORKEY, ctxt)
 {
 }
 
-CovStorkey::CovStorkey(const CovStorkey &r)
-: ACovFunc(r)
+CovStorkey::CovStorkey(const CovStorkey& r)
+  : ACovFunc(r)
 {
 }
 
-CovStorkey& CovStorkey::operator=(const CovStorkey &r)
+CovStorkey& CovStorkey::operator=(const CovStorkey& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovTriangle.cpp
+++ b/src/Covariances/CovTriangle.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovTriangle.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovTriangle::CovTriangle(const CovContext& ctxt)
-: ACovFunc(ECov::TRIANGLE, ctxt)
+  : ACovFunc(ECov::TRIANGLE, ctxt)
 {
 }
 
-CovTriangle::CovTriangle(const CovTriangle &r)
-: ACovFunc(r)
+CovTriangle::CovTriangle(const CovTriangle& r)
+  : ACovFunc(r)
 {
 }
 
-CovTriangle& CovTriangle::operator=(const CovTriangle &r)
+CovTriangle& CovTriangle::operator=(const CovTriangle& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }

--- a/src/Covariances/CovWendland0.cpp
+++ b/src/Covariances/CovWendland0.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovWendland0.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovWendland0::CovWendland0(const CovContext& ctxt)
-: ACovFunc(ECov::WENDLAND0, ctxt)
+  : ACovFunc(ECov::WENDLAND0, ctxt)
 {
 }
 
-CovWendland0::CovWendland0(const CovWendland0 &r)
-: ACovFunc(r)
+CovWendland0::CovWendland0(const CovWendland0& r)
+  : ACovFunc(r)
 {
 }
 
-CovWendland0& CovWendland0::operator=(const CovWendland0 &r)
+CovWendland0& CovWendland0::operator=(const CovWendland0& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -40,8 +39,8 @@ CovWendland0::~CovWendland0()
 double CovWendland0::_evaluateCov(double h) const
 {
   double cov = 0.;
-  double h2 = h * h;
-  if (h < 1) cov = 1. - 2*h + h2;
+  double h2  = h * h;
+  if (h < 1) cov = 1. - 2 * h + h2;
   return (cov);
 }
 

--- a/src/Covariances/CovWendland1.cpp
+++ b/src/Covariances/CovWendland1.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovWendland1.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovWendland1::CovWendland1(const CovContext& ctxt)
-: ACovFunc(ECov::WENDLAND1, ctxt)
+  : ACovFunc(ECov::WENDLAND1, ctxt)
 {
 }
 
-CovWendland1::CovWendland1(const CovWendland1 &r)
-: ACovFunc(r)
+CovWendland1::CovWendland1(const CovWendland1& r)
+  : ACovFunc(r)
 {
 }
 
-CovWendland1& CovWendland1::operator=(const CovWendland1 &r)
+CovWendland1& CovWendland1::operator=(const CovWendland1& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -40,7 +39,7 @@ CovWendland1::~CovWendland1()
 double CovWendland1::_evaluateCov(double h) const
 {
   double cov = 0.;
-  double h2 = h * h;
+  double h2  = h * h;
   if (h < 1) cov = 1. - h2 * (10. - h * (20. - h * (15. - h * 4)));
   return (cov);
 }

--- a/src/Covariances/CovWendland2.cpp
+++ b/src/Covariances/CovWendland2.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/CovWendland2.hpp"
-
 #include "Covariances/CovContext.hpp"
 
 namespace gstlrn
 {
 CovWendland2::CovWendland2(const CovContext& ctxt)
-: ACovFunc(ECov::WENDLAND2, ctxt)
+  : ACovFunc(ECov::WENDLAND2, ctxt)
 {
 }
 
-CovWendland2::CovWendland2(const CovWendland2 &r)
-: ACovFunc(r)
+CovWendland2::CovWendland2(const CovWendland2& r)
+  : ACovFunc(r)
 {
 }
 
-CovWendland2& CovWendland2::operator=(const CovWendland2 &r)
+CovWendland2& CovWendland2::operator=(const CovWendland2& r)
 {
   if (this != &r)
   {
-    ACovFunc::operator =(r);
+    ACovFunc::operator=(r);
   }
   return *this;
 }
@@ -40,12 +39,9 @@ CovWendland2::~CovWendland2()
 double CovWendland2::_evaluateCov(double h) const
 {
   double cov = 0.;
-  double h2 = h * h;
+  double h2  = h * h;
   if (h < 1)
-    cov = 1
-        - h2 * ((28. / 3.)
-            - h2 * (70.
-                - h * ((448. / 3.) - h * (140. - h * (64 - h * (35. / 3.))))));
+    cov = 1 - h2 * ((28. / 3.) - h2 * (70. - h * ((448. / 3.) - h * (140. - h * (64 - h * (35. / 3.))))));
   return (cov);
 }
 
@@ -54,20 +50,17 @@ double CovWendland2::_evaluateCovDerivative(int degree, double h) const
   double h2, res;
 
   res = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h > 1) return res;
 
   switch (degree)
   {
     case 1:
-      res = -h
-          * (56. - h2
-              * (840. - h * (2240. - h * (2520. - h * (1344. - h * 280.)))));
+      res = -h * (56. - h2 * (840. - h * (2240. - h * (2520. - h * (1344. - h * 280.)))));
       break;
 
     case 2:
-      res = -56.
-          + h2 * (2520. - h * (8960. - h * (12600. - h * (8064. - h * 1960.))));
+      res = -56. + h2 * (2520. - h * (8960. - h * (12600. - h * (8064. - h * 1960.))));
       break;
 
     case 3:

--- a/src/Covariances/NoStatArray.cpp
+++ b/src/Covariances/NoStatArray.cpp
@@ -1,9 +1,18 @@
-
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/NoStatArray.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Calculators/CalcMigrate.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "geoslib_define.h"
 #include <memory>
 

--- a/src/Covariances/NoStatFunctional.cpp
+++ b/src/Covariances/NoStatFunctional.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/NoStatFunctional.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "geoslib_define.h"
@@ -5,44 +15,42 @@
 namespace gstlrn
 {
 NoStatFunctional::NoStatFunctional(const AFunctional* func)
-:_func(func)
+  : _func(func)
 {
-
 }
 
 NoStatFunctional::~NoStatFunctional()
 {
-
 }
 
 void NoStatFunctional::_informField(const VectorVectorDouble& coords,
                                     VectorDouble& tab,
-                                    bool verbose) 
+                                    bool verbose)
 {
-    DECLARE_UNUSED(verbose)
-    int size = (int)coords[0].size();
-    int ndim = (int)coords.size();
-    VectorDouble vec(ndim);
-    for (int icoords = 0; icoords < size; icoords++)
+  DECLARE_UNUSED(verbose)
+  int size = (int)coords[0].size();
+  int ndim = (int)coords.size();
+  VectorDouble vec(ndim);
+  for (int icoords = 0; icoords < size; icoords++)
+  {
+    for (int idim = 0; idim < ndim; idim++)
     {
-        for (int idim = 0; idim < ndim; idim ++)
-        {
-            vec[idim] = coords[idim][icoords];
-        }
-        tab[icoords] =  _func->getFunctionValue(vec);
+      vec[idim] = coords[idim][icoords];
     }
+    tab[icoords] = _func->getFunctionValue(vec);
+  }
 }
 
 String NoStatFunctional::toString(const AStringFormat* strfmt) const
 {
-    DECLARE_UNUSED(strfmt)
-    std::stringstream sstr;
-    if (_func == nullptr) return sstr.str();
-    sstr << ANoStat::toString(strfmt);
-    AStringFormat sf;
-    if (strfmt != nullptr) sf = *strfmt;
-    if (sf.getLevel() > 0)
-        sstr << "Functional" << std::endl;
-    return sstr.str();
+  DECLARE_UNUSED(strfmt)
+  std::stringstream sstr;
+  if (_func == nullptr) return sstr.str();
+  sstr << ANoStat::toString(strfmt);
+  AStringFormat sf;
+  if (strfmt != nullptr) sf = *strfmt;
+  if (sf.getLevel() > 0)
+    sstr << "Functional" << std::endl;
+  return sstr.str();
 }
 }

--- a/src/Covariances/ParamId.cpp
+++ b/src/Covariances/ParamId.cpp
@@ -8,48 +8,46 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Space/ASpaceObject.hpp"
 #include "Covariances/ParamId.hpp"
+#include "Space/ASpaceObject.hpp"
 
 namespace gstlrn
 {
 ParamId::ParamId(const EConsElem& elem,
                  int iv1,
                  int iv2)
-    : AStringable(),
-      _elemType(elem),
-      _iv1(iv1),
-      _iv2(iv2)
+  : AStringable()
+  , _elemType(elem)
+  , _iv1(iv1)
+  , _iv2(iv2)
 {
 }
 
-ParamId::ParamId(const ParamId &m)
-    : AStringable(m),
-      _elemType(m._elemType),
-      _iv1(m._iv1),
-      _iv2(m._iv2)
+ParamId::ParamId(const ParamId& m)
+  : AStringable(m)
+  , _elemType(m._elemType)
+  , _iv1(m._iv1)
+  , _iv2(m._iv2)
 {
-
 }
 
-ParamId& ParamId::operator=(const ParamId &m)
+ParamId& ParamId::operator=(const ParamId& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
     _elemType = m._elemType;
-    _iv1   = m._iv1;
-    _iv2   = m._iv2;
+    _iv1      = m._iv1;
+    _iv2      = m._iv2;
   }
   return *this;
 }
 
 ParamId::~ParamId()
 {
-
 }
 
-ParamId* ParamId::create(const EConsElem &elem,
+ParamId* ParamId::create(const EConsElem& elem,
                          int iv1,
                          int iv2)
 {
@@ -60,9 +58,9 @@ int ParamId::init(const EConsElem& type,
                   int v1,
                   int v2)
 {
-  _elemType  = type;
-  _iv1   = v1;
-  _iv2   = v2;
+  _elemType = type;
+  _iv1      = v1;
+  _iv2      = v2;
 
   // Check to avoid rotation of a Model defined on the sphere
   bool flag_sphere = (getDefaultSpaceType() == ESpaceType::SN);

--- a/src/Covariances/TabNoStat.cpp
+++ b/src/Covariances/TabNoStat.cpp
@@ -1,11 +1,21 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/TabNoStat.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/ParamId.hpp"
+#include "Db/Db.hpp"
 #include "Enum/EConsElem.hpp"
 #include "geoslib_define.h"
 #include <memory>
-#include "Db/Db.hpp"
 
 namespace gstlrn 
 {
@@ -36,7 +46,7 @@ TabNoStat& TabNoStat::operator=(const TabNoStat& m)
 int TabNoStat::removeElem(const EConsElem& econs, int iv1, int iv2)
 {
   ParamId param(econs, iv1, iv2);
-  int res = (int) _items.erase(param);
+  int res = (int)_items.erase(param);
   updateDescription();
   return res;
 }
@@ -109,7 +119,7 @@ int TabNoStat::addElem(std::shared_ptr<ANoStat>& nostat, const EConsElem& econs,
   if (!isValid(econs))
     return 0;
   ParamId param(econs, iv1, iv2);
-  int res       = (int) _items.count(param);
+  int res       = (int)_items.count(param);
   _items[param] = nostat;
   if (res == 1)
   {
@@ -125,7 +135,7 @@ void TabNoStat::setDbNoStatRef(const Db* dbref)
 {
   if (dbref != nullptr)
   {
-    //Db* db       = dynamic_cast<Db*>(dbref->clone());
+    // Db* db       = dynamic_cast<Db*>(dbref->clone());
     _dbNoStatRef = std::shared_ptr<const Db>(dynamic_cast<Db*>(dbref->clone()));
   }
   else

--- a/src/Covariances/TabNoStatCovAniso.cpp
+++ b/src/Covariances/TabNoStatCovAniso.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/TabNoStatCovAniso.hpp"
 #include "Basic/AStringable.hpp"
 #include "Covariances/TabNoStat.hpp"
@@ -6,51 +16,48 @@
 namespace gstlrn
 {
 TabNoStatCovAniso::TabNoStatCovAniso()
-: _nAngles(0)
-, _nRanges(0)
-, _nScales(0)
-, _nTensor(0)
-, _param(false)
-, _definedForAnisotropy(false)
-, _definedByAnglesAndScales(false)
-, _definedForRotation(false)
-, _definedForTensor(false)
+  : _nAngles(0)
+  , _nRanges(0)
+  , _nScales(0)
+  , _nTensor(0)
+  , _param(false)
+  , _definedForAnisotropy(false)
+  , _definedByAnglesAndScales(false)
+  , _definedForRotation(false)
+  , _definedForTensor(false)
 {
-
-    
-}   
-
-TabNoStatCovAniso::TabNoStatCovAniso(const TabNoStatCovAniso &m):
-    TabNoStat(m)
-{
-    _definedByAnglesAndScales = m._definedByAnglesAndScales;
-    _definedForAnisotropy = m._definedForAnisotropy;
-    _definedForRotation = m._definedForRotation;
-    _definedForTensor = m._definedForTensor;
-    _nTensor = m._nTensor;
-    _nAngles = m._nAngles;
-    _nRanges = m._nRanges;
-    _nScales = m._nScales;
-    _param = m._param;
 }
 
-
-TabNoStatCovAniso& TabNoStatCovAniso::operator= (const TabNoStatCovAniso &m)
+TabNoStatCovAniso::TabNoStatCovAniso(const TabNoStatCovAniso& m)
+  : TabNoStat(m)
 {
-    TabNoStat::operator =(m);
-    if (this != &m)
-    {
-        _definedByAnglesAndScales = m._definedByAnglesAndScales;
-        _definedForAnisotropy = m._definedForAnisotropy;
-        _definedForRotation = m._definedForRotation;
-        _definedForTensor = m._definedForTensor;
-        _nTensor = m._nTensor;
-        _nAngles = m._nAngles;
-        _nRanges = m._nRanges;
-        _nScales = m._nScales;
-        _param = m._param;
-    }
-    return *this;
+  _definedByAnglesAndScales = m._definedByAnglesAndScales;
+  _definedForAnisotropy     = m._definedForAnisotropy;
+  _definedForRotation       = m._definedForRotation;
+  _definedForTensor         = m._definedForTensor;
+  _nTensor                  = m._nTensor;
+  _nAngles                  = m._nAngles;
+  _nRanges                  = m._nRanges;
+  _nScales                  = m._nScales;
+  _param                    = m._param;
+}
+
+TabNoStatCovAniso& TabNoStatCovAniso::operator=(const TabNoStatCovAniso& m)
+{
+  TabNoStat::operator=(m);
+  if (this != &m)
+  {
+    _definedByAnglesAndScales = m._definedByAnglesAndScales;
+    _definedForAnisotropy     = m._definedForAnisotropy;
+    _definedForRotation       = m._definedForRotation;
+    _definedForTensor         = m._definedForTensor;
+    _nTensor                  = m._nTensor;
+    _nAngles                  = m._nAngles;
+    _nRanges                  = m._nRanges;
+    _nScales                  = m._nScales;
+    _param                    = m._param;
+  }
+  return *this;
 }
 
 /**
@@ -68,112 +75,110 @@ bool TabNoStatCovAniso::isDefinedForAnisotropy() const
  * only by angle / range / scale
  * @return
  */
- 
+
 bool TabNoStatCovAniso::isDefinedForRotation() const
 {
-    return _definedForRotation;
+  return _definedForRotation;
 }
 
 void TabNoStatCovAniso::_clear()
 {
-    _nAngles = 0;
-    _nRanges = 0;
-    _nScales = 0;
-    _nTensor = 0;
-    _param = false;
-    _definedForAnisotropy = false;
-    _definedByAnglesAndScales = false;
-    _definedForRotation = false;
-    _definedForTensor = false;
+  _nAngles                  = 0;
+  _nRanges                  = 0;
+  _nScales                  = 0;
+  _nTensor                  = 0;
+  _param                    = false;
+  _definedForAnisotropy     = false;
+  _definedByAnglesAndScales = false;
+  _definedForRotation       = false;
+  _definedForTensor         = false;
 }
 void TabNoStatCovAniso::_updateDescription()
 {
-  _definedForRotation = (_nAngles > 0) || (_nRanges > 0) || (_nScales > 0);
-  _definedForTensor   = _nTensor > 0;
+  _definedForRotation   = (_nAngles > 0) || (_nRanges > 0) || (_nScales > 0);
+  _definedForTensor     = _nTensor > 0;
   _definedForAnisotropy = _definedForRotation || _definedForTensor;
 }
 
-
-int TabNoStatCovAniso::addElem(std::shared_ptr<ANoStat> &nostat,const EConsElem &econs, int iv1, int iv2) 
+int TabNoStatCovAniso::addElem(std::shared_ptr<ANoStat>& nostat, const EConsElem& econs, int iv1, int iv2)
 {
-    if (econs == EConsElem::RANGE)
+  if (econs == EConsElem::RANGE)
+  {
+    if (isElemDefined(EConsElem::SCALE, iv1, iv2) && _nScales == 1)
     {
-        if (isElemDefined(EConsElem::SCALE, iv1, iv2) && _nScales == 1)
-        {
-            removeElem(EConsElem::SCALE,iv1,iv2);
-            messerr("Warning, you gave a non-stationary specification for the range");
-            messerr("but it was already given for the scale.");
-            messerr("The new specification has replaced the previous one.");
-        }
-        else if(_nScales > 0)
-        {
-            messerr("You try to specify non stationarities for range whereas");
-            messerr("you had already specified one for the scale in another dimension.");
-            messerr("It is invalid");
-            return 0;
-        }          
+      removeElem(EConsElem::SCALE, iv1, iv2);
+      messerr("Warning, you gave a non-stationary specification for the range");
+      messerr("but it was already given for the scale.");
+      messerr("The new specification has replaced the previous one.");
     }
-    if (econs == EConsElem::SCALE)
+    else if (_nScales > 0)
     {
-        if (isElemDefined(EConsElem::RANGE, iv1, iv2) && _nRanges == 1)
-        {
-            removeElem(EConsElem::RANGE,iv1,iv2);
-            messerr("Warning, you gave a non-stationary specification for the scale");
-            messerr("but it was already given for the range.");
-            messerr("The new specification has replaced the previous one.");
-        }
-        else if (_nRanges > 0) 
-        {
-            messerr("You try to specify non stationarities for scale whereas");
-            messerr("you had already specified one for the range in another dimension.");
-            messerr("It is invalid");
-            return 0;
-        }
+      messerr("You try to specify non stationarities for range whereas");
+      messerr("you had already specified one for the scale in another dimension.");
+      messerr("It is invalid");
+      return 0;
     }
-    int res = TabNoStat::addElem(nostat, econs, iv1,iv2);
-    if (res == 0) return res;
-    if (econs == EConsElem::PARAM)
-        _param = true;
-    if (econs == EConsElem::TENSOR)
-        _nTensor += res;
-    if (econs == EConsElem::RANGE) 
-        _nRanges += res;
-    if (econs == EConsElem::SCALE) 
-        _nScales += res;
-    if (econs == EConsElem::ANGLE)
-        _nAngles += res;
-    updateDescription();
-    return res;
+  }
+  if (econs == EConsElem::SCALE)
+  {
+    if (isElemDefined(EConsElem::RANGE, iv1, iv2) && _nRanges == 1)
+    {
+      removeElem(EConsElem::RANGE, iv1, iv2);
+      messerr("Warning, you gave a non-stationary specification for the scale");
+      messerr("but it was already given for the range.");
+      messerr("The new specification has replaced the previous one.");
+    }
+    else if (_nRanges > 0)
+    {
+      messerr("You try to specify non stationarities for scale whereas");
+      messerr("you had already specified one for the range in another dimension.");
+      messerr("It is invalid");
+      return 0;
+    }
+  }
+  int res = TabNoStat::addElem(nostat, econs, iv1, iv2);
+  if (res == 0) return res;
+  if (econs == EConsElem::PARAM)
+    _param = true;
+  if (econs == EConsElem::TENSOR)
+    _nTensor += res;
+  if (econs == EConsElem::RANGE)
+    _nRanges += res;
+  if (econs == EConsElem::SCALE)
+    _nScales += res;
+  if (econs == EConsElem::ANGLE)
+    _nAngles += res;
+  updateDescription();
+  return res;
 }
 
-int TabNoStatCovAniso::removeElem(const EConsElem &econs, int iv1, int iv2) 
+int TabNoStatCovAniso::removeElem(const EConsElem& econs, int iv1, int iv2)
 {
-    int res = TabNoStat::removeElem(econs, iv1,iv2);
-    if (res == 0) return res;
-    if (econs == EConsElem::PARAM)
-        _param = false;
-    if (econs == EConsElem::TENSOR)
-        _nTensor -= res;
-    if (econs == EConsElem::RANGE)
-        _nRanges -= res;
-    if (econs == EConsElem::SCALE)
-        _nScales -= res;
-    if (econs == EConsElem::ANGLE)
-        _nAngles -= res;
-    updateDescription();
-    return res;
+  int res = TabNoStat::removeElem(econs, iv1, iv2);
+  if (res == 0) return res;
+  if (econs == EConsElem::PARAM)
+    _param = false;
+  if (econs == EConsElem::TENSOR)
+    _nTensor -= res;
+  if (econs == EConsElem::RANGE)
+    _nRanges -= res;
+  if (econs == EConsElem::SCALE)
+    _nScales -= res;
+  if (econs == EConsElem::ANGLE)
+    _nAngles -= res;
+  updateDescription();
+  return res;
 }
 
 bool TabNoStatCovAniso::_isValid(const EConsElem& econs) const
 {
-    return (econs == EConsElem::RANGE || econs == EConsElem::ANGLE ||
-            econs == EConsElem::SCALE || econs == EConsElem::TENSOR|| 
-            econs == EConsElem::PARAM);
+  return (econs == EConsElem::RANGE || econs == EConsElem::ANGLE ||
+          econs == EConsElem::SCALE || econs == EConsElem::TENSOR ||
+          econs == EConsElem::PARAM);
 }
 
 TabNoStatCovAniso::~TabNoStatCovAniso()
 {
-
 }
 
 }

--- a/src/Covariances/TabNoStatSills.cpp
+++ b/src/Covariances/TabNoStatSills.cpp
@@ -1,3 +1,13 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
 #include "Covariances/TabNoStatSills.hpp"
 #include "Covariances/ParamId.hpp"
 #include "Covariances/TabNoStat.hpp"
@@ -13,7 +23,6 @@ TabNoStatSills::TabNoStatSills()
 TabNoStatSills::TabNoStatSills(const TabNoStatSills& m)
   : TabNoStat(m)
 {
-
 }
 
 TabNoStatSills& TabNoStatSills::operator=(const TabNoStatSills& m)
@@ -51,7 +60,7 @@ String TabNoStatSills::toStringInside(const AStringFormat* strfmt, int i) const
 
 bool TabNoStatSills::isDefinedForVariance() const
 {
- return !empty();
+  return !empty();
 }
 
 int TabNoStatSills::getNSills() const


### PR DESCRIPTION
This branch has been instantiated but not used explicitely.
Instead, we used this branch to test the automatic sorting of the #include in a CPP file.
This has been run as a test on the CPP files included in src/Covariance directory. 
It should be applied more systematically on the whole code in a dedicated new branch.
This branch should be close after a successfull PR