### PR TITLE
No more reference to EIGEN_MPL2_ONLY

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -198,9 +198,6 @@ foreach(FLAVOR ${FLAVORS})
     target_link_libraries(${FLAVOR} PRIVATE ${HDF5_LIBRARIES})
   endif()
   
-  # Exclude [L]GPL features from Eigen
-  #target_compile_definitions(${FLAVOR} PUBLIC EIGEN_MPL2_ONLY) 
-
   # Link to specific libraries (only for Microsoft Visual Studio)
   if (MSVC)
     target_link_libraries(${FLAVOR} PUBLIC iphlpapi rpcrt4)


### PR DESCRIPTION
EIGEN library is now totally MPL2. EIGEN_MPL2_ONLY symbol can be removed.