### PR TITLE
ASerializable: Remove creation of "gstlearn_dir" folder

### DIFF
--- a/src/Basic/ASerializable.cpp
+++ b/src/Basic/ASerializable.cpp
@@ -183,8 +183,8 @@ String ASerializable::buildFileName(int status, const String& filename, bool ens
   fileLocal.clear();
 
   // container name: first search for the GSTLEARN_OUTPUT_DIR
-  // environment variable, then if empty create a `gstlearn_dir'
-  // folder in the current directory
+  // environment variable. If not defined, use the current directory
+  // instead.
   const auto output_dir = gslGetEnv("GSTLEARN_OUTPUT_DIR");
 
   if (!output_dir.empty())


### PR DESCRIPTION
Without the `GSTLEARN_OUTPUT_DIR` env var defined, read & write files in the current working directory.

Fix #570.

Pierre