### PR TITLE
GitHub Actions: Use uv in publish workflows

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -62,15 +62,15 @@ jobs:
         brew install boost
         brew install eigen
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
       with:
-        python-version: ${{matrix.python.py}}
+        python-version: ${{ matrix.python.py }}
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy twine build uv
+        uv venv
+        uv pip install numpy
 
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
@@ -80,7 +80,7 @@ jobs:
 
     - name : Configure build directory
       run : |
-        cmake \
+        uv run cmake \
           -B${{ env.BUILD_DIR }} \
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
@@ -99,7 +99,7 @@ jobs:
       run : |
         cd ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python -m build --wheel
+        uv build --wheel
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 
@@ -140,23 +140,25 @@ jobs:
       with:
         name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
       with:
-        python-version: ${{matrix.python.py}}
+        python-version: ${{ matrix.python.py }}
 
     - name: Install macOS dependencies
       run: brew install llvm
 
     - name: Install Python package
-      run: pip install "./$(ls *.whl)[conv]"
+      run: |
+        uv venv
+        uv pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
-        python tests/py/test_Arguments.py
-        python tests/py/test_Assessors.py
-        python tests/py/test_Matrix.py
+        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        uv run python tests/py/test_Arguments.py
+        uv run python tests/py/test_Assessors.py
+        uv run python tests/py/test_Matrix.py
 
   publish:
     needs: test

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -76,9 +76,13 @@ jobs:
       run: |
         echo "/opt/python/${{ matrix.python }}/bin" >> $GITHUB_PATH
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
     - name: Install Python dependencies
       run: |
-        python -m pip install numpy uv
+        uv venv
+        uv pip install numpy
 
     - name: Build & install NLopt static libraries
       uses: ./.github/actions/nlopt_static_unix
@@ -88,7 +92,7 @@ jobs:
 
     - name : Configure build directory
       run : |
-        cmake \
+        uv run cmake \
           -B${{ env.BUILD_DIR }} \
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
@@ -105,7 +109,7 @@ jobs:
       run : |
         cd ${{ env.BUILD_DIR }}/python/${{ env.CMAKE_BUILD_TYPE }}
         # Note: wheel must be declared not pure (see setup.py)
-        python3 -m build --wheel -C="--build-option=--plat-name=${{ matrix.image }}"
+        uv build --wheel -C="--build-option=--plat-name=${{ matrix.image }}"
         cd ../../..
         echo "MY_PKG=$(ls ${{ env.BUILD_DIR }}/python/${{ env.CMAKE_BUILD_TYPE }}/dist/*)" >> "$GITHUB_ENV"
 
@@ -146,15 +150,20 @@ jobs:
       run: |
         echo "/opt/python/${{ matrix.python }}/bin" >> $GITHUB_PATH
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
     - name: Install Python package
-      run: python -m pip install "./$(ls *.whl)[conv]"
+      run: |
+        uv venv
+        uv pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
-        python tests/py/test_Arguments.py
-        python tests/py/test_Assessors.py
-        python tests/py/test_Matrix.py
+        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        uv run python tests/py/test_Arguments.py
+        uv run python tests/py/test_Assessors.py
+        uv run python tests/py/test_Matrix.py
 
   publish:
     needs: test

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -148,20 +148,22 @@ jobs:
       with:
         name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
       with:
-        python-version: ${{matrix.python.py}}
+        python-version: ${{ matrix.python.py }}
 
     - name: Install Python package
-      run: pip install "$(ls *.whl)[conv]"
+      run: |
+        uv venv
+        uv pip install "$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        python -c "import gstlearn as gl; gl.acknowledge_gstlearn()"
-        python tests/py/test_Arguments.py
-        python tests/py/test_Assessors.py
-        python tests/py/test_Matrix.py
+        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        uv run python tests/py/test_Arguments.py
+        uv run python tests/py/test_Assessors.py
+        uv run python tests/py/test_Matrix.py
 
   publish:
     needs: test


### PR DESCRIPTION
This PR replaces the use of `pip` with `uv` in the `publish_python_macos`, `publish_python_manylinux` and `publish_python_windows` workflows.

In particular, it should accelerate a bit the test jobs of the macOS workflow, which are very contended (GitHub only allows running 5 parallel macOS jobs).

Note that due to cross-compiling to 32 bits on Windows, we cannot (yet) use `uv` in the build job, only in the test job.

Enjoy,
Pierre