### PR TITLE
Cleaning memalloc

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ EmptyLineBeforeAccessModifier: Always
 IndentCaseLabels: true
 IndentWidth: 2
 IndentPPDirectives: AfterHash
-NamespaceIndentation: All
+NamespaceIndentation: None
 PackConstructorInitializers: Never
 PenaltyReturnTypeOnItsOwnLine: 10  # Strongly discourages breaking return type
 PenaltyBreakBeforeFirstCallParameter: 100  # Keeps function name & first parameter together

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >-
   -bugprone-narrowing-conversions,
   -bugprone-macro-parentheses,
   -bugprone-reserved-identifier,
+  modernize-deprecated-headers,
   mpi-*,
   openmp-*,
   -openmp-use-default-none,

--- a/include/Basic/ASerializable.hpp
+++ b/include/Basic/ASerializable.hpp
@@ -10,23 +10,23 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/AStringable.hpp"
 #include "Basic/SerializeNeutralFile.hpp"
 #include "Enum/EFormatNF.hpp"
-#include "gstlearn_export.hpp"
 #include "geoslib_define.h"
+#include "gstlearn_export.hpp"
 
-#include "Basic/AStringable.hpp"
-
-#include <iostream>
-#include <stdarg.h>
+#include <cstdarg>
 #include <fstream>
+#include <iostream>
 
 namespace H5
 {
-  class Group;
+class Group;
 };
 
-namespace gstlrn{
+namespace gstlrn
+{
 
 class GSTLEARN_EXPORT ASerializable
 {
@@ -78,20 +78,20 @@ protected:
 
   static bool _commentWrite(std::ostream& os,
                             const String& comment);
-  template <typename T>
+  template<typename T>
   static bool _recordWrite(std::ostream& os,
-                            const String& title,
-                            const T& val);
-  template <typename T>
-  static bool _recordWriteVec(std::ostream& os,
-                               const String& title,
-                               const std::vector<T>& vec);
-
-  template <typename T>
-  static bool _recordRead(std::istream& is,
                            const String& title,
-                           T& val);
-  template <typename T>
+                           const T& val);
+  template<typename T>
+  static bool _recordWriteVec(std::ostream& os,
+                              const String& title,
+                              const std::vector<T>& vec);
+
+  template<typename T>
+  static bool _recordRead(std::istream& is,
+                          const String& title,
+                          T& val);
+  template<typename T>
   static bool _recordReadVec(std::istream& is,
                              const String& title,
                              VectorT<T>& vec,
@@ -99,22 +99,22 @@ protected:
 
   template<typename T>
   static bool _recordReadVecInPlace(std::istream& is,
-                             const String& title,
-                             VectorDouble::iterator& it,
-                             int nvalues);
+                                    const String& title,
+                                    VectorDouble::iterator& it,
+                                    int nvalues);
 
-  static bool _tableRead(std::istream &is,
-                         const String &string,
+  static bool _tableRead(std::istream& is,
+                         const String& string,
                          int ntab,
-                         double *tab);
-  static bool _tableWrite(std::ostream &os,
-                          const String &string,
+                         double* tab);
+  static bool _tableWrite(std::ostream& os,
+                          const String& string,
                           int ntab,
-                          const VectorDouble &tab);
+                          const VectorDouble& tab);
 
 private:
   static String _myPrefixName;
-  EFormatNF _defaultFormatNF{EFormatNF::H5};
+  EFormatNF _defaultFormatNF {EFormatNF::H5};
 };
 
 template<typename T>
@@ -154,4 +154,4 @@ bool ASerializable::_recordReadVecInPlace(std::istream& is,
 {
   return SerializeNeutralFile::recordReadVecInPlace<T>(is, title, it, nvalues);
 }
-}
+} // namespace gstlrn

--- a/include/Basic/FFT.hpp
+++ b/include/Basic/FFT.hpp
@@ -10,10 +10,10 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
 #include "Arrays/Array.hpp"
+#include "gstlearn_export.hpp"
 
-#include <math.h>
+#include <cmath>
 #include <complex>
 #include <functional>
 
@@ -23,11 +23,9 @@ GSTLEARN_EXPORT int FFTn(int ndim,
                          const VectorInt& dims,
                          VectorDouble& Re,
                          VectorDouble& Im,
-                         int iSign = 1,
+                         int iSign      = 1,
                          double scaling = 1.);
-GSTLEARN_EXPORT Array evalCovFFTTimeSlice(const VectorDouble& hmax, double time, int N,
-                                          const std::function<std::complex<double>(VectorDouble, double)>& funcSpectrum);
-GSTLEARN_EXPORT Array evalCovFFTSpatial(const VectorDouble& hmax, int N,
-                                        const std::function<double(const VectorDouble&)>& funcSpectrum);
+GSTLEARN_EXPORT Array evalCovFFTTimeSlice(const VectorDouble& hmax, double time, int N, const std::function<std::complex<double>(VectorDouble, double)>& funcSpectrum);
+GSTLEARN_EXPORT Array evalCovFFTSpatial(const VectorDouble& hmax, int N, const std::function<double(const VectorDouble&)>& funcSpectrum);
 GSTLEARN_EXPORT void fftshift(const VectorInt& dims, VectorDouble& data);
-}
+} // namespace gstlrn

--- a/include/Basic/ParamInfo.hpp
+++ b/include/Basic/ParamInfo.hpp
@@ -11,7 +11,6 @@
 #include <limits>
 #include <string>
 
-
 #define INF std::numeric_limits<double>::infinity()
 
 namespace gstlrn

--- a/include/Basic/Utilities.hpp
+++ b/include/Basic/Utilities.hpp
@@ -10,15 +10,14 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
-#include "geoslib_define.h"
 #include "Basic/VectorNumT.hpp"
-#include "Matrix/MatrixSquare.hpp"
 #include "Enum/EOperator.hpp"
+#include "Matrix/MatrixSquare.hpp"
+#include "geoslib_define.h"
+#include "gstlearn_export.hpp"
 
-#include <map>
 #include <cmath>
-#include <math.h>
+#include <map>
 
 namespace gstlrn
 {
@@ -33,14 +32,14 @@ typedef struct
   double stdv;
 } StatResults;
 
-GSTLEARN_EXPORT bool   isInteger(double value, double eps = EPSILON10);
-GSTLEARN_EXPORT int    getClosestInteger(double value);
-GSTLEARN_EXPORT bool   isMultiple(int nbig, int nsmall);
-GSTLEARN_EXPORT bool   isOdd(int number);
-GSTLEARN_EXPORT bool   isEven(int number);
-GSTLEARN_EXPORT bool   isZero(double value, double eps = EPSILON10);
-GSTLEARN_EXPORT bool   isOne(double value, double eps = EPSILON10);
-GSTLEARN_EXPORT bool   isEqual(double v1, double v2, double eps = EPSILON10);
+GSTLEARN_EXPORT bool isInteger(double value, double eps = EPSILON10);
+GSTLEARN_EXPORT int getClosestInteger(double value);
+GSTLEARN_EXPORT bool isMultiple(int nbig, int nsmall);
+GSTLEARN_EXPORT bool isOdd(int number);
+GSTLEARN_EXPORT bool isEven(int number);
+GSTLEARN_EXPORT bool isZero(double value, double eps = EPSILON10);
+GSTLEARN_EXPORT bool isOne(double value, double eps = EPSILON10);
+GSTLEARN_EXPORT bool isEqual(double v1, double v2, double eps = EPSILON10);
 GSTLEARN_EXPORT double getMin(double val1, double val2);
 GSTLEARN_EXPORT double getMax(double val1, double val2);
 GSTLEARN_EXPORT double ut_deg2rad(double angle);
@@ -56,68 +55,102 @@ GSTLEARN_EXPORT bool isEqualExtended(double v1,
 // No need this stuff through SWIG (because we use target language NAs)
 #ifndef SWIG
 
-GSTLEARN_EXPORT bool   FFFF(double value); // TODO isNA<double>
-GSTLEARN_EXPORT bool   IFFFF(int value);   // TODO isNA<int>
-GSTLEARN_EXPORT double getTEST();  // TODO getNA<double>
-GSTLEARN_EXPORT int    getITEST(); // TODO getNA<int>
+GSTLEARN_EXPORT bool FFFF(double value); // TODO isNA<double>
+GSTLEARN_EXPORT bool IFFFF(int value);   // TODO isNA<int>
+GSTLEARN_EXPORT double getTEST();        // TODO getNA<double>
+GSTLEARN_EXPORT int getITEST();          // TODO getNA<int>
 
-#define DOUBLE_NA  TEST
-#define    INT_NA  ITEST
-#define STRING_NA  "NA"
-#define  FLOAT_NA  static_cast<float>(TEST)   // 1.234e30 is ok for 4 bytes but needs a cast for Windows
+#  define DOUBLE_NA TEST
+#  define INT_NA    ITEST
+#  define STRING_NA "NA"
+#  define FLOAT_NA  static_cast<float>(TEST) // 1.234e30 is ok for 4 bytes but needs a cast for Windows
 
-template <typename T> inline T getNA();
-template <> inline double getNA() { return DOUBLE_NA; }
-template <> inline int    getNA() { return INT_NA; }
-template <> inline String getNA() { return STRING_NA; }
-template <> inline float  getNA() { return FLOAT_NA; }
+template<typename T>
+inline T getNA();
+template<>
+inline double getNA()
+{
+  return DOUBLE_NA;
+}
+template<>
+inline int getNA()
+{
+  return INT_NA;
+}
+template<>
+inline String getNA()
+{
+  return STRING_NA;
+}
+template<>
+inline float getNA()
+{
+  return FLOAT_NA;
+}
 
-template <typename T> inline bool isNA(const T& v);
-template <> inline bool isNA(const double& v) { return (v == getNA<double>() || std::isnan(v) || std::isinf(v)); }
-template <> inline bool isNA(const int& v)    { return (v == getNA<int>()); }
-template <> inline bool isNA(const String& v) { return (v == getNA<String>()); }
-template <> inline bool isNA(const float& v)  { return (v == getNA<float>()  || std::isnan(v) || std::isinf(v)); }
+template<typename T>
+inline bool isNA(const T& v);
+template<>
+inline bool isNA(const double& v)
+{
+  return (v == getNA<double>() || std::isnan(v) || std::isinf(v));
+}
+template<>
+inline bool isNA(const int& v)
+{
+  return (v == getNA<int>());
+}
+template<>
+inline bool isNA(const String& v)
+{
+  return (v == getNA<String>());
+}
+template<>
+inline bool isNA(const float& v)
+{
+  return (v == getNA<float>() || std::isnan(v) || std::isinf(v));
+}
 
 #endif // SWIG
 
 // Other Utility functions
 
-GSTLEARN_EXPORT void ut_sort_double(int safe, int nech, int *ind, double *value);
+GSTLEARN_EXPORT void ut_sort_double(int safe, int nech, int* ind, double* value);
 GSTLEARN_EXPORT StatResults ut_statistics(int nech,
-                                          const double *tab,
-                                          const double *sel = nullptr,
-                                          const double *wgt = nullptr);
-GSTLEARN_EXPORT void ut_stats_mima_print(const char *title, int nech, double *tab, double *sel);
+                                          const double* tab,
+                                          const double* sel = nullptr,
+                                          const double* wgt = nullptr);
+GSTLEARN_EXPORT void ut_stats_mima_print(const char* title, int nech, double* tab, double* sel);
 GSTLEARN_EXPORT void ut_facies_statistics(int nech,
-                                          double *tab,
-                                          double *sel,
-                                          int *nval,
-                                          int *mini,
-                                          int *maxi);
+                                          double* tab,
+                                          double* sel,
+                                          int* nval,
+                                          int* mini,
+                                          int* maxi);
 GSTLEARN_EXPORT void ut_classify(int nech,
-                                 const double *tab,
-                                 double *sel,
+                                 const double* tab,
+                                 double* sel,
                                  int nclass,
                                  double start,
                                  double pas,
-                                 int *nmask,
-                                 int *ntest,
-                                 int *nout,
-                                 int *classe);
+                                 int* nmask,
+                                 int* ntest,
+                                 int* nout,
+                                 int* classe);
 GSTLEARN_EXPORT double ut_median(VectorDouble& tab, int ntab);
 GSTLEARN_EXPORT double ut_cnp(int n, int k);
 GSTLEARN_EXPORT MatrixSquare ut_pascal(int ndim);
-GSTLEARN_EXPORT int* ut_combinations(int n, int maxk, int *ncomb);
+GSTLEARN_EXPORT int* ut_combinations(int n, int maxk, int* ncomb);
 GSTLEARN_EXPORT void ut_shuffle_array(int nrow, int ncol, VectorDouble& tab);
 
-GSTLEARN_EXPORT VectorInt getListActiveToAbsolute(const VectorDouble &sel);
-GSTLEARN_EXPORT std::map<int, int> getMapAbsoluteToRelative(const VectorDouble &sel,
+GSTLEARN_EXPORT VectorInt getListActiveToAbsolute(const VectorDouble& sel);
+GSTLEARN_EXPORT std::map<int, int> getMapAbsoluteToRelative(const VectorDouble& sel,
                                                             bool verbose = false);
 GSTLEARN_EXPORT int getRankMapAbsoluteToRelative(const std::map<int, int>& map, int iabs);
 GSTLEARN_EXPORT int getRankMapRelativeToAbsolute(const std::map<int, int>& map, int irel);
 
 typedef double (*operate_function)(double);
-GSTLEARN_EXPORT operate_function operate_Identify( int oper );
+GSTLEARN_EXPORT operate_function operate_Identify(int oper);
 GSTLEARN_EXPORT double operate_Identity(double x);
 GSTLEARN_EXPORT double operate_Inverse(double x);
 GSTLEARN_EXPORT double operate_Square(double x);
@@ -137,4 +170,4 @@ GSTLEARN_EXPORT bool isInternalDebug();
 GSTLEARN_EXPORT void print_range(const char* title, int ntab, const double* tab, const double* sel);
 
 GSTLEARN_EXPORT void convertIndptrToIndices(int ncumul, const int* cumul, int* tab);
-}
+} // namespace gstlrn

--- a/include/Core/Seismic.hpp
+++ b/include/Core/Seismic.hpp
@@ -67,3 +67,4 @@ GSTLEARN_EXPORT int seismic_convolve(DbGrid* db,
                                      double val_middle,
                                      double val_after,
                                      VectorDouble& wavelet);
+}

--- a/include/Core/Seismic.hpp
+++ b/include/Core/Seismic.hpp
@@ -35,9 +35,19 @@ GSTLEARN_EXPORT int seismic_simulate_XZ(DbGrid* db,
                                         int flag_sort,
                                         int flag_stat);
 GSTLEARN_EXPORT int seismic_z2t_grid(
-  int verbose, DbGrid* db_z, int iatt_v, int* nx, double* x0, double* dx);
+  int verbose,
+  DbGrid* db_z,
+  int iatt_v,
+  int* nx,
+  double* x0,
+  double* dx);
 GSTLEARN_EXPORT int seismic_t2z_grid(
-  int verbose, DbGrid* db_t, int iatt_v, int* nx, double* x0, double* dx);
+  int verbose,
+  DbGrid* db_t,
+  int iatt_v,
+  int* nx,
+  double* x0,
+  double* dx);
 GSTLEARN_EXPORT int seismic_z2t_convert(DbGrid* db_z, int iatt_v, DbGrid* db_t);
 GSTLEARN_EXPORT int seismic_t2z_convert(DbGrid* db_t, int iatt_v, DbGrid* db_z);
 GSTLEARN_EXPORT int seismic_operate(DbGrid* db, int oper);
@@ -55,5 +65,4 @@ GSTLEARN_EXPORT int seismic_convolve(DbGrid* db,
                                      double val_before,
                                      double val_middle,
                                      double val_after,
-                                     double* wavelet);
-}
+                                     VectorDouble& wavelet);

--- a/include/Core/Seismic.hpp
+++ b/include/Core/Seismic.hpp
@@ -10,6 +10,7 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/VectorNumT.hpp"
 #include "gstlearn_export.hpp"
 
 namespace gstlrn

--- a/include/Core/io.hpp
+++ b/include/Core/io.hpp
@@ -12,11 +12,11 @@
 
 #include "gstlearn_export.hpp"
 
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 
 namespace gstlrn
-{   
+{
 GSTLEARN_EXPORT int _file_read(FILE* file, const char* format, va_list ap);
 GSTLEARN_EXPORT int _file_get_ncol(FILE* file);
 GSTLEARN_EXPORT void _file_delimitors(char del_com, const char* del_sep, char del_blk);
@@ -37,4 +37,4 @@ GSTLEARN_EXPORT double _lire_double(const char* question,
                                     double valmax);
 GSTLEARN_EXPORT int _lire_logical(const char* question, int flag_def, int valdef);
 GSTLEARN_EXPORT void _erase_current_string(void);
-}
+} // namespace gstlrn

--- a/include/OutputFormat/AOF.hpp
+++ b/include/OutputFormat/AOF.hpp
@@ -13,7 +13,7 @@
 #include "gstlearn_export.hpp"
 
 #include "Basic/VectorNumT.hpp"
-#include <stdio.h>
+#include <cstdio>
 
 namespace gstlrn
 {
@@ -33,7 +33,7 @@ public:
   virtual bool mustBeForNDim(int /*ndim*/) const { return true; }
   virtual bool mustBeForRotation(int /*mode*/) const { return true; }
   virtual bool isAuthorized() const;
-  virtual int  writeInFile()  { return 1; }
+  virtual int writeInFile() { return 1; }
   virtual Db* readFromFile() { return nullptr; }
   virtual DbGrid* readGridFromFile() { return nullptr; }
 
@@ -49,15 +49,15 @@ public:
   const String& getFilename() const { return _filename; }
 
 protected:
-  int  _fileWriteOpen();
-  int  _fileReadOpen();
+  int _fileWriteOpen();
+  int _fileReadOpen();
   void _fileClose();
 
 protected:
   String _filename;
-  const Db*     _db;
+  const Db* _db;
   const DbGrid* _dbgrid;
-  VectorInt     _cols;
+  VectorInt _cols;
   FILE* _file;
 };
 
@@ -109,4 +109,4 @@ GSTLEARN_EXPORT Db* db_well_read_las(const char* filename,
                                      double ywell,
                                      double cwell,
                                      int verbose = 0);
-}
+} // namespace gstlrn

--- a/include/Simulation/SimuSpherical.hpp
+++ b/include/Simulation/SimuSpherical.hpp
@@ -17,10 +17,10 @@
 #include "Simulation/ACalcSimulation.hpp"
 #include "Simulation/SimuSphericalParam.hpp"
 
-class MeshSpherical;
-
 namespace gstlrn
 {
+
+class MeshSpherical;
 
 class GSTLEARN_EXPORT SimuSpherical: public ACalcSimulation
 {

--- a/include/Stats/Classical.hpp
+++ b/include/Stats/Classical.hpp
@@ -18,15 +18,15 @@
 #include "Basic/VectorNumT.hpp"
 #include "Basic/NamingConvention.hpp"
 
+namespace gstlrn
+{
 
 class Polygons;
 class Table;
 class VarioParam;
-
-namespace gstlrn
-{
 class Db;
 class DbGrid;
+
 GSTLEARN_EXPORT VectorString statOptionToName(const std::vector<EStatOption>& opers);
 GSTLEARN_EXPORT std::vector<EStatOption> KeysToStatOptions(const VectorString& opers);
 

--- a/include/Tree/ball_algorithm.h
+++ b/include/Tree/ball_algorithm.h
@@ -27,25 +27,25 @@ License: BSD 3-clause
 
 #pragma once
 
-#include "gstlearn_export.hpp"
-#include "Tree/KNN.hpp"
 #include "Basic/VectorNumT.hpp"
+#include "Tree/KNN.hpp"
+#include "gstlearn_export.hpp"
 
-# include <stdlib.h>
-# include <limits.h>
-# include <math.h>
-# include <float.h>
-# include <sys/stat.h>
+#include <cfloat>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <sys/stat.h>
 
-# define TRUE 1
-# define FALSE 0
+#define TRUE  1
+#define FALSE 0
 
 namespace gstlrn
 {
 struct t_nheap
 {
-  double **distances;
-  int **indices;
+  double** distances;
+  int** indices;
   int n_pts;
   int n_nbrs;
 };
@@ -60,11 +60,11 @@ typedef struct
 
 struct t_btree
 {
-  double **data;
-  bool *accept;
-  int *idx_array;
-  t_nodedata *node_data;
-  double ***node_bounds;
+  double** data;
+  bool* accept;
+  int* idx_array;
+  t_nodedata* node_data;
+  double*** node_bounds;
 
   int n_samples;
   int n_features;
@@ -97,10 +97,10 @@ GSTLEARN_EXPORT t_btree* btree_init(const double** data,
                                                             int n_features),
                                     int leaf_size,
                                     int default_distance_function);
-GSTLEARN_EXPORT void free_2d_double(double **arr, int row);
-GSTLEARN_EXPORT void free_2d_int(int **arr, int row);
-GSTLEARN_EXPORT void free_tree(t_btree *tree);
-GSTLEARN_EXPORT void finalize_tree(t_btree *tree); // to be suppressed when bug is corrected
+GSTLEARN_EXPORT void free_2d_double(double** arr, int row);
+GSTLEARN_EXPORT void free_2d_int(int** arr, int row);
+GSTLEARN_EXPORT void free_tree(t_btree* tree);
+GSTLEARN_EXPORT void finalize_tree(t_btree* tree); // to be suppressed when bug is corrected
 GSTLEARN_EXPORT void btree_display(const t_btree* tree, int level = -1);
 
 /*
@@ -114,10 +114,10 @@ double euclidean_distance(const double* x1, const double* x2, int n_features);
 */
 t_nheap* nheap_init(int n_pts, int n_nbrs);
 t_nheap* nheap_free(t_nheap* heap);
-double   nheap_largest(t_nheap* h, int row);
-int		   nheap_push(t_nheap *h, int row, double val, int i_val);
-void     nheap_sort(t_nheap *h);
-void     nheap_load(t_nheap *heap, t_btree *b, const double **x);
-double   min_dist(const t_btree *tree, int i_node, const double *pt);
-int      query_depth_first(const t_btree *b, int i_node, const double *pt, int i_pt, t_nheap *heap, double dist);
-}
+double nheap_largest(t_nheap* h, int row);
+int nheap_push(t_nheap* h, int row, double val, int i_val);
+void nheap_sort(t_nheap* h);
+void nheap_load(t_nheap* heap, t_btree* b, const double** x);
+double min_dist(const t_btree* tree, int i_node, const double* pt);
+int query_depth_first(const t_btree* b, int i_node, const double* pt, int i_pt, t_nheap* heap, double dist);
+} // namespace gstlrn

--- a/include/geoslib_d.h
+++ b/include/geoslib_d.h
@@ -23,14 +23,14 @@ namespace gstlrn
 class Koption
 {
 public:
-  EKrigOpt calcul; /* Type of calculation (EKrigOpt) */
-  int ndim; /* Space dimension */
-  int ntot; /* Number of discretization points */
-  int *ndisc; /* Array of discretization counts */
-  double *disc1; /* Discretization coordinates */
-  double *disc2; /* Discretization randomized coordinates */
+  EKrigOpt calcul;    /* Type of calculation (EKrigOpt) */
+  int ndim;           /* Space dimension */
+  int ntot;           /* Number of discretization points */
+  int* ndisc;         /* Array of discretization counts */
+  double* disc1;      /* Discretization coordinates */
+  double* disc2;      /* Discretization randomized coordinates */
   int flag_data_disc; /* Discretization flag */
-  double *dsize;
+  double* dsize;
 };
 
 class Model;
@@ -39,9 +39,9 @@ typedef struct
   int norder;
   int nmodel;
   int npar_init;
-  Model *models[2];
+  Model* models[2];
   Option_VarioFit optvar;
-  void *user_data;
+  void* user_data;
   VectorInt parid;
   VectorDouble covtab;
 } StrMod;
@@ -49,21 +49,21 @@ typedef struct
 class Db;
 typedef struct
 {
-  int case_facies; /* TRUE when Gibbs used for Facies */
-  int case_stat; /* TRUE if proportions are constant */
+  int case_facies;      /* TRUE when Gibbs used for Facies */
+  int case_stat;        /* TRUE if proportions are constant */
   int case_prop_interp; /* TRUE when props are given in proportion file */
-  int ngrf[2]; /* Number of GRF for the PGSs */
-  int nfac[2]; /* Number of facies for the PGSs */
-  int nfaccur; /* Number of facies for current PGS */
-  int nfacprod; /* Product of the number of facies */
-  int nfacmax; /* Maximum number of facies over all PGS */
-  int mode; /* Type of process */
+  int ngrf[2];          /* Number of GRF for the PGSs */
+  int nfac[2];          /* Number of facies for the PGSs */
+  int nfaccur;          /* Number of facies for current PGS */
+  int nfacprod;         /* Product of the number of facies */
+  int nfacmax;          /* Maximum number of facies over all PGS */
+  int mode;             /* Type of process */
   VectorDouble propfix;
   VectorDouble propmem;
   VectorDouble propwrk;
   VectorDouble proploc;
   VectorDouble coor;
-  const Db *dbprop; /* Pointer to the Proportion file */
+  const Db* dbprop; /* Pointer to the Proportion file */
 } Props;
 
 class Rule;
@@ -72,8 +72,8 @@ typedef struct
 {
   int ipgs;
   int flag_used[2];
-  const Rule  *rule;
-  PropDef *propdef;
+  const Rule* rule;
+  PropDef* propdef;
 } Modif_Categorical;
 
 typedef struct
@@ -93,23 +93,23 @@ typedef struct
 class QChol;
 typedef struct
 {
-  QChol *QCtt;
-  QChol *QCtd;
+  QChol* QCtt;
+  QChol* QCtd;
 } QSimu;
 
 class Cheb_Elem
 {
 public:
-  int ncoeffs; /* Number of coefficients */
-  int ncmax; /* Maximum number of polynomials */
-  int ndisc; /* Number of discretizations */
+  int ncoeffs;  /* Number of coefficients */
+  int ncmax;    /* Maximum number of polynomials */
+  int ndisc;    /* Number of discretizations */
   double power; /* Power of the transform */
   double a;
   double b;
   double v1;
   double v2;
-  double tol; /* Tolerance */
-  double *coeffs; /* Array of coefficients */
+  double tol;     /* Tolerance */
+  double* coeffs; /* Array of coefficients */
 };
 
 #ifndef SWIG
@@ -117,16 +117,16 @@ class cs_MGS;
 typedef struct
 {
   VectorDouble Lambda;
-  MatrixSparse *S;
-  MatrixSparse *Aproj;
-  QChol *QC;
-  QChol **QCov;
-  double *Isill;
-  double *Csill;
-  QSimu *qsimu;
-  cs_MGS *mgs;
-  Cheb_Elem *s_cheb;
-  AMesh *amesh;
+  MatrixSparse* S;
+  MatrixSparse* Aproj;
+  QChol* QC;
+  QChol** QCov;
+  double* Isill;
+  double* Csill;
+  QSimu* qsimu;
+  cs_MGS* mgs;
+  Cheb_Elem* s_cheb;
+  AMesh* amesh;
 } SPDE_Matelem;
 #endif
 
@@ -144,20 +144,20 @@ typedef struct
 
 typedef struct
 {
-  double *res;
+  double* res;
 } CTable;
 
 typedef struct
 {
-  int nconf;                // Number of covariance configurations
-  int ndisc;                // Number of discretization steps
-  int flag_cumul;           // 1 if storing integer from -infinity to value
-                            // 0 if storing the value per discretized class
-  double cmin;              // Minimum correlation value
-  double cmax;              // Maximum correlation value
-  double dc;                // Covariance class interval
-  double dp;                // Probability quantum for discretization
-  double *v;                // Array of thresholds (Dim: ndisc+1)
+  int nconf;      // Number of covariance configurations
+  int ndisc;      // Number of discretization steps
+  int flag_cumul; // 1 if storing integer from -infinity to value
+                  // 0 if storing the value per discretized class
+  double cmin;    // Minimum correlation value
+  double cmax;    // Maximum correlation value
+  double dc;      // Covariance class interval
+  double dp;      // Probability quantum for discretization
+  double* v;      // Array of thresholds (Dim: ndisc+1)
   CTable** CT;
 } CTables;
 
@@ -165,25 +165,25 @@ struct Local_Relem;
 
 struct Local_Split
 {
-  int oper;                   // Rank of operator
-  int nrule;                  // Number of generated rules
-  int nbyrule;                // Number of symbols in the Rules
-  int *Srules;                // List of rules (Dim: [nitem][NRULE])
-  int *Sfipos;                // Position of facies (Dim: [nprod][NCOLOR])
-  Local_Relem *old_relem;     // Not allocated
-  std::vector<Local_Relem *> relems;
+  int oper;               // Rank of operator
+  int nrule;              // Number of generated rules
+  int nbyrule;            // Number of symbols in the Rules
+  int* Srules;            // List of rules (Dim: [nitem][NRULE])
+  int* Sfipos;            // Position of facies (Dim: [nprod][NCOLOR])
+  Local_Relem* old_relem; // Not allocated
+  std::vector<Local_Relem*> relems;
 };
 
 struct Local_Relem
 {
-  VectorInt facies;           // List of facies
-  int nrule;                  // Number of generated rules
-  int nbyrule;                // Number of symbols in the Rules
-  int nsplit;                 // Number of splits
-  int *Rrules;                // List of rules (Dim: [nitem][NRULE])
-  int *Rfipos;                // Position of facies (Dim: [nprod][NCOLOR])
-  Local_Split *old_split;     // Not allocated
-  std::vector<Local_Split *> splits;
+  VectorInt facies;       // List of facies
+  int nrule;              // Number of generated rules
+  int nbyrule;            // Number of symbols in the Rules
+  int nsplit;             // Number of splits
+  int* Rrules;            // List of rules (Dim: [nitem][NRULE])
+  int* Rfipos;            // Position of facies (Dim: [nprod][NCOLOR])
+  Local_Split* old_split; // Not allocated
+  std::vector<Local_Split*> splits;
 };
 
 typedef struct Local_Relem Relem;

--- a/include/geoslib_d.h
+++ b/include/geoslib_d.h
@@ -144,7 +144,7 @@ typedef struct
 
 typedef struct
 {
-  double* res;
+  VectorDouble res;
 } CTable;
 
 typedef struct

--- a/include/geoslib_old_f.h
+++ b/include/geoslib_old_f.h
@@ -63,18 +63,18 @@ GSTLEARN_EXPORT int foxleg_f(int ndat,
                              int npar,
                              int ncont,
                              const MatrixDense& acont,
-                             VectorDouble &param,
-                             VectorDouble &lower,
-                             VectorDouble &upper,
-                             VectorDouble &scale,
-                             const Option_AutoFit &mauto,
+                             VectorDouble& param,
+                             VectorDouble& lower,
+                             VectorDouble& upper,
+                             VectorDouble& scale,
+                             const Option_AutoFit& mauto,
                              int flag_title,
                              void (*func_evaluate)(int ndat,
                                                    int npar,
-                                                   VectorDouble &param,
-                                                   VectorDouble &work),
-                             VectorDouble &tabexp,
-                             VectorDouble &tabwgt);
+                                                   VectorDouble& param,
+                                                   VectorDouble& work),
+                             VectorDouble& tabexp,
+                             VectorDouble& tabwgt);
 
 /***************************************/
 /* Prototyping the functions in util.c */
@@ -83,94 +83,94 @@ GSTLEARN_EXPORT int foxleg_f(int ndat,
 GSTLEARN_EXPORT int* ut_split_into_two(int ncolor,
                                        int flag_half,
                                        int verbose,
-                                       int *nposs);
-GSTLEARN_EXPORT void projec_query(int *actif);
+                                       int* nposs);
+GSTLEARN_EXPORT void projec_query(int* actif);
 GSTLEARN_EXPORT void projec_print(void);
 GSTLEARN_EXPORT void projec_toggle(int mode);
-GSTLEARN_EXPORT void set_last_message(int mode, const char *string);
+GSTLEARN_EXPORT void set_last_message(int mode, const char* string);
 GSTLEARN_EXPORT void print_last_message(void);
 
 GSTLEARN_EXPORT void ut_trace_discretize(int nseg,
-                                         const double *trace,
+                                         const double* trace,
                                          double disc,
-                                         int *np_arg,
-                                         double **xp_arg,
-                                         double **yp_arg,
-                                         double **dd_arg,
-                                         double **del_arg,
-                                         double *dist_arg);
-GSTLEARN_EXPORT void ut_trace_sample(Db *db,
+                                         int* np_arg,
+                                         VectorDouble& xp,
+                                         VectorDouble& yp,
+                                         VectorDouble& dd,
+                                         VectorDouble& del,
+                                         double* dist_arg);
+GSTLEARN_EXPORT void ut_trace_sample(Db* db,
                                      const ELoc& ptype,
                                      int np,
-                                     const double *xp,
-                                     const double *yp,
-                                     const double *dd,
+                                     const double* xp,
+                                     const double* yp,
+                                     const double* dd,
                                      double radius,
-                                     int *ns_arg,
-                                     double **xs_arg,
-                                     double **ys_arg,
-                                     int **rks_arg,
-                                     int **lys_arg,
-                                     int **typ_arg);
-GSTLEARN_EXPORT double ut_distance(int ndim, const double *tab1, const double *tab2);
+                                     int* ns_arg,
+                                     double** xs_arg,
+                                     double** ys_arg,
+                                     int** rks_arg,
+                                     int** lys_arg,
+                                     int** typ_arg);
+GSTLEARN_EXPORT double ut_distance(int ndim, const double* tab1, const double* tab2);
 GSTLEARN_EXPORT void ut_distance_allocated(int ndim,
-                                           double **tab1,
-                                           double **tab2);
+                                           double** tab1,
+                                           double** tab2);
 
 /*****************************************/
 /* Prototyping the functions in matrix.c */
 /*****************************************/
 
-GSTLEARN_EXPORT int matrix_invert(double *a, int neq, int rank);
+GSTLEARN_EXPORT int matrix_invert(double* a, int neq, int rank);
 GSTLEARN_EXPORT double matrix_determinant(int neq, const VectorDouble& b);
-GSTLEARN_EXPORT int matrix_eigen(const double *a,
+GSTLEARN_EXPORT int matrix_eigen(const double* a,
                                  int neq,
-                                 double *value,
-                                 double *vector);
+                                 double* value,
+                                 double* vector);
 GSTLEARN_EXPORT void matrix_product_safe(int n1,
                                          int n2,
                                          int n3,
-                                         const double *v1,
-                                         const double *v2,
-                                         double *v3);
+                                         const double* v1,
+                                         const double* v2,
+                                         double* v3);
 GSTLEARN_EXPORT int matrix_prod_norme(int transpose,
                                       int n1,
                                       int n2,
-                                      const double *v1,
-                                      const double *a,
-                                      double *w);
+                                      const double* v1,
+                                      const double* a,
+                                      double* w);
 GSTLEARN_EXPORT void matrix_transpose(int n1, int n2, VectorDouble& v1, VectorDouble& w1);
-GSTLEARN_EXPORT int matrix_cholesky_decompose(const double *a,
-                                              double *tl,
+GSTLEARN_EXPORT int matrix_cholesky_decompose(const double* a,
+                                              double* tl,
                                               int neq);
 GSTLEARN_EXPORT void matrix_cholesky_product(int mode,
                                              int neq,
                                              int nrhs,
-                                             const double *tl,
-                                             const double *a,
-                                             double *x);
-GSTLEARN_EXPORT void matrix_cholesky_invert(int neq, const double *tl, double *xl);
+                                             const double* tl,
+                                             const double* a,
+                                             double* x);
+GSTLEARN_EXPORT void matrix_cholesky_invert(int neq, const double* tl, double* xl);
 GSTLEARN_EXPORT void matrix_combine(int nval,
                                     double coeffa,
-                                    const double *a,
+                                    const double* a,
                                     double coeffb,
-                                    const double *b,
-                                    double *c);
+                                    const double* b,
+                                    double* c);
 GSTLEARN_EXPORT void matrix_product_by_diag(int mode,
                                             int neq,
-                                            double *a,
-                                            double *c,
-                                            double *b);
+                                            double* a,
+                                            double* c,
+                                            double* b);
 GSTLEARN_EXPORT void matrix_triangle_to_square(int mode,
                                                int neq,
-                                               const double *tl,
-                                               double *a);
-GSTLEARN_EXPORT int matrix_eigen_tridiagonal(const double *vecdiag,
-                                             const double *vecinf,
-                                             const double *vecsup,
+                                               const double* tl,
+                                               double* a);
+GSTLEARN_EXPORT int matrix_eigen_tridiagonal(const double* vecdiag,
+                                             const double* vecinf,
+                                             const double* vecsup,
                                              int neq,
-                                             double *eigvec,
-                                             double *eigval);
+                                             double* eigvec,
+                                             double* eigval);
 
 /*****************************************/
 /* Prototyping the functions in morpho.c */
@@ -195,202 +195,202 @@ GSTLEARN_EXPORT int spill_point(DbGrid* dbgrid,
 GSTLEARN_EXPORT int model_fitting_sills(Vario* vario,
                                         Model* model,
                                         const Constraints& constraints = Constraints(),
-                                        const Option_VarioFit& optvar = Option_VarioFit(),
-                                        const Option_AutoFit& mauto = Option_AutoFit());
+                                        const Option_VarioFit& optvar  = Option_VarioFit(),
+                                        const Option_AutoFit& mauto    = Option_AutoFit());
 GSTLEARN_EXPORT int model_covmat_inchol(int verbose,
-                                        Db *db,
-                                        Model *model,
+                                        Db* db,
+                                        Model* model,
                                         double eta,
                                         int npivot_max,
                                         int nsize1,
-                                        const int *ranks1,
-                                        const double *center,
+                                        const int* ranks1,
+                                        const double* center,
                                         int flag_sort,
-                                        int *npivot_arg,
-                                        int **Pret,
-                                        double **Gret,
+                                        int* npivot_arg,
+                                        int** Pret,
+                                        double** Gret,
                                         const CovCalcMode* mode = nullptr);
-GSTLEARN_EXPORT Model* model_duplicate_for_gradient(const Model *model,
-                                       double ball_radius);
-GSTLEARN_EXPORT void model_covupdt(Model *model,
-                                   const double *c0,
+GSTLEARN_EXPORT Model* model_duplicate_for_gradient(const Model* model,
+                                                    double ball_radius);
+GSTLEARN_EXPORT void model_covupdt(Model* model,
+                                   const double* c0,
                                    int flag_verbose,
-                                   int *flag_nugget,
-                                   double *nugget);
-GSTLEARN_EXPORT void model_cova_characteristics(const ECov &type,
+                                   int* flag_nugget,
+                                   double* nugget);
+GSTLEARN_EXPORT void model_cova_characteristics(const ECov& type,
                                                 char cov_name[STRING_LENGTH],
-                                                int *flag_range,
-                                                int *flag_param,
-                                                int *min_order,
-                                                int *max_ndim,
-                                                int *flag_int_1d,
-                                                int *flag_int_2d,
-                                                int *flag_aniso,
-                                                int *flag_rotation,
-                                                double *scale,
-                                                double *parmax);
-GSTLEARN_EXPORT Model* model_combine(const Model *model1,
-                                     const Model *model2,
+                                                int* flag_range,
+                                                int* flag_param,
+                                                int* min_order,
+                                                int* max_ndim,
+                                                int* flag_int_1d,
+                                                int* flag_int_2d,
+                                                int* flag_aniso,
+                                                int* flag_rotation,
+                                                double* scale,
+                                                double* parmax);
+GSTLEARN_EXPORT Model* model_combine(const Model* model1,
+                                     const Model* model2,
                                      double r);
 
 /*************************************/
 /* Prototyping the functions in db.c */
 /*************************************/
 
-GSTLEARN_EXPORT void grid_iterator_init(Grid *grid,
-                                        const VectorInt &order = VectorInt());
-GSTLEARN_EXPORT VectorInt grid_iterator_next(Grid *grid);
+GSTLEARN_EXPORT void grid_iterator_init(Grid* grid,
+                                        const VectorInt& order = VectorInt());
+GSTLEARN_EXPORT VectorInt grid_iterator_next(Grid* grid);
 
-GSTLEARN_EXPORT int db_name_identify(Db *db, const String &string);
-GSTLEARN_EXPORT int db_locator_attribute_add(Db *db,
+GSTLEARN_EXPORT int db_name_identify(Db* db, const String& string);
+GSTLEARN_EXPORT int db_locator_attribute_add(Db* db,
                                              const ELoc& locatorType,
                                              int number,
                                              int r_tem,
                                              double valinit,
-                                             int *iptr);
-GSTLEARN_EXPORT void db_locators_correct(VectorString &strings,
-                                         const VectorInt &current,
+                                             int* iptr);
+GSTLEARN_EXPORT void db_locators_correct(VectorString& strings,
+                                         const VectorInt& current,
                                          int flag_locnew);
-GSTLEARN_EXPORT void db_grid_print(Db *db);
+GSTLEARN_EXPORT void db_grid_print(Db* db);
 
-GSTLEARN_EXPORT int db_grid_define_coordinates(DbGrid *db);
+GSTLEARN_EXPORT int db_grid_define_coordinates(DbGrid* db);
 GSTLEARN_EXPORT void db_sample_print(Db* db,
                                      int iech,
                                      int flag_ndim = 1,
                                      int flag_nvar = 0,
                                      int flag_nerr = 0,
                                      int flag_blk  = 0);
-GSTLEARN_EXPORT int db_center(Db *db, double *center);
-GSTLEARN_EXPORT void db_extension_rotated(Db *db,
-                                          double *rotmat,
+GSTLEARN_EXPORT int db_center(Db* db, double* center);
+GSTLEARN_EXPORT void db_extension_rotated(Db* db,
+                                          double* rotmat,
                                           VectorDouble& mini,
                                           VectorDouble& maxi,
                                           VectorDouble& delta);
 GSTLEARN_EXPORT int db_selref(int ndim,
-                              const int *nx,
-                              const int *ref,
-                              const double *tabin,
-                              double *tabout);
-GSTLEARN_EXPORT Db* db_regularize(Db *db, DbGrid *dbgrid, int flag_center);
-GSTLEARN_EXPORT int compat_NDIM(Db *db1, Db *db2);
-GSTLEARN_EXPORT double get_grid_value(DbGrid *dbgrid,
+                              const int* nx,
+                              const int* ref,
+                              const double* tabin,
+                              double* tabout);
+GSTLEARN_EXPORT Db* db_regularize(Db* db, DbGrid* dbgrid, int flag_center);
+GSTLEARN_EXPORT int compat_NDIM(Db* db1, Db* db2);
+GSTLEARN_EXPORT double get_grid_value(DbGrid* dbgrid,
                                       int iptr,
                                       VectorInt& indg,
                                       int ix,
                                       int iy,
                                       int iz);
-GSTLEARN_EXPORT void set_grid_value(DbGrid *dbgrid,
+GSTLEARN_EXPORT void set_grid_value(DbGrid* dbgrid,
                                     int iptr,
                                     VectorInt& indg,
                                     int ix,
                                     int iy,
                                     int iz,
                                     double value);
-GSTLEARN_EXPORT int get_LOCATOR_NITEM(const Db *db, const ELoc& locatorType);
-GSTLEARN_EXPORT int is_grid_multiple(DbGrid *db1, DbGrid *db2);
-GSTLEARN_EXPORT DbGrid* db_grid_reduce(DbGrid *db_grid,
+GSTLEARN_EXPORT int get_LOCATOR_NITEM(const Db* db, const ELoc& locatorType);
+GSTLEARN_EXPORT int is_grid_multiple(DbGrid* db1, DbGrid* db2);
+GSTLEARN_EXPORT DbGrid* db_grid_reduce(DbGrid* db_grid,
                                        int iptr,
-                                       const int *margin,
-                                       const int *limmin,
+                                       const int* margin,
+                                       const int* limmin,
                                        int flag_sel,
                                        int flag_copy,
                                        int verbose,
                                        double vmin,
                                        double vmax);
-GSTLEARN_EXPORT double distance_inter(const Db *db1,
-                                      const Db *db2,
+GSTLEARN_EXPORT double distance_inter(const Db* db1,
+                                      const Db* db2,
                                       int iech1,
                                       int iech2,
-                                      double *dist_vect);
-GSTLEARN_EXPORT double distance_intra(const Db *db,
+                                      double* dist_vect);
+GSTLEARN_EXPORT double distance_intra(const Db* db,
                                       int iech1,
                                       int iech2,
-                                      double *dist_vect);
-GSTLEARN_EXPORT double distance_grid(DbGrid *db,
+                                      double* dist_vect);
+GSTLEARN_EXPORT double distance_grid(DbGrid* db,
                                      int flag_moins1,
                                      int iech1,
                                      int iech2,
-                                     double *dist_vect);
-GSTLEARN_EXPORT double* db_distances_general(Db *db1,
-                                             Db *db2,
-                                             int niso,
-                                             int mode,
-                                             int flag_same,
-                                             int *n1,
-                                             int *n2,
-                                             double *dmin,
-                                             double *dmax);
-GSTLEARN_EXPORT int point_to_grid(const DbGrid *db,
-                                  const double *coor,
+                                     double* dist_vect);
+GSTLEARN_EXPORT VectorDouble db_distances_general(Db* db1,
+                                                  Db* db2,
+                                                  int niso,
+                                                  int mode,
+                                                  int flag_same,
+                                                  int* n1,
+                                                  int* n2,
+                                                  double* dmin,
+                                                  double* dmax);
+GSTLEARN_EXPORT int point_to_grid(const DbGrid* db,
+                                  const double* coor,
                                   int flag_outside,
-                                  int *indg);
-GSTLEARN_EXPORT int point_to_bench(const DbGrid *db,
-                                   double *coor,
+                                  int* indg);
+GSTLEARN_EXPORT int point_to_bench(const DbGrid* db,
+                                   double* coor,
                                    int flag_outside,
-                                   int *indb);
-GSTLEARN_EXPORT int index_point_to_grid(const Db *db,
+                                   int* indb);
+GSTLEARN_EXPORT int index_point_to_grid(const Db* db,
                                         int iech,
                                         int flag_outside,
-                                        const DbGrid *dbout,
-                                        double *coor);
-GSTLEARN_EXPORT int point_to_point(Db *db, const double *coor);
-GSTLEARN_EXPORT int point_inside_grid(Db *db, int iech, const DbGrid *dbgrid);
-GSTLEARN_EXPORT int db_gradient_components(DbGrid *dbgrid);
-GSTLEARN_EXPORT int db_streamline(DbGrid *dbgrid,
-                                  Db *dbpoint,
+                                        const DbGrid* dbout,
+                                        double* coor);
+GSTLEARN_EXPORT int point_to_point(Db* db, const double* coor);
+GSTLEARN_EXPORT int point_inside_grid(Db* db, int iech, const DbGrid* dbgrid);
+GSTLEARN_EXPORT int db_gradient_components(DbGrid* dbgrid);
+GSTLEARN_EXPORT int db_streamline(DbGrid* dbgrid,
+                                  Db* dbpoint,
                                   int niter,
                                   double step,
                                   int flag_norm,
                                   int use_grad,
                                   int save_grad,
-                                  int *nbline_loc,
-                                  int *npline_loc,
-                                  double **line_loc);
-GSTLEARN_EXPORT void db_monostat(Db *db,
+                                  int* nbline_loc,
+                                  int* npline_loc,
+                                  double** line_loc);
+GSTLEARN_EXPORT void db_monostat(Db* db,
                                  int iatt,
-                                 double *wtot,
-                                 double *mean,
-                                 double *var,
-                                 double *mini,
-                                 double *maxi);
-GSTLEARN_EXPORT int db_gradient_update(Db *db);
-GSTLEARN_EXPORT int surface(Db *db_point,
-                            DbGrid *db_grid,
+                                 double* wtot,
+                                 double* mean,
+                                 double* var,
+                                 double* mini,
+                                 double* maxi);
+GSTLEARN_EXPORT int db_gradient_update(Db* db);
+GSTLEARN_EXPORT int surface(Db* db_point,
+                            DbGrid* db_grid,
                             int icol,
                             double dlim,
-                            double *dtab,
-                            double *gtab);
-GSTLEARN_EXPORT int db_edit(Db *db, int *flag_valid);
-GSTLEARN_EXPORT int db_grid_copy(DbGrid *db1,
-                                 DbGrid *db2,
-                                 const int *ind1,
-                                 const int *ind2,
+                            double* dtab,
+                            double* gtab);
+GSTLEARN_EXPORT int db_edit(Db* db, int* flag_valid);
+GSTLEARN_EXPORT int db_grid_copy(DbGrid* db1,
+                                 DbGrid* db2,
+                                 const int* ind1,
+                                 const int* ind2,
                                  int ncol,
-                                 int *cols);
-GSTLEARN_EXPORT int db_grid_copy_dilate(DbGrid *db1,
+                                 int* cols);
+GSTLEARN_EXPORT int db_grid_copy_dilate(DbGrid* db1,
                                         int iatt1,
-                                        DbGrid *db2,
+                                        DbGrid* db2,
                                         int iatt2,
                                         int mode,
-                                        const int *nshift);
-GSTLEARN_EXPORT int db_proportion(Db *db,
-                                  DbGrid *dbgrid,
+                                        const int* nshift);
+GSTLEARN_EXPORT int db_proportion(Db* db,
+                                  DbGrid* dbgrid,
                                   int nfac1max,
                                   int nfac2max,
-                                  int *nclout);
-GSTLEARN_EXPORT int db_merge(Db *db, int ncol, int *cols);
-GSTLEARN_EXPORT int db_count_defined(Db *db, int icol);
+                                  int* nclout);
+GSTLEARN_EXPORT int db_merge(Db* db, int ncol, int* cols);
+GSTLEARN_EXPORT int db_count_defined(Db* db, int icol);
 
-GSTLEARN_EXPORT int db_prop_read(DbGrid *db, int ix, int iy, double *props);
-GSTLEARN_EXPORT int db_prop_write(DbGrid *db, int ix, int iy, double *props);
-GSTLEARN_EXPORT int db_resind(Db *db, int ivar, const VectorDouble& zcut);
-GSTLEARN_EXPORT int db_gradient_modang_to_component(Db *db,
+GSTLEARN_EXPORT int db_prop_read(DbGrid* db, int ix, int iy, double* props);
+GSTLEARN_EXPORT int db_prop_write(DbGrid* db, int ix, int iy, double* props);
+GSTLEARN_EXPORT int db_resind(Db* db, int ivar, const VectorDouble& zcut);
+GSTLEARN_EXPORT int db_gradient_modang_to_component(Db* db,
                                                     int ang_conv,
                                                     int iad_mod,
                                                     int iad_ang,
                                                     int iad_gx,
                                                     int iad_gy);
-GSTLEARN_EXPORT int db_gradient_component_to_modang(Db *db,
+GSTLEARN_EXPORT int db_gradient_component_to_modang(Db* db,
                                                     int verbose,
                                                     int iad_gx,
                                                     int iad_gy,
@@ -399,26 +399,26 @@ GSTLEARN_EXPORT int db_gradient_component_to_modang(Db *db,
                                                     double scale,
                                                     double ve);
 GSTLEARN_EXPORT Db* db_point_init(int nech,
-                                  const VectorDouble &coormin = VectorDouble(),
-                                  const VectorDouble &coormax = VectorDouble(),
-                                  DbGrid *dbgrid = nullptr,
-                                  bool flag_exact = true,
-                                  bool flag_repulsion = false,
-                                  double range = 0.,
-                                  double beta = 0.,
-                                  double extend = 0.,
-                                  int seed = 43241,
-                                  bool flagAddSampleRank = true);
-GSTLEARN_EXPORT int db_smooth_vpc(DbGrid *db, int width, double range);
-GSTLEARN_EXPORT int db_grid2point_sampling(DbGrid *dbgrid,
+                                  const VectorDouble& coormin = VectorDouble(),
+                                  const VectorDouble& coormax = VectorDouble(),
+                                  DbGrid* dbgrid              = nullptr,
+                                  bool flag_exact             = true,
+                                  bool flag_repulsion         = false,
+                                  double range                = 0.,
+                                  double beta                 = 0.,
+                                  double extend               = 0.,
+                                  int seed                    = 43241,
+                                  bool flagAddSampleRank      = true);
+GSTLEARN_EXPORT int db_smooth_vpc(DbGrid* db, int width, double range);
+GSTLEARN_EXPORT int db_grid2point_sampling(DbGrid* dbgrid,
                                            int nvar,
-                                           int *vars,
-                                           const int *npacks,
+                                           int* vars,
+                                           const int* npacks,
                                            int npcell,
                                            int nmini,
-                                           int *nech,
-                                           double **coor,
-                                           double **data);
+                                           int* nech,
+                                           VectorDouble& coor,
+                                           VectorDouble& data);
 GSTLEARN_EXPORT int db_grid_patch(DbGrid* ss_grid,
                                   DbGrid* db_grid,
                                   int iptr_ss,
@@ -434,26 +434,25 @@ GSTLEARN_EXPORT int db_grid_patch(DbGrid* ss_grid,
 
 GSTLEARN_EXPORT int stats_residuals(int verbose,
                                     int nech,
-                                    double *tab,
+                                    double* tab,
                                     int ncut,
-                                    double *zcut,
-                                    int *nsorted,
-                                    double *mean,
-                                    double *residuals,
-                                    double *T,
-                                    double *Q);
-GSTLEARN_EXPORT int db_upscale(DbGrid *dbgrid1,
-                               DbGrid *dbgrid2,
+                                    double* zcut,
+                                    int* nsorted,
+                                    double* mean,
+                                    double* residuals,
+                                    double* T,
+                                    double* Q);
+GSTLEARN_EXPORT int db_upscale(DbGrid* dbgrid1,
+                               DbGrid* dbgrid2,
                                int orient,
                                int verbose);
-GSTLEARN_EXPORT int db_diffusion(DbGrid *dbgrid1,
-                                 DbGrid *dbgrid2,
+GSTLEARN_EXPORT int db_diffusion(DbGrid* dbgrid1,
+                                 DbGrid* dbgrid2,
                                  int orient,
                                  int niter,
                                  int nseed,
                                  int seed,
                                  int verbose);
-
 
 /****************************************/
 /* Prototyping the functions in krige.c */
@@ -464,33 +463,33 @@ GSTLEARN_EXPORT void set_DBIN(Db* dbin);
 GSTLEARN_EXPORT void set_DBOUT(Db* dbout);
 GSTLEARN_EXPORT int krige_koption_manage(int mode,
                                          int flag_check,
-                                         const EKrigOpt &calcul,
+                                         const EKrigOpt& calcul,
                                          int flag_rand,
                                          const VectorInt& ndiscs = VectorInt());
 GSTLEARN_EXPORT void krige_lhs_print(int nech,
                                      int neq,
                                      int nred,
-                                     const int *flag,
-                                     const double *lhs);
+                                     const int* flag,
+                                     const double* lhs);
 GSTLEARN_EXPORT void krige_rhs_print(int nvar,
                                      int nech,
                                      int neq,
                                      int nred,
-                                     const int *flag,
-                                     double *rhs);
+                                     const int* flag,
+                                     double* rhs);
 GSTLEARN_EXPORT void krige_dual_print(int nech,
                                       int neq,
                                       int nred,
-                                      const int *flag,
-                                      double *dual);
-GSTLEARN_EXPORT int bayes_simulate(Model *model,
+                                      const int* flag,
+                                      double* dual);
+GSTLEARN_EXPORT int bayes_simulate(Model* model,
                                    int nbsimu,
                                    const VectorDouble& rmean,
                                    const VectorDouble& rcov,
                                    VectorDouble& smean);
-GSTLEARN_EXPORT int krigsampling_f(Db *dbin,
-                                   Db *dbout,
-                                   Model *model,
+GSTLEARN_EXPORT int krigsampling_f(Db* dbin,
+                                   Db* dbout,
+                                   Model* model,
                                    double beta,
                                    VectorInt& ranks1,
                                    VectorInt& ranks2,
@@ -504,22 +503,22 @@ GSTLEARN_EXPORT int global_transitive(DbGrid* dbgrid,
                                       double* abundance,
                                       double* sse,
                                       double* cvtrans);
-GSTLEARN_EXPORT int anakexp_f(DbGrid *db,
-                              double *covdd,
-                              double *covd0,
+GSTLEARN_EXPORT int anakexp_f(DbGrid* db,
+                              double* covdd,
+                              double* covd0,
                               double top,
                               double bot,
                               int ncov_radius,
                               int neigh_radius,
                               int flag_sym,
                               int nfeq);
-GSTLEARN_EXPORT int anakexp_3D(DbGrid *db,
-                               double *cov_ref,
+GSTLEARN_EXPORT int anakexp_3D(DbGrid* db,
+                               double* cov_ref,
                                int cov_radius,
                                int neigh_ver,
                                int neigh_hor,
                                int flag_sym,
-                               Model *model,
+                               Model* model,
                                double nugget,
                                int nfeq,
                                int dbg_ix,
@@ -534,13 +533,13 @@ GSTLEARN_EXPORT int sampling_f(Db* db,
                                int nsize2_max,
                                VectorInt& ranks2,
                                int verbose);
-GSTLEARN_EXPORT int inhomogeneous_kriging(Db *dbdat,
-                                          Db *dbsrc,
-                                          Db *dbout,
+GSTLEARN_EXPORT int inhomogeneous_kriging(Db* dbdat,
+                                          Db* dbsrc,
+                                          Db* dbout,
                                           double power,
                                           int flag_source,
-                                          Model *model_dat,
-                                          Model *model_src);
+                                          Model* model_dat,
+                                          Model* model_src);
 
 /*****************************************/
 /* Prototyping the functions in simtub.c */
@@ -557,31 +556,31 @@ GSTLEARN_EXPORT void simu_define_func_update(void (*st_simu_update)(Db*,
 GSTLEARN_EXPORT void simu_define_func_scale(void (*st_simu_scale)(Db*,
                                                                   int,
                                                                   int));
-GSTLEARN_EXPORT void simu_func_categorical_transf(Db *db,
+GSTLEARN_EXPORT void simu_func_categorical_transf(Db* db,
                                                   int verbose,
                                                   int isimu,
                                                   int nbsimu);
-GSTLEARN_EXPORT void simu_func_continuous_update(Db *db,
+GSTLEARN_EXPORT void simu_func_continuous_update(Db* db,
                                                  int verbose,
                                                  int isimu,
                                                  int nbsimu);
-GSTLEARN_EXPORT void simu_func_categorical_update(Db *db,
+GSTLEARN_EXPORT void simu_func_categorical_update(Db* db,
                                                   int verbose,
                                                   int isimu0,
                                                   int nbsimu0);
-GSTLEARN_EXPORT void simu_func_continuous_scale(Db *db,
+GSTLEARN_EXPORT void simu_func_continuous_scale(Db* db,
                                                 int verbose,
                                                 int nbsimu);
-GSTLEARN_EXPORT void simu_func_categorical_scale(Db *db,
+GSTLEARN_EXPORT void simu_func_categorical_scale(Db* db,
                                                  int verbose,
                                                  int nbsimu);
 
-GSTLEARN_EXPORT void check_mandatory_attribute(const char *method,
-                                               Db *db,
+GSTLEARN_EXPORT void check_mandatory_attribute(const char* method,
+                                               Db* db,
                                                const ELoc& locatorType);
-GSTLEARN_EXPORT int simcond(Db *dbin,
-                            Db *dbout,
-                            Model *model,
+GSTLEARN_EXPORT int simcond(Db* dbin,
+                            Db* dbout,
+                            Model* model,
                             int seed,
                             int nbsimu,
                             int nbtuba,
@@ -591,19 +590,19 @@ GSTLEARN_EXPORT int simcond(Db *dbin,
                             int flag_ce,
                             int flag_cstd,
                             int verbose);
-GSTLEARN_EXPORT int simmaxstable(Db *dbout,
-                                 Model *model,
+GSTLEARN_EXPORT int simmaxstable(Db* dbout,
+                                 Model* model,
                                  double ratio,
                                  int seed,
                                  int nbtuba,
                                  int flag_simu,
                                  int flag_rank,
                                  int verbose);
-GSTLEARN_EXPORT int simRI(Db *dbout,
-                          Model *model,
+GSTLEARN_EXPORT int simRI(Db* dbout,
+                          Model* model,
                           int ncut,
-                          double *zcut,
-                          double *wcut,
+                          double* zcut,
+                          double* wcut,
                           int seed,
                           int nbtuba,
                           int verbose);
@@ -626,39 +625,39 @@ GSTLEARN_EXPORT int simtub_constraints(Db* dbin,
                                                          double nonval,
                                                          double percent,
                                                          VectorDouble& tab));
-GSTLEARN_EXPORT int db_simulations_to_ce(Db *db,
+GSTLEARN_EXPORT int db_simulations_to_ce(Db* db,
                                          const ELoc& locatorType,
                                          int nbsimu,
                                          int nvar,
-                                         int *iptr_ce_arg,
-                                         int *iptr_cstd_arg);
+                                         int* iptr_ce_arg,
+                                         int* iptr_cstd_arg);
 
 /*****************************************/
 /* Prototyping the functions in simreg.c */
 /*****************************************/
 
-GSTLEARN_EXPORT int simfine_dim(DbGrid *dbin,
+GSTLEARN_EXPORT int simfine_dim(DbGrid* dbin,
                                 int nmult,
-                                int *ndim,
-                                int *ntot,
-                                int *nx,
-                                double *x0,
-                                double *dx);
-GSTLEARN_EXPORT int simfine_f(DbGrid *dbin,
-                              Model *model,
+                                int* ndim,
+                                int* ntot,
+                                int* nx,
+                                double* x0,
+                                double* dx);
+GSTLEARN_EXPORT int simfine_f(DbGrid* dbin,
+                              Model* model,
                               const SimuRefineParam& param,
                               int seed,
-                              VectorDouble &tab);
+                              VectorDouble& tab);
 
 /*****************************************/
 /* Prototyping the functions in thresh.c */
 /*****************************************/
 
-GSTLEARN_EXPORT int db_bounds_shadow(Db *db,
-                                     Db *dbprop,
-                                     RuleShadow *rule,
-                                     Model *model,
-                                     const VectorDouble &props,
+GSTLEARN_EXPORT int db_bounds_shadow(Db* db,
+                                     Db* dbprop,
+                                     RuleShadow* rule,
+                                     Model* model,
+                                     const VectorDouble& props,
                                      int flag_stat,
                                      int nfacies);
 
@@ -666,8 +665,8 @@ GSTLEARN_EXPORT int db_bounds_shadow(Db *db,
 /* Prototyping the functions in geophy.c */
 /*****************************************/
 
-GSTLEARN_EXPORT int time_3db(double *HS,
-                             double *T,
+GSTLEARN_EXPORT int time_3db(double* HS,
+                             double* T,
                              int NX,
                              int NY,
                              int NZ,
@@ -680,13 +679,12 @@ GSTLEARN_EXPORT int time_3db(double *HS,
                              double HS_EPS_INIT,
                              int MSG);
 
-
 /******************************************/
 /* Prototyping the functions in mlayers.c */
 /******************************************/
-GSTLEARN_EXPORT int multilayers_vario(Db *dbin,
-                                      DbGrid *dbout,
-                                      Vario *vario,
+GSTLEARN_EXPORT int multilayers_vario(Db* dbin,
+                                      DbGrid* dbout,
+                                      Vario* vario,
                                       int nlayers,
                                       int flag_vel,
                                       int flag_ext,
@@ -728,20 +726,20 @@ GSTLEARN_EXPORT int multilayers_get_prior(Db* dbin,
                                           int colrefb,
                                           int verbose,
                                           int* npar_arg,
-                                          double** mean,
-                                          double** vars);
+                                          VectorDouble& mean,
+                                          VectorDouble& vars);
 
 /***************************************/
 /* Prototyping the functions in spde.c */
 /***************************************/
-GSTLEARN_EXPORT QChol* qchol_manage(int mode, QChol *qchol);
+GSTLEARN_EXPORT QChol* qchol_manage(int mode, QChol* qchol);
 GSTLEARN_EXPORT double spde_compute_correc(int ndim, double param);
-GSTLEARN_EXPORT int spde_check(const Db *dbin,
-                               const Db *dbout,
-                               Model *model1,
-                               Model *model2,
+GSTLEARN_EXPORT int spde_check(const Db* dbin,
+                               const Db* dbout,
+                               Model* model1,
+                               Model* model2,
                                bool verbose,
-                               const VectorDouble &gext,
+                               const VectorDouble& gext,
                                bool mesh_dbin,
                                bool mesh_dbout,
                                bool flag_advanced,
@@ -749,10 +747,10 @@ GSTLEARN_EXPORT int spde_check(const Db *dbin,
                                bool flag_std,
                                bool flag_gibbs,
                                bool flag_modif);
-GSTLEARN_EXPORT int spde_attach_model(Model *model);
-GSTLEARN_EXPORT int m2d_gibbs_spde(Db *dbin,
-                                   Db *dbout,
-                                   Model *model,
+GSTLEARN_EXPORT int spde_attach_model(Model* model);
+GSTLEARN_EXPORT int m2d_gibbs_spde(Db* dbin,
+                                   Db* dbout,
+                                   Model* model,
                                    int flag_ed,
                                    int nlayer,
                                    int niter,
@@ -764,16 +762,16 @@ GSTLEARN_EXPORT int m2d_gibbs_spde(Db *dbin,
                                    int flag_cstd,
                                    int verbose);
 GSTLEARN_EXPORT SPDE_Option spde_option_alloc(void);
-GSTLEARN_EXPORT void spde_option_update(SPDE_Option &s_option,
-                                        const String &triswitch);
-GSTLEARN_EXPORT int spde_prepar(Db *dbin,
-                                Db *dbout,
-                                const VectorDouble &gext,
-                                SPDE_Option &s_option);
+GSTLEARN_EXPORT void spde_option_update(SPDE_Option& s_option,
+                                        const String& triswitch);
+GSTLEARN_EXPORT int spde_prepar(Db* dbin,
+                                Db* dbout,
+                                const VectorDouble& gext,
+                                SPDE_Option& s_option);
 GSTLEARN_EXPORT int spde_posterior();
-GSTLEARN_EXPORT int spde_process(Db *dbin,
-                                 Db *dbout,
-                                 SPDE_Option &s_option,
+GSTLEARN_EXPORT int spde_process(Db* dbin,
+                                 Db* dbout,
+                                 SPDE_Option& s_option,
                                  int nbsimu,
                                  int ngibbs_nburn,
                                  int ngibbs_niter,
@@ -781,12 +779,12 @@ GSTLEARN_EXPORT int spde_process(Db *dbin,
 #ifndef SWIG
 GSTLEARN_EXPORT SPDE_Matelem& spde_get_current_matelem(int icov);
 #endif
-GSTLEARN_EXPORT AMesh* spde_mesh_load(Db *dbin,
-                                      Db *dbout,
-                                      const VectorDouble &gext,
-                                      SPDE_Option &s_option,
+GSTLEARN_EXPORT AMesh* spde_mesh_load(Db* dbin,
+                                      Db* dbout,
+                                      const VectorDouble& gext,
+                                      SPDE_Option& s_option,
                                       bool verbose = false);
-GSTLEARN_EXPORT void spde_mesh_assign(AMesh *amesh,
+GSTLEARN_EXPORT void spde_mesh_assign(AMesh* amesh,
                                       int ndim,
                                       int ncorner,
                                       int nvertex,
@@ -794,39 +792,39 @@ GSTLEARN_EXPORT void spde_mesh_assign(AMesh *amesh,
                                       const VectorInt& arg_meshes,
                                       const VectorDouble& arg_points,
                                       int verbose);
-GSTLEARN_EXPORT int spde_build_matrices(Model *model, int verbose);
+GSTLEARN_EXPORT int spde_build_matrices(Model* model, int verbose);
 GSTLEARN_EXPORT int spde_eval(const VectorDouble& blin,
-                              MatrixSparse *S,
-                              const VectorDouble &Lambda,
-                              const VectorDouble &TildeC,
+                              MatrixSparse* S,
+                              const VectorDouble& Lambda,
+                              const VectorDouble& TildeC,
                               double power,
                               VectorDouble& x,
                               VectorDouble& y);
-GSTLEARN_EXPORT void spde_external_mesh_define(int icov0, AMesh *mesh);
+GSTLEARN_EXPORT void spde_external_mesh_define(int icov0, AMesh* mesh);
 GSTLEARN_EXPORT void spde_external_mesh_undefine(int icov0);
 #ifndef SWIG
-GSTLEARN_EXPORT int spde_external_copy(SPDE_Matelem &matelem, int icov0);
-GSTLEARN_EXPORT MatrixSparse* spde_external_A_define(int icov0, MatrixSparse *A);
-GSTLEARN_EXPORT MatrixSparse* spde_external_Q_define(int icov0, MatrixSparse *Q);
+GSTLEARN_EXPORT int spde_external_copy(SPDE_Matelem& matelem, int icov0);
+GSTLEARN_EXPORT MatrixSparse* spde_external_A_define(int icov0, MatrixSparse* A);
+GSTLEARN_EXPORT MatrixSparse* spde_external_Q_define(int icov0, MatrixSparse* Q);
 GSTLEARN_EXPORT MatrixSparse* spde_external_A_undefine(int icov0);
 GSTLEARN_EXPORT MatrixSparse* spde_external_Q_undefine(int icov0);
 #endif
-GSTLEARN_EXPORT int kriging2D_spde(Db *dbin,
-                                   Model *model,
-                                   SPDE_Option &s_option,
+GSTLEARN_EXPORT int kriging2D_spde(Db* dbin,
+                                   Model* model,
+                                   SPDE_Option& s_option,
                                    int verbose,
-                                   int *nmesh_arg,
-                                   int *nvertex_arg,
+                                   int* nmesh_arg,
+                                   int* nvertex_arg,
                                    VectorInt& meshes_arg,
                                    VectorDouble& points_arg);
 #ifndef SWIG
-GSTLEARN_EXPORT MatrixSparse* db_mesh_neigh(const Db *db,
-                                            AMesh *amesh,
+GSTLEARN_EXPORT MatrixSparse* db_mesh_neigh(const Db* db,
+                                            AMesh* amesh,
                                             double radius,
                                             int flag_exact,
                                             bool verbose,
-                                            int *nactive,
-                                            int **ranks);
+                                            int* nactive,
+                                            int** ranks);
 #endif
 GSTLEARN_EXPORT void spde_free_all(void);
 
@@ -834,19 +832,18 @@ GSTLEARN_EXPORT void spde_free_all(void);
 /* Prototyping the functions in math.c */
 /***************************************/
 
-GSTLEARN_EXPORT int db_trisurf(Db *db,
-                               Model *model,
-                               const String &triswitch,
+GSTLEARN_EXPORT int db_trisurf(Db* db,
+                               Model* model,
+                               const String& triswitch,
                                int icode0,
                                int verbose,
-                               int *ncode_arg,
-                               int *ntri_arg,
-                               int *npoint_arg,
-                               double *codesel,
-                               VectorInt &ntcode,
-                               VectorInt &triangles,
-                               VectorDouble &points);
-
+                               int* ncode_arg,
+                               int* ntri_arg,
+                               int* npoint_arg,
+                               double* codesel,
+                               VectorInt& ntcode,
+                               VectorInt& triangles,
+                               VectorDouble& points);
 
 /******************************************/
 /* Prototyping the functions in cluster.c */

--- a/src/API/SPDE.cpp
+++ b/src/API/SPDE.cpp
@@ -34,8 +34,8 @@
 #include "Mesh/MeshETurbo.hpp"
 #include "Model/Model.hpp"
 #include "geoslib_define.h"
-#include "LinearOp/PrecisionOpMultiMatrix.hpp"
-#include <math.h>
+
+#include <cmath>
 #include <vector>
 
 namespace gstlrn
@@ -1684,4 +1684,4 @@ VectorMeshes defineMeshesFromDbs(const Db* dbin,
 
   return meshes;
 }
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/AAnam.cpp
+++ b/src/Anamorphosis/AAnam.cpp
@@ -10,34 +10,32 @@
 /******************************************************************************/
 #include "Anamorphosis/AAnam.hpp"
 #include "Anamorphosis/CalcAnamTransform.hpp"
-#include "Db/Db.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
 
-#include <math.h>
+#define QT_EST        0
+#define QT_STD        1
+#define QT_VARS(i, j) (qt_vars[(i) + 2 * (j)])
+#define QT_FLAG(j)    (QT_VARS(QT_EST, j) > 0 || \
+                    QT_VARS(QT_STD, j) > 0)
 
-#define QT_EST    0
-#define QT_STD    1
-#define QT_VARS(i,j)              (qt_vars[(i) + 2 * (j)])
-#define QT_FLAG(j)                (QT_VARS(QT_EST,j) > 0 || \
-                                   QT_VARS(QT_STD,j) > 0)
-
-namespace gstlrn{
-
+namespace gstlrn
+{
 AAnam::AAnam()
-    : AStringable(),
-      ASerializable(),
-      _flagFitted(false)
+  : AStringable()
+  , ASerializable()
+  , _flagFitted(false)
 {
 }
 
-AAnam::AAnam(const AAnam &m)
-    : AStringable(m),
-      ASerializable(m),
-      _flagFitted(m._flagFitted)
+AAnam::AAnam(const AAnam& m)
+  : AStringable(m)
+  , ASerializable(m)
+  , _flagFitted(m._flagFitted)
 {
 }
 
-AAnam& AAnam::operator=(const AAnam &m)
+AAnam& AAnam::operator=(const AAnam& m)
 {
   if (this != &m)
   {
@@ -71,23 +69,23 @@ VectorDouble AAnam::z2factor(double z, const VectorInt& ifacs) const
  *****************************************************************************/
 double AAnam::invertVariance(double cvv) const
 {
-  if (! allowChangeSupport()) return TEST;
+  if (!allowChangeSupport()) return TEST;
   double s0, s1, s2, var0, var1;
   int converge, niter;
   static int niter_max = 1000;
 
-  s1 = 0.;
+  s1   = 0.;
   var1 = computeVariance(s1);
 
   /* Dichotomy */
 
-  s2 = 1.;
+  s2       = 1.;
   converge = niter = 0;
   while (!converge)
   {
     niter++;
-    s0 = (s1 + s2) / 2.;
-    var0 = computeVariance(s0);
+    s0       = (s1 + s2) / 2.;
+    var0     = computeVariance(s0);
     converge = (ABS(var0 - cvv) < EPSILON8 || niter > niter_max);
     if ((var1 - cvv) * (var0 - cvv) < 0.)
     {
@@ -95,7 +93,7 @@ double AAnam::invertVariance(double cvv) const
     }
     else
     {
-      s1 = s0;
+      s1   = s0;
       var1 = var0;
     }
   }
@@ -123,7 +121,7 @@ int AAnam::updatePointToBlock(double /*r_coef*/)
 
 double AAnam::rawToTransformValue(double /*z*/) const
 {
-  if (! hasGaussian())
+  if (!hasGaussian())
     messerr("This function is not possible");
   else
     messerr("This function is not programmed yet");
@@ -132,7 +130,7 @@ double AAnam::rawToTransformValue(double /*z*/) const
 
 double AAnam::transformToRawValue(double /*y*/) const
 {
-  if (! hasGaussian())
+  if (!hasGaussian())
     messerr("This function is not available");
   else
     messerr("This function is not programmed yet");
@@ -149,7 +147,7 @@ double AAnam::transformToRawValue(double /*y*/) const
  ** \param[in]  cols_std     Array of columns for factor st. dev.
  **
  *****************************************************************************/
-bool AAnam::_isSampleSkipped(Db *db,
+bool AAnam::_isSampleSkipped(Db* db,
                              int iech,
                              const VectorInt& cols_est,
                              const VectorInt& cols_std)
@@ -158,7 +156,7 @@ bool AAnam::_isSampleSkipped(Db *db,
 
   if (!db->isActive(iech)) return true;
 
-  int nb_est = (int) cols_est.size();
+  int nb_est = (int)cols_est.size();
   if (!cols_est.empty())
   {
     for (int ivar = 0; ivar < nb_est; ivar++)
@@ -168,7 +166,7 @@ bool AAnam::_isSampleSkipped(Db *db,
     }
   }
 
-  int nb_std = (int) cols_std.size();
+  int nb_std = (int)cols_std.size();
   if (!cols_std.empty())
   {
     for (int ivar = 0; ivar < nb_std; ivar++)
@@ -214,7 +212,7 @@ bool AAnam::_isProbaValid(double proba)
  ** \param[in]  number       Number of cutoffs
  **
  *****************************************************************************/
-void AAnam::_printQTvars(const char *title, int type, int number)
+void AAnam::_printQTvars(const char* title, int type, int number)
 {
   message("- %s", title);
   if (type == 1)
@@ -227,7 +225,7 @@ void AAnam::_printQTvars(const char *title, int type, int number)
 VectorDouble AAnam::rawToTransformVec(const VectorDouble& z) const
 {
   VectorDouble y = VectorDouble(z.size(), TEST);
-  for (int i = 0; i < (int) z.size(); i++)
+  for (int i = 0; i < (int)z.size(); i++)
     y[i] = rawToTransformValue(z[i]);
   return y;
 }
@@ -235,36 +233,36 @@ VectorDouble AAnam::rawToTransformVec(const VectorDouble& z) const
 VectorDouble AAnam::transformToRawVec(const VectorDouble& y) const
 {
   VectorDouble z = VectorDouble(y.size(), TEST);
-  for (int i = 0; i < (int) z.size(); i++)
+  for (int i = 0; i < (int)z.size(); i++)
     z[i] = transformToRawValue(y[i]);
   return z;
 }
 
-int AAnam::fitFromLocator(Db *db, const ELoc& locatorType)
+int AAnam::fitFromLocator(Db* db, const ELoc& locatorType)
 {
   int number = db->getNLoc(locatorType);
   if (number != 1)
   {
     messerr("The number of items for locator(%d) is %d. It should be 1",
-            locatorType.getValue(),number);
+            locatorType.getValue(), number);
     return 1;
   }
-  VectorDouble tab = db->getColumnByLocator(locatorType,0,true);
+  VectorDouble tab = db->getColumnByLocator(locatorType, 0, true);
   VectorDouble wt;
   if (db->hasLocVariable(ELoc::W))
-    wt = db->getColumnByLocator(ELoc::W,0,true);
+    wt = db->getColumnByLocator(ELoc::W, 0, true);
 
   if (fitFromArray(tab, wt)) return 1;
   _flagFitted = true;
   return 0;
 }
 
-int AAnam::fit(Db *db, const String& name)
+int AAnam::fit(Db* db, const String& name)
 {
-  VectorDouble tab = db->getColumn(name,true);
+  VectorDouble tab = db->getColumn(name, true);
   VectorDouble wt;
   if (db->hasLocVariable(ELoc::W))
-    wt = db->getColumnByLocator(ELoc::W,0,true);
+    wt = db->getColumnByLocator(ELoc::W, 0, true);
 
   if (fitFromArray(tab, wt)) return 1;
   _flagFitted = true;
@@ -277,7 +275,7 @@ int AAnam::fit(Db *db, const String& name)
  * @param namconv Naming Convention
  * @return
  */
-int AAnam::rawToGaussianByLocator(Db *db, const NamingConvention &namconv)
+int AAnam::rawToGaussianByLocator(Db* db, const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(this);
   transfo.setFlagVars(true);
@@ -291,9 +289,9 @@ int AAnam::rawToGaussianByLocator(Db *db, const NamingConvention &namconv)
   return error;
 }
 
-int AAnam::rawToGaussian(Db *db,
-                         const String &name,
-                         const NamingConvention &namconv)
+int AAnam::rawToGaussian(Db* db,
+                         const String& name,
+                         const NamingConvention& namconv)
 {
   if (db == nullptr) return 1;
   db->setLocator(name, ELoc::Z, 0, true);
@@ -310,7 +308,7 @@ int AAnam::rawToGaussian(Db *db,
   return error;
 }
 
-int AAnam::gaussianToRawByLocator(Db *db, const NamingConvention &namconv)
+int AAnam::gaussianToRawByLocator(Db* db, const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(this);
   transfo.setFlagZToY(true);
@@ -323,9 +321,9 @@ int AAnam::gaussianToRawByLocator(Db *db, const NamingConvention &namconv)
   return error;
 }
 
-int AAnam::gaussianToRaw(Db *db,
-                         const String &name,
-                         const NamingConvention &namconv)
+int AAnam::gaussianToRaw(Db* db,
+                         const String& name,
+                         const NamingConvention& namconv)
 {
   if (db == nullptr) return 1;
   db->setLocator(name, ELoc::Z, 0, true);
@@ -353,9 +351,9 @@ int AAnam::gaussianToRaw(Db *db,
  ** \param[in]  namconv    Naming convention
  **
  *****************************************************************************/
-int AAnam::normalScore(Db *db,
-                       const String &name,
-                       const NamingConvention &namconv)
+int AAnam::normalScore(Db* db,
+                       const String& name,
+                       const NamingConvention& namconv)
 {
   if (db == nullptr) return 1;
   db->setLocator(name, ELoc::Z, 0, true);
@@ -383,9 +381,9 @@ int AAnam::normalScore(Db *db,
  ** \param[in]  namconv     Naming convention
  **
  *****************************************************************************/
-int AAnam::rawToFactorByRanks(Db *db,
-                              const VectorInt &ifacs,
-                              const NamingConvention &namconv)
+int AAnam::rawToFactorByRanks(Db* db,
+                              const VectorInt& ifacs,
+                              const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(this);
   transfo.setDb(db);
@@ -409,9 +407,9 @@ int AAnam::rawToFactorByRanks(Db *db,
  ** \param[in]  namconv     Naming convention
  **
  *****************************************************************************/
-int AAnam::rawToFactor(Db *db,
+int AAnam::rawToFactor(Db* db,
                        int nfactor,
-                       const NamingConvention &namconv)
+                       const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(this);
   transfo.setDb(db);
@@ -424,4 +422,4 @@ int AAnam::rawToFactor(Db *db,
   int error = (transfo.run()) ? 0 : 1;
   return error;
 }
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/AnamDiscrete.cpp
+++ b/src/Anamorphosis/AnamDiscrete.cpp
@@ -14,53 +14,52 @@
 #include "Matrix/MatrixDense.hpp"
 #include "Stats/Selectivity.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #define ANAM_KD_NELEM 6
 
 namespace gstlrn
 {
 AnamDiscrete::AnamDiscrete()
-    : AAnam(),
-      _nCut(0),
-      _nElem(ANAM_KD_NELEM),
-      _mean(TEST),
-      _variance(TEST),
-      _zCut(),
-      _stats()
+  : AAnam()
+  , _nCut(0)
+  , _nElem(ANAM_KD_NELEM)
+  , _mean(TEST)
+  , _variance(TEST)
+  , _zCut()
+  , _stats()
 {
   _resize();
 }
 
-AnamDiscrete::AnamDiscrete(const AnamDiscrete &m)
-    : AAnam(m),
-      _nCut(m._nCut),
-      _nElem(m._nElem),
-      _mean(m._mean),
-      _variance(m._variance),
-      _zCut(m._zCut),
-      _stats(m._stats)
+AnamDiscrete::AnamDiscrete(const AnamDiscrete& m)
+  : AAnam(m)
+  , _nCut(m._nCut)
+  , _nElem(m._nElem)
+  , _mean(m._mean)
+  , _variance(m._variance)
+  , _zCut(m._zCut)
+  , _stats(m._stats)
 {
 }
 
-AnamDiscrete& AnamDiscrete::operator=(const AnamDiscrete &m)
+AnamDiscrete& AnamDiscrete::operator=(const AnamDiscrete& m)
 {
   if (this != &m)
   {
-    AAnam::operator= (m);
-    _nCut = m._nCut;
-    _nElem = m._nElem;
-    _zCut = m._zCut;
-    _mean = m._mean;
+    AAnam::operator=(m);
+    _nCut     = m._nCut;
+    _nElem    = m._nElem;
+    _zCut     = m._zCut;
+    _mean     = m._mean;
     _variance = m._variance;
-    _stats = m._stats;
+    _stats    = m._stats;
   }
   return *this;
 }
 
 AnamDiscrete::~AnamDiscrete()
 {
-
 }
 
 void AnamDiscrete::_resize()
@@ -69,27 +68,27 @@ void AnamDiscrete::_resize()
   int nclass = getNClass();
   int nelem  = getNElem();
 
-  _zCut.resize(ncut,0.);
-  _stats.resetFromValue(nclass,nelem,0.);
+  _zCut.resize(ncut, 0.);
+  _stats.resetFromValue(nclass, nelem, 0.);
 }
 
 String AnamDiscrete::toString(const AStringFormat* /*strfmt*/) const
 {
   std::stringstream sstr;
 
-  if (! _isFitted()) return sstr.str();
+  if (!_isFitted()) return sstr.str();
 
   sstr << "Number of cutoffs = " << _nCut << std::endl;
   sstr << "Number of classes = " << getNClass() << std::endl;
-  if (! FFFF(_mean))
+  if (!FFFF(_mean))
     sstr << "Mean              = " << _mean << std::endl;
-  if (! FFFF(_variance))
+  if (!FFFF(_variance))
     sstr << "Variance          = " << _variance << std::endl;
 
   sstr << std::endl;
   sstr << toMatrix("Cutoffs", VectorString(), VectorString(), true, _nCut, 1, _zCut);
 
-  sstr << toMatrix(String(),VectorString(),VectorString(),true,getNClass(),getNElem(),
+  sstr << toMatrix(String(), VectorString(), VectorString(), true, getNClass(), getNElem(),
                    getStats().getValues());
 
   return sstr.str();
@@ -97,131 +96,131 @@ String AnamDiscrete::toString(const AStringFormat* /*strfmt*/) const
 
 void AnamDiscrete::calculateMeanAndVariance()
 {
-  _mean = TEST;
+  _mean     = TEST;
   _variance = TEST;
 }
 
-double AnamDiscrete::getDDStatProp  (int iclass) const
+double AnamDiscrete::getDDStatProp(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,0);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 0);
 }
-double AnamDiscrete::getDDStatZmoy  (int iclass) const
+double AnamDiscrete::getDDStatZmoy(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,1);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 1);
 }
-double AnamDiscrete::getDDStatCnorm (int iclass) const
+double AnamDiscrete::getDDStatCnorm(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,2);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 2);
 }
 double AnamDiscrete::getDDStatLambda(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,3);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 3);
 }
-double AnamDiscrete::getDDStatU     (int iclass) const
+double AnamDiscrete::getDDStatU(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,4);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 4);
 }
-double AnamDiscrete::getDDStatMul   (int iclass) const
+double AnamDiscrete::getDDStatMul(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,5);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 5);
 }
-void   AnamDiscrete::setDDStatProp  (int iclass, double value)
+void AnamDiscrete::setDDStatProp(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,0,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 0, value);
 }
-void   AnamDiscrete::setDDStatZmoy  (int iclass, double value)
+void AnamDiscrete::setDDStatZmoy(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,1,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 1, value);
 }
-void   AnamDiscrete::setDDStatCnorm (int iclass, double value)
+void AnamDiscrete::setDDStatCnorm(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,2,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 2, value);
 }
-void   AnamDiscrete::setDDStatLambda(int iclass, double value)
+void AnamDiscrete::setDDStatLambda(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,3,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 3, value);
 }
-void   AnamDiscrete::setDDStatU     (int iclass, double value)
+void AnamDiscrete::setDDStatU(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,4,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 4, value);
 }
-void   AnamDiscrete::setDDStatMul   (int iclass, double value)
+void AnamDiscrete::setDDStatMul(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,5,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 5, value);
 }
 
 // Function for using Stats in IR anamorphosis
-double AnamDiscrete::getIRStatT   (int iclass) const
+double AnamDiscrete::getIRStatT(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,0);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 0);
 }
-double AnamDiscrete::getIRStatQ   (int iclass) const
+double AnamDiscrete::getIRStatQ(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,1);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 1);
 }
-double AnamDiscrete::getIRStatZ   (int iclass) const
+double AnamDiscrete::getIRStatZ(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,2);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 2);
 }
-double AnamDiscrete::getIRStatB   (int iclass) const
+double AnamDiscrete::getIRStatB(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,3);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 3);
 }
-double AnamDiscrete::getIRStatR   (int iclass) const
+double AnamDiscrete::getIRStatR(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,4);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 4);
 }
-double AnamDiscrete::getIRStatRV  (int iclass) const
+double AnamDiscrete::getIRStatRV(int iclass) const
 {
-  if (! _isClassValid(iclass)) return TEST;
-  return _stats.getValue(iclass,5);
+  if (!_isClassValid(iclass)) return TEST;
+  return _stats.getValue(iclass, 5);
 }
 void AnamDiscrete::setIRStatT(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,0,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 0, value);
 }
 void AnamDiscrete::setIRStatQ(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,1,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 1, value);
 }
 void AnamDiscrete::setIRStatZ(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,2,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 2, value);
 }
 void AnamDiscrete::setIRStatB(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,3,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 3, value);
 }
 void AnamDiscrete::setIRStatR(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,4,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 4, value);
 }
 void AnamDiscrete::setIRStatRV(int iclass, double value)
 {
-  if (! _isClassValid(iclass)) return;
-  _stats.setValue(iclass,5,value);
+  if (!_isClassValid(iclass)) return;
+  _stats.setValue(iclass, 5, value);
 }
 
 bool AnamDiscrete::_isClassValid(int iclass) const
@@ -232,25 +231,25 @@ bool AnamDiscrete::_isClassValid(int iclass) const
 bool AnamDiscrete::_serializeAscii(std::ostream& os, bool /*verbose*/) const
 {
   bool ret = true;
-  ret = ret && _recordWrite<int>(os, "Number of Cuttofs", getNCut());
-  ret = ret && _recordWrite<int>(os, "Number of classes", getNClass());
-  ret = ret && _recordWrite<int>(os, "Number of elements", getNElem());
-  ret = ret && _tableWrite(os, "Cutoff value", getNCut(), getZCut());
-  ret = ret && _tableWrite(os, "DD Stats", getNClass() * getNElem(), getStats().getValues());
+  ret      = ret && _recordWrite<int>(os, "Number of Cuttofs", getNCut());
+  ret      = ret && _recordWrite<int>(os, "Number of classes", getNClass());
+  ret      = ret && _recordWrite<int>(os, "Number of elements", getNElem());
+  ret      = ret && _tableWrite(os, "Cutoff value", getNCut(), getZCut());
+  ret      = ret && _tableWrite(os, "DD Stats", getNClass() * getNElem(), getStats().getValues());
   return ret;
 }
 
 bool AnamDiscrete::_deserializeAscii(std::istream& is, bool /*verbose*/)
 {
   VectorDouble zCut, stats;
-  int nCut = 0;
+  int nCut   = 0;
   int nClass = 0;
-  int nElem = 0;
+  int nElem  = 0;
 
   bool ret = true;
-  ret = ret && _recordRead<int>(is, "Number of Cutoffs", nCut);
-  ret = ret && _recordRead<int>(is, "Number of Classes", nClass);
-  ret = ret && _recordRead<int>(is, "Number of Statistic Columns", nElem);
+  ret      = ret && _recordRead<int>(is, "Number of Cutoffs", nCut);
+  ret      = ret && _recordRead<int>(is, "Number of Classes", nClass);
+  ret      = ret && _recordRead<int>(is, "Number of Statistic Columns", nElem);
 
   if (ret)
   {
@@ -282,7 +281,7 @@ void AnamDiscrete::setNCut(int ncut)
 
 void AnamDiscrete::setZCut(const VectorDouble& zcut)
 {
-  _nCut = (int) zcut.size();
+  _nCut = (int)zcut.size();
   _resize();
   _zCut = zcut;
 };
@@ -296,11 +295,11 @@ void AnamDiscrete::setNElem(int nelem)
 void AnamDiscrete::setStats(const VectorDouble& stats)
 {
   int nclass = getNClass();
-  int nelem = getNElem();
-  if ((int) stats.size() != nclass * nelem)
+  int nelem  = getNElem();
+  if ((int)stats.size() != nclass * nelem)
   {
     messerr("Argument 'stats' incorrect. Its dimension (%d) should be %d * %d",
-            stats.size(),nclass,nelem);
+            stats.size(), nclass, nelem);
     return;
   }
   _stats.setValues(stats);
@@ -315,10 +314,10 @@ bool AnamDiscrete::_deserializeH5(H5::Group& grp, [[maybe_unused]] bool verbose)
   }
 
   /* Read the grid characteristics */
-  bool ret = true;
-  int ncut = 0;
+  bool ret   = true;
+  int ncut   = 0;
   int nclass = 0;
-  int nelem = 0;
+  int nelem  = 0;
   VectorDouble zcuts;
   VectorDouble stats;
 
@@ -354,4 +353,4 @@ bool AnamDiscrete::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) c
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/AnamDiscreteIR.cpp
+++ b/src/Anamorphosis/AnamDiscreteIR.cpp
@@ -9,30 +9,29 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Anamorphosis/AnamDiscreteIR.hpp"
-#include "Db/Db.hpp"
-#include "Basic/Utilities.hpp"
 #include "Basic/SerializeHDF5.hpp"
+#include "Basic/Utilities.hpp"
+#include "Db/Db.hpp"
 
-#include <math.h>
+#include <cmath>
 
-#define RESIDUALS(icut,iech) (residuals[iech * ncut + icut])
+#define RESIDUALS(icut, iech) (residuals[iech * ncut + icut])
 
 namespace gstlrn
 {
 AnamDiscreteIR::AnamDiscreteIR(double rcoef)
-    : AnamDiscrete(),
-      _sCoef(rcoef)
+  : AnamDiscrete()
+  , _sCoef(rcoef)
 {
 }
 
-AnamDiscreteIR::AnamDiscreteIR(const AnamDiscreteIR &m)
-    : AnamDiscrete(m),
-      _sCoef(m._sCoef)
+AnamDiscreteIR::AnamDiscreteIR(const AnamDiscreteIR& m)
+  : AnamDiscrete(m)
+  , _sCoef(m._sCoef)
 {
-
 }
 
-AnamDiscreteIR& AnamDiscreteIR::operator=(const AnamDiscreteIR &m)
+AnamDiscreteIR& AnamDiscreteIR::operator=(const AnamDiscreteIR& m)
 {
   if (this != &m)
   {
@@ -44,7 +43,6 @@ AnamDiscreteIR& AnamDiscreteIR::operator=(const AnamDiscreteIR &m)
 
 AnamDiscreteIR::~AnamDiscreteIR()
 {
-
 }
 
 AnamDiscreteIR* AnamDiscreteIR::createFromNF(const String& NFFilename, bool verbose)
@@ -62,8 +60,8 @@ AnamDiscreteIR* AnamDiscreteIR::create(double rcoef)
 
 void AnamDiscreteIR::reset(int ncut,
                            double r_coef,
-                           const VectorDouble &zcut,
-                           const VectorDouble &stats)
+                           const VectorDouble& zcut,
+                           const VectorDouble& stats)
 {
   setNCut(ncut);
   setZCut(zcut);
@@ -81,7 +79,7 @@ String AnamDiscreteIR::toString(const AStringFormat* strfmt) const
 
   sstr << AnamDiscrete::toString(strfmt);
 
-  if (! _isFitted()) return sstr.str();
+  if (!_isFitted()) return sstr.str();
 
   if (_sCoef != 1.)
   {
@@ -127,9 +125,9 @@ int AnamDiscreteIR::fitFromArray(const VectorDouble& tab,
 
   /* Initializations */
 
-  int nech = static_cast<int> (tab.size());
+  int nech   = static_cast<int>(tab.size());
   int nclass = getNClass();
-  int ncut = getNCut();
+  int ncut   = getNCut();
 
   /* Core allocation */
 
@@ -160,9 +158,9 @@ int AnamDiscreteIR::fitFromArray(const VectorDouble& tab,
   {
     tnext = (iclass < nclass - 1) ? getIRStatT(iclass + 1) : 0.;
     qnext = (iclass < nclass - 1) ? getIRStatQ(iclass + 1) : 0.;
-    tcur = getIRStatT(iclass);
-    dt = tcur - tnext;
-    dq = getIRStatQ(iclass) - qnext;
+    tcur  = getIRStatT(iclass);
+    dt    = tcur - tnext;
+    dq    = getIRStatQ(iclass) - qnext;
     setIRStatZ(iclass, (dt > 0) ? dq / dt : 0.);
     setIRStatB(iclass, getIRStatQ(iclass) - tcur * getIRStatZ(iclass));
     if (iclass <= 0)
@@ -184,12 +182,12 @@ int AnamDiscreteIR::fitFromArray(const VectorDouble& tab,
 
 int AnamDiscreteIR::_stats_residuals(int verbose,
                                      int nech,
-                                     const VectorDouble &tab,
-                                     int *nsorted,
-                                     double *mean,
-                                     double *residuals,
-                                     double *T,
-                                     double *Q)
+                                     const VectorDouble& tab,
+                                     int* nsorted,
+                                     double* mean,
+                                     double* residuals,
+                                     double* T,
+                                     double* Q)
 {
   double value, moyenne;
   int iech, icut, jcut, nactive;
@@ -198,12 +196,12 @@ int AnamDiscreteIR::_stats_residuals(int verbose,
 
   int ncut = getNCut();
   nactive = (*nsorted) = 0;
-  moyenne = 0.;
+  moyenne              = 0.;
   for (icut = 0; icut < ncut; icut++)
   {
     T[icut] = Q[icut] = 0.;
     for (iech = 0; iech < nech; iech++)
-      RESIDUALS(icut,iech) = 0.;
+      RESIDUALS(icut, iech) = 0.;
   }
 
   /* Loop on the samples to calculate the indicators */
@@ -220,7 +218,7 @@ int AnamDiscreteIR::_stats_residuals(int verbose,
     for (icut = 0; icut < ncut; icut++)
     {
       if (value < getZCut(icut)) continue;
-      RESIDUALS(icut,iech) = 1.;
+      RESIDUALS(icut, iech) = 1.;
       Q[icut] += value;
       T[icut] += 1.;
     }
@@ -233,11 +231,11 @@ int AnamDiscreteIR::_stats_residuals(int verbose,
 
   /* Calculate the tonnage and meal quantity per class */
 
-  moyenne /= (double) nactive;
+  moyenne /= (double)nactive;
   for (icut = 0; icut < ncut; icut++)
   {
-    T[icut] /= (double) nactive;
-    Q[icut] /= (double) nactive;
+    T[icut] /= (double)nactive;
+    Q[icut] /= (double)nactive;
   }
 
   /* Calculate the residuals */
@@ -251,17 +249,17 @@ int AnamDiscreteIR::_stats_residuals(int verbose,
 
     for (icut = ncut - 1; icut >= 0; icut--)
     {
-      value = RESIDUALS(icut,iech) / T[icut];
+      value = RESIDUALS(icut, iech) / T[icut];
       if (icut > 0)
       {
         jcut = icut - 1;
-        value -= RESIDUALS(jcut,iech) / T[jcut];
+        value -= RESIDUALS(jcut, iech) / T[jcut];
       }
       else
       {
         value -= 1.;
       }
-      RESIDUALS(icut,iech) = value;
+      RESIDUALS(icut, iech) = value;
     }
   }
 
@@ -277,21 +275,21 @@ int AnamDiscreteIR::_stats_residuals(int verbose,
   }
 
   (*nsorted) = nactive;
-  (*mean) = moyenne;
+  (*mean)    = moyenne;
   return (0);
 }
 
 VectorDouble AnamDiscreteIR::z2factor(double z, const VectorInt& ifacs) const
 {
   VectorDouble factors;
-  int nfact = (int) ifacs.size();
+  int nfact = (int)ifacs.size();
   factors.resize(nfact, 0);
 
   for (int ifac = 0; ifac < nfact; ifac++)
   {
-    int iclass = ifacs[ifac] - 1;
-    double v1 = _getResidual(iclass, z);
-    double v2 = _getResidual(iclass - 1, z);
+    int iclass    = ifacs[ifac] - 1;
+    double v1     = _getResidual(iclass, z);
+    double v2     = _getResidual(iclass - 1, z);
     factors[ifac] = v1 - v2;
   }
   return factors;
@@ -305,7 +303,7 @@ VectorDouble AnamDiscreteIR::z2factor(double z, const VectorInt& ifacs) const
  */
 double AnamDiscreteIR::_getResidual(int iclass, double z) const
 {
-  double seuil = (iclass < 0) ? 0. : getZCut(iclass);
+  double seuil  = (iclass < 0) ? 0. : getZCut(iclass);
   double retval = (z >= seuil) ? 1. : 0.;
   retval /= getIRStatT(iclass + 1);
 
@@ -315,8 +313,8 @@ double AnamDiscreteIR::_getResidual(int iclass, double z) const
 bool AnamDiscreteIR::_serializeAscii(std::ostream& os, bool verbose) const
 {
   bool ret = true;
-  ret = ret && AnamDiscrete::_serializeAscii(os, verbose);
-  ret = ret && _recordWrite<double>(os, "Change of support coefficient", getRCoef());
+  ret      = ret && AnamDiscrete::_serializeAscii(os, verbose);
+  ret      = ret && _recordWrite<double>(os, "Change of support coefficient", getRCoef());
   return ret;
 }
 
@@ -325,25 +323,24 @@ bool AnamDiscreteIR::_deserializeAscii(std::istream& is, bool verbose)
   double r = TEST;
 
   bool ret = true;
-  ret = ret && AnamDiscrete::_deserializeAscii(is, verbose);
-  ret = ret && _recordRead<double>(is, "Anamorphosis 'r' coefficient", r);
+  ret      = ret && AnamDiscrete::_deserializeAscii(is, verbose);
+  ret      = ret && _recordRead<double>(is, "Anamorphosis 'r' coefficient", r);
   if (ret) setRCoef(r);
   return ret;
 }
 
 double AnamDiscreteIR::computeVariance(double sval) const
 {
-  if (! allowChangeSupport()) return TEST;
+  if (!allowChangeSupport()) return TEST;
   int nclass = getNClass();
 
   double var = 0.;
   for (int iclass = 0; iclass < nclass - 1; iclass++)
   {
-    double b = getIRStatB(iclass);
-    double tcur = getIRStatT(iclass + 1);
+    double b     = getIRStatB(iclass);
+    double tcur  = getIRStatT(iclass + 1);
     double tprev = getIRStatT(iclass);
-    double resid = (tprev > 0 && tcur > 0) ?
-        1. / pow(tcur, sval) - 1. / pow(tprev, sval) : 0.;
+    double resid = (tprev > 0 && tcur > 0) ? 1. / pow(tcur, sval) - 1. / pow(tprev, sval) : 0.;
     var += b * b * resid;
   }
   return (var);
@@ -351,7 +348,7 @@ double AnamDiscreteIR::computeVariance(double sval) const
 
 int AnamDiscreteIR::updatePointToBlock(double r_coef)
 {
-  if (! allowChangeSupport()) return 1;
+  if (!allowChangeSupport()) return 1;
   setRCoef(r_coef);
 
   int nclass = getNClass();
@@ -386,10 +383,10 @@ int AnamDiscreteIR::updatePointToBlock(double r_coef)
       setIRStatRV(iclass, 0.);
     else
     {
-      tcur = getIRStatT(iclass);
+      tcur         = getIRStatT(iclass);
       double tprev = getIRStatT(iclass - 1);
       setIRStatRV(
-          iclass, (tprev > 0 && tcur > 0) ? 1. / tcur - 1 / tprev : 0.);
+        iclass, (tprev > 0 && tcur > 0) ? 1. / tcur - 1 / tprev : 0.);
     }
   }
 
@@ -461,16 +458,16 @@ void AnamDiscreteIR::_globalSelectivity(Selectivity* selectivity)
  ** \param[in]  iptr0        Rank for storing the results
  **
  *****************************************************************************/
-int AnamDiscreteIR::factor2Selectivity(Db *db,
+int AnamDiscreteIR::factor2Selectivity(Db* db,
                                        Selectivity* selectivity,
                                        const VectorInt& cols_est,
                                        const VectorInt& cols_std,
                                        int iptr0)
 {
-  int nech = db->getNSample();
-  int nb_est = (int) cols_est.size();
-  int nb_std = (int) cols_std.size();
-  int ncleff = MAX(nb_est, nb_std);
+  int nech        = db->getNSample();
+  int nb_est      = (int)cols_est.size();
+  int nb_std      = (int)cols_std.size();
+  int ncleff      = MAX(nb_est, nb_std);
   bool cutDefined = (selectivity->getNCuts() > 0);
 
   if (db == nullptr)
@@ -534,12 +531,11 @@ int AnamDiscreteIR::factor2Selectivity(Db *db,
 
     if (selloc->isUsedEst(ESelectivity::Q))
     {
-      selloc->setQest(ncleff-1, getIRStatZ(ncleff) * selloc->getTest(ncleff-1));
+      selloc->setQest(ncleff - 1, getIRStatZ(ncleff) * selloc->getTest(ncleff - 1));
       for (int ivar = ncleff - 2; ivar >= 0; ivar--)
       {
         selloc->setQest(ivar,
-                       selloc->getQest(ivar+1) + getIRStatZ(ivar + 1)
-                       * (selloc->getTest(ivar) - selloc->getTest(ivar + 1)));
+                        selloc->getQest(ivar + 1) + getIRStatZ(ivar + 1) * (selloc->getTest(ivar) - selloc->getTest(ivar + 1)));
       }
     }
 
@@ -556,7 +552,7 @@ int AnamDiscreteIR::factor2Selectivity(Db *db,
           total += value * value;
         }
         double prod = getIRStatB(ivar + 1) +
-            getIRStatZ(ivar + 1) * getIRStatT(ivar + 1);
+                      getIRStatZ(ivar + 1) * getIRStatT(ivar + 1);
         total *= prod * prod;
         for (int jvar = ivar + 1; jvar < ncleff; jvar++)
         {
@@ -572,10 +568,9 @@ int AnamDiscreteIR::factor2Selectivity(Db *db,
     double zestim = 0.;
     if (selloc->isUsedEst(ESelectivity::Z))
     {
-      zestim = getIRStatZ(ncleff) * selloc->getTest(ncleff-1);
+      zestim = getIRStatZ(ncleff) * selloc->getTest(ncleff - 1);
       for (int ivar = 0; ivar < ncleff - 1; ivar++)
-        zestim += getIRStatZ(ivar + 1)
-            * (selloc->getTest(ivar) - selloc->getTest(ivar + 1));
+        zestim += getIRStatZ(ivar + 1) * (selloc->getTest(ivar) - selloc->getTest(ivar + 1));
     }
 
     /* Z: Standard Deviation */
@@ -586,8 +581,7 @@ int AnamDiscreteIR::factor2Selectivity(Db *db,
       total = 0.;
       for (int ivar = 0; ivar < ncleff; ivar++)
       {
-        double prod = db->getArray(iech, cols_std[ivar])
-            * getIRStatB(ivar + 1);
+        double prod = db->getArray(iech, cols_std[ivar]) * getIRStatB(ivar + 1);
         total += prod * prod;
       }
       zstdev = sqrt(total);
@@ -627,7 +621,7 @@ bool AnamDiscreteIR::_deserializeH5(H5::Group& grp, [[maybe_unused]] bool verbos
 
   ret = ret && AnamDiscrete::_deserializeH5(*anamG, verbose);
 
-  if (ret) 
+  if (ret)
     setRCoef(r);
 
   return ret;
@@ -646,4 +640,4 @@ bool AnamDiscreteIR::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose)
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/AnamHermite.cpp
+++ b/src/Anamorphosis/AnamHermite.cpp
@@ -11,48 +11,48 @@
 #include "Anamorphosis/AnamHermite.hpp"
 #include "Anamorphosis/AnamContinuous.hpp"
 #include "Basic/Interval.hpp"
-#include "Basic/Utilities.hpp"
 #include "Basic/Law.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "Basic/SerializeHDF5.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Db/Db.hpp"
 #include "Model/Model.hpp"
 #include "Polynomials/Hermite.hpp"
 #include "Stats/Selectivity.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #define ANAM_YMIN -10.
-#define ANAM_YMAX  10.
-#define YPAS       0.1
+#define ANAM_YMAX 10.
+#define YPAS      0.1
 
 namespace gstlrn
-{ 
+{
 AnamHermite::AnamHermite(int nbpoly, bool flagBound, double rCoef)
-    : AnamContinuous(),
-      _flagBound(flagBound),
-      _rCoef(rCoef),
-      _psiHn()
+  : AnamContinuous()
+  , _flagBound(flagBound)
+  , _rCoef(rCoef)
+  , _psiHn()
 {
   _psiHn.resize(nbpoly);
 }
 
-AnamHermite::AnamHermite(const AnamHermite &m)
-    : AnamContinuous(m),
-      _flagBound(m._flagBound),
-      _rCoef(m._rCoef),
-      _psiHn(m._psiHn)
+AnamHermite::AnamHermite(const AnamHermite& m)
+  : AnamContinuous(m)
+  , _flagBound(m._flagBound)
+  , _rCoef(m._rCoef)
+  , _psiHn(m._psiHn)
 {
 }
 
-AnamHermite& AnamHermite::operator=(const AnamHermite &m)
+AnamHermite& AnamHermite::operator=(const AnamHermite& m)
 {
   if (this != &m)
   {
     AnamContinuous::operator=(m);
     _flagBound = m._flagBound;
-    _rCoef = m._rCoef;
-    _psiHn = m._psiHn;
+    _rCoef     = m._rCoef;
+    _psiHn     = m._psiHn;
   }
   return *this;
 }
@@ -67,7 +67,7 @@ String AnamHermite::toString(const AStringFormat* strfmt) const
   int nbpoly = getNbPoly();
   if (nbpoly <= 0) return sstr.str();
 
-  sstr << toTitle(1,"Hermitian Anamorphosis");
+  sstr << toTitle(1, "Hermitian Anamorphosis");
 
   sstr << AnamContinuous::toString(strfmt);
 
@@ -75,7 +75,7 @@ String AnamHermite::toString(const AStringFormat* strfmt) const
   if (isChangeSupportDefined())
     sstr << "Change of Support Coefficient = " << _rCoef << std::endl;
 
-  if (! _isFitted()) return sstr.str();
+  if (!_isFitted()) return sstr.str();
 
   sstr << toVector("Normalized coefficients for Hermite polynomials (punctual variable)",
                    _psiHn);
@@ -105,7 +105,7 @@ void AnamHermite::reset(double pymin,
                         double aymax,
                         double azmax,
                         double r,
-                        const VectorDouble &psi_hn)
+                        const VectorDouble& psi_hn)
 {
   setPsiHns(psi_hn);
   setRCoef(r);
@@ -116,12 +116,12 @@ void AnamHermite::reset(double pymin,
 
 double AnamHermite::rawToTransformValue(double z) const
 {
-  double y,y1,y2,yg,z1,z2,zg,dz,dzmax,dy,dymax;
-  int i,iter;
+  double y, y1, y2, yg, z1, z2, zg, dz, dzmax, dy, dymax;
+  int i, iter;
 
   /* Initializations */
 
-  if (getNbPoly() < 1) return(TEST);
+  if (getNbPoly() < 1) return (TEST);
   if (FFFF(z)) return TEST;
 
   /* Check the bounds */
@@ -129,28 +129,28 @@ double AnamHermite::rawToTransformValue(double z) const
   y1 = y2 = 0.;
   if (_flagBound)
   {
-    if (_az.isOutsideBelow(z)) return(_ay.getVmin());
-    if (_az.isOutsideAbove(z)) return(_ay.getVmax());
+    if (_az.isOutsideBelow(z)) return (_ay.getVmin());
+    if (_az.isOutsideAbove(z)) return (_ay.getVmax());
     if (_pz.isOutsideBelow(z))
     {
-      if(isEqual(_pz.getVmin(),_az.getVmin())) return(_py.getVmin());
-      return(_ay.getVmin() + (_py.getVmin() - _ay.getVmin()) *
-          (z - _az.getVmin()) / (_pz.getVmin() - _az.getVmin()));
+      if (isEqual(_pz.getVmin(), _az.getVmin())) return (_py.getVmin());
+      return (_ay.getVmin() + (_py.getVmin() - _ay.getVmin()) *
+                                (z - _az.getVmin()) / (_pz.getVmin() - _az.getVmin()));
     }
 
     if (_pz.isOutsideAbove(z))
     {
-      if(isEqual(_pz.getVmax(),_az.getVmax())) return(_py.getVmax());
-      return(_ay.getVmax() + (_py.getVmax() - _ay.getVmax()) *
-          (z - _az.getVmax()) / (_pz.getVmax() - _az.getVmax()));
+      if (isEqual(_pz.getVmax(), _az.getVmax())) return (_py.getVmax());
+      return (_ay.getVmax() + (_py.getVmax() - _ay.getVmax()) *
+                                (z - _az.getVmax()) / (_pz.getVmax() - _az.getVmax()));
     }
   }
 
   /* Calculate the precision on Z */
 
-  z1 = transformToRawValue(-1);
-  z2 = transformToRawValue( 1);
-  dzmax = ABS((z2 - z1)/100000.);
+  z1    = transformToRawValue(-1);
+  z2    = transformToRawValue(1);
+  dzmax = ABS((z2 - z1) / 100000.);
 
   /* Look for a first interval in Y containing Z */
 
@@ -160,42 +160,42 @@ double AnamHermite::rawToTransformValue(double z) const
 
   if (z > z1)
   {
-    for( i=0 ; i<101 ; i++ )
+    for (i = 0; i < 101; i++)
     {
       y2 = y1 + dy;
       z2 = transformToRawValue(y2);
-      if(z2 > z) break;
+      if (z2 > z) break;
       y1 = y2;
       z1 = z2;
     }
-    if (y1 > ANAM_YMAX) return(ANAM_YMAX + 1.);
+    if (y1 > ANAM_YMAX) return (ANAM_YMAX + 1.);
   }
   else
   {
     y2 = y1;
     z2 = z1;
-    for( i=0 ; i<101 ; i++ )
+    for (i = 0; i < 101; i++)
     {
       y1 = y2 - dy;
       z1 = transformToRawValue(y1);
-      if(z1 < z) break;
+      if (z1 < z) break;
       y2 = y1;
       z2 = z1;
     }
-    if (y1 < ANAM_YMIN) return(ANAM_YMIN - 1.);
+    if (y1 < ANAM_YMIN) return (ANAM_YMIN - 1.);
   }
 
-  dz = z2 - z1;
-  dy = 1.;
-  iter = 0;
+  dz    = z2 - z1;
+  dy    = 1.;
+  iter  = 0;
   dymax = 0.0000001;
 
-  while( iter<1000000 && dz>dzmax && dy>dymax )
+  while (iter < 1000000 && dz > dzmax && dy > dymax)
   {
-    yg = (y1 + y2)/2.;
+    yg = (y1 + y2) / 2.;
     zg = transformToRawValue(yg);
 
-    if(zg > z)
+    if (zg > z)
     {
       z2 = zg;
       y2 = yg;
@@ -212,44 +212,44 @@ double AnamHermite::rawToTransformValue(double z) const
   }
 
   dz = z2 - z1;
-  if(isZero(dz))
-    y = (y1 + y2)/2.;
+  if (isZero(dz))
+    y = (y1 + y2) / 2.;
   else
-    y = y1 + (z - z1)*(y2 - y1)/dz;
+    y = y1 + (z - z1) * (y2 - y1) / dz;
 
   if (_flagBound)
   {
     if (y < _ay.getVmin()) y = _ay.getVmin();
     if (y > _ay.getVmax()) y = _ay.getVmax();
   }
-  return(y);
+  return (y);
 }
 
 double AnamHermite::transformToRawValue(double y) const
 {
   double z;
-  if (getNbPoly() < 1) return(TEST);
+  if (getNbPoly() < 1) return (TEST);
   if (FFFF(y)) return TEST;
 
   /* Check the bounds */
 
   if (_flagBound)
   {
-    if (_ay.isOutsideBelow(y)) return(_az.getVmin());
-    if (_ay.isOutsideAbove(y)) return(_az.getVmax());
+    if (_ay.isOutsideBelow(y)) return (_az.getVmin());
+    if (_ay.isOutsideAbove(y)) return (_az.getVmax());
 
     if (_py.isOutsideBelow(y))
     {
-      if (isEqual(_py.getVmin(),_ay.getVmin())) return(_pz.getVmin());
-      return(_az.getVmin() + (_pz.getVmin() - _az.getVmin()) *
-          (y - _ay.getVmin()) / (_py.getVmin() - _ay.getVmin()));
+      if (isEqual(_py.getVmin(), _ay.getVmin())) return (_pz.getVmin());
+      return (_az.getVmin() + (_pz.getVmin() - _az.getVmin()) *
+                                (y - _ay.getVmin()) / (_py.getVmin() - _ay.getVmin()));
     }
 
     if (_py.isOutsideAbove(y))
     {
-      if (isEqual(_py.getVmax(),_ay.getVmax())) return(_pz.getVmax());
-      return(_az.getVmax() + (_pz.getVmax() - _az.getVmax()) *
-          (y - _ay.getVmax()) / (_py.getVmax() - _ay.getVmax()));
+      if (isEqual(_py.getVmax(), _ay.getVmax())) return (_pz.getVmax());
+      return (_az.getVmax() + (_pz.getVmax() - _az.getVmax()) *
+                                (y - _ay.getVmax()) / (_py.getVmax() - _ay.getVmax()));
     }
   }
 
@@ -265,7 +265,7 @@ double AnamHermite::transformToRawValue(double y) const
     if (z > _az.getVmax()) z = _az.getVmax();
   }
 
-  return(z);
+  return (z);
 }
 
 /**
@@ -290,9 +290,9 @@ VectorDouble AnamHermite::cumulateVarianceRatio(double chh) const
 {
   VectorDouble vec;
 
-  int nbpoly = getNbPoly();
-  double rho = 1.;
-  double var = 0.;
+  int nbpoly   = getNbPoly();
+  double rho   = 1.;
+  double var   = 0.;
   double total = getVariance();
   for (int ih = 1; ih < nbpoly; ih++)
   {
@@ -305,7 +305,7 @@ VectorDouble AnamHermite::cumulateVarianceRatio(double chh) const
 
 void AnamHermite::calculateMeanAndVariance()
 {
-  _mean = _psiHn[0];
+  _mean     = _psiHn[0];
   _variance = computeVariance(1.);
 }
 
@@ -317,27 +317,27 @@ void AnamHermite::setRCoef(double r_coef)
 
 int AnamHermite::fitFromArray(const VectorDouble& tab, const VectorDouble& wt)
 {
-  int     icl,ih,ncl;
-  double  Gcy1,Gcy2,Gy1,Gy2;
+  int icl, ih, ncl;
+  double Gcy1, Gcy2, Gy1, Gy2;
   VectorDouble psi, h1, h2, zs, ys;
 
-  int nech = static_cast<int> (tab.size());
+  int nech = static_cast<int>(tab.size());
   if (nech <= 0) return 1;
 
   int nbpoly = getNbPoly();
-  zs.resize(nech+2);
-  ys.resize(nech+2);
+  zs.resize(nech + 2);
+  ys.resize(nech + 2);
   _psiHn.resize(nbpoly, 0.);
 
   /* Sort the data by classes */
 
-  ncl = _data_sort(nech,tab,wt,zs,ys);
+  ncl = _data_sort(nech, tab, wt, zs, ys);
   if (ncl <= 0) return 1;
 
   /* Calculate Hermite_0 coefficients */
 
   Gcy1 = 0.;
-  for (icl=0; icl<ncl; icl++)
+  for (icl = 0; icl < ncl; icl++)
   {
     Gcy2 = law_cdf_gaussian(ys[icl]);
     _psiHn[0] += zs[icl] * (Gcy2 - Gcy1);
@@ -346,20 +346,20 @@ int AnamHermite::fitFromArray(const VectorDouble& tab, const VectorDouble& wt)
 
   /* Calculate the Hermite coefficients */
 
-  h1 = hermitePolynomials(ys[0],1.,nbpoly);
+  h1  = hermitePolynomials(ys[0], 1., nbpoly);
   Gy1 = 0.;
 
-  for (icl=0 ; icl<ncl ; icl++)
+  for (icl = 0; icl < ncl; icl++)
   {
-    h2 = hermitePolynomials(ys[icl],1.,nbpoly);
+    h2 = hermitePolynomials(ys[icl], 1., nbpoly);
 
     Gy2 = law_df_gaussian(ys[icl]);
 
-    for( ih=1 ; ih<nbpoly ; ih++ )
-      _psiHn[ih] += zs[icl] * (h2[ih-1]*Gy2 - h1[ih-1]*Gy1) / sqrt((double) ih);
+    for (ih = 1; ih < nbpoly; ih++)
+      _psiHn[ih] += zs[icl] * (h2[ih - 1] * Gy2 - h1[ih - 1] * Gy1) / sqrt((double)ih);
 
     Gy1 = Gy2;
-    for( ih=0 ; ih<nbpoly ; ih++) h1[ih] = h2[ih];
+    for (ih = 0; ih < nbpoly; ih++) h1[ih] = h2[ih];
   }
 
   /* Ultimate calculations */
@@ -373,10 +373,10 @@ int AnamHermite::fitFromArray(const VectorDouble& tab, const VectorDouble& wt)
 
 double AnamHermite::getPsiHn(int ih) const
 {
-  if (! _isIndexValid(ih)) return TEST;
+  if (!_isIndexValid(ih)) return TEST;
   double value = _psiHn[ih];
   if (isChangeSupportDefined())
-    value *= pow(_rCoef, (double) ih);
+    value *= pow(_rCoef, (double)ih);
   return value;
 }
 
@@ -385,7 +385,7 @@ VectorDouble AnamHermite::getPsiHns() const
   if (isChangeSupportDefined())
   {
     VectorDouble psi = _psiHn;
-    double rval = 1.;
+    double rval      = 1.;
     for (int ih = 1; ih < getNbPoly(); ih++)
     {
       rval *= _rCoef;
@@ -398,7 +398,7 @@ VectorDouble AnamHermite::getPsiHns() const
 
 void AnamHermite::setPsiHn(int i, double psi_hn)
 {
-  if (! _isIndexValid(i)) return;
+  if (!_isIndexValid(i)) return;
   _psiHn[i] = psi_hn;
 }
 
@@ -416,8 +416,8 @@ void AnamHermite::_defineBounds(double pymin,
                                 double aymax,
                                 double azmax)
 {
-  int nlag,ind,ind0;
-  VectorDouble ym,zm;
+  int nlag, ind, ind0;
+  VectorDouble ym, zm;
 
   // Switch off the flagBound during the calculation of bounds
 
@@ -439,47 +439,47 @@ void AnamHermite::_defineBounds(double pymin,
 
   /* Evaluate the experimental anamorphosis */
 
-  ind0 = (nlag - 1) / 2;
+  ind0     = (nlag - 1) / 2;
   ym[ind0] = 0.;
   zm[ind0] = transformToRawValue(ym[ind0]);
-  for (ind=ind0-1; ind>=0; ind--)
+  for (ind = ind0 - 1; ind >= 0; ind--)
   {
-    ym[ind] = ym[ind+1] - YPAS;
+    ym[ind] = ym[ind + 1] - YPAS;
     zm[ind] = transformToRawValue(ym[ind]);
   }
-  for (ind=ind0+1; ind<nlag; ind++)
+  for (ind = ind0 + 1; ind < nlag; ind++)
   {
-    ym[ind] = ym[ind-1] + YPAS;
+    ym[ind] = ym[ind - 1] + YPAS;
     zm[ind] = transformToRawValue(ym[ind]);
   }
 
   /* Look for a starting search point */
 
-  for (ind0=0; ind0<nlag; ind0++)
+  for (ind0 = 0; ind0 < nlag; ind0++)
     if (ym[ind0] > pymin) break;
   for (; ind0 < nlag; ind0++)
-    if (zm[ind0] > (pzmin+pzmax) / 2.) break;
+    if (zm[ind0] > (pzmin + pzmax) / 2.) break;
   if (ind0 == nlag) ind0 = (int)(nlag / 2.);
 
   /* Look for the first non-monotonous point, starting from the median */
 
-  for (ind=ind0; ind>0; ind--)
+  for (ind = ind0; ind > 0; ind--)
   {
     if (zm[ind] < azmin)
     {
-      _az.setVmin(zm[ind+1]);
+      _az.setVmin(zm[ind + 1]);
       _ay.setVmin(rawToTransformValue(_az.getVmin()));
       break;
     }
     if (ind == 0)
       break;
-    if (FFFF(_pz.getVmin()) && zm[ind-1] > zm[ind])
+    if (FFFF(_pz.getVmin()) && zm[ind - 1] > zm[ind])
     {
       _py.setVmin(ym[ind]);
       _pz.setVmin(zm[ind]);
     }
   }
-  for (ind=ind0; ind<nlag-1; ind++)
+  for (ind = ind0; ind < nlag - 1; ind++)
   {
     if (zm[ind] > azmax)
     {
@@ -487,9 +487,9 @@ void AnamHermite::_defineBounds(double pymin,
       _ay.setVmax(rawToTransformValue(_az.getVmax()));
       break;
     }
-    if (ind == nlag-1)
+    if (ind == nlag - 1)
       break;
-    if (FFFF(_pz.getVmax()) && zm[ind] > zm[ind+1])
+    if (FFFF(_pz.getVmax()) && zm[ind] > zm[ind + 1])
     {
       _py.setVmax(ym[ind]);
       _pz.setVmax(zm[ind]);
@@ -505,7 +505,7 @@ void AnamHermite::_defineBounds(double pymin,
   }
   if (FFFF(_pz.getVmin()))
   {
-    _py.setVmin(MAX(ANAM_YMIN,_ay.getVmin()));
+    _py.setVmin(MAX(ANAM_YMIN, _ay.getVmin()));
     _pz.setVmin(transformToRawValue(_py.getVmin()));
   }
   if (FFFF(_az.getVmax()))
@@ -515,7 +515,7 @@ void AnamHermite::_defineBounds(double pymin,
   }
   if (FFFF(_pz.getVmax()))
   {
-    _py.setVmax(MIN(ANAM_YMAX,_ay.getVmax()));
+    _py.setVmax(MIN(ANAM_YMAX, _ay.getVmax()));
     _pz.setVmax(transformToRawValue(_py.getVmax()));
   }
 
@@ -530,7 +530,7 @@ int AnamHermite::_data_sort(int nech,
                             VectorDouble& ys)
 {
   double sum, frc, eps, wgt;
-  int    i,ncl,nval;
+  int i, ncl, nval;
 
   /* Initializations */
 
@@ -539,12 +539,12 @@ int AnamHermite::_data_sort(int nech,
   /* Copy the variable in arrays zs and ys eliminating undefined values */
 
   sum = 0.;
-  for( i=nval=0 ; i<nech ; i++)
+  for (i = nval = 0; i < nech; i++)
   {
     if (FFFF(z[i])) continue;
     zs[nval] = z[i];
-    wgt = 1.;
-    if (! wt.empty())
+    wgt      = 1.;
+    if (!wt.empty())
     {
       if (FFFF(wt[i])) continue;
       if (wt[i] <= 0.) continue;
@@ -554,7 +554,7 @@ int AnamHermite::_data_sort(int nech,
     sum += wgt;
     nval++;
   }
-  if (nval <= 0) return(ncl);
+  if (nval <= 0) return (ncl);
 
   /* Sorting the data */
 
@@ -562,10 +562,10 @@ int AnamHermite::_data_sort(int nech,
   {
     VectorDouble tmp(nval);
     VectorInt ind(nval);
-    for (i = 0; i < nval; i++)  ind[i] = i;
+    for (i = 0; i < nval; i++) ind[i] = i;
     VH::arrangeInPlace(0, ind, zs, true, nval);
     for (i = 0; i < nval; i++) tmp[i] = ys[ind[i]];
-    for (i = 0; i < nval; i++) ys[i]  = tmp[i];
+    for (i = 0; i < nval; i++) ys[i] = tmp[i];
   }
   else
   {
@@ -574,46 +574,46 @@ int AnamHermite::_data_sort(int nech,
 
   /* Loop on the data */
 
-  eps = EPSILON5 * (zs[nval-1] - zs[0]);
-  for( i=0 ; i<nval-1 ; i++)
+  eps = EPSILON5 * (zs[nval - 1] - zs[0]);
+  for (i = 0; i < nval - 1; i++)
   {
     frc += ys[i];
-    if( zs[i] < zs[i+1] )
+    if (zs[i] < zs[i + 1])
     {
       zs[ncl] = zs[i];
-      ys[ncl] = law_invcdf_gaussian(frc/sum);
+      ys[ncl] = law_invcdf_gaussian(frc / sum);
       ncl++;
     }
   }
 
   /* Adding the upper bound */
 
-  zs[ncl] = zs[nval-1];
-  ys[ncl] = ys[ncl-1] + .5;
+  zs[ncl] = zs[nval - 1];
+  ys[ncl] = ys[ncl - 1] + .5;
   ncl++;
-  zs[ncl] = zs[ncl-1] + eps;
+  zs[ncl] = zs[ncl - 1] + eps;
   ys[ncl] = ANAM_YMAX + 1.;
   ncl++;
 
   /* Adding the lower bound */
 
-  for( i=ncl ; i>0 ; i-- )
+  for (i = ncl; i > 0; i--)
   {
-    ys[i] = ys[i-1];
-    zs[i] = zs[i-1];
+    ys[i] = ys[i - 1];
+    zs[i] = zs[i - 1];
   }
   ncl++;
   zs[0] = zs[1] - eps;
   ys[0] = ys[1] - .5;
 
-  return(ncl);
+  return (ncl);
 }
 
 bool AnamHermite::_serializeAscii(std::ostream& os, bool verbose) const
 {
   bool ret = true;
-  ret && ret && AnamContinuous::_serializeAscii(os, verbose);
-  ret = ret && _recordWrite<double>(os,"Change of support coefficient", getRCoef());
+  ret&& ret&& AnamContinuous::_serializeAscii(os, verbose);
+  ret = ret && _recordWrite<double>(os, "Change of support coefficient", getRCoef());
   ret = ret && _recordWrite<int>(os, "Number of Hermite Polynomials", getNbPoly());
   ret = ret && _tableWrite(os, "Hermite Polynomial", getNbPoly(), getPsiHns());
   return ret;
@@ -622,7 +622,7 @@ bool AnamHermite::_serializeAscii(std::ostream& os, bool verbose) const
 bool AnamHermite::_deserializeAscii(std::istream& is, bool verbose)
 {
   VectorDouble hermite;
-  double r = TEST;
+  double r   = TEST;
   int nbpoly = 0;
 
   bool ret = true;
@@ -648,7 +648,7 @@ VectorDouble AnamHermite::z2factor(double z, const VectorInt& ifacs) const
 
 int AnamHermite::updatePointToBlock(double r_coef)
 {
-  if (! allowChangeSupport()) return 1;
+  if (!allowChangeSupport()) return 1;
   setRCoef(r_coef);
 
   /* Update mean and variance */
@@ -673,14 +673,14 @@ void AnamHermite::_globalSelectivity(Selectivity* selectivity)
 
   for (int icut = 0; icut < ncut; icut++)
   {
-    double zval = selectivity->getZcut(icut);
-    double yval = rawToTransformValue(zval);
-    double tval = 1. - law_cdf_gaussian(yval);
-    double gval = law_df_gaussian(yval);
+    double zval     = selectivity->getZcut(icut);
+    double yval     = rawToTransformValue(zval);
+    double tval     = 1. - law_cdf_gaussian(yval);
+    double gval     = law_df_gaussian(yval);
     VectorDouble hn = hermitePolynomials(yval, 1., nbpoly);
-    double qval = getPsiHn(0) * (1. - law_cdf_gaussian(yval));
+    double qval     = getPsiHn(0) * (1. - law_cdf_gaussian(yval));
     for (int ih = 1; ih < nbpoly; ih++)
-      qval -= getPsiHn(ih) * hn[ih - 1] * gval / sqrt((double) ih);
+      qval -= getPsiHn(ih) * hn[ih - 1] * gval / sqrt((double)ih);
     selectivity->setTest(icut, zval);
     selectivity->setTest(icut, tval);
     selectivity->setQest(icut, qval);
@@ -702,19 +702,19 @@ void AnamHermite::_globalSelectivity(Selectivity* selectivity)
  ** \param[in]  iptr0        Rank for storing the results
  **
  *****************************************************************************/
-int AnamHermite::factor2Selectivity(Db *db,
+int AnamHermite::factor2Selectivity(Db* db,
                                     Selectivity* selectivity,
                                     const VectorInt& cols_est,
                                     const VectorInt& cols_std,
                                     int iptr0)
 {
   setFlagBound(1);
-  int nbpoly = getNbPoly();
+  int nbpoly  = getNbPoly();
   bool need_T = selectivity->isNeededT();
   bool need_Q = selectivity->isNeededQ();
-  int ncut = selectivity->getNCuts();
-  int nb_est = (int) cols_est.size();
-  int nb_std = (int) cols_std.size();
+  int ncut    = selectivity->getNCuts();
+  int nb_est  = (int)cols_est.size();
+  int nb_std  = (int)cols_std.size();
 
   /* Preliminary checks */
 
@@ -730,7 +730,7 @@ int AnamHermite::factor2Selectivity(Db *db,
   if (nfactor >= getNbPoly())
   {
     messerr("Number of Factors (%d) must be smaller than Number of Hermite polynomials (%d)",
-        nfactor, getNbPoly());
+            nfactor, getNbPoly());
     return 1;
   }
 
@@ -768,14 +768,14 @@ int AnamHermite::factor2Selectivity(Db *db,
     if (selectivity->isUsedStD(ESelectivity::Z))
     {
       double total = 0.;
-      for (int ivar = 0; ivar < nbpoly-1; ivar++)
+      for (int ivar = 0; ivar < nbpoly - 1; ivar++)
       {
-    	double value = 1.0;
-    	  if (ivar < nb_std)
-    	  {
-    	   value = db->getArray(iech, cols_std[ivar]);
-    	  }
-		total += coeffs[ivar + 1] * coeffs[ivar + 1] * value * value;
+        double value = 1.0;
+        if (ivar < nb_std)
+        {
+          value = db->getArray(iech, cols_std[ivar]);
+        }
+        total += coeffs[ivar + 1] * coeffs[ivar + 1] * value * value;
       }
       zstdev = sqrt(total);
     }
@@ -812,7 +812,7 @@ int AnamHermite::factor2Selectivity(Db *db,
             double value = 1.0;
             if (ivar < nb_std)
             {
-           	value = db->getArray(iech, cols_std[ivar]);
+              value = db->getArray(iech, cols_std[ivar]);
             }
             total += s_cc[ivar + 1] * s_cc[ivar + 1] * value * value;
           }
@@ -846,9 +846,9 @@ int AnamHermite::factor2Selectivity(Db *db,
           {
             double value = 1.0;
             if (ivar < nb_std)
-			{
-			value = db->getArray(iech, cols_std[ivar]);
-			}
+            {
+              value = db->getArray(iech, cols_std[ivar]);
+            }
             total += s_cc[ivar + 1] * s_cc[ivar + 1] * value * value;
           }
           selectivity->setQstd(icut, sqrt(total));
@@ -865,9 +865,9 @@ int AnamHermite::factor2Selectivity(Db *db,
 }
 
 double AnamHermite::evalSupportCoefficient(int option,
-                                           Model *model,
-                                           const VectorDouble &dxs,
-                                           const VectorInt &ndisc,
+                                           Model* model,
+                                           const VectorDouble& dxs,
+                                           const VectorInt& ndisc,
                                            const VectorDouble& angles,
                                            bool verbose)
 {
@@ -890,13 +890,13 @@ double AnamHermite::evalSupportCoefficient(int option,
     // DGM1 Method
     model->setActiveFactor(0); // Y Variable
     double cvv = model->evalCvv(dxs, ndisc, angles);
-    double r2 = sqrt(cvv);
+    double r2  = sqrt(cvv);
     if (verbose)
-      message("Change of Support coefficient (DGM-2) = %6.3lf\n",r2);
+      message("Change of Support coefficient (DGM-2) = %6.3lf\n", r2);
     return r2;
   }
 
-  messerr("The argument 'option'(%d) should be 1 or 2",option);
+  messerr("The argument 'option'(%d) should be 1 or 2", option);
   return TEST;
 }
 #ifdef HDF5
@@ -909,8 +909,8 @@ bool AnamHermite::_deserializeH5(H5::Group& grp, [[maybe_unused]] bool verbose)
   }
 
   /* Read the grid characteristics */
-  bool ret = true;
-  double r = 0.;
+  bool ret   = true;
+  double r   = 0.;
   int nbpoly = 0;
   VectorDouble hermite;
 
@@ -935,12 +935,12 @@ bool AnamHermite::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) co
 
   bool ret = true;
 
-  ret      = ret && AnamContinuous::_serializeH5(anamG, verbose);
-  ret      = ret && SerializeHDF5::writeValue(anamG, "Support", getRCoef());
-  ret      = ret && SerializeHDF5::writeValue(anamG, "NbPoly", getNbPoly());
-  ret      = ret && SerializeHDF5::writeVec(anamG, "Hermite", getPsiHns());
+  ret = ret && AnamContinuous::_serializeH5(anamG, verbose);
+  ret = ret && SerializeHDF5::writeValue(anamG, "Support", getRCoef());
+  ret = ret && SerializeHDF5::writeValue(anamG, "NbPoly", getNbPoly());
+  ret = ret && SerializeHDF5::writeVec(anamG, "Hermite", getPsiHns());
 
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/CalcAnamTransform.cpp
+++ b/src/Anamorphosis/CalcAnamTransform.cpp
@@ -12,43 +12,43 @@
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
 
-#include "Db/Db.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/Law.hpp"
 #include "Anamorphosis/AAnam.hpp"
-#include "Anamorphosis/CalcAnamTransform.hpp"
 #include "Anamorphosis/AnamContinuous.hpp"
-#include "Anamorphosis/AnamHermite.hpp"
-#include "Anamorphosis/AnamDiscreteIR.hpp"
 #include "Anamorphosis/AnamDiscreteDD.hpp"
+#include "Anamorphosis/AnamDiscreteIR.hpp"
+#include "Anamorphosis/AnamHermite.hpp"
+#include "Anamorphosis/CalcAnamTransform.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
 #include "Polynomials/Hermite.hpp"
 #include "Polynomials/MonteCarlo.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
-{ 
+{
 
 CalcAnamTransform::CalcAnamTransform(AAnam* anam)
-    : ACalcDbVarCreator(),
-      _iattVar(-1),
-      _iattFac(-1),
-      _iattSel(-1),
-      _flagVars(false),
-      _flagToFactors(false),
-      _flagDisjKrig(false),
-      _flagCondExp(false),
-      _flagUniCond(false),
-      _flagZToY(true),
-      _flagNormalScore(false),
-      _ifacs(),
-      _iptrEst(),
-      _iptrStd(),
-      _nbsimu(0),
-      _flagOK(false),
-      _proba(TEST),
-      _anam(anam),
-      _selectivity(nullptr)
+  : ACalcDbVarCreator()
+  , _iattVar(-1)
+  , _iattFac(-1)
+  , _iattSel(-1)
+  , _flagVars(false)
+  , _flagToFactors(false)
+  , _flagDisjKrig(false)
+  , _flagCondExp(false)
+  , _flagUniCond(false)
+  , _flagZToY(true)
+  , _flagNormalScore(false)
+  , _ifacs()
+  , _iptrEst()
+  , _iptrStd()
+  , _nbsimu(0)
+  , _flagOK(false)
+  , _proba(TEST)
+  , _anam(anam)
+  , _selectivity(nullptr)
 {
 }
 
@@ -82,7 +82,7 @@ bool CalcAnamTransform::_hasInputVarDefined(int mode) const
   }
 
   // Check that the UID are valid
-  for (int i = 0; i < (int) _iptrEst.size(); i++)
+  for (int i = 0; i < (int)_iptrEst.size(); i++)
     if (_iptrEst[i] < 0)
     {
       messerr("An estimation variable is not correctly defined");
@@ -100,7 +100,7 @@ bool CalcAnamTransform::_hasInputVarDefined(int mode) const
   }
 
   // Check that the UID are valid
-  for (int i = 0; i < (int) _iptrStd.size(); i++)
+  for (int i = 0; i < (int)_iptrStd.size(); i++)
     if (_iptrStd[i] < 0)
     {
       if (mode == 0)
@@ -116,7 +116,7 @@ bool CalcAnamTransform::_hasInputVarDefined(int mode) const
 bool CalcAnamTransform::_hasSelectivity() const
 {
   int ncuts = _selectivity->getNCuts();
-  if (ncuts <= 0 && ! _selectivity->isOnlyZDefined())
+  if (ncuts <= 0 && !_selectivity->isOnlyZDefined())
   {
     messerr("You must define some cutoff values");
     return false;
@@ -133,7 +133,7 @@ bool CalcAnamTransform::_hasSelectivity() const
 bool CalcAnamTransform::_hasVariableNumber(bool equal1) const
 {
   int number = getDb()->getNLoc(ELoc::Z);
-  if (! equal1)
+  if (!equal1)
   {
     if (number <= 0)
     {
@@ -157,8 +157,8 @@ bool CalcAnamTransform::_check()
   if (!ACalcDbVarCreator::_check()) return false;
 
   if (!hasDb()) return false;
-  if (! _hasAnam()) return false;
-  if (! _hasVariableNumber()) return false;
+  if (!_hasAnam()) return false;
+  if (!_hasVariableNumber()) return false;
 
   if (_flagVars)
   {
@@ -173,8 +173,8 @@ bool CalcAnamTransform::_check()
 
   if (_flagToFactors)
   {
-    if (! _hasVariableNumber(true)) return false;
-    int nmax = _anam->getNFactor();
+    if (!_hasVariableNumber(true)) return false;
+    int nmax  = _anam->getNFactor();
     int nfact = _getNfact();
     for (int ifac = 0; ifac < nfact; ifac++)
       if (_ifacs[ifac] < 1 || _ifacs[ifac] > nmax)
@@ -188,25 +188,25 @@ bool CalcAnamTransform::_check()
 
   if (_flagDisjKrig)
   {
-    if (! _hasAnam(EAnam::HERMITIAN)) return false;
-    if (! _hasInputVarDefined()) return false;
-    if (! _hasSelectivity()) return false;
+    if (!_hasAnam(EAnam::HERMITIAN)) return false;
+    if (!_hasInputVarDefined()) return false;
+    if (!_hasSelectivity()) return false;
     return true;
   }
 
   if (_flagCondExp)
   {
-    if (! _hasAnam(EAnam::HERMITIAN)) return false;
-    if (! _hasInputVarDefined()) return false;
-    if (! _hasSelectivity()) return false;
+    if (!_hasAnam(EAnam::HERMITIAN)) return false;
+    if (!_hasInputVarDefined()) return false;
+    if (!_hasSelectivity()) return false;
     return true;
   }
 
   if (_flagUniCond)
   {
-    if (! _hasAnam(EAnam::HERMITIAN)) return false;
-    if (! _hasInputVarDefined(1)) return false;
-    if (! _hasSelectivity()) return false;
+    if (!_hasAnam(EAnam::HERMITIAN)) return false;
+    if (!_hasInputVarDefined(1)) return false;
+    if (!_hasSelectivity()) return false;
     if (_selectivity->isUsed(ESelectivity::Z))
     {
       messerr("The recovery option 'Z' is not available in this function");
@@ -222,7 +222,7 @@ bool CalcAnamTransform::_check()
 bool CalcAnamTransform::_preprocess()
 {
   if (!ACalcDbVarCreator::_preprocess()) return false;
-  
+
   if (_flagVars)
   {
     int nvar = _getNVar();
@@ -233,14 +233,14 @@ bool CalcAnamTransform::_preprocess()
   if (_flagToFactors)
   {
     int nfact = _getNfact();
-    _iattFac = getDb()->addColumnsByConstant(nfact);
+    _iattFac  = getDb()->addColumnsByConstant(nfact);
     return (_iattFac >= 0);
   }
 
   if (_flagDisjKrig)
   {
     int nvarout = _getNSel();
-    _iattSel = getDb()->addColumnsByConstant(nvarout, TEST);
+    _iattSel    = getDb()->addColumnsByConstant(nvarout, TEST);
     if (_iattSel < 0) return 1;
     return true;
   }
@@ -248,7 +248,7 @@ bool CalcAnamTransform::_preprocess()
   if (_flagCondExp)
   {
     int nvarout = _getNSel();
-    _iattSel = getDb()->addColumnsByConstant(nvarout, TEST);
+    _iattSel    = getDb()->addColumnsByConstant(nvarout, TEST);
     if (_iattSel < 0) return 1;
     return true;
   }
@@ -256,7 +256,7 @@ bool CalcAnamTransform::_preprocess()
   if (_flagUniCond)
   {
     int nvarout = _getNSel();
-    _iattSel = getDb()->addColumnsByConstant(nvarout, TEST);
+    _iattSel    = getDb()->addColumnsByConstant(nvarout, TEST);
     if (_iattSel < 0) return 1;
     return true;
   }
@@ -287,7 +287,7 @@ bool CalcAnamTransform::_postprocess()
   {
     int nsel = _getNSel();
     for (int i = 0; i < nsel; i++)
-      _renameVariable(1, _iattSel+i, ELoc::UNKNOWN, _selectivity->getVariableName(i), 1);
+      _renameVariable(1, _iattSel + i, ELoc::UNKNOWN, _selectivity->getVariableName(i), 1);
     return true;
   }
 
@@ -295,7 +295,7 @@ bool CalcAnamTransform::_postprocess()
   {
     int nsel = _getNSel();
     for (int i = 0; i < nsel; i++)
-      _renameVariable(1, _iattSel+i, ELoc::Z, _selectivity->getVariableName(i), 1);
+      _renameVariable(1, _iattSel + i, ELoc::Z, _selectivity->getVariableName(i), 1);
     return true;
   }
 
@@ -303,7 +303,7 @@ bool CalcAnamTransform::_postprocess()
   {
     int nsel = _getNSel();
     for (int i = 0; i < nsel; i++)
-      _renameVariable(1, _iattSel+i, ELoc::Z, _selectivity->getVariableName(i), 1);
+      _renameVariable(1, _iattSel + i, ELoc::Z, _selectivity->getVariableName(i), 1);
     return true;
   }
 
@@ -357,8 +357,8 @@ bool CalcAnamTransform::_run()
   if (_flagCondExp)
   {
     return (!_conditionalExpectation(getDb(), _anam, _selectivity, _iattSel,
-                                 _iptrEst[0], _iptrStd[0], _flagOK, _proba,
-                                 _nbsimu));
+                                     _iptrEst[0], _iptrStd[0], _flagOK, _proba,
+                                     _nbsimu));
   }
 
   if (_flagUniCond)
@@ -389,8 +389,8 @@ bool CalcAnamTransform::_ZToYByNormalScore()
   for (int ivar = 0; ivar < nvar; ivar++)
   {
     VectorDouble data = getDb()->getColumnByLocator(ELoc::Z, ivar);
-    VectorDouble vec = VH::normalScore(data, wt);
-    if (! vec.empty())
+    VectorDouble vec  = VH::normalScore(data, wt);
+    if (!vec.empty())
       getDb()->setColumnByUID(vec, _iattVar + ivar);
   }
   return true;
@@ -398,7 +398,7 @@ bool CalcAnamTransform::_ZToYByNormalScore()
 
 bool CalcAnamTransform::_ZToYByHermite()
 {
-  int nvar = _getNVar();
+  int nvar                    = _getNVar();
   const AnamContinuous* anamC = dynamic_cast<const AnamContinuous*>(getAnam());
 
   for (int ivar = 0; ivar < nvar; ivar++)
@@ -413,7 +413,7 @@ bool CalcAnamTransform::_ZToYByHermite()
 
 bool CalcAnamTransform::_YToZByHermite()
 {
-  int nvar = _getNVar();
+  int nvar                    = _getNVar();
   const AnamContinuous* anamC = dynamic_cast<const AnamContinuous*>(getAnam());
 
   for (int ivar = 0; ivar < nvar; ivar++)
@@ -432,7 +432,7 @@ bool CalcAnamTransform::_ZToFactors()
 
   for (int iech = 0; iech < getDb()->getNSample(); iech++)
   {
-    if (! getDb()->isActive(iech)) continue;
+    if (!getDb()->isActive(iech)) continue;
     double zval = getDb()->getZVariable(iech, 0);
     if (FFFF(zval)) continue;
     VectorDouble factors = _anam->z2factor(zval, _ifacs);
@@ -445,9 +445,9 @@ bool CalcAnamTransform::_ZToFactors()
 
 bool CalcAnamTransform::_FactorsToSelectivity()
 {
-  AnamHermite    *anam_hermite     = dynamic_cast<AnamHermite*>(_anam);
-  AnamDiscreteDD *anam_discrete_DD = dynamic_cast<AnamDiscreteDD*>(_anam);
-  AnamDiscreteIR *anam_discrete_IR = dynamic_cast<AnamDiscreteIR*>(_anam);
+  AnamHermite* anam_hermite        = dynamic_cast<AnamHermite*>(_anam);
+  AnamDiscreteDD* anam_discrete_DD = dynamic_cast<AnamDiscreteDD*>(_anam);
+  AnamDiscreteIR* anam_discrete_IR = dynamic_cast<AnamDiscreteIR*>(_anam);
 
   /* Dispatch according to the type of Anamorphosis */
 
@@ -474,7 +474,6 @@ bool CalcAnamTransform::_FactorsToSelectivity()
   }
 }
 
-
 /*****************************************************************************/
 /*!
  **  Calculate the recoveries (z,T,Q,m,B) starting from the factors
@@ -489,12 +488,12 @@ bool CalcAnamTransform::_FactorsToSelectivity()
  ** \param[in]  namconv      Naming convention
  **
  *****************************************************************************/
-int DisjunctiveKriging(Db *db,
-                        AAnam *anam,
-                        Selectivity *selectivity,
-                        const VectorString &name_est,
-                        const VectorString &name_std,
-                        const NamingConvention &namconv)
+int DisjunctiveKriging(Db* db,
+                       AAnam* anam,
+                       Selectivity* selectivity,
+                       const VectorString& name_est,
+                       const VectorString& name_std,
+                       const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(anam);
   transfo.setDb(db);
@@ -526,15 +525,15 @@ int DisjunctiveKriging(Db *db,
  ** \param[in]  namconv      Naming convention
  **
  *****************************************************************************/
-int ConditionalExpectation(Db *db,
-                           AAnam *anam,
-                           Selectivity *selectivity,
-                           const String &name_est,
-                           const String &name_std,
+int ConditionalExpectation(Db* db,
+                           AAnam* anam,
+                           Selectivity* selectivity,
+                           const String& name_est,
+                           const String& name_std,
                            bool flag_OK,
                            double proba,
                            int nbsimu,
-                           const NamingConvention &namconv)
+                           const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(anam);
   transfo.setDb(db);
@@ -569,12 +568,12 @@ int ConditionalExpectation(Db *db,
  ** \remark temporarily stored in a member names iptrStd.
  **
  *****************************************************************************/
-int UniformConditioning(Db *db,
-                        AAnam *anam,
-                        Selectivity *selectivity,
-                        const String &name_est,
-                        const String &name_varz,
-                        const NamingConvention &namconv)
+int UniformConditioning(Db* db,
+                        AAnam* anam,
+                        Selectivity* selectivity,
+                        const String& name_est,
+                        const String& name_varz,
+                        const NamingConvention& namconv)
 {
   CalcAnamTransform transfo(anam);
   transfo.setDb(db);
@@ -628,7 +627,7 @@ int CalcAnamTransform::_conditionalExpectation(Db* db,
   if (selectivity->isUsed(ESelectivity::Z))
   {
     if (_ceZ(db, anam_hermite, selectivity, iptr0, col_est, col_std, nbsimu,
-                flag_OK))
+             flag_OK))
       return 1;
   }
 
@@ -637,7 +636,7 @@ int CalcAnamTransform::_conditionalExpectation(Db* db,
   if (selectivity->isUsed(ESelectivity::T))
   {
     if (_ceT(1, db, selectivity, iptr0, col_est, col_std, ycuts, nbsimu,
-                flag_OK))
+             flag_OK))
       return 1;
   }
 
@@ -646,7 +645,7 @@ int CalcAnamTransform::_conditionalExpectation(Db* db,
   if (selectivity->isUsed(ESelectivity::Q))
   {
     if (_ceQ(db, anam_hermite, selectivity, iptr0, col_est, col_std, ycuts,
-                nbsimu, flag_OK))
+             nbsimu, flag_OK))
       return 1;
   }
 
@@ -669,7 +668,7 @@ int CalcAnamTransform::_conditionalExpectation(Db* db,
   if (selectivity->isUsed(ESelectivity::PROP) && need_T)
   {
     if (_ceT(2, db, selectivity, iptr0, col_est, col_std, ycuts, nbsimu,
-                flag_OK))
+             flag_OK))
       return 1;
   }
 
@@ -678,7 +677,7 @@ int CalcAnamTransform::_conditionalExpectation(Db* db,
   if (selectivity->isUsed(ESelectivity::QUANT))
   {
     if (_ceQuant(db, anam_hermite, selectivity, iptr0, col_est, col_std,
-                    proba, flag_OK))
+                 proba, flag_OK))
       return 1;
   }
 
@@ -873,11 +872,11 @@ void CalcAnamTransform::_correctForOK(Db* db,
  **
  *****************************************************************************/
 void CalcAnamTransform::_getVectorsForCE(Db* db,
-                                          int col_est,
-                                          int col_std,
-                                          bool flag_OK,
-                                          VectorDouble& krigest,
-                                          VectorDouble& krigstd)
+                                         int col_est,
+                                         int col_std,
+                                         bool flag_OK,
+                                         VectorDouble& krigest,
+                                         VectorDouble& krigstd)
 {
   int nech = db->getNSample();
   krigest.resize(nech);
@@ -1295,4 +1294,4 @@ int anamPointToBlock(AAnam* anam, int verbose, double cvv, double coeff, double 
 
   return 0;
 }
-}
+} // namespace gstlrn

--- a/src/Anamorphosis/PPMT.cpp
+++ b/src/Anamorphosis/PPMT.cpp
@@ -10,19 +10,19 @@
 /******************************************************************************/
 #include "geoslib_define.h"
 
-#include "Anamorphosis/PPMT.hpp"
 #include "Anamorphosis/AnamHermite.hpp"
+#include "Anamorphosis/PPMT.hpp"
+#include "Basic/MathFunc.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "Geometry/GeometryHelper.hpp"
 #include "Matrix/AMatrix.hpp"
 #include "Matrix/MatrixDense.hpp"
-#include "Db/Db.hpp"
 #include "Stats/Classical.hpp"
-#include "Geometry/GeometryHelper.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/MathFunc.hpp"
 
-#include <math.h>
+#include <cmath>
 
-namespace gstlrn 
+namespace gstlrn
 {
 
 PPMT::PPMT(int ndir,
@@ -31,66 +31,66 @@ PPMT::PPMT(int ndir,
            const EGaussInv& methodTrans,
            int nbpoly,
            double alpha)
-    : AStringable(),
-      _niter(0),
-      _ndir(ndir),
-      _nbpoly(nbpoly),
-      _alpha(alpha),
-      _methodDir(methodDir),
-      _methodTrans(methodTrans),
-      _flagPreprocessing(flagPreprocessing),
-      _isFitted(false),
-      _ndim(0),
-      _serieAngle(),
-      _serieScore(),
-      _dirmat(nullptr),
-      _anams(),
-      _initAnams(),
-      _initSphering(nullptr)
+  : AStringable()
+  , _niter(0)
+  , _ndir(ndir)
+  , _nbpoly(nbpoly)
+  , _alpha(alpha)
+  , _methodDir(methodDir)
+  , _methodTrans(methodTrans)
+  , _flagPreprocessing(flagPreprocessing)
+  , _isFitted(false)
+  , _ndim(0)
+  , _serieAngle()
+  , _serieScore()
+  , _dirmat(nullptr)
+  , _anams()
+  , _initAnams()
+  , _initSphering(nullptr)
 {
 }
 
-PPMT::PPMT(const PPMT &m)
-    : AStringable(m),
-      _niter(m._niter),
-      _ndir(m._ndir),
-      _nbpoly(m._nbpoly),
-      _alpha(m._alpha),
-      _methodDir(m._methodDir),
-      _methodTrans(m._methodTrans),
-      _flagPreprocessing(m._flagPreprocessing),
-      _isFitted(m._isFitted),
-      _ndim(m._ndim),
-      _serieAngle(m._serieAngle),
-      _serieScore(m._serieScore),
-      _dirmat(m._dirmat),
-      _anams(m._anams),
-      _initAnams(m._initAnams),
-      _initSphering(m._initSphering)
+PPMT::PPMT(const PPMT& m)
+  : AStringable(m)
+  , _niter(m._niter)
+  , _ndir(m._ndir)
+  , _nbpoly(m._nbpoly)
+  , _alpha(m._alpha)
+  , _methodDir(m._methodDir)
+  , _methodTrans(m._methodTrans)
+  , _flagPreprocessing(m._flagPreprocessing)
+  , _isFitted(m._isFitted)
+  , _ndim(m._ndim)
+  , _serieAngle(m._serieAngle)
+  , _serieScore(m._serieScore)
+  , _dirmat(m._dirmat)
+  , _anams(m._anams)
+  , _initAnams(m._initAnams)
+  , _initSphering(m._initSphering)
 {
 }
 
-PPMT& PPMT::operator=(const PPMT &m)
+PPMT& PPMT::operator=(const PPMT& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
-    _niter = m._niter;
-    _ndir = m._ndir;
-    _nbpoly = m._nbpoly;
-    _ndim = m._ndim;
-    _alpha = m._alpha;
-    _methodDir = m._methodDir;
-    _methodTrans = m._methodTrans;
+    _niter             = m._niter;
+    _ndir              = m._ndir;
+    _nbpoly            = m._nbpoly;
+    _ndim              = m._ndim;
+    _alpha             = m._alpha;
+    _methodDir         = m._methodDir;
+    _methodTrans       = m._methodTrans;
     _flagPreprocessing = m._flagPreprocessing;
-    _isFitted = m._isFitted;
-    _ndim = m._ndim;
-    _serieAngle = m._serieAngle;
-    _serieScore = m._serieScore;
-    _dirmat = m._dirmat;
-    _anams = m._anams;
-    _initAnams = m._initAnams;
-    _initSphering = m._initSphering;
+    _isFitted          = m._isFitted;
+    _ndim              = m._ndim;
+    _serieAngle        = m._serieAngle;
+    _serieScore        = m._serieScore;
+    _dirmat            = m._dirmat;
+    _anams             = m._anams;
+    _initAnams         = m._initAnams;
+    _initSphering      = m._initSphering;
   }
   return *this;
 }
@@ -98,14 +98,14 @@ PPMT& PPMT::operator=(const PPMT &m)
 PPMT::~PPMT()
 {
   delete _dirmat;
-  if (! _anams.empty())
+  if (!_anams.empty())
   {
-    for (int i = 0; i < (int) _anams.size(); i++)
+    for (int i = 0; i < (int)_anams.size(); i++)
       delete _anams[i];
   }
-  if (! _initAnams.empty())
+  if (!_initAnams.empty())
   {
-    for (int i = 0; i < (int) _initAnams.size(); i++)
+    for (int i = 0; i < (int)_initAnams.size(); i++)
       delete _initAnams[i];
   }
   delete _initSphering;
@@ -161,8 +161,8 @@ String PPMT::toString(const AStringFormat* strfmt) const
 
 double PPMT::_gaussianizeForward(double Yi,
                                  int rank,
-                                 const AnamHermite *anam,
-                                 const VectorDouble &N0)
+                                 const AnamHermite* anam,
+                                 const VectorDouble& N0)
 {
   double theo = 0.;
   if (anam != nullptr)
@@ -178,7 +178,7 @@ double PPMT::_gaussianizeForward(double Yi,
  * @param anam Anamorphosis
  * @return The back-anamorphosed value
  */
-double PPMT::_gaussianizeBackward(double Yi, const AnamHermite *anam)
+double PPMT::_gaussianizeBackward(double Yi, const AnamHermite* anam)
 {
   double theo = anam->transformToRawValue(Yi);
   return (theo - Yi);
@@ -208,11 +208,11 @@ void PPMT::_initGaussianizeBackward(AMatrix* Y)
   }
 }
 
-double PPMT::_getGaussianDistance(const VectorDouble &Yi,
-                                  const VectorInt &Ri,
-                                  const VectorDouble &N0) const
+double PPMT::_getGaussianDistance(const VectorDouble& Yi,
+                                  const VectorInt& Ri,
+                                  const VectorDouble& N0) const
 {
-  int np = (int) Yi.size();
+  int np = (int)Yi.size();
 
   double di = 0.;
   for (int ip = 0; ip < np; ip++)
@@ -220,11 +220,11 @@ double PPMT::_getGaussianDistance(const VectorDouble &Yi,
     double value = _gaussianizeForward(Yi[ip], Ri[ip], nullptr, N0);
     di += pow(ABS(value), getAlpha());
   }
-  di /= (double) np;
+  di /= (double)np;
   return di;
 }
 
-void PPMT::_iterationFit(AMatrix *Y, const VectorDouble& N0)
+void PPMT::_iterationFit(AMatrix* Y, const VectorDouble& N0)
 {
   int np = Y->getNRows();
 
@@ -232,13 +232,13 @@ void PPMT::_iterationFit(AMatrix *Y, const VectorDouble& N0)
 
   VectorDouble Y0(np, TEST);
   VectorDouble Yi(np, TEST);
-  VectorInt    R0(np, ITEST);
-  int    idmax = -1;
+  VectorInt R0(np, ITEST);
+  int idmax    = -1;
   double ddmax = MINIMUM_BIG;
 
   // Loop on directions
 
-  AnamHermite* anam = nullptr;
+  AnamHermite* anam      = nullptr;
   const bool flagHermite = (getMethodTrans() == EGaussInv::HMT);
   if (flagHermite) anam = new AnamHermite(getNbpoly());
 
@@ -258,8 +258,8 @@ void PPMT::_iterationFit(AMatrix *Y, const VectorDouble& N0)
     {
       idmax = id;
       ddmax = di;
-      Y0 = Yi;
-      R0 = Ri;
+      Y0    = Yi;
+      R0    = Ri;
     }
   }
 
@@ -272,12 +272,12 @@ void PPMT::_iterationFit(AMatrix *Y, const VectorDouble& N0)
   if (flagHermite) _anams.push_back(anam);
 }
 
-void PPMT::_shiftForward(AMatrix *Y,
+void PPMT::_shiftForward(AMatrix* Y,
                          int id,
-                         const AnamHermite *anam,
-                         const VectorDouble &Y0,
-                         const VectorInt    &R0,
-                         const VectorDouble &N0) const
+                         const AnamHermite* anam,
+                         const VectorDouble& Y0,
+                         const VectorInt& R0,
+                         const VectorDouble& N0) const
 {
   int np   = Y->getNRows();
   int ndim = getNdim();
@@ -293,10 +293,10 @@ void PPMT::_shiftForward(AMatrix *Y,
   }
 }
 
-void PPMT::_shiftBackward(AMatrix *Y,
+void PPMT::_shiftBackward(AMatrix* Y,
                           int id,
-                          const AnamHermite *anam,
-                          const VectorDouble &Y0) const
+                          const AnamHermite* anam,
+                          const VectorDouble& Y0) const
 {
   int np   = Y->getNRows();
   int ndim = getNdim();
@@ -332,7 +332,7 @@ void PPMT::_projectOnDirection(const AMatrix* Y, int id, VectorDouble& Y0)
   }
 }
 
-void PPMT::_iterationForward(AMatrix *Y, const VectorDouble& N0, int iter)
+void PPMT::_iterationForward(AMatrix* Y, const VectorDouble& N0, int iter)
 {
   int np    = Y->getNRows();
   int idmax = _serieAngle[iter];
@@ -348,7 +348,7 @@ void PPMT::_iterationForward(AMatrix *Y, const VectorDouble& N0, int iter)
   _shiftForward(Y, idmax, _anams[iter], Y0, R0, N0);
 }
 
-void PPMT::_iterationBackward(AMatrix *Y, const VectorDouble& N0, int iter)
+void PPMT::_iterationBackward(AMatrix* Y, const VectorDouble& N0, int iter)
 {
   DECLARE_UNUSED(N0);
   int np    = Y->getNRows();
@@ -374,7 +374,7 @@ void PPMT::_generateAllDirections()
   else
   {
     VectorDouble X = VH::simulateUniform(ndir * _ndim);
-    Umat = MatrixDense::createFromVD(X, ndir, _ndim);
+    Umat           = MatrixDense::createFromVD(X, ndir, _ndim);
   }
   _dirmat = GeometryHelper::getDirectionsInRn(Umat);
   delete Umat;
@@ -393,7 +393,7 @@ void PPMT::_fitInitHermite(AMatrix* Y)
   }
 }
 
-int PPMT::fitFromMatrix(AMatrix *Y, int niter, bool verbose)
+int PPMT::fitFromMatrix(AMatrix* Y, int niter, bool verbose)
 {
   if (Y == nullptr)
   {
@@ -411,9 +411,9 @@ int PPMT::fitFromMatrix(AMatrix *Y, int niter, bool verbose)
   // Creating the directions
   _generateAllDirections();
 
-  int np = Y->getNRows();
+  int np                = Y->getNRows();
   VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
-  VectorDouble N0 = VH::qnormVec(sequence);
+  VectorDouble N0       = VH::qnormVec(sequence);
 
   // Optional Pre-processing
   if (_flagPreprocessing)
@@ -440,7 +440,7 @@ int PPMT::fitFromMatrix(AMatrix *Y, int niter, bool verbose)
 
     if (verbose)
     {
-      message("Iteration %3d/%3d: Score = %lf\n",iter+1,niter, _serieScore[iter]);
+      message("Iteration %3d/%3d: Score = %lf\n", iter + 1, niter, _serieScore[iter]);
     }
   }
 
@@ -450,15 +450,15 @@ int PPMT::fitFromMatrix(AMatrix *Y, int niter, bool verbose)
   return 0;
 }
 
-int PPMT::fit(Db *db,
-              const VectorString &names,
+int PPMT::fit(Db* db,
+              const VectorString& names,
               bool flagStoreInDb,
               int niter,
               bool verbose,
-              const NamingConvention &namconv)
+              const NamingConvention& namconv)
 {
   VectorString exp_names = db->expandNameList(names);
-  MatrixDense Y = db->getColumnsAsMatrix(exp_names, true);
+  MatrixDense Y          = db->getColumnsAsMatrix(exp_names, true);
   if (Y.empty())
   {
     messerr("This Multivariate Transform requires several variables to be defined");
@@ -478,10 +478,10 @@ int PPMT::fit(Db *db,
   return 0;
 }
 
-int PPMT::rawToGaussian(Db *db,
-                        const VectorString &names,
+int PPMT::rawToGaussian(Db* db,
+                        const VectorString& names,
                         int niter,
-                        const NamingConvention &namconv)
+                        const NamingConvention& namconv)
 {
   // Extract the relevant information
 
@@ -491,13 +491,13 @@ int PPMT::rawToGaussian(Db *db,
     return 1;
   }
   VectorString exp_names = db->expandNameList(names);
-  MatrixDense Y = db->getColumnsAsMatrix(exp_names, true);
+  MatrixDense Y          = db->getColumnsAsMatrix(exp_names, true);
   if (Y.empty())
   {
     messerr("This Multivariate Transform requires several variables to be defined");
     return 1;
   }
-  if (! isFitted())
+  if (!isFitted())
   {
     messerr("You must Fit PPMT beforehand");
     return 1;
@@ -507,7 +507,7 @@ int PPMT::rawToGaussian(Db *db,
   niter = MIN(niter, getNiter());
 
   VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
-  VectorDouble N0 = VH::qnormVec(sequence);
+  VectorDouble N0       = VH::qnormVec(sequence);
 
   // Pre-processing
   if (_flagPreprocessing)
@@ -527,10 +527,10 @@ int PPMT::rawToGaussian(Db *db,
   return 0;
 }
 
-int PPMT::gaussianToRaw(Db *db,
-                        const VectorString &names,
+int PPMT::gaussianToRaw(Db* db,
+                        const VectorString& names,
                         int niter,
-                        const NamingConvention &namconv)
+                        const NamingConvention& namconv)
 {
   // Extract the relevant information
 
@@ -540,7 +540,7 @@ int PPMT::gaussianToRaw(Db *db,
     return 1;
   }
   VectorString exp_names = db->expandNameList(names);
-  MatrixDense Y = db->getColumnsAsMatrix(exp_names, true);
+  MatrixDense Y          = db->getColumnsAsMatrix(exp_names, true);
   if (Y.empty())
   {
     messerr("This Multivariate Back-Transform requires several variables to be defined");
@@ -551,7 +551,7 @@ int PPMT::gaussianToRaw(Db *db,
     messerr("The PPMT back-trasform is only available when methodTrans = 'hermite'");
     return 1;
   }
-  if (! isFitted())
+  if (!isFitted())
   {
     messerr("You must Fit PPMT beforehand");
     return 1;
@@ -561,10 +561,10 @@ int PPMT::gaussianToRaw(Db *db,
   niter = MIN(niter, getNiter());
 
   VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
-  VectorDouble N0 = VH::qnormVec(sequence);
+  VectorDouble N0       = VH::qnormVec(sequence);
 
   // Loop on the iterations (reverse order)
-  for (int iter = niter-1; iter >= 0; iter--)
+  for (int iter = niter - 1; iter >= 0; iter--)
     _iterationBackward(&Y, N0, iter);
 
   // Post-processing
@@ -594,4 +594,4 @@ VectorDouble PPMT::getSerieScore(bool flagLog) const
   }
   return vec;
 }
-}
+} // namespace gstlrn

--- a/src/Basic/AStringable.cpp
+++ b/src/Basic/AStringable.cpp
@@ -9,26 +9,25 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Basic/AStringable.hpp"
-#include "Basic/VectorNumT.hpp"
+#include "Basic/OptCst.hpp"
 #include "Basic/String.hpp"
 #include "Basic/Utilities.hpp"
-#include "Basic/OptCst.hpp"
+#include "Basic/VectorNumT.hpp"
 
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <typeinfo>
-#include <iomanip>
-#include <stdio.h>
-#include <stdarg.h>
-#include <math.h>
-#include <string.h>
 
 #define CASE_DOUBLE 0
 #define CASE_REAL   1
 #define CASE_INT    2
 #define CASE_COL    3
 #define CASE_ROW    4
-
 
 namespace gstlrn
 {
@@ -40,62 +39,62 @@ static char TABSTR[100];
 
 static int _getColumnRank()
 {
-  return (int) OptCst::query(ECst::NTRANK);
+  return (int)OptCst::query(ECst::NTRANK);
 }
 static int _getColumnName()
 {
-  return (int) OptCst::query(ECst::NTNAME);
+  return (int)OptCst::query(ECst::NTNAME);
 }
 static int _getColumnSize()
 {
-  return (int) OptCst::query(ECst::NTCAR);
+  return (int)OptCst::query(ECst::NTCAR);
 }
 static int _getDecimalNumber()
 {
-  return (int) OptCst::query(ECst::NTDEC);
+  return (int)OptCst::query(ECst::NTDEC);
 }
 static double _getThresh()
 {
-  int ndec = (int) OptCst::query(ECst::NTDEC);
-  double thresh = (0.5 * pow(10, - ndec));
+  int ndec      = (int)OptCst::query(ECst::NTDEC);
+  double thresh = (0.5 * pow(10, -ndec));
   return thresh;
 }
 static int _getMaxNCols()
 {
-  return (int) OptCst::query(ECst::NTCOL);
+  return (int)OptCst::query(ECst::NTCOL);
 }
 static int _getMaxNRows()
 {
-  return (int) OptCst::query(ECst::NTROW);
+  return (int)OptCst::query(ECst::NTROW);
 }
 static int _getNBatch()
 {
-  return (int) OptCst::query(ECst::NTBATCH);
+  return (int)OptCst::query(ECst::NTBATCH);
 }
 static void _buildFormat(int mode)
 {
   switch (mode)
   {
     case CASE_INT:
-      (void) gslSPrintf(FORMAT, "%%%dd", (int) OptCst::query(ECst::NTCAR));
+      (void)gslSPrintf(FORMAT, "%%%dd", (int)OptCst::query(ECst::NTCAR));
       break;
 
     case CASE_REAL:
-      (void) gslSPrintf(FORMAT, "%%%d.%dlf", (int) OptCst::query(ECst::NTCAR),
-                        (int) OptCst::query(ECst::NTDEC));
+      (void)gslSPrintf(FORMAT, "%%%d.%dlf", (int)OptCst::query(ECst::NTCAR),
+                       (int)OptCst::query(ECst::NTDEC));
       break;
 
     case CASE_DOUBLE:
-      (void) gslSPrintf(FORMAT, "%%%d.%dlg", (int) OptCst::query(ECst::NTCAR),
-                        (int) OptCst::query(ECst::NTDEC));
+      (void)gslSPrintf(FORMAT, "%%%d.%dlg", (int)OptCst::query(ECst::NTCAR),
+                       (int)OptCst::query(ECst::NTDEC));
       break;
 
     case CASE_COL:
-      (void) gslSPrintf(FORMAT, "[,%%%dd]", (int) OptCst::query(ECst::NTCAR) - 3);
+      (void)gslSPrintf(FORMAT, "[,%%%dd]", (int)OptCst::query(ECst::NTCAR) - 3);
       break;
 
     case CASE_ROW:
-      (void) gslSPrintf(FORMAT, "[%%%dd,]", (int) OptCst::query(ECst::NTCAR) - 3);
+      (void)gslSPrintf(FORMAT, "[%%%dd,]", (int)OptCst::query(ECst::NTCAR) - 3);
       break;
   }
 }
@@ -117,7 +116,6 @@ AStringable& AStringable::operator=(const AStringable& /*r*/)
 {
   return *this;
 }
-
 
 AStringable::~AStringable()
 {
@@ -147,8 +145,8 @@ String _tabPrintString(const String& string,
                        int localSize = 0)
 {
   std::stringstream sstr = _formatColumn(justify, localSize);
-  int size = static_cast<int> (string.size());
-  int truncSize = (localSize > 0) ? localSize : _getColumnSize();
+  int size               = static_cast<int>(string.size());
+  int truncSize          = (localSize > 0) ? localSize : _getColumnSize();
   if (size > truncSize)
   {
     // String must be truncated
@@ -283,13 +281,13 @@ String _printTrailer(int ncols, int nrows, int ncols_util, int nrows_util)
  * @param format Output format
  * @param ...    Additional arguments
  */
-void message(const char *format, ...)
+void message(const char* format, ...)
 {
   char str[LONG_SIZE];
 
   va_list ap;
   va_start(ap, format);
-  (void) vsnprintf(str, sizeof(str), format, ap);
+  (void)vsnprintf(str, sizeof(str), format, ap);
   va_end(ap);
   message_extern(str);
 }
@@ -299,13 +297,13 @@ void message(const char *format, ...)
  * @param format Output format
  * @param ...    Additional arguments
  */
-void messageNoDiff(const char *format, ...)
+void messageNoDiff(const char* format, ...)
 {
   char str[LONG_SIZE];
   va_list ap;
 
   va_start(ap, format);
-  (void) vsnprintf(str, sizeof(str), format, ap);
+  (void)vsnprintf(str, sizeof(str), format, ap);
   va_end(ap);
   std::stringstream sstr;
   sstr << "#NO_DIFF# " << str;
@@ -332,7 +330,6 @@ void messerrFlush(const String& string)
 {
   message_extern(string.c_str());
 }
-
 
 /**
  * Print a standard Error Message if an argument does not lie in Interval
@@ -366,41 +363,41 @@ bool checkArg(const char* title, int current, int nmax)
  * @param format Output format
  * @param ...    Additional arguments
  */
-void mestitle(int level, const char *format, ...)
+void mestitle(int level, const char* format, ...)
 {
   char STRING[1000];
   va_list ap;
 
   message_extern("\n");
   va_start(ap, format);
-  (void) vsnprintf(STRING, sizeof(STRING), format, ap);
+  (void)vsnprintf(STRING, sizeof(STRING), format, ap);
   va_end(ap);
-  int size = (int) strlen(STRING);
+  int size = (int)strlen(STRING);
 
-  (void) gslStrcat(STRING, "\n");
+  (void)gslStrcat(STRING, "\n");
   message_extern(STRING);
 
   /* Underline the string */
 
-  (void) gslStrcpy(STRING, "");
+  (void)gslStrcpy(STRING, "");
   for (int i = 0; i < size; i++)
   {
     switch (level)
     {
       case 0:
-        (void) gslStrcat(STRING, "=");
+        (void)gslStrcat(STRING, "=");
         break;
 
       case 1:
-        (void) gslStrcat(STRING, "-");
+        (void)gslStrcat(STRING, "-");
         break;
 
       case 2:
-        (void) gslStrcat(STRING, ".");
+        (void)gslStrcat(STRING, ".");
         break;
     }
   }
-  (void) gslStrcat(STRING, "\n");
+  (void)gslStrcat(STRING, "\n");
   message_extern(STRING);
 }
 
@@ -413,17 +410,17 @@ void mestitle(int level, const char *format, ...)
  * @remarks The value 'nproc' designates the quantile such that,
  * @remarks when changed, the printout is provoked.
  */
-void mes_process(const char *string, int ntot, int iech)
+void mes_process(const char* string, int ntot, int iech)
 {
   static int quant_memo = 0;
-  int nproc = (int) OptCst::query(ECst::NPROC);
+  int nproc             = (int)OptCst::query(ECst::NPROC);
   if (nproc <= 0) return;
   int jech = iech + 1;
 
   /* Calculate the current quantile */
 
-  double ratio = nproc * (double) jech / (double) ntot;
-  int quant = (int) (ratio);
+  double ratio = nproc * (double)jech / (double)ntot;
+  int quant    = (int)(ratio);
 
   /* Conditional printout */
 
@@ -445,28 +442,28 @@ String toTitle(int level, const char* format, ...)
 
   sstr << std::endl;
   va_start(ap, format);
-  (void) vsnprintf(STRING, sizeof(STRING), format, ap);
+  (void)vsnprintf(STRING, sizeof(STRING), format, ap);
   va_end(ap);
   sstr << STRING << std::endl;
 
   /* Underline the string */
 
-  int size = (int) strlen(STRING);
-  (void) gslStrcpy(STRING, "");
+  int size = (int)strlen(STRING);
+  (void)gslStrcpy(STRING, "");
   for (int i = 0; i < size; i++)
   {
     switch (level)
     {
       case 0:
-        (void) gslStrcat(STRING, "=");
+        (void)gslStrcat(STRING, "=");
         break;
 
       case 1:
-        (void) gslStrcat(STRING, "-");
+        (void)gslStrcat(STRING, "-");
         break;
 
       case 2:
-        (void) gslStrcat(STRING, ".");
+        (void)gslStrcat(STRING, ".");
         break;
     }
   }
@@ -480,13 +477,13 @@ String toTitle(int level, const char* format, ...)
  * @param format Fatal error format
  * @param ...    Additional arguments
  */
-void messageAbort(const char *format, ...)
+void messageAbort(const char* format, ...)
 {
   char STRING[1000];
   va_list ap;
 
   va_start(ap, format);
-  (void) vsnprintf(STRING, sizeof(STRING), format, ap);
+  (void)vsnprintf(STRING, sizeof(STRING), format, ap);
   va_end(ap);
   message_extern("Abort : ");
   message_extern(STRING);
@@ -525,8 +522,8 @@ void AStringable::display(int level) const
  * @param flagSkipZero when true, skip the zero values (represented by a '.' as for sparse matrix)
  *                     always true for sparse matrix
  */
-String toMatrix(const String &title,
-                const AMatrix &mat,
+String toMatrix(const String& title,
+                const AMatrix& mat,
                 bool flagOverride,
                 bool flagSkipZero)
 {
@@ -571,22 +568,22 @@ String toMatrix(const String& title,
  * @param title        Title of the printout
  * @param colnames     Names of the columns (optional)
  * @param rownames     Names of the rows (optional)
- * @param bycol        true if values as sorted by column; false otherwise     
+ * @param bycol        true if values as sorted by column; false otherwise
  * @param nrows        Number of rows
  * @param ncols        Number of columns
  * @param tab          VectorDouble containing the values
  * @param flagOverride true to override printout limitations
  * @param flagSkipZero when true, skip the zero values (represented by a '.' as for sparse matrix)
- */ 
-  String toMatrix(const String& title,
-                  const VectorString& colnames,
-                  const VectorString& rownames,
-                  bool bycol,
-                  int nrows,
-                  int ncols,
-                  const double* tab,
-                  bool flagOverride,
-                  bool flagSkipZero)
+ */
+String toMatrix(const String& title,
+                const VectorString& colnames,
+                const VectorString& rownames,
+                bool bycol,
+                int nrows,
+                int ncols,
+                const double* tab,
+                bool flagOverride,
+                bool flagSkipZero)
 {
   std::stringstream sstr;
 
@@ -596,7 +593,7 @@ String toMatrix(const String& title,
   int nrutil = nrows;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   if (_getMaxNRows() > 0 && nrutil > _getMaxNRows() && !flagOverride) nrutil = _getMaxNRows();
-  int npass = (int) ceil((double) ncutil / (double) _getNBatch());
+  int npass      = (int)ceil((double)ncutil / (double)_getNBatch());
   bool multi_row = nrutil > 1 || npass > 1;
 
   int colSize = 0;
@@ -615,7 +612,7 @@ String toMatrix(const String& title,
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -678,7 +675,7 @@ String toMatrix(const String& title,
                 bool bycol,
                 int nrows,
                 int ncols,
-                const VectorInt &tab,
+                const VectorInt& tab,
                 bool flagOverride,
                 bool flagSkipZero)
 {
@@ -691,7 +688,7 @@ String toMatrix(const String& title,
   int nrutil = nrows;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   if (_getMaxNRows() > 0 && nrutil > _getMaxNRows() && !flagOverride) nrutil = _getMaxNRows();
-  int npass = (int) ceil((double) ncutil / (double) _getNBatch());
+  int npass      = (int)ceil((double)ncutil / (double)_getNBatch());
   bool multi_row = nrutil > 1 || npass > 1;
 
   int colSize = 0;
@@ -710,7 +707,7 @@ String toMatrix(const String& title,
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -767,14 +764,14 @@ String toVector(const String& title, const VectorDouble& tab, bool flagOverride)
   std::stringstream sstr;
   if (tab.empty()) return sstr.str();
 
-  int ncols = static_cast<int> (tab.size());
+  int ncols  = static_cast<int>(tab.size());
   int ncutil = ncols;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   bool multi_row = ncutil > _getNBatch();
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -815,14 +812,14 @@ String toVector(const String& title, constvect tab, bool flagOverride)
   std::stringstream sstr;
   if (tab.empty()) return sstr.str();
 
-  int ncols = static_cast<int> (tab.size());
+  int ncols  = static_cast<int>(tab.size());
   int ncutil = ncols;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   bool multi_row = ncutil > _getNBatch();
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -863,10 +860,10 @@ String toVector(const String& title, const VectorVectorDouble& tab, bool flagOve
   std::stringstream sstr;
   if (tab.empty()) return sstr.str();
 
-  if (! title.empty())
+  if (!title.empty())
     sstr << title << std::endl;
 
-  int nrows = (int) tab.size();
+  int nrows  = (int)tab.size();
   int nrutil = nrows;
   if (_getMaxNRows() > 0 && nrutil > _getMaxNRows() && !flagOverride) nrutil = _getMaxNRows();
 
@@ -922,14 +919,14 @@ String toVector(const String& title, const VectorString& tab, bool flagOverride)
   std::stringstream sstr;
   if (tab.empty()) return sstr.str();
 
-  int ncols = static_cast<int> (tab.size());
+  int ncols  = static_cast<int>(tab.size());
   int ncutil = ncols;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   bool multi_row = ncutil > _getNBatch();
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -971,14 +968,14 @@ String toVector(const String& title, const VectorInt& tab, bool flagOverride)
   std::stringstream sstr;
   if (tab.empty()) return sstr.str();
 
-  int ncols = static_cast<int> (tab.size());
+  int ncols  = static_cast<int>(tab.size());
   int ncutil = ncols;
   if (_getMaxNCols() > 0 && ncutil > _getMaxNCols() && !flagOverride) ncutil = _getMaxNCols();
   bool multi_row = ncutil > _getNBatch();
 
   /* Print the title (optional) */
 
-  if (! title.empty())
+  if (!title.empty())
   {
     sstr << title;
     if (multi_row) sstr << std::endl;
@@ -1023,7 +1020,7 @@ String toDouble(double value, const EJustify& justify)
 VectorString toVectorDouble(const VectorDouble& values, const EJustify& justify)
 {
   VectorString strings;
-  for (int i = 0; i < (int) values.size(); i++)
+  for (int i = 0; i < (int)values.size(); i++)
     strings.push_back(toDouble(values[i], justify));
   return strings;
 }
@@ -1065,17 +1062,17 @@ String toInterval(double zmin, double zmax)
  **                      (EJustify::LEFT, EJustify::CENTER or EJustify::RIGHT)
  **
  *****************************************************************************/
-void tab_prints(const char *title,
-                const char *string,
+void tab_prints(const char* title,
+                const char* string,
                 int ncol,
-                const EJustify &justify)
+                const EJustify& justify)
 {
-  int taille = (1 + (int) OptCst::query(ECst::NTCAR)) * ncol;
-  int size = static_cast<int>(strlen(string));
-  int neff = MIN(taille, size);
-  int nrst = taille - neff;
-  int n1 = nrst / 2;
-  int n2 = taille - size - n1;
+  int taille = (1 + (int)OptCst::query(ECst::NTCAR)) * ncol;
+  int size   = static_cast<int>(strlen(string));
+  int neff   = MIN(taille, size);
+  int nrst   = taille - neff;
+  int n1     = nrst / 2;
+  int n2     = taille - size - n1;
 
   /* Encode the title (if defined) */
 
@@ -1083,32 +1080,32 @@ void tab_prints(const char *title,
 
   /* Blank the string out */
 
-  (void) gslStrcpy(TABSTR, "");
+  (void)gslStrcpy(TABSTR, "");
 
   /* Switch according to the justification */
 
   switch (justify.toEnum())
   {
     case EJustify::E_LEFT:
-      (void) gslStrncpy(TABSTR, string, neff);
+      (void)gslStrncpy(TABSTR, string, neff);
       TABSTR[neff] = '\0';
       for (int i = 0; i < nrst; i++)
-        (void) gslStrcat(TABSTR, " ");
+        (void)gslStrcat(TABSTR, " ");
       break;
 
     case EJustify::E_CENTER:
       for (int i = 0; i < n1; i++)
-        (void) gslStrcat(TABSTR, " ");
-      (void) gslStrncpy(&TABSTR[n1], string, neff);
+        (void)gslStrcat(TABSTR, " ");
+      (void)gslStrncpy(&TABSTR[n1], string, neff);
       TABSTR[n1 + neff] = '\0';
       for (int i = 0; i < n2; i++)
-        (void) gslStrcat(TABSTR, " ");
+        (void)gslStrcat(TABSTR, " ");
       break;
 
     case EJustify::E_RIGHT:
       for (int i = 0; i < nrst; i++)
-        (void) gslStrcat(TABSTR, " ");
-      (void) gslStrncpy(&TABSTR[nrst], string, neff);
+        (void)gslStrcat(TABSTR, " ");
+      (void)gslStrncpy(&TABSTR[nrst], string, neff);
       TABSTR[nrst + neff] = '\0';
       break;
   }
@@ -1126,20 +1123,20 @@ void tab_prints(const char *title,
  **                      (EJustify::LEFT, EJustify::CENTER or EJustify::RIGHT)
  **
  *****************************************************************************/
-void tab_printg(const char *title,
+void tab_printg(const char* title,
                 double value,
                 int ncol,
-                const EJustify &justify)
+                const EJustify& justify)
 {
   _buildFormat(CASE_REAL);
 
   if (FFFF(value))
-    (void) gslStrcpy(DECODE, "N/A");
+    (void)gslStrcpy(DECODE, "N/A");
   else
   {
     // Prevent -0.00 : https://stackoverflow.com/a/12536500/3952924
     value = (ABS(value) < _getThresh()) ? 0. : value;
-    (void) gslSPrintf(DECODE, FORMAT, value);
+    (void)gslSPrintf(DECODE, FORMAT, value);
   }
   tab_prints(title, DECODE, ncol, justify);
 }
@@ -1155,17 +1152,17 @@ void tab_printg(const char *title,
  **                      (EJustify::LEFT, EJustify::CENTER or EJustify::RIGHT)
  **
  *****************************************************************************/
-void tab_printd(const char *title,
+void tab_printd(const char* title,
                 double value,
                 int ncol,
-                const EJustify &justify)
+                const EJustify& justify)
 {
   _buildFormat(CASE_DOUBLE);
 
   if (FFFF(value))
-    (void) gslStrcpy(DECODE, "N/A");
+    (void)gslStrcpy(DECODE, "N/A");
   else
-    (void) gslSPrintf(DECODE, FORMAT, value);
+    (void)gslSPrintf(DECODE, FORMAT, value);
 
   tab_prints(title, DECODE, ncol, justify);
 }
@@ -1181,14 +1178,14 @@ void tab_printd(const char *title,
  **                      (EJustify::LEFT, EJustify::CENTER or EJustify::RIGHT)
  **
  *****************************************************************************/
-void tab_printi(const char *title, int value, int ncol, const EJustify &justify)
+void tab_printi(const char* title, int value, int ncol, const EJustify& justify)
 {
   _buildFormat(CASE_INT);
 
   if (IFFFF(value))
-    (void) gslStrcpy(DECODE, "N/A");
+    (void)gslStrcpy(DECODE, "N/A");
   else
-    (void) gslSPrintf(DECODE, FORMAT, value);
+    (void)gslSPrintf(DECODE, FORMAT, value);
 
   tab_prints(title, DECODE, ncol, justify);
 }
@@ -1205,15 +1202,15 @@ void tab_printi(const char *title, int value, int ncol, const EJustify &justify)
  **                      (EJustify::LEFT, EJustify::CENTER or EJustify::RIGHT)
  **
  *****************************************************************************/
-void tab_print_rc(const char *title,
+void tab_print_rc(const char* title,
                   int mode,
                   int value,
                   int ncol,
-                  const EJustify &justify)
+                  const EJustify& justify)
 {
   _buildFormat(mode);
 
-  (void) gslSPrintf(DECODE, FORMAT, value);
+  (void)gslSPrintf(DECODE, FORMAT, value);
   string_strip_blanks(DECODE, 0);
   tab_prints(title, DECODE, ncol, justify);
 }
@@ -1228,7 +1225,7 @@ void tab_print_rc(const char *title,
  ** \remarks The string is printed (left-adjusted) on 'taille' characters
  **
  *****************************************************************************/
-void tab_print_rowname(const char *string, int taille)
+void tab_print_rowname(const char* string, int taille)
 {
   int size = static_cast<int>(strlen(string));
   int neff = MIN(taille, size);
@@ -1236,11 +1233,11 @@ void tab_print_rowname(const char *string, int taille)
 
   /* Blank the string out */
 
-  (void) gslStrcpy(TABSTR, "");
-  (void) gslStrncpy(TABSTR, string, neff);
+  (void)gslStrcpy(TABSTR, "");
+  (void)gslStrncpy(TABSTR, string, neff);
   TABSTR[neff] = '\0';
   for (int i = 0; i < nrst; i++)
-    (void) gslStrcat(TABSTR, " ");
+    (void)gslStrcat(TABSTR, " ");
   message(TABSTR);
 }
 
@@ -1262,19 +1259,17 @@ void tab_print_rowname(const char *string, int taille)
  ** \remarks of the one used in R-packages where dim[1]=nrow and dim[2]=ncol
  **
  *****************************************************************************/
-void print_matrix(const char *title,
+void print_matrix(const char* title,
                   int flag_limit,
                   int bycol,
                   int nx,
                   int ny,
-                  const double *sel,
-                  const double *tab)
+                  const double* sel,
+                  const double* tab)
 {
   if (tab == nullptr || nx <= 0 || ny <= 0) return;
-  int nx_util = (flag_limit && (int) OptCst::query(ECst::NTCOL) > 0) ?
-      MIN((int) OptCst::query(ECst::NTCOL), nx) : nx;
-  int ny_util = (flag_limit && (int) OptCst::query(ECst::NTROW) > 0) ?
-      MIN((int) OptCst::query(ECst::NTROW), ny) : ny;
+  int nx_util   = (flag_limit && (int)OptCst::query(ECst::NTCOL) > 0) ? MIN((int)OptCst::query(ECst::NTCOL), nx) : nx;
+  int ny_util   = (flag_limit && (int)OptCst::query(ECst::NTROW) > 0) ? MIN((int)OptCst::query(ECst::NTROW), ny) : ny;
   int multi_row = (ny > 1 || title == NULL);
 
   /* Print the title (optional) */
@@ -1331,9 +1326,9 @@ void print_matrix(const char *title,
   }
 }
 
-void print_matrix(const char *title,
+void print_matrix(const char* title,
                   int flag_limit,
-                  const AMatrix &mat)
+                  const AMatrix& mat)
 {
   print_matrix(title, flag_limit, true, mat.getNCols(), mat.getNRows(), nullptr, mat.getValues().data());
 }
@@ -1351,11 +1346,11 @@ void print_matrix(const char *title,
  ** \remarks The ordering (compatible with matrix_solve is mode==2)
  **
  *****************************************************************************/
-void print_trimat(const char *title, int mode, int neq, const double *tl)
+void print_trimat(const char* title, int mode, int neq, const double* tl)
 {
-#define TRI(i)        (((i) * ((i) + 1)) / 2)
-#define TL1(i,j)      (tl[(j)*neq+(i)-TRI(j)])  /* only for i >= j */
-#define TL2(i,j)      (tl[TRI(i)+(j)])          /* only for i >= j */
+#define TRI(i)    (((i) * ((i) + 1)) / 2)
+#define TL1(i, j) (tl[(j) * neq + (i) - TRI(j)]) /* only for i >= j */
+#define TL2(i, j) (tl[TRI(i) + (j)])             /* only for i >= j */
 
   /* Initializations */
 
@@ -1411,19 +1406,17 @@ void print_trimat(const char *title, int mode, int neq, const double *tl)
  ** \param[in]  tab    array containing the matrix
  **
  *****************************************************************************/
-void print_imatrix(const char *title,
+void print_imatrix(const char* title,
                    int flag_limit,
                    int bycol,
                    int nx,
                    int ny,
-                   const double *sel,
-                   const int *tab)
+                   const double* sel,
+                   const int* tab)
 {
   if (tab == nullptr || nx <= 0 || ny <= 0) return;
-  int nx_util = (flag_limit && (int) OptCst::query(ECst::NTCOL) > 0) ?
-      MIN((int) OptCst::query(ECst::NTCOL), nx) : nx;
-  int ny_util = (flag_limit && (int) OptCst::query(ECst::NTROW) > 0) ?
-      MIN((int) OptCst::query(ECst::NTROW), ny) : ny;
+  int nx_util   = (flag_limit && (int)OptCst::query(ECst::NTCOL) > 0) ? MIN((int)OptCst::query(ECst::NTCOL), nx) : nx;
+  int ny_util   = (flag_limit && (int)OptCst::query(ECst::NTROW) > 0) ? MIN((int)OptCst::query(ECst::NTROW), ny) : ny;
   int multi_row = (ny > 1 || title == NULL);
 
   /* Print the title (optional) */
@@ -1490,18 +1483,17 @@ void print_imatrix(const char *title,
  ** \param[in]  tab        Array to be printed
  **
  *****************************************************************************/
-void print_vector(const char *title,
+void print_vector(const char* title,
                   int flag_limit,
                   int ntab,
-                  const double *tab)
+                  const double* tab)
 {
   static int nby_def = 5;
 
   /* Initializations */
 
   if (ntab <= 0) return;
-  int nby = (flag_limit && (int) OptCst::query(ECst::NTCOL) >= 0) ?
-      (int) OptCst::query(ECst::NTCOL) : nby_def;
+  int nby        = (flag_limit && (int)OptCst::query(ECst::NTCOL) >= 0) ? (int)OptCst::query(ECst::NTCOL) : nby_def;
   bool flag_many = (ntab > nby);
 
   if (title != NULL)
@@ -1523,10 +1515,10 @@ void print_vector(const char *title,
   }
 }
 
-void print_vector(const char *title,
+void print_vector(const char* title,
                   int flag_limit,
                   int ntab,
-                  const VectorDouble &tab)
+                  const VectorDouble& tab)
 {
   print_vector(title, flag_limit, ntab, tab.data());
 }
@@ -1541,15 +1533,14 @@ void print_vector(const char *title,
  ** \param[in]  itab       Array to be printed
  **
  *****************************************************************************/
-void print_ivector(const char *title, int flag_limit, int ntab, const int *itab)
+void print_ivector(const char* title, int flag_limit, int ntab, const int* itab)
 {
   static int nby_def = 5;
 
   /* Initializations */
 
   if (ntab <= 0) return;
-  int nby = (flag_limit && (int) OptCst::query(ECst::NTCOL) >= 0) ?
-      (int) OptCst::query(ECst::NTCOL) : nby_def;
+  int nby        = (flag_limit && (int)OptCst::query(ECst::NTCOL) >= 0) ? (int)OptCst::query(ECst::NTCOL) : nby_def;
   bool flag_many = (ntab > nby);
 
   if (title != NULL)
@@ -1571,31 +1562,29 @@ void print_ivector(const char *title, int flag_limit, int ntab, const int *itab)
   }
 }
 
-void print_ivector(const char *title,
+void print_ivector(const char* title,
                    int flag_limit,
                    int ntab,
-                   const VectorInt &itab)
+                   const VectorInt& itab)
 {
   print_ivector(title, flag_limit, ntab, itab.data());
 }
-
-
 
 /**
  * Print Error message
  * @param format Output format
  * @param ...    Additional arguments
  */
-void messerr(const char *format, ...)
+void messerr(const char* format, ...)
 {
   char str[1000];
   va_list ap;
 
   va_start(ap, format);
-  (void) vsnprintf(str, sizeof(str), format, ap);
+  (void)vsnprintf(str, sizeof(str), format, ap);
   va_end(ap);
 
   message_extern(str);
   message_extern("\n");
 }
-}
+} // namespace gstlrn

--- a/src/Basic/FFT.cpp
+++ b/src/Basic/FFT.cpp
@@ -8,11 +8,12 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/VectorNumT.hpp"
 #include "Basic/FFT.hpp"
 #include "Arrays/Array.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "Core/fftn.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -30,8 +31,8 @@ int FFTn(int ndim,
          int iSign,
          double scaling)
 {
-  int n = (int) Re.size();
-  Im.resize(n,0.);
+  int n = (int)Re.size();
+  Im.resize(n, 0.);
   return fftn(ndim, dims.data(), Re.data(), Im.data(), iSign, scaling);
 }
 
@@ -48,21 +49,21 @@ Array evalCovFFTTimeSlice(const VectorDouble& hmax,
                           int N,
                           const std::function<std::complex<double>(VectorDouble, double)>& funcSpectrum)
 {
-  int ndim = (int) hmax.size();
+  int ndim = (int)hmax.size();
   VectorInt nxs(ndim);
   for (int idim = 0; idim < ndim; idim++)
-    nxs[idim] = N ;
+    nxs[idim] = N;
   Array array(nxs);
 
-  int ntotal = (int) pow(N, ndim);
+  int ntotal = (int)pow(N, ndim);
   VectorDouble a(ndim);
   double coeff = 0;
-  double prod = 1.;
+  double prod  = 1.;
 
-  for(int idim = 0; idim < ndim; idim++)
+  for (int idim = 0; idim < ndim; idim++)
   {
-    coeff = 1. / (2. * hmax[idim]);
-    a[idim] = GV_PI * (N-1) / (hmax[idim]);
+    coeff   = 1. / (2. * hmax[idim]);
+    a[idim] = GV_PI * (N - 1) / (hmax[idim]);
     prod *= coeff;
   }
 
@@ -72,7 +73,7 @@ Array evalCovFFTTimeSlice(const VectorDouble& hmax,
   VectorDouble temp(ndim);
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
+    array.rankToIndice(iad, indices);
 
     int s = 1;
     for (int idim = 0; idim < ndim; idim++)
@@ -81,9 +82,9 @@ Array evalCovFFTTimeSlice(const VectorDouble& hmax,
       s *= (indices[idim] % 2) ? -1 : 1;
     }
 
-    std::complex<double> fourier = funcSpectrum(temp,time);
-    Re[iad] = s * prod * fourier.real();
-    Im[iad] = s * prod * fourier.imag();
+    std::complex<double> fourier = funcSpectrum(temp, time);
+    Re[iad]                      = s * prod * fourier.real();
+    Im[iad]                      = s * prod * fourier.imag();
   }
   FFTn(ndim, nxs, Re, Im);
 
@@ -91,35 +92,35 @@ Array evalCovFFTTimeSlice(const VectorDouble& hmax,
 
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
+    array.rankToIndice(iad, indices);
     int s = 1;
-    for (int idim = 0;  idim < ndim; idim++)
+    for (int idim = 0; idim < ndim; idim++)
     {
       s *= (indices[idim] % 2) ? -1 : 1;
     }
-    array.setValue(indices,Re[iad] * s);
+    array.setValue(indices, Re[iad] * s);
   }
   return array;
 }
 
-Array evalCovFFTSpatial(const VectorDouble &hmax,
+Array evalCovFFTSpatial(const VectorDouble& hmax,
                         int N,
                         const std::function<double(const VectorDouble&)>& funcSpectrum)
 {
-  int ndim = (int) hmax.size();
+  int ndim = (int)hmax.size();
   VectorInt nxs(ndim);
   for (int idim = 0; idim < ndim; idim++)
     nxs[idim] = N;
   Array array(nxs);
 
-  int ntotal = (int) pow(N, ndim);
+  int ntotal = (int)pow(N, ndim);
   VectorDouble a(ndim);
   double coeff = 0;
-  double prod = 1.;
+  double prod  = 1.;
 
   for (int idim = 0; idim < ndim; idim++)
   {
-    coeff = 1. / (2. * hmax[idim]);
+    coeff   = 1. / (2. * hmax[idim]);
     a[idim] = GV_PI * (N - 1) / (hmax[idim]);
     prod *= coeff;
   }
@@ -136,7 +137,7 @@ Array evalCovFFTSpatial(const VectorDouble &hmax,
     int s = 1;
     for (int idim = 0; idim < ndim; idim++)
     {
-      temp[idim] = a[idim] * ((double) indices[idim] / (N - 1) - 0.5);
+      temp[idim] = a[idim] * ((double)indices[idim] / (N - 1) - 0.5);
       s *= (indices[idim] % 2) ? -1 : 1;
     }
     Re[iad] = s * prod * funcSpectrum(temp);
@@ -147,13 +148,13 @@ Array evalCovFFTSpatial(const VectorDouble &hmax,
 
   for (int iad = 0; iad < ntotal; iad++)
   {
-    array.rankToIndice(iad,indices);
+    array.rankToIndice(iad, indices);
     int s = 1;
-    for (int idim = 0;  idim < ndim; idim++)
+    for (int idim = 0; idim < ndim; idim++)
     {
       s *= (indices[idim] % 2) ? -1 : 1;
     }
-    array.setValue(indices,Re[iad] * s);
+    array.setValue(indices, Re[iad] * s);
   }
 
   return array;
@@ -194,7 +195,7 @@ static int _getIndex(int ndim, const VectorInt& strides, const VectorInt& indice
 // Fonction pour effectuer un fftshift sur un tenseur nD stocké en 1D
 void fftshift(const VectorInt& dims, VectorDouble& data)
 {
-  int ndim = (int) dims.size();
+  int ndim       = (int)dims.size();
   int total_size = (int)data.size();
 
   // Calcul des moitiés des dimensions
@@ -222,8 +223,8 @@ void fftshift(const VectorInt& dims, VectorDouble& data)
       coords_new[dim] = (coords_old[dim] + half[dim]) % dims[dim];
 
     // Reconvertir en index linéaire
-    int new_index = _getIndex(ndim, strides, coords_new);
+    int new_index   = _getIndex(ndim, strides, coords_new);
     data[new_index] = temp[index];
   }
 }
-}
+} // namespace gstlrn

--- a/src/Basic/File.cpp
+++ b/src/Basic/File.cpp
@@ -10,33 +10,34 @@
 /******************************************************************************/
 #include "Basic/File.hpp"
 #include "geoslib_define.h"
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
-#include <stdlib.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 
 #if defined(_WIN32) || defined(_WIN64)
-#include <windows.h>
-#include <io.h>
-#include <fcntl.h>
+#  include <fcntl.h>
+#  include <io.h>
+#  include <windows.h>
 #endif
 namespace gstlrn
 {
-StdoutRedirect::StdoutRedirect(const String &file,
+StdoutRedirect::StdoutRedirect(const String& file,
                                int argc,
-                               char *argv[],
+                               char* argv[],
                                int number)
-    :
-  _flagActive(true),
+  : _flagActive(true)
+  ,
 #if defined(_WIN32) || defined(_WIN64)
   _old_stdout(0)
 #else
-  _coutbuf(nullptr),
-  _out()
+  _coutbuf(nullptr)
+  , _out()
 #endif
 {
   DECLARE_UNUSED(argv);
@@ -60,10 +61,10 @@ void StdoutRedirect::start(const String& file)
 {
 #if defined(_WIN32) || defined(_WIN64)
   // https://stackoverflow.com/questions/54094127/redirecting-stdout-in-win32-does-not-redirect-stdout/54096218
-  _old_stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+  _old_stdout       = GetStdHandle(STD_OUTPUT_HANDLE);
   HANDLE new_stdout = CreateFileA(file.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   SetStdHandle(STD_OUTPUT_HANDLE, new_stdout);
-  int fd = _open_osfhandle((intptr_t)new_stdout, _O_WRONLY|_O_TEXT);
+  int fd = _open_osfhandle((intptr_t)new_stdout, _O_WRONLY | _O_TEXT);
   _dup2(fd, _fileno(stdout));
   _close(fd);
 #else
@@ -81,11 +82,11 @@ void StdoutRedirect::stop()
 #if defined(_WIN32) || defined(_WIN64)
   // https://stackoverflow.com/questions/32185512/output-to-console-from-a-win32-gui-application-on-windows-10
   SetStdHandle(STD_OUTPUT_HANDLE, _old_stdout);
-  int fd = _open_osfhandle((intptr_t)_old_stdout, _O_WRONLY|_O_TEXT);
+  int fd = _open_osfhandle((intptr_t)_old_stdout, _O_WRONLY | _O_TEXT);
   if (fd >= 0) // fd could be negative for an unknown reason (https://github.com/gstlearn/gstlearn/issues/111)
   {
     FILE* fp = _fdopen(fd, "w");
-    freopen_s( &fp, "CONOUT$", "w", stdout);
+    freopen_s(&fp, "CONOUT$", "w", stdout);
   }
 #else
   std::cout.rdbuf(_coutbuf);
@@ -94,8 +95,8 @@ void StdoutRedirect::stop()
 }
 
 // Skips the Byte Order Mark (BOM) that defines UTF-8 in some text files.
-//https://stackoverflow.com/a/17219495
-void skipBOM(std::ifstream &in)
+// https://stackoverflow.com/a/17219495
+void skipBOM(std::ifstream& in)
 {
   char test[3] = {0};
   in.read(test, 3);
@@ -103,21 +104,21 @@ void skipBOM(std::ifstream &in)
       (unsigned char)test[1] == 0xBB &&
       (unsigned char)test[2] == 0xBF)
   {
-      return;
+    return;
   }
   in.seekg(0);
 }
 
 FILE* gslFopen(const char* path, const char* mode)
 {
-  FILE *file;
+  FILE* file;
 
 #if defined(__linux__) || defined(__APPLE__)
   file = fopen(path, mode);
 #else
   errno_t err;
-  err = fopen_s( &file, path, mode );
-  if ( err != 0 ) return nullptr;
+  err = fopen_s(&file, path, mode);
+  if (err != 0) return nullptr;
 #endif
   return file;
 }
@@ -127,9 +128,9 @@ FILE* gslFopen(const String& path, const String& mode)
   return gslFopen(path.c_str(), mode.c_str());
 }
 
-bool gslFileExist(const char *path, const char* mode)
+bool gslFileExist(const char* path, const char* mode)
 {
-  FILE* file = gslFopen(path, mode);
+  FILE* file  = gslFopen(path, mode);
   bool exists = file != nullptr;
   if (exists) fclose(file);
   return exists;
@@ -137,7 +138,7 @@ bool gslFileExist(const char *path, const char* mode)
 
 bool gslFileExist(const String& path, const String& mode)
 {
-  FILE* file = gslFopen(path, mode);
+  FILE* file  = gslFopen(path, mode);
   bool exists = file != nullptr;
   if (exists) fclose(file);
   return exists;
@@ -148,7 +149,6 @@ String gslBaseName(const String& path, bool keepExtension)
   std::filesystem::path p {path};
   return (keepExtension ? p.filename() : p.stem()).string();
 }
-
 
 String gslGetEnv(const String& name)
 {
@@ -177,7 +177,7 @@ std::istream& gslSafeGetline(std::istream& is, String& t)
   // such as thread synchronization and updating the stream state.
 
   std::istream::sentry se(is, true);
-  std::streambuf *sb = is.rdbuf();
+  std::streambuf* sb = is.rdbuf();
 
   for (;;)
   {
@@ -194,9 +194,8 @@ std::istream& gslSafeGetline(std::istream& is, String& t)
         if (t.empty()) is.setstate(std::ios::eofbit);
         return is;
       default:
-        t += (char) c;
+        t += (char)c;
     }
   }
 }
-}
-
+} // namespace gstlrn

--- a/src/Basic/FunctionalSpirale.cpp
+++ b/src/Basic/FunctionalSpirale.cpp
@@ -10,24 +10,24 @@
 /******************************************************************************/
 #include "geoslib_define.h"
 
-#include "Db/Db.hpp"
+#include "Basic/AFunctional.hpp"
+#include "Basic/FunctionalSpirale.hpp"
 #include "Covariances/CovAniso.hpp"
+#include "Db/Db.hpp"
 #include "Matrix/MatrixSquare.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
-#include "Basic/FunctionalSpirale.hpp"
-#include "Basic/AFunctional.hpp"
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 FunctionalSpirale::FunctionalSpirale()
-    : AFunctional(2),
-      _a(0.),
-      _b(0.),
-      _c(0.),
-      _d(0.),
-      _xcenter(0.),
-      _ycenter(0.)
+  : AFunctional(2)
+  , _a(0.)
+  , _b(0.)
+  , _c(0.)
+  , _d(0.)
+  , _xcenter(0.)
+  , _ycenter(0.)
 {
 }
 
@@ -37,36 +37,36 @@ FunctionalSpirale::FunctionalSpirale(double a,
                                      double d,
                                      double sx,
                                      double sy)
-    : AFunctional(2),
-      _a(a),
-      _b(b),
-      _c(c),
-      _d(d),
-      _xcenter(sx),
-      _ycenter(sy)
+  : AFunctional(2)
+  , _a(a)
+  , _b(b)
+  , _c(c)
+  , _d(d)
+  , _xcenter(sx)
+  , _ycenter(sy)
 {
 }
 
-FunctionalSpirale::FunctionalSpirale(const FunctionalSpirale &m)
-    : AFunctional(m),
-      _a(m._a),
-      _b(m._b),
-      _c(m._c),
-      _d(m._d),
-      _xcenter(m._xcenter),
-      _ycenter(m._ycenter)
+FunctionalSpirale::FunctionalSpirale(const FunctionalSpirale& m)
+  : AFunctional(m)
+  , _a(m._a)
+  , _b(m._b)
+  , _c(m._c)
+  , _d(m._d)
+  , _xcenter(m._xcenter)
+  , _ycenter(m._ycenter)
 {
 }
 
-FunctionalSpirale& FunctionalSpirale::operator=(const FunctionalSpirale &m)
+FunctionalSpirale& FunctionalSpirale::operator=(const FunctionalSpirale& m)
 {
   if (this != &m)
   {
     AFunctional::operator=(m);
-    _a = m._a;
-    _b = m._b;
-    _c = m._c;
-    _d = m._d;
+    _a       = m._a;
+    _b       = m._b;
+    _c       = m._c;
+    _d       = m._d;
     _xcenter = m._xcenter;
     _ycenter = m._ycenter;
   }
@@ -79,7 +79,7 @@ FunctionalSpirale::~FunctionalSpirale()
 
 double FunctionalSpirale::_linearCombination(double x, double y, double a, double b)
 {
-    return a*x + b*y;
+  return a * x + b * y;
 }
 
 /**
@@ -109,20 +109,20 @@ double FunctionalSpirale::getFunctionValue(const VectorDouble& coor) const
  */
 MatrixSquare FunctionalSpirale::getFunctionMatrix(const VectorDouble& coor) const
 {
-  int ndim = 2;
+  int ndim          = 2;
   MatrixSquare dirs = MatrixSquare(ndim);
 
   double angle = getFunctionValue(coor) * GV_PI / 180.;
-  double u1 = cos(angle);
-  double u2 = sin(angle);
-  dirs.setValue(0, 0,  u1);
+  double u1    = cos(angle);
+  double u2    = sin(angle);
+  dirs.setValue(0, 0, u1);
   dirs.setValue(1, 0, -u2);
-  dirs.setValue(0, 1,  u2);
-  dirs.setValue(1, 1,  u1);
+  dirs.setValue(0, 1, u2);
+  dirs.setValue(1, 1, u1);
   return dirs;
 }
 
-VectorVectorDouble FunctionalSpirale::getFunctionVectors(const Db *db, const CovAniso* cova) const
+VectorVectorDouble FunctionalSpirale::getFunctionVectors(const Db* db, const CovAniso* cova) const
 {
   if (db == nullptr) return VectorVectorDouble();
   if (getNdim() != db->getNDim())
@@ -144,15 +144,15 @@ VectorVectorDouble FunctionalSpirale::getFunctionVectors(const Db *db, const Cov
 
   for (int iech = 0; iech < nech; iech++)
   {
-    VectorDouble coor = db->getSampleCoordinates(iech);
+    VectorDouble coor   = db->getSampleCoordinates(iech);
     MatrixSquare rotmat = getFunctionMatrix(coor);
     hh.normMatrix(rotmat, temp);
 
-    vec[0][iech] = hh.getValue(0,0);
-    vec[1][iech] = hh.getValue(0,1);
-    vec[2][iech] = hh.getValue(1,1);
+    vec[0][iech] = hh.getValue(0, 0);
+    vec[1][iech] = hh.getValue(0, 1);
+    vec[2][iech] = hh.getValue(1, 1);
   }
 
   return vec;
 }
-}
+} // namespace gstlrn

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -10,15 +10,15 @@
 /******************************************************************************/
 #include "Basic/Grid.hpp"
 
-#include "Basic/VectorNumT.hpp"
-#include "Geometry/Rotation.hpp"
-#include "Matrix/MatrixSquare.hpp"
 #include "Basic/SerializeHDF5.hpp"
 #include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Basic/VectorNumT.hpp"
+#include "Geometry/Rotation.hpp"
+#include "Matrix/MatrixSquare.hpp"
 #include "geoslib_define.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
@@ -76,8 +76,8 @@ static void _dimensionRecursion(int idim, bool verbose, DimLoop& dlp)
   }
 
   order = dlp.order[idim];
-  sdim = ABS(order) - 1;
-  nval = dlp.nx[sdim];
+  sdim  = ABS(order) - 1;
+  nval  = dlp.nx[sdim];
 
   // Loop
 
@@ -89,11 +89,11 @@ static void _dimensionRecursion(int idim, bool verbose, DimLoop& dlp)
 }
 
 Grid::Grid(int ndim,
-           const VectorInt &nx,
-           const VectorDouble &x0,
-           const VectorDouble &dx)
-  : AStringable(),
-    _nDim(ndim)
+           const VectorInt& nx,
+           const VectorDouble& x0,
+           const VectorDouble& dx)
+  : AStringable()
+  , _nDim(ndim)
   , _nx()
   , _x0()
   , _dx()
@@ -105,19 +105,19 @@ Grid::Grid(int ndim,
   , _indices()
 {
   _allocate();
-  if ((int) nx.size() == ndim) _nx = nx;
-  if ((int) dx.size() == ndim) _dx = dx;
-  if ((int) x0.size() == ndim) _x0 = x0;
+  if ((int)nx.size() == ndim) _nx = nx;
+  if ((int)dx.size() == ndim) _dx = dx;
+  if ((int)x0.size() == ndim) _x0 = x0;
 }
 
-Grid::Grid(const Grid &r)
+Grid::Grid(const Grid& r)
   : AStringable(r)
   , ASerializable()
 {
   _recopy(r);
 }
 
-Grid& Grid::operator= (const Grid &r)
+Grid& Grid::operator=(const Grid& r)
 {
   AStringable::operator=(r);
   _recopy(r);
@@ -139,7 +139,7 @@ int Grid::resetFromVector(const VectorInt& nx,
                           const VectorDouble& x0,
                           const VectorDouble& angles)
 {
-  _nDim = static_cast<int> (nx.size());
+  _nDim = static_cast<int>(nx.size());
   _allocate();
   _nx = nx;
   for (int idim = 0; idim < _nDim; idim++)
@@ -147,15 +147,15 @@ int Grid::resetFromVector(const VectorInt& nx,
     if (nx[idim] < 0)
     {
       messerr("The number of grid mesh (%d) in direction (%d) may not be negative",
-              nx[idim],idim+1);
+              nx[idim], idim + 1);
       return 1;
     }
   }
-  if (! x0.empty())
+  if (!x0.empty())
     _x0 = x0;
   else
     for (int idim = 0; idim < _nDim; idim++) _x0[idim] = 0.;
-  if (! dx.empty())
+  if (!dx.empty())
   {
     _dx = dx;
     for (int idim = 0; idim < _nDim; idim++)
@@ -163,7 +163,7 @@ int Grid::resetFromVector(const VectorInt& nx,
       if (dx[idim] < 0.)
       {
         messerr("The mesh (%lf) in direction (%d) may not be negative",
-            dx[idim],idim+1);
+                dx[idim], idim + 1);
         return 1;
       }
     }
@@ -179,7 +179,7 @@ void Grid::resetFromGrid(Grid* grid)
 {
   _nDim = grid->getNDim();
   _allocate();
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
   {
     _nx[idim] = grid->getNX(idim);
     _x0[idim] = grid->getX0(idim);
@@ -194,20 +194,20 @@ void Grid::resetFromGrid(Grid* grid)
 
 void Grid::setX0(int idim, double value)
 {
-  if (! _isSpaceDimensionValid(idim)) return;
+  if (!_isSpaceDimensionValid(idim)) return;
   _x0[idim] = value;
 }
 
 void Grid::setDX(int idim, double value)
 {
-  if (! _isSpaceDimensionValid(idim)) return;
+  if (!_isSpaceDimensionValid(idim)) return;
   if (value < 0) messageAbort("Argument 'dx' may not be negative");
   _dx[idim] = value;
 }
 
 void Grid::setNX(int idim, int value)
 {
-  if (! _isSpaceDimensionValid(idim)) return;
+  if (!_isSpaceDimensionValid(idim)) return;
   if (value < 0) messageAbort("Argument 'nx' may not be negative");
   _nx[idim] = value;
 }
@@ -239,26 +239,26 @@ void Grid::setRotationByAngles(const VectorDouble& angles)
 void Grid::setRotationByAngle(double angle)
 {
   _rotation.resetFromSpaceDimension(_nDim);
-  VectorDouble angles(_nDim,0.);
+  VectorDouble angles(_nDim, 0.);
   angles[0] = angle;
   _rotation.setAngles(angles);
 }
 
 double Grid::getX0(int idim) const
 {
-  if (! _isSpaceDimensionValid(idim)) return TEST;
+  if (!_isSpaceDimensionValid(idim)) return TEST;
   return _x0[idim];
 }
 
 double Grid::getDX(int idim) const
 {
-  if (! _isSpaceDimensionValid(idim)) return TEST;
+  if (!_isSpaceDimensionValid(idim)) return TEST;
   return _dx[idim];
 }
 
 int Grid::getNX(int idim) const
 {
-  if (! _isSpaceDimensionValid(idim)) return ITEST;
+  if (!_isSpaceDimensionValid(idim)) return ITEST;
   return _nx[idim];
 }
 
@@ -266,7 +266,7 @@ int Grid::getNTotal() const
 {
   if (_nDim <= 0) return 0;
   int ntotal = 1;
-  for (int idim=0; idim<_nDim; idim++) 
+  for (int idim = 0; idim < _nDim; idim++)
     ntotal *= _nx[idim];
   return ntotal;
 }
@@ -293,14 +293,14 @@ VectorDouble Grid::getExtends(bool flagCell) const
 {
   VectorDouble ext(_nDim);
   for (int idim = 0; idim < _nDim; idim++)
-      ext[idim] = getExtend(idim, flagCell);
+    ext[idim] = getExtend(idim, flagCell);
   return ext;
 }
 
 double Grid::getCellSize() const
 {
   double size = 1.;
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
     size *= _dx[idim];
   return size;
 }
@@ -310,19 +310,19 @@ String Grid::toString(const AStringFormat* strfmt) const
   std::stringstream sstr;
   if (_nDim <= 0) return sstr.str();
 
-  sstr << toTitle(1,"Grid characteristics:");
+  sstr << toTitle(1, "Grid characteristics:");
   sstr << "Origin : ";
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
     sstr << toDouble(_x0[idim]);
   sstr << std::endl;
 
   sstr << "Mesh   : ";
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
     sstr << toDouble(_dx[idim]);
   sstr << std::endl;
 
   sstr << "Number : ";
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
     sstr << toInt(_nx[idim]);
   sstr << std::endl;
 
@@ -361,17 +361,17 @@ double Grid::getCoordinate(int rank, int idim0, bool flag_rotate) const
  * @param dxsPerCell   Vector of variable grid meshes (optional)
  * @return
  */
-const VectorDouble& Grid::getCoordinatesByIndice(const VectorInt &indice,
-                                          bool flag_rotate,
-                                          const VectorInt& shift,
-                                          const VectorDouble& dxsPerCell) const
+const VectorDouble& Grid::getCoordinatesByIndice(const VectorInt& indice,
+                                                 bool flag_rotate,
+                                                 const VectorInt& shift,
+                                                 const VectorDouble& dxsPerCell) const
 {
   /* Calculate the coordinates in the grid system */
 
   for (int idim = 0; idim < _nDim; idim++)
   {
     _work1[idim] = indice[idim] * _dx[idim];
-    if (! shift.empty())
+    if (!shift.empty())
     {
       double ext = (dxsPerCell.empty()) ? _dx[idim] : dxsPerCell[idim];
       _work1[idim] += shift[idim] * ext / 2.;
@@ -400,7 +400,7 @@ const VectorDouble& Grid::getCoordinatesByCorner(const VectorInt& icorner) const
   initThread();
   VH::fill(_iwork0, 0);
   for (int idim = 0; idim < _nDim; idim++)
-    if (icorner[idim] > 0) _iwork0[idim] = _nx[idim]-1;
+    if (icorner[idim] > 0) _iwork0[idim] = _nx[idim] - 1;
   return getCoordinatesByIndice(_iwork0);
 }
 
@@ -413,8 +413,8 @@ const VectorDouble& Grid::getCoordinatesByCorner(const VectorInt& icorner) const
  * @return The coordinates of a cell corner (possibly shifted)
  */
 const VectorDouble& Grid::getCellCoordinatesByCorner(int node,
-                                              const VectorInt& shift,
-                                              const VectorDouble& dxsPerCell) const
+                                                     const VectorInt& shift,
+                                                     const VectorDouble& dxsPerCell) const
 {
 
   rankToIndice(node, _iwork0);
@@ -460,10 +460,10 @@ double Grid::indiceToCoordinate(int idim0,
 {
   /* Calculate the coordinates in the grid system */
 
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
   {
-    _work1[idim] = (double) indice[idim];
-    if (! percent.empty()) _work1[idim] += percent[idim];
+    _work1[idim] = (double)indice[idim];
+    if (!percent.empty()) _work1[idim] += percent[idim];
     _work1[idim] *= _dx[idim];
   }
 
@@ -495,17 +495,16 @@ void Grid::indicesToCoordinateInPlace(const constvectint indice,
 
   /* Calculate the coordinates in the grid system */
 
-
-  for (int idim=0; idim<_nDim; idim++)
+  for (int idim = 0; idim < _nDim; idim++)
   {
     _work1[idim] = indice[idim];
-    if (! percent.empty()) _work1[idim] += percent[idim];
+    if (!percent.empty()) _work1[idim] += percent[idim];
     _work1[idim] *= _dx[idim];
   }
 
   if (flag_rotate)
   {
-    _rotation.rotateDirect(_work1,_work2);
+    _rotation.rotateDirect(_work1, _work2);
     for (int idim = 0; idim < _nDim; idim++)
       coor[idim] = _work2[idim] + _x0[idim];
   }
@@ -527,7 +526,7 @@ VectorDouble Grid::rankToCoordinates(int rank, const VectorDouble& percent) cons
 {
 
   rankToIndice(rank, _iwork0);
-  return indicesToCoordinate(_iwork0,percent);
+  return indicesToCoordinate(_iwork0, percent);
 }
 
 void Grid::rankToCoordinatesInPlace(int rank, VectorDouble& coor, const VectorDouble& percent) const
@@ -538,11 +537,11 @@ void Grid::rankToCoordinatesInPlace(int rank, VectorDouble& coor, const VectorDo
 
 int Grid::indiceToRank(const constvectint indice) const
 {
-  int ival = indice[_nDim-1];
-  if (ival < 0 || ival >= _nx[_nDim-1]) return(-1);
-  for (int idim=_nDim-2; idim>=0; idim--)
+  int ival = indice[_nDim - 1];
+  if (ival < 0 || ival >= _nx[_nDim - 1]) return (-1);
+  for (int idim = _nDim - 2; idim >= 0; idim--)
   {
-    if (indice[idim] < 0 || indice[idim] >= _nx[idim]) return(-1);
+    if (indice[idim] < 0 || indice[idim] >= _nx[idim]) return (-1);
     ival = ival * _nx[idim] + indice[idim];
   }
   return ival;
@@ -571,7 +570,7 @@ void Grid::rankToIndice(int rank, vectint indices, bool minusOne) const
   for (int idim = _nDim - 1; idim >= 0; idim--)
   {
     nval /= (*(nxadd + idim) - minus);
-    newind           = rank / nval;
+    newind        = rank / nval;
     indices[idim] = newind;
     rank -= newind * nval;
   }
@@ -587,9 +586,9 @@ void Grid::initThread() const
   }
 }
 
-VectorInt& Grid::coordinateToIndices(const VectorDouble &coor,
-                                    bool centered,
-                                    double eps) const
+VectorInt& Grid::coordinateToIndices(const VectorDouble& coor,
+                                     bool centered,
+                                     double eps) const
 {
   if (coordinateToIndicesInPlace(coor, _iwork0, centered, eps)) return _dummy;
   return _iwork0;
@@ -603,8 +602,8 @@ VectorInt& Grid::coordinateToIndices(const VectorDouble &coor,
  * @param eps      Epsilon to over-pass roundoff problem
  * @return Error return code
  */
-int Grid::coordinateToIndicesInPlace(const VectorDouble &coor,
-                                     VectorInt &indice,
+int Grid::coordinateToIndicesInPlace(const VectorDouble& coor,
+                                     VectorInt& indice,
                                      bool centered,
                                      double eps) const
 {
@@ -635,18 +634,18 @@ int Grid::coordinateToIndicesInPlace(const VectorDouble &coor,
   {
     int ix;
     if (centered)
-      ix = (int) floor(_work2[idim] / _dx[idim] + 0.5 + eps);
+      ix = (int)floor(_work2[idim] / _dx[idim] + 0.5 + eps);
     else
-      ix = (int) floor(_work2[idim] / _dx[idim] + eps);
+      ix = (int)floor(_work2[idim] / _dx[idim] + eps);
     indice[idim] = ix;
     if (ix < 0 || ix >= _nx[idim]) outside = true;
   }
-  return (int) outside;
+  return (int)outside;
 }
 
 int Grid::coordinateToRank(const VectorDouble& coor, bool centered, double eps) const
 {
-  if (coordinateToIndicesInPlace(coor,_iwork0,centered,eps)) return -1;
+  if (coordinateToIndicesInPlace(coor, _iwork0, centered, eps)) return -1;
   return indiceToRank(_iwork0);
 }
 
@@ -666,17 +665,16 @@ void Grid::_allocate(void)
 {
   initThread();
   _nx.resize(_nDim);
-  for (int i=0; i<_nDim; i++) _nx[i] = 1;
+  for (int i = 0; i < _nDim; i++) _nx[i] = 1;
   _x0.resize(_nDim);
-  for (int i=0; i<_nDim; i++) _x0[i] = 0.;
+  for (int i = 0; i < _nDim; i++) _x0[i] = 0.;
   _dx.resize(_nDim);
-  for (int i=0; i<_nDim; i++) _dx[i] = 0.;
+  for (int i = 0; i < _nDim; i++) _dx[i] = 0.;
 
   _rotation.resetFromSpaceDimension(_nDim);
-
 }
 
-void Grid::_recopy(const Grid &r)
+void Grid::_recopy(const Grid& r)
 {
   _nDim = r._nDim;
   _allocate();
@@ -689,12 +687,11 @@ void Grid::_recopy(const Grid &r)
 
   _rotation = r._rotation;
 
-  _iter = r._iter;
-  _nprod = r._nprod;
-  _counts = r._counts;
-  _order = r._order;
+  _iter    = r._iter;
+  _nprod   = r._nprod;
+  _counts  = r._counts;
+  _order   = r._order;
   _indices = r._indices;
-
 }
 
 /**
@@ -708,7 +705,7 @@ void Grid::_recopy(const Grid &r)
  */
 void Grid::copyParams(int mode, const Grid& gridaux)
 {
-  if (gridaux.getNDim() != _nDim)  return;
+  if (gridaux.getNDim() != _nDim) return;
 
   /* Dispatch */
 
@@ -809,9 +806,9 @@ void Grid::iteratorInit(const VectorInt& order)
   _counts = _nx;
 
   // Define the order
-  if (order.empty() || _nDim != (int) order.size())
+  if (order.empty() || _nDim != (int)order.size())
   {
-    _order.resize(_nDim,0);
+    _order.resize(_nDim, 0);
     for (int idim = 0; idim < _nDim; idim++)
       _order[idim] = idim;
   }
@@ -826,12 +823,12 @@ void Grid::iteratorInit(const VectorInt& order)
         int rank = ABS(order[jdim]) - 1;
         if (rank == idim) found = true;
       }
-      if (! found)
+      if (!found)
       {
         messerr("When provided, 'order' should contain all Space dimensions. Iterator cancelled.");
-        _iter = 0;
+        _iter   = 0;
         _counts = {};
-        _order = VectorInt();
+        _order  = VectorInt();
         return;
       }
     }
@@ -866,9 +863,9 @@ void Grid::iteratorNext(std::vector<int>& indices)
   for (int jdim = _nDim - 1; jdim >= 0; jdim--)
   {
     int order = _order[jdim];
-    idim = ABS(order);
+    idim      = ABS(order);
     nval /= _counts[idim];
-    int divid = iech / nval;
+    int divid     = iech / nval;
     indices[idim] = divid;
     iech -= divid * nval;
   }
@@ -936,11 +933,11 @@ void Grid::dilate(int mode,
  ** \param[out] x0    Array of grid origins
  **
  *****************************************************************************/
-void Grid::multiple(const VectorInt &nmult,
+void Grid::multiple(const VectorInt& nmult,
                     bool flagCell,
-                    VectorInt &nx,
-                    VectorDouble &dx,
-                    VectorDouble &x0) const
+                    VectorInt& nx,
+                    VectorDouble& dx,
+                    VectorDouble& x0) const
 {
   VectorDouble perc(_nDim);
   VectorDouble coor1(_nDim); // cannot use _work1 and _work2 (as already used inside)
@@ -950,11 +947,11 @@ void Grid::multiple(const VectorInt &nmult,
 
   for (int idim = 0; idim < _nDim; idim++)
   {
-    double value = (double) getNX(idim);
+    double value = (double)getNX(idim);
     if (flagCell)
-      nx[idim] = (int) floor(value / (double) nmult[idim]);
+      nx[idim] = (int)floor(value / (double)nmult[idim]);
     else
-      nx[idim] = 1 + (int) floor((value - 1.) / (double) nmult[idim]);
+      nx[idim] = 1 + (int)floor((value - 1.) / (double)nmult[idim]);
   }
 
   /* Get the new grid meshes */
@@ -976,7 +973,7 @@ void Grid::multiple(const VectorInt &nmult,
   {
     double delta = (coor2[idim] - coor1[idim]) / 2.;
     if (flagCell)
-      x0[idim] = coor1[idim] + delta * (double) nmult[idim];
+      x0[idim] = coor1[idim] + delta * (double)nmult[idim];
     else
       x0[idim] = getX0(idim);
   }
@@ -994,11 +991,11 @@ void Grid::multiple(const VectorInt &nmult,
  ** \param[out] x0    Array of grid origins
  **
  *****************************************************************************/
-void Grid::divider(const VectorInt &nmult,
+void Grid::divider(const VectorInt& nmult,
                    bool flagCell,
-                   VectorInt &nx,
-                   VectorDouble &dx,
-                   VectorDouble &x0) const
+                   VectorInt& nx,
+                   VectorDouble& dx,
+                   VectorDouble& x0) const
 {
   VectorDouble perc(_nDim);
   VectorDouble coor1(_nDim); // cannot use _work1 and _work2 (as already used inside)
@@ -1017,7 +1014,7 @@ void Grid::divider(const VectorInt &nmult,
   /* Get the new grid meshes */
 
   for (int idim = 0; idim < _nDim; idim++)
-    dx[idim] = getDX(idim) / ((double) nmult[idim]);
+    dx[idim] = getDX(idim) / ((double)nmult[idim]);
 
   /* Get the lower left corner of the small grid */
 
@@ -1033,7 +1030,7 @@ void Grid::divider(const VectorInt &nmult,
   {
     double delta = (coor2[idim] - coor1[idim]) / 2.;
     if (flagCell)
-      x0[idim] = coor1[idim] + delta / (double) nmult[idim];
+      x0[idim] = coor1[idim] + delta / (double)nmult[idim];
     else
       x0[idim] = getX0(idim);
   }
@@ -1088,13 +1085,13 @@ bool Grid::isInside(const VectorInt& indices) const
  ** \remark   in position 'i' of the regular grid of gstlearn
  **
  *****************************************************************************/
-VectorInt Grid::gridIndices(const VectorInt &nx,
-                            const String &string,
+VectorInt Grid::gridIndices(const VectorInt& nx,
+                            const String& string,
                             bool startFromZero,
                             bool invert,
                             bool verbose)
 {
-  int ndim = (int) nx.size();
+  int ndim  = (int)nx.size();
   int ncell = VH::product(nx);
 
   // Decode the string
@@ -1106,15 +1103,15 @@ VectorInt Grid::gridIndices(const VectorInt &nx,
 
   DimLoop dlp;
   dlp.curech = 0;
-  dlp.ndim = ndim;
-  dlp.nx = nx;
-  dlp.order = order;
-  dlp.indg = VectorInt(ndim,0);
-  dlp.tab = VectorInt(ncell);
+  dlp.ndim   = ndim;
+  dlp.nx     = nx;
+  dlp.order  = order;
+  dlp.indg   = VectorInt(ndim, 0);
+  dlp.tab    = VectorInt(ncell);
 
   // Recursion
 
-  _dimensionRecursion(ndim-1, verbose, dlp);
+  _dimensionRecursion(ndim - 1, verbose, dlp);
 
   // Invert order
 
@@ -1140,7 +1137,7 @@ VectorInt Grid::gridIndices(const VectorInt &nx,
   return tab2;
 }
 
-VectorInt Grid::generateGridIndices(const String &string,
+VectorInt Grid::generateGridIndices(const String& string,
                                     bool startFromZero,
                                     bool invert,
                                     bool verbose) const
@@ -1228,7 +1225,7 @@ bool Grid::sampleBelongsToCell(const VectorDouble& coor,
                                const VectorDouble& center,
                                const VectorDouble& dxsPerCell) const
 {
- return sampleBelongsToCell(constvect(coor),constvect(center),dxsPerCell);
+  return sampleBelongsToCell(constvect(coor), constvect(center), dxsPerCell);
 }
 
 /**
@@ -1240,9 +1237,9 @@ bool Grid::sampleBelongsToCell(const VectorDouble& coor,
  *
  * @remark Samples located exactly on the edge are considered as INSIDE
  */
-bool Grid::sampleBelongsToCell(const VectorDouble &coor,
+bool Grid::sampleBelongsToCell(const VectorDouble& coor,
                                int rank,
-                               const VectorDouble &dxsPerCell) const
+                               const VectorDouble& dxsPerCell) const
 {
 
   // Identify the coordinates of the center of the grid cell, referred by its 'rank' and
@@ -1250,7 +1247,7 @@ bool Grid::sampleBelongsToCell(const VectorDouble &coor,
   VectorDouble center = rankToCoordinates(rank);
 
   // Complement 'coor' to the grid space dimension
-  int ndim_coor = (int) coor.size();
+  int ndim_coor = (int)coor.size();
   VectorDouble coor_loc;
   if (ndim_coor == _nDim)
     coor_loc = coor;
@@ -1284,12 +1281,12 @@ bool Grid::sampleBelongsToCell(const VectorDouble &coor,
   else
   {
     // Calculate the departure between sample and grid center
-     for (int idim = 0; idim < MIN(ndim_coor, _nDim); idim++)
-     {
-       double dxloc = (dxsPerCell.empty()) ? _dx[idim] : dxsPerCell[idim];
-       double delta = center[idim] - coor_loc[idim];
-       if (ABS(delta) > dxloc / 2.) return false;
-     }
+    for (int idim = 0; idim < MIN(ndim_coor, _nDim); idim++)
+    {
+      double dxloc = (dxsPerCell.empty()) ? _dx[idim] : dxsPerCell[idim];
+      double delta = center[idim] - coor_loc[idim];
+      if (ABS(delta) > dxloc / 2.) return false;
+    }
   }
   return true;
 }
@@ -1385,12 +1382,12 @@ bool Grid::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) const
   auto gridG = grp.createGroup("Grid");
 
   bool ret = true;
-  ret = ret && SerializeHDF5::writeVec(gridG, "NX", getNXs());
-  ret = ret && SerializeHDF5::writeVec(gridG, "X0", getX0s());
-  ret = ret && SerializeHDF5::writeVec(gridG, "DX", getDXs());
-  ret = ret && SerializeHDF5::writeVec(gridG, "ANGLE", getRotAngles());
+  ret      = ret && SerializeHDF5::writeVec(gridG, "NX", getNXs());
+  ret      = ret && SerializeHDF5::writeVec(gridG, "X0", getX0s());
+  ret      = ret && SerializeHDF5::writeVec(gridG, "DX", getDXs());
+  ret      = ret && SerializeHDF5::writeVec(gridG, "ANGLE", getRotAngles());
 
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Basic/Law.cpp
+++ b/src/Basic/Law.cpp
@@ -10,12 +10,12 @@
 /******************************************************************************/
 #include "Basic/Law.hpp"
 
-#include "Basic/Utilities.hpp"
 #include "Basic/MathFunc.hpp"
+#include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "geoslib_define.h"
 
-#include <math.h>
+#include <cmath>
 #include <random>
 
 namespace gstlrn
@@ -27,11 +27,11 @@ static bool Random_Old_Style = true;
 std::mt19937 Random_gen;
 
 /*! \cond */
-#define TABIN_BY_COL(iech,ivar)       (tabin [(ivar) * nechin  + (iech)])
-#define TABIN_BY_LINE(iech,ivar)      (tabin [(iech) * nvarin  + (ivar)])
-#define TABOUT_BY_COL(iech,ivar)      (tabout[(ivar) * nechout + (iech)])
-#define TABOUT_BY_LINE(iech,ivar)     (tabout[(iech) * nvarout + (ivar)])
-#define CONSTS(iconst,ivar1)          (consts[(iconst) * nvar1 + (ivar1)])
+#define TABIN_BY_COL(iech, ivar)   (tabin[(ivar) * nechin + (iech)])
+#define TABIN_BY_LINE(iech, ivar)  (tabin[(iech) * nvarin + (ivar)])
+#define TABOUT_BY_COL(iech, ivar)  (tabout[(ivar) * nechout + (iech)])
+#define TABOUT_BY_LINE(iech, ivar) (tabout[(iech) * nvarout + (ivar)])
+#define CONSTS(iconst, ivar1)      (consts[(iconst) * nvar1 + (ivar1)])
 /*! \endcond */
 
 /**
@@ -68,8 +68,8 @@ void law_set_random_seed(int seed)
   if (seed > 0)
   {
     Random_value = seed;
-    if (! Random_Old_Style)
-      Random_gen.seed((unsigned) seed);
+    if (!Random_Old_Style)
+      Random_gen.seed((unsigned)seed);
   }
 }
 
@@ -92,13 +92,13 @@ double law_uniform(double mini, double maxi)
   {
     unsigned int random_product;
     random_product = Random_factor * Random_value;
-    Random_value = random_product % Random_congruent;
-    value = (double) Random_value / (double) Random_congruent;
-    value = mini + value * (maxi - mini);
+    Random_value   = random_product % Random_congruent;
+    value          = (double)Random_value / (double)Random_congruent;
+    value          = mini + value * (maxi - mini);
   }
   else
   {
-    std::uniform_real_distribution<double> d{mini,maxi};
+    std::uniform_real_distribution<double> d {mini, maxi};
     value = d(Random_gen);
   }
   return (value);
@@ -120,8 +120,8 @@ int law_int_uniform(int mini, int maxi)
   int number, rank;
 
   number = maxi - mini + 1;
-  rndval = law_uniform(0., (double) number);
-  rank = (int) floor(rndval);
+  rndval = law_uniform(0., (double)number);
+  rank   = (int)floor(rndval);
   return (rank + mini);
 }
 
@@ -144,12 +144,12 @@ double law_gaussian(double mean, double sigma)
   {
     double random1 = law_uniform();
     double random2 = law_uniform(0., 2. * GV_PI);
-    value = sqrt(-2. * log(random1)) * cos(random2);
-    value = value * sigma + mean;
+    value          = sqrt(-2. * log(random1)) * cos(random2);
+    value          = value * sigma + mean;
   }
   else
   {
-    std::normal_distribution<double> d{mean,sigma};
+    std::normal_distribution<double> d {mean, sigma};
     value = d(Random_gen);
   }
   return value;
@@ -254,13 +254,13 @@ double law_stable_standard_abgd(double alpha)
 {
   double unif, expo, temp, ialpha, b, res;
 
-  b = GV_PI / 2;
-  unif = law_uniform(-b, b);
-  expo = law_exponential(1.);
+  b      = GV_PI / 2;
+  unif   = law_uniform(-b, b);
+  expo   = law_exponential(1.);
   ialpha = 1. / alpha;
   if (alpha > 1) b *= (1 - 2. / alpha);
   temp = alpha * (unif + b);
-  res = sin(temp) / pow(cos(unif), ialpha);
+  res  = sin(temp) / pow(cos(unif), ialpha);
   res *= pow(cos(unif - temp) / expo, ialpha - 1.);
   res = (!FFFF(unif) && !FFFF(expo)) ? res : TEST;
   return (res);
@@ -280,19 +280,18 @@ double law_stable_standard_agd(double alpha, double beta)
 {
   double unif, expo, unif_norm, ialpha, temp, temp1, b, temp2, temp3, res;
 
-  temp = alpha * GV_PI / 2;
-  ialpha = 1. / alpha;
-  unif = law_uniform(-temp, temp);
-  expo = law_exponential(1.);
+  temp      = alpha * GV_PI / 2;
+  ialpha    = 1. / alpha;
+  unif      = law_uniform(-temp, temp);
+  expo      = law_exponential(1.);
   unif_norm = unif * ialpha;
-  temp1 = beta * tan(temp);
-  b = atan(temp1);
-  temp2 = pow(1 + temp1 * temp1, ialpha / 2);
-  temp3 = unif + b;
-  res = temp2 * sin(temp3) / pow(cos(unif_norm), ialpha);
+  temp1     = beta * tan(temp);
+  b         = atan(temp1);
+  temp2     = pow(1 + temp1 * temp1, ialpha / 2);
+  temp3     = unif + b;
+  res       = temp2 * sin(temp3) / pow(cos(unif_norm), ialpha);
   res *= pow(cos(unif_norm - temp3) / expo, ialpha - 1);
-  res = (!FFFF(unif) && !FFFF(expo)) ? res :
-                                       TEST;
+  res = (!FFFF(unif) && !FFFF(expo)) ? res : TEST;
   return (res);
 }
 
@@ -308,15 +307,14 @@ double law_stable_standard_a1gd(double beta)
 {
   double unif, expo, temp, temp2, res;
 
-  temp = GV_PI / 2;
-  unif = law_uniform(-temp, temp);
-  expo = law_exponential(1.);
+  temp  = GV_PI / 2;
+  unif  = law_uniform(-temp, temp);
+  expo  = law_exponential(1.);
   temp2 = temp + beta * unif;
-  res = temp2 * tan(unif);
+  res   = temp2 * tan(unif);
   res -= beta * log(expo * cos(unif) / temp2);
   res /= temp;
-  res = (!FFFF(unif) && !FFFF(expo)) ? res :
-                                       TEST;
+  res = (!FFFF(unif) && !FFFF(expo)) ? res : TEST;
   return (res);
 }
 
@@ -335,9 +333,8 @@ double law_stable_a(double alpha, double beta, double gamma, double delta)
 {
   double stable, res;
   stable = law_stable_standard_agd(alpha, beta);
-  res = pow(gamma, 1. / alpha) * stable + gamma * delta;
-  res = (!FFFF(stable)) ? res :
-                          TEST;
+  res    = pow(gamma, 1. / alpha) * stable + gamma * delta;
+  res    = (!FFFF(stable)) ? res : TEST;
   return (res);
 }
 
@@ -355,9 +352,8 @@ double law_stable_a1(double beta, double gamma, double delta)
 {
   double stable, res;
   stable = law_stable_standard_a1gd(beta);
-  res = gamma * (stable + delta + 2. / GV_PI * beta * log(gamma));
-  res = (!FFFF(stable)) ? res :
-                          TEST;
+  res    = gamma * (stable + delta + 2. / GV_PI * beta * log(gamma));
+  res    = (!FFFF(stable)) ? res : TEST;
   return (res);
 }
 
@@ -397,8 +393,8 @@ double law_beta1(double parameter1, double parameter2)
 {
   double a, b, res;
 
-  a = law_gamma(parameter1,1.);
-  b = law_gamma(parameter2,1.);
+  a = law_gamma(parameter1, 1.);
+  b = law_gamma(parameter2, 1.);
 
   res = (!FFFF(a) && !FFFF(b)) ? a / (a + b) : TEST;
   return (res);
@@ -418,8 +414,8 @@ double law_beta2(double parameter1, double parameter2)
 {
   double a, b, res;
 
-  a = law_gamma(parameter1,1.);
-  b = law_gamma(parameter2,1.);
+  a = law_gamma(parameter1, 1.);
+  b = law_gamma(parameter2, 1.);
 
   res = (!FFFF(a) && !FFFF(b)) ? a / b : TEST;
   return (res);
@@ -481,12 +477,12 @@ double law_dnorm(double value, double mean, double std)
  *****************************************************************************/
 double law_cdf_gaussian(double value)
 {
-  static double b[] = { 0.319381530,
-                        -0.356563782,
-                        1.781477937,
-                        -1.821255978,
-                        1.330274429 };
-  static double p = 0.2316419;
+  static double b[] = {0.319381530,
+                       -0.356563782,
+                       1.781477937,
+                       -1.821255978,
+                       1.330274429};
+  static double p   = 0.2316419;
   double u, v, x, t;
   int i;
 
@@ -521,31 +517,28 @@ double law_cdf_gaussian(double value)
 double law_invcdf_gaussian(double value)
 
 {
-  static double b[] = { 0.319381530,
-                        -0.356563782,
-                        1.781477937,
-                        -1.821255978,
-                        1.330274429 };
-  static double c[] = { 2.515517, 0.802853, 0.010328 };
-  static double d[] = { 1.432788, 0.189269, 0.001308 };
-  static double p = 0.2316419;
+  static double b[] = {0.319381530,
+                       -0.356563782,
+                       1.781477937,
+                       -1.821255978,
+                       1.330274429};
+  static double c[] = {2.515517, 0.802853, 0.010328};
+  static double d[] = {1.432788, 0.189269, 0.001308};
+  static double p   = 0.2316419;
   double xmin, xmax, v, t, freq, x = 0.;
 
   if (value <= 0.) return (-10.);
   if (value >= 1.) return (10.);
-  v = (value < 0.5) ? 1 - value :
-                      value;
-  t = sqrt(-2 * log(1 - v));
-  xmin = t
-      - (c[0] + t * (c[1] + t * c[2])) / (1.
-          + t * (d[0] + t * (d[1] + t * d[2])));
+  v    = (value < 0.5) ? 1 - value : value;
+  t    = sqrt(-2 * log(1 - v));
+  xmin = t - (c[0] + t * (c[1] + t * c[2])) / (1. + t * (d[0] + t * (d[1] + t * d[2])));
   xmin = xmin - 0.001;
   xmax = xmin + 0.002;
 
   while ((xmax - xmin) > 0.0000001)
   {
-    x = (xmin + xmax) / 2.;
-    t = 1. / (1. + p * x);
+    x    = (xmin + xmax) / 2.;
+    t    = 1. / (1. + p * x);
     freq = t * (b[0] + t * (b[1] + t * (b[2] + t * (b[3] + t * b[4]))));
     if (freq * exp(-x * x / 2) / sqrt(2. * GV_PI) > 1. - v)
       xmin = x;
@@ -575,70 +568,70 @@ double law_gaussian_between_bounds(double binf, double bsup)
   int k, n, isim, type, ok, rank, itab[4];
   static double seuil = 2.;
   static double large = 20.;
-  static double sqe = 1.6487212707;
+  static double sqe   = 1.6487212707;
 
   x = 0.;
 
   /* Loop on the intervals */
 
-  n = 0;
-  a = (FFFF(binf)) ? -large : binf;
-  b = (FFFF(bsup)) ? large : bsup;
+  n  = 0;
+  a  = (FFFF(binf)) ? -large : binf;
+  b  = (FFFF(bsup)) ? large : bsup;
   aa = a;
   bb = b;
 
   if (aa < -seuil)
   {
-    atab[n] = aa;
-    btab[n] = MIN(bb, -seuil);
+    atab[n]   = aa;
+    btab[n]   = MIN(bb, -seuil);
     itab[n++] = 1;
-    aa = -seuil;
+    aa        = -seuil;
     if (aa >= bb) goto label_norme;
   }
   if (aa < 0)
   {
-    atab[n] = aa;
-    btab[n] = MIN(bb, 0.);
+    atab[n]   = aa;
+    btab[n]   = MIN(bb, 0.);
     itab[n++] = 2;
-    aa = 0.;
+    aa        = 0.;
     if (aa >= bb) goto label_norme;
   }
   if (aa < seuil)
   {
-    atab[n] = aa;
-    btab[n] = MIN(bb, seuil);
+    atab[n]   = aa;
+    btab[n]   = MIN(bb, seuil);
     itab[n++] = 3;
-    aa = seuil;
+    aa        = seuil;
     if (aa >= bb) goto label_norme;
   }
-  atab[n] = aa;
-  btab[n] = bb;
+  atab[n]   = aa;
+  btab[n]   = bb;
   itab[n++] = 4;
 
-  label_norme:
+label_norme:
   total = 0.;
   double wgt;
   for (k = 0; k < n; k++)
   {
-    aa = atab[k];
-    bb = btab[k];
+    aa   = atab[k];
+    bb   = btab[k];
     type = itab[k];
-    wgt = 0.;
+    wgt  = 0.;
     if (ABS(aa - bb) > 0.) switch (type)
-    {
-      case 1:
-        wgt = (exp(-aa * aa / 2.) - exp(-bb * bb / 2.)) / bb;
-        break;
-      case 2:
-        wgt = sqe * (exp(bb) - exp(aa));
-        break;
-      case 3:
-        wgt = sqe * (exp(-aa) - exp(-bb));
-        break;
-      case 4:
-        wgt = (exp(-aa * aa / 2.) - exp(-bb * bb / 2.)) / aa;
-        break;
-    }
+      {
+        case 1:
+          wgt = (exp(-aa * aa / 2.) - exp(-bb * bb / 2.)) / bb;
+          break;
+        case 2:
+          wgt = sqe * (exp(bb) - exp(aa));
+          break;
+        case 3:
+          wgt = sqe * (exp(-aa) - exp(-bb));
+          break;
+        case 4:
+          wgt = (exp(-aa * aa / 2.) - exp(-bb * bb / 2.)) / aa;
+          break;
+      }
     total += wgt;
     ptab[k] = total;
   }
@@ -647,8 +640,8 @@ double law_gaussian_between_bounds(double binf, double bsup)
 
   if (total <= 0.)
   {
-    rank = (int) ((double) n * law_uniform(0., 1.));
-    x = atab[rank];
+    rank = (int)((double)n * law_uniform(0., 1.));
+    x    = atab[rank];
     return (x);
   }
 
@@ -661,24 +654,24 @@ double law_gaussian_between_bounds(double binf, double bsup)
   while (ok)
   {
     isim = 0;
-    u = law_uniform(0., 1.);
+    u    = law_uniform(0., 1.);
     while (ptab[isim] < u)
       isim++;
 
     /* Simulate a value in the interval */
 
     type = itab[isim];
-    aa = atab[isim];
-    bb = btab[isim];
-    a2 = aa * aa;
-    b2 = bb * bb;
+    aa   = atab[isim];
+    bb   = btab[isim];
+    a2   = aa * aa;
+    b2   = bb * bb;
 
     u = law_uniform(0., 1.);
     switch (type)
     {
       case 1:
         c2 = 1. - exp((b2 - a2) / 2.);
-        x = -sqrt(b2 - 2. * log(1. - u * c2));
+        x  = -sqrt(b2 - 2. * log(1. - u * c2));
         break;
 
       case 2:
@@ -691,7 +684,7 @@ double law_gaussian_between_bounds(double binf, double bsup)
 
       case 4:
         c2 = 1. - exp((a2 - b2) / 2.);
-        x = sqrt(a2 - 2. * log(1. - u * c2));
+        x  = sqrt(a2 - 2. * log(1. - u * c2));
         break;
     }
 
@@ -731,16 +724,16 @@ double law_gaussian_between_bounds(double binf, double bsup)
  ** \param[in]  correl Correlation matrix (Dimension: 2*2)
  **
  *****************************************************************************/
-double law_df_bigaussian(VectorDouble &vect,
-                         VectorDouble &mean,
+double law_df_bigaussian(VectorDouble& vect,
+                         VectorDouble& mean,
                          MatrixSymmetric& correl)
 {
   VectorDouble xc(2);
-  xc[0] = vect[0] - mean[0];
-  xc[1] = vect[1] - mean[1];
-  double detv = correl.getValue(0,0) * correl.getValue(1,1) - correl.getValue(0,1) * correl.getValue(1,0);
-  double det2 = (correl.getValue(1,1) * xc[0] * xc[0] - 2. * correl.getValue(0,1) * xc[0] * xc[1] + correl.getValue(0,0) * xc[1] * xc[1]);
-  double logres = 2. * log(2. * GV_PI) + log(detv) + det2 / detv;
+  xc[0]          = vect[0] - mean[0];
+  xc[1]          = vect[1] - mean[1];
+  double detv    = correl.getValue(0, 0) * correl.getValue(1, 1) - correl.getValue(0, 1) * correl.getValue(1, 0);
+  double det2    = (correl.getValue(1, 1) * xc[0] * xc[0] - 2. * correl.getValue(0, 1) * xc[0] * xc[1] + correl.getValue(0, 0) * xc[1] * xc[1]);
+  double logres  = 2. * log(2. * GV_PI) + log(detv) + det2 / detv;
   double density = exp(-logres / 2.);
   return (density);
 }
@@ -757,7 +750,7 @@ double law_df_bigaussian(VectorDouble &vect,
  *****************************************************************************/
 double law_df_quadgaussian(VectorDouble& vect, MatrixSymmetric& correl)
 {
-  int nvar = (int) vect.size();
+  int nvar       = (int)vect.size();
   double density = -2. * log(2 * GV_PI);
 
   if (correl.computeEigen()) return TEST;
@@ -787,7 +780,7 @@ double law_df_quadgaussian(VectorDouble& vect, MatrixSymmetric& correl)
 double law_df_multigaussian(VectorDouble& vect, MatrixSymmetric& correl)
 
 {
-  int nvar = (int) vect.size();
+  int nvar       = (int)vect.size();
   double density = -0.5 * nvar * log(2 * GV_PI);
 
   if (correl.computeEigen()) return TEST;
@@ -806,7 +799,7 @@ double law_df_multigaussian(VectorDouble& vect, MatrixSymmetric& correl)
 
 VectorDouble law_df_poisson_vec(VectorInt is, double parameter)
 {
-  int size = (int) is.size();
+  int size = (int)is.size();
   VectorDouble res(size);
   for (int ii = 0; ii < size; ii++)
     res[ii] = law_df_poisson(is[ii], parameter);
@@ -836,7 +829,7 @@ int law_poisson(double parameter)
     double x, p, q;
     int n, ok;
 
-    int k = 0;
+    int k    = 0;
     double t = parameter;
 
     while (t >= 16)
@@ -890,7 +883,7 @@ VectorInt law_random_path(int nech)
 
   for (int i = 0; i < nech; i++)
   {
-    path[i] = i;
+    path[i]  = i;
     order[i] = law_uniform(0., 1.);
   }
   VH::arrangeInPlace(0, path, order, true, nech);
@@ -914,9 +907,9 @@ int law_binomial(int n, double p)
   {
     const double s = p / q;
     const double a = (n + 1) * s;
-    double r = exp(n * log(q)); /* pow() causes a crash on AIX */
-    int x = 0;
-    double u = law_uniform(0., 1.);
+    double r       = exp(n * log(q)); /* pow() causes a crash on AIX */
+    int x          = 0;
+    double u       = law_uniform(0., 1.);
     while (1)
     {
       if (u < r) return x;
@@ -928,20 +921,20 @@ int law_binomial(int n, double p)
   else /* Algorithm BTPE */
   {
     /* Step 0 */
-    const double fm = n * p + p;
-    const int m = (int) fm;
-    const double p1 = floor(2.195 * sqrt(n * p * q) - 4.6 * q) + 0.5;
-    const double xm = m + 0.5;
-    const double xl = xm - p1;
-    const double xr = xm + p1;
-    const double c = 0.134 + 20.5 / (15.3 + m);
-    const double a = (fm - xl) / (fm - xl * p);
-    const double b = (xr - fm) / (xr * q);
+    const double fm      = n * p + p;
+    const int m          = (int)fm;
+    const double p1      = floor(2.195 * sqrt(n * p * q) - 4.6 * q) + 0.5;
+    const double xm      = m + 0.5;
+    const double xl      = xm - p1;
+    const double xr      = xm + p1;
+    const double c       = 0.134 + 20.5 / (15.3 + m);
+    const double a       = (fm - xl) / (fm - xl * p);
+    const double b       = (xr - fm) / (xr * q);
     const double lambdal = a * (1.0 + 0.5 * a);
     const double lambdar = b * (1.0 + 0.5 * b);
-    const double p2 = p1 * (1 + 2 * c);
-    const double p3 = p2 + c / lambdal;
-    const double p4 = p3 + c / lambdar;
+    const double p2      = p1 * (1 + 2 * c);
+    const double p3      = p2 + c / lambdal;
+    const double p4      = p3 + c / lambdar;
     while (1)
     {
       /* Step 1 */
@@ -950,7 +943,7 @@ int law_binomial(int n, double p)
       double u = law_uniform(0., 1.);
       double v = law_uniform(0., 1.);
       u *= p4;
-      if (u <= p1) return (int) (xm - p1 * v + u);
+      if (u <= p1) return (int)(xm - p1 * v + u);
       /* Step 2 */
       if (u > p2)
       {
@@ -958,14 +951,14 @@ int law_binomial(int n, double p)
         if (u > p3)
         {
           /* Step 4 */
-          y = (int) (xr - log(v) / lambdar);
+          y = (int)(xr - log(v) / lambdar);
           if (y > n) continue;
           /* Go to step 5 */
           v = v * (u - p3) * lambdar;
         }
         else
         {
-          y = (int) (xl + log(v) / lambdal);
+          y = (int)(xl + log(v) / lambdal);
           if (y < 0) continue;
           /* Go to step 5 */
           v = v * (u - p2) * lambdal;
@@ -974,10 +967,10 @@ int law_binomial(int n, double p)
       else
       {
         const double x = xl + (u - p1) / c;
-        v = v * c + 1.0 - fabs(m - x + 0.5) / p1;
+        v              = v * c + 1.0 - fabs(m - x + 0.5) / p1;
         if (v > 1) continue;
         /* Go to step 5 */
-        y = (int) x;
+        y = (int)x;
       }
       /* Step 5 */
       /* Step 5.0 */
@@ -985,10 +978,9 @@ int law_binomial(int n, double p)
       if (k > 20 && k < 0.5 * n * p * q - 1.0)
       {
         /* Step 5.2 */
-        double rho = (k / (n * p * q))
-            * ((k * (k / 3.0 + 0.625) + 0.1666666666666) / (n * p * q) + 0.5);
-        double t = -k * k / (2 * n * p * q);
-        double A = log(v);
+        double rho = (k / (n * p * q)) * ((k * (k / 3.0 + 0.625) + 0.1666666666666) / (n * p * q) + 0.5);
+        double t   = -k * k / (2 * n * p * q);
+        double A   = log(v);
         if (A < t - rho) return y;
         if (A > t + rho) continue;
         /* Step 5.3 */
@@ -1019,10 +1011,8 @@ int law_binomial(int n, double p)
       const double s  = p / q;
       const double aa = s * (n + 1);
       double f        = 1.0;
-      for (i = m; i < y; f *= (aa / (++i) - s))
-        ;
-      for (i = y; i < m; f /= (aa / (++i) - s))
-        ;
+      for (i = m; i < y; f *= (aa / (++i) - s));
+      for (i = y; i < m; f /= (aa / (++i) - s));
       if (v > f) continue;
       return y;
     }
@@ -1080,7 +1070,7 @@ VectorDouble law_exp_sample(const double* tabin,
 
   law_set_random_seed(seed);
   nvarin = nvarout = nvar;
-  nvar1 = nvar + 1;
+  nvar1            = nvar + 1;
 
   /* Internal core allocation */
 
@@ -1096,8 +1086,7 @@ VectorDouble law_exp_sample(const double* tabin,
   {
     for (int ivar = 0; ivar < nvarin; ivar++)
     {
-      value = (mode == 1) ? TABIN_BY_COL(iechin, ivar) :
-                            TABIN_BY_LINE(iechin, ivar);
+      value = (mode == 1) ? TABIN_BY_COL(iechin, ivar) : TABIN_BY_LINE(iechin, ivar);
       if (FFFF(value))
       {
         messerr("The sample %d of the Training Data Base", iechin + 1);
@@ -1115,8 +1104,8 @@ VectorDouble law_exp_sample(const double* tabin,
 
   for (int ivar = 0; ivar < nvarin; ivar++)
   {
-    mean[ivar] /= (double) nechin;
-    stdv[ivar] = stdv[ivar] / (double) nechin - mean[ivar] * mean[ivar];
+    mean[ivar] /= (double)nechin;
+    stdv[ivar] = stdv[ivar] / (double)nechin - mean[ivar] * mean[ivar];
     stdv[ivar] = (stdv[ivar] > 0) ? sqrt(stdv[ivar]) : 0.;
     stdv[ivar] *= percent / 100.;
   }
@@ -1138,7 +1127,7 @@ VectorDouble law_exp_sample(const double* tabin,
 
       /* Get the closest experimental sample (the reference) */
 
-      selec = (int) law_uniform(1., (double) nechin);
+      selec            = (int)law_uniform(1., (double)nechin);
       auto placeholder = (selec + 0.5);
       iechin           = (int)placeholder;
       if (iechin < 0) iechin = 0;
@@ -1150,9 +1139,9 @@ VectorDouble law_exp_sample(const double* tabin,
       {
         rab = stdv[ivar] * law_gaussian();
         if (mode == 1)
-          temp[ivar] = TABIN_BY_COL(iechin,ivar) + rab;
+          temp[ivar] = TABIN_BY_COL(iechin, ivar) + rab;
         else
-          temp[ivar] = TABIN_BY_LINE(iechin,ivar) + rab;
+          temp[ivar] = TABIN_BY_LINE(iechin, ivar) + rab;
       }
       temp[nvar] = 1;
 
@@ -1165,7 +1154,7 @@ VectorDouble law_exp_sample(const double* tabin,
         {
           total = 0.;
           for (int ivar1 = 0; ivar1 < nvar1; ivar1++)
-            total += CONSTS(iconst,ivar1) * temp[ivar1];
+            total += CONSTS(iconst, ivar1) * temp[ivar1];
           if (total < 0) flag_ok = 0;
         }
       }
@@ -1177,9 +1166,9 @@ VectorDouble law_exp_sample(const double* tabin,
         for (int ivar = 0; ivar < nvar; ivar++)
         {
           if (mode == 1)
-            TABOUT_BY_COL(iechout,ivar) = temp[ivar];
+            TABOUT_BY_COL(iechout, ivar) = temp[ivar];
           else
-            TABOUT_BY_LINE(iechout,ivar) = temp[ivar];
+            TABOUT_BY_LINE(iechout, ivar) = temp[ivar];
         }
         flag_cont = 0;
       }
@@ -1212,8 +1201,8 @@ int sampleInteger(int mini, int maxi)
 {
   double rmini = mini - 0.5;
   double rmaxi = maxi + 0.5;
-  double rand = law_uniform(rmini, rmaxi);
-  int retval = (rand > 0) ? (int) trunc(rand + 0.5) : (int) -trunc(-rand + 0.5);
+  double rand  = law_uniform(rmini, rmaxi);
+  int retval   = (rand > 0) ? (int)trunc(rand + 0.5) : (int)-trunc(-rand + 0.5);
   return retval;
 }
-}
+} // namespace gstlrn

--- a/src/Basic/MathFunc.cpp
+++ b/src/Basic/MathFunc.cpp
@@ -18,11 +18,10 @@
 #include "Core/fftn.hpp"
 #include "Basic/Memory.hpp"
 
-#include <math.h>
+#include <cmath>
 #include <boost/math/special_functions/legendre.hpp>
 #include <boost/math/special_functions/spherical_harmonic.hpp>
 #include <Geometry/GeometryHelper.hpp>
-
 
 DISABLE_WARNING_PUSH
 

--- a/src/Basic/Plane.cpp
+++ b/src/Basic/Plane.cpp
@@ -12,44 +12,43 @@
 #include "Basic/Law.hpp"
 #include "Db/DbGrid.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 Plane::Plane()
-    : AStringable(),
-      _coor(3),
-      _intercept(0),
-      _value(0.),
-      _rndval(0.)
+  : AStringable()
+  , _coor(3)
+  , _intercept(0)
+  , _value(0.)
+  , _rndval(0.)
 {
 }
 
-Plane::Plane(const Plane &m)
-    : AStringable(m),
-      _coor(m._coor),
-      _intercept(m._intercept),
-      _value(m._value),
-      _rndval(m._rndval)
+Plane::Plane(const Plane& m)
+  : AStringable(m)
+  , _coor(m._coor)
+  , _intercept(m._intercept)
+  , _value(m._value)
+  , _rndval(m._rndval)
 {
 }
 
-Plane& Plane::operator=(const Plane &m)
+Plane& Plane::operator=(const Plane& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
-    _coor = m._coor;
+    _coor      = m._coor;
     _intercept = m._intercept;
-    _value = m._value;
-    _rndval = m._rndval;
+    _value     = m._value;
+    _rndval    = m._rndval;
   }
   return *this;
 }
 
 Plane::~Plane()
 {
-
 }
 
 String Plane::toString(const AStringFormat* /*strfmt*/) const
@@ -70,12 +69,12 @@ String Plane::toString(const AStringFormat* /*strfmt*/) const
  ** \remarks  The valuation of each line is assigned a uniform value [0,1]
  **
  *****************************************************************************/
-std::vector<Plane> Plane::poissonPlanesGenerate(DbGrid *dbgrid, int np)
+std::vector<Plane> Plane::poissonPlanesGenerate(DbGrid* dbgrid, int np)
 {
   double ap[3];
 
   VectorDouble center = dbgrid->getCenters();
-  center.resize(3,0.);
+  center.resize(3, 0.);
   double diagonal = dbgrid->getExtensionDiagonal();
   std::vector<Plane> planes;
   planes.resize(np);
@@ -85,7 +84,7 @@ std::vector<Plane> Plane::poissonPlanesGenerate(DbGrid *dbgrid, int np)
   for (int ip = 0; ip < np; ip++)
   {
     double d0 = diagonal * law_uniform(-1., 1.) / 2.;
-    double u = 0.;
+    double u  = 0.;
     for (int idim = 0; idim < 3; idim++)
     {
       ap[idim] = law_gaussian();
@@ -97,7 +96,7 @@ std::vector<Plane> Plane::poissonPlanesGenerate(DbGrid *dbgrid, int np)
       ap[idim] /= u;
     }
     // Check position of the Center (in its OWN space dimension)
-    for (int idim = 0; idim < (int) center.size(); idim++)
+    for (int idim = 0; idim < (int)center.size(); idim++)
     {
       d0 -= ap[idim] * center[idim];
     }
@@ -121,14 +120,14 @@ std::vector<Plane> Plane::poissonPlanesGenerate(DbGrid *dbgrid, int np)
 
 double Plane::getCoor(int idim) const
 {
-  if (idim < (int) _coor.size())
+  if (idim < (int)_coor.size())
     return _coor[idim];
   return 0.;
 }
 
 void Plane::setCoor(int idim, double value)
 {
-  if (idim < (int) _coor.size())
+  if (idim < (int)_coor.size())
     _coor[idim] = value;
 }
-}
+} // namespace gstlrn

--- a/src/Basic/String.cpp
+++ b/src/Basic/String.cpp
@@ -13,30 +13,29 @@
 #include "Basic/Utilities.hpp"
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
-#include <sstream>
-#include <string.h>
-#include <regex>
 #include <locale>
+#include <regex>
+#include <sstream>
 
-#include <ctype.h>
-#include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdarg.h>
-#include <math.h>
+#include <cctype>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
 
 namespace gstlrn
-{ 
+{
 /**
  * Protect the matching pattern against Crash which happens when the string
  * contains "*" without any preceding character
  * @param match Initial matching pattern
  * @return The std::regex item used for further comparisons
  */
-std::regex _protectRegexp(const String &match)
+std::regex _protectRegexp(const String& match)
 {
-  String str = match;
+  String str        = match;
   std::size_t found = str.find('*');
   if (found != String::npos)
   {
@@ -49,32 +48,28 @@ std::regex _protectRegexp(const String &match)
 
 String toUpper(const std::string_view string)
 {
-  String str{string};
+  String str {string};
   toUpper(str);
   return (str);
 }
 
 String toLower(const std::string_view string)
 {
-  String str{string};
+  String str {string};
   toLower(str);
   return (str);
 }
 
-void toUpper(String &string)
+void toUpper(String& string)
 {
-  std::for_each(string.begin(), string.end(), [](char &c)
-  {
-    c = static_cast<char>(::toupper(c));
-  });
+  std::for_each(string.begin(), string.end(), [](char& c)
+                { c = static_cast<char>(::toupper(c)); });
 }
 
-void toLower(String &string)
+void toLower(String& string)
 {
-  std::for_each(string.begin(), string.end(), [](char &c)
-  {
-    c = static_cast<char>(::tolower(c));
-  });
+  std::for_each(string.begin(), string.end(), [](char& c)
+                { c = static_cast<char>(::tolower(c)); });
 }
 
 enum charTypeT
@@ -91,29 +86,29 @@ charTypeT _charType(char c)
   return other;
 }
 
-String incrementStringVersion(const String &string,
+String incrementStringVersion(const String& string,
                               int rank,
-                              const String &delim)
+                              const String& delim)
 {
   std::stringstream ss;
   ss << string << delim << rank;
   return ss.str();
 }
 
-String concatenateString(const String &string,
+String concatenateString(const String& string,
                          double value,
-                         const String &delim)
+                         const String& delim)
 {
   std::stringstream ss;
   ss << string << delim << value;
   return ss.str();
 }
 
-String concatenateStrings(const String &delim,
-                          const String &string1,
-                          const String &string2,
-                          const String &string3,
-                          const String &string4)
+String concatenateStrings(const String& delim,
+                          const String& string1,
+                          const String& string2,
+                          const String& string3,
+                          const String& string4)
 {
   bool started = false;
   std::stringstream ss;
@@ -138,12 +133,12 @@ String concatenateStrings(const String &delim,
   {
     if (started) ss << delim;
     ss << string4;
-//    started = true; // never reached
+    //    started = true; // never reached
   }
   return ss.str();
 }
 
-VectorString generateMultipleNames(const String &radix, int number, const String& delim)
+VectorString generateMultipleNames(const String& radix, int number, const String& delim)
 {
   VectorString list;
 
@@ -159,14 +154,14 @@ VectorString generateMultipleNames(const String &radix, int number, const String
  * If it does, increment its name by a version number.
  * @param list
  */
-void correctNamesForDuplicates(VectorString &list)
+void correctNamesForDuplicates(VectorString& list)
 {
   int number = static_cast<int>(list.size());
   for (int i = 1; i < number; i++)
   {
     // Check that a similar name does not appear among the previous names in list
 
-    label_try:
+  label_try:
     int found = -1;
     for (int j = 0; j < i && found < 0; j++)
     {
@@ -181,10 +176,10 @@ void correctNamesForDuplicates(VectorString &list)
   }
 }
 
-void correctNewNameForDuplicates(VectorString &list, int rank)
+void correctNewNameForDuplicates(VectorString& list, int rank)
 {
   int number = static_cast<int>(list.size());
-  int found = 1;
+  int found  = 1;
   while (found > 0)
   {
     found = 0;
@@ -193,7 +188,8 @@ void correctNewNameForDuplicates(VectorString &list, int rank)
       if (i == rank) continue;
       if (list[rank] == list[i]) found++;
     }
-    if (found <= 0) break;;
+    if (found <= 0) break;
+    ;
 
     // We have found a similar name
 
@@ -212,7 +208,7 @@ int getRankInList(const VectorString& list,
                   const String& match,
                   bool caseSensitive)
 {
-  for (int i = 0; i < (int) list.size(); i++)
+  for (int i = 0; i < (int)list.size(); i++)
   {
     if (matchRegexp(list[i], match, caseSensitive)) return i;
   }
@@ -229,10 +225,10 @@ int getRankInList(const VectorString& list,
  * @param caseSensitive
  * @return Error returned code
  */
-int decodeInString(const String &symbol,
-                                   const String &node,
-                                   int *facies,
-                                   bool caseSensitive)
+int decodeInString(const String& symbol,
+                   const String& node,
+                   int* facies,
+                   bool caseSensitive)
 {
   String locnode = node;
   String locsymb = symbol;
@@ -246,7 +242,7 @@ int decodeInString(const String &symbol,
 
   // Decode the remaining part: it should be an integer
 
-  for (char &c : locnode)
+  for (char& c: locnode)
   {
     if (!isdigit(c)) c = ' ';
   }
@@ -274,7 +270,7 @@ int decodeInList(const VectorString& symbols,
                  int* facies,
                  bool caseSensitive)
 {
-  for (int i = 0; i < (int) symbols.size(); i++)
+  for (int i = 0; i < (int)symbols.size(); i++)
   {
     if (decodeInString(symbols[i], node, facies, caseSensitive)) continue;
     *rank = i;
@@ -291,8 +287,8 @@ int decodeInList(const VectorString& symbols,
  * Otherwise, both strings are converted into upper case before comparison
  * @return true if both keywords are identical; false otherwise
  */
-bool matchRegexp(const String &string1,
-                 const String &string2,
+bool matchRegexp(const String& string1,
+                 const String& string2,
                  bool caseSensitive)
 {
   String local1 = string1;
@@ -314,8 +310,8 @@ bool matchRegexp(const String &string1,
  * Otherwise, both strings are converted into upper case before comparison
  * @return true if both keywords are identical; false otherwise
  */
-bool matchKeyword(const String &string1,
-                  const String &string2,
+bool matchKeyword(const String& string1,
+                  const String& string2,
                   bool caseSensitive)
 {
   String local1 = string1;
@@ -338,14 +334,14 @@ bool matchKeyword(const String &string1,
  *       several matches have been found but onlyOne flag is True (message issued).
  * @remark Example:  expandList(["x", "y", "xcol"], "x.*") -> ("x", "xcol")
  */
-VectorString expandList(const VectorString &list,
-                        const String &match,
+VectorString expandList(const VectorString& list,
+                        const String& match,
                         bool onlyOne)
 {
   std::regex regexpr = _protectRegexp(match);
 
   VectorString sublist;
-  for (int i = 0; i < (int) list.size(); i++)
+  for (int i = 0; i < (int)list.size(); i++)
   {
     const String& toto = list[i];
     if (std::regex_match(toto, regexpr)) sublist.push_back(toto);
@@ -357,9 +353,9 @@ VectorString expandList(const VectorString &list,
     if (number > 1)
     {
       messerr(
-          "The name (%s) has been expanded to several matching possibilities",
-          match.c_str());
-      for (int i = 0; i < (int) sublist.size(); i++)
+        "The name (%s) has been expanded to several matching possibilities",
+        match.c_str());
+      for (int i = 0; i < (int)sublist.size(); i++)
         messerr("- %s", sublist[i].c_str());
     }
     else
@@ -371,15 +367,15 @@ VectorString expandList(const VectorString &list,
   return sublist;
 }
 
-VectorString expandList(const VectorString &list, const VectorString &matches)
+VectorString expandList(const VectorString& list, const VectorString& matches)
 {
   VectorString sublist;
 
   // Loop on the patterns to be matched
-  for (int i = 0; i < (int) matches.size(); i++)
+  for (int i = 0; i < (int)matches.size(); i++)
   {
     // Loop for eligible names
-    for (int j = 0; j < (int) list.size(); j++)
+    for (int j = 0; j < (int)list.size(); j++)
     {
       std::regex regexpr = _protectRegexp(matches[i]);
       if (std::regex_match(list[j], regexpr))
@@ -394,7 +390,7 @@ VectorString expandList(const VectorString &list, const VectorString &matches)
         }
 
         // If the name is not already registered: add it
-        if (! already) sublist.push_back(list[j]);
+        if (!already) sublist.push_back(list[j]);
       }
     }
   }
@@ -406,11 +402,11 @@ VectorString expandList(const VectorString &list, const VectorString &matches)
  * @param list List of strings
  * @return The maximum number of characters
  */
-int getMaxStringSize(const VectorString &list)
+int getMaxStringSize(const VectorString& list)
 {
   int size = 0;
   if (list.empty()) return size;
-  for (int i = 0; i < (int) list.size(); i++)
+  for (int i = 0; i < (int)list.size(); i++)
   {
     int local = static_cast<int>(list[i].length());
     if (local > size) size = local;
@@ -424,16 +420,14 @@ int getMaxStringSize(const VectorString &list)
  * @param code String to be split
  * @return
  */
-VectorString separateKeywords(const String &code)
+VectorString separateKeywords(const String& code)
 {
   VectorString result;
   String oString;
   charTypeT st = other;
-  for (auto c : code)
+  for (auto c: code)
   {
-    if ((st == alpha && _charType(c) != alpha) || (st == digit
-        && _charType(c) != digit)
-        || (st == other && _charType(c) != other))
+    if ((st == alpha && _charType(c) != alpha) || (st == digit && _charType(c) != digit) || (st == other && _charType(c) != other))
     {
       if (oString.size() > 0) result.push_back(oString);
       oString = "";
@@ -450,7 +444,7 @@ VectorString separateKeywords(const String &code)
  * @param v String to be decoded
  * @return The integer value or ITEST (in case of failure)
  */
-int toInteger(const String &v)
+int toInteger(const String& v)
 {
   std::istringstream iss(v);
   int number;
@@ -470,10 +464,10 @@ class dec_separator: public std::numpunct<T>
 {
 public:
   dec_separator(char dec = ',')
-      :
-      _dec(dec)
+    : _dec(dec)
   {
   }
+
 private:
   typename std::numpunct<T>::char_type do_decimal_point() const
   {
@@ -482,7 +476,7 @@ private:
   char _dec;
 };
 
-double toDouble(const String &v, char dec)
+double toDouble(const String& v, char dec)
 {
   std::istringstream iss(v);
   double number;
@@ -512,10 +506,10 @@ String toString(double value)
  * @param defval Default value (or IFFFF)
  * @param authTest True if TEST value is authorized (TEST)
  */
-int askInt(const String &text, int defval, bool authTest)
+int askInt(const String& text, int defval, bool authTest)
 {
   bool hasDefault = !IFFFF(defval) || authTest;
-  int answer = defval;
+  int answer      = defval;
   std::cin.exceptions(std::istream::failbit | std::istream::badbit);
 
   try
@@ -559,7 +553,7 @@ int askInt(const String &text, int defval, bool authTest)
       std::cout << "The answer is not a valid integer!" << std::endl;
     }
   }
-  catch (std::istream::failure &e)
+  catch (std::istream::failure& e)
   {
     std::cerr << "Problem when reading integer:" << e.what() << std::endl;
   }
@@ -572,12 +566,12 @@ int askInt(const String &text, int defval, bool authTest)
  * @param defval Default value (or IFFFF)
  * @param authTest True if a TEST answer is authorized (TEST)
  */
-double askDouble(const String &text,
-                                 double defval,
-                                 bool authTest)
+double askDouble(const String& text,
+                 double defval,
+                 bool authTest)
 {
   bool hasDefault = !FFFF(defval) || authTest;
-  double answer = defval;
+  double answer   = defval;
   std::cin.exceptions(std::istream::failbit | std::istream::badbit);
 
   try
@@ -620,7 +614,7 @@ double askDouble(const String &text,
       std::cout << "The answer is not a valid double!" << std::endl;
     }
   }
-  catch (std::istream::failure &e)
+  catch (std::istream::failure& e)
   {
     std::cerr << "Problem when reading double:" << e.what() << std::endl;
   }
@@ -632,10 +626,10 @@ double askDouble(const String &text,
  * @param text Text of the question
  * @param defval Default value
  */
-int askBool(const String &text, bool defval)
+int askBool(const String& text, bool defval)
 {
   bool hasDefault = !IFFFF(defval);
-  bool answer = defval;
+  bool answer     = defval;
   std::cin.exceptions(std::istream::failbit | std::istream::badbit);
 
   try
@@ -681,14 +675,14 @@ int askBool(const String &text, bool defval)
       std::cout << "The answer is not a valid bool!" << std::endl;
     }
   }
-  catch (std::istream::failure &e)
+  catch (std::istream::failure& e)
   {
     std::cerr << "Problem when reading bool:" << e.what() << std::endl;
   }
   return answer;
 }
 
-String trimRight(const String &s, const String &t)
+String trimRight(const String& s, const String& t)
 {
   String d(s);
   String::size_type i(d.find_last_not_of(t));
@@ -696,19 +690,19 @@ String trimRight(const String &s, const String &t)
   return d.erase(d.find_last_not_of(t) + 1);
 }
 
-String trimLeft(const String &s, const String &t)
+String trimLeft(const String& s, const String& t)
 {
   String d(s);
   return d.erase(0, s.find_first_not_of(t));
 }
 
-String trim(const String &s, const String &t)
+String trim(const String& s, const String& t)
 {
   const String& d(s);
   return trimLeft(trimRight(d, t), t);
 }
 
-String erase(const String &s, const String &t)
+String erase(const String& s, const String& t)
 {
   String d(s);
   for (unsigned int i = 0; i < t.size(); i++)
@@ -716,22 +710,22 @@ String erase(const String &s, const String &t)
   return d;
 }
 
-char* gslStrcpy(char *dst, const char *src)
+char* gslStrcpy(char* dst, const char* src)
 {
   return strcpy(dst, src);
   //(void)gslSPrintf(dst, "%s", src);
-  //return dst;
+  // return dst;
 }
 
-char* gslStrcat(char *dst, const char *src)
+char* gslStrcat(char* dst, const char* src)
 {
   return strcat(dst, src);
-//  size_t size = String(dst).size();
-//  (void)gslSPrintf(&dst[size], "%s%s", dst, src);
-//  return dst;
+  //  size_t size = String(dst).size();
+  //  (void)gslSPrintf(&dst[size], "%s%s", dst, src);
+  //  return dst;
 }
 
-int gslSPrintf(char *dst, const char *fmt, ...)
+int gslSPrintf(char* dst, const char* fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -740,7 +734,7 @@ int gslSPrintf(char *dst, const char *fmt, ...)
   return n;
 }
 
-int gslScanf(const char *format, ...)
+int gslScanf(const char* format, ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -749,7 +743,7 @@ int gslScanf(const char *format, ...)
   return n;
 }
 
-int gslSScanf(const char *str, const char *format, ...)
+int gslSScanf(const char* str, const char* format, ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -758,7 +752,7 @@ int gslSScanf(const char *str, const char *format, ...)
   return n;
 }
 
-int gslFScanf(FILE *stream, const char *format, ...)
+int gslFScanf(FILE* stream, const char* format, ...)
 {
   va_list ap;
   va_start(ap, format);
@@ -767,12 +761,12 @@ int gslFScanf(FILE *stream, const char *format, ...)
   return n;
 }
 
-char* gslStrtok(char *str, const char *delim)
+char* gslStrtok(char* str, const char* delim)
 {
   return strtok(str, delim);
 }
 
-char* gslStrncpy(char *dest, const char *src, size_t n)
+char* gslStrncpy(char* dest, const char* src, size_t n)
 {
   return strncpy(dest, src, n);
 }
@@ -798,22 +792,22 @@ VectorInt decodeGridSorting(const String& string,
                             const VectorInt& nx,
                             bool verbose)
 {
-  int ndim = (int) nx.size();
-  VectorInt order(ndim,0);
-  VectorInt ranks(ndim,0);
+  int ndim = (int)nx.size();
+  VectorInt order(ndim, 0);
+  VectorInt ranks(ndim, 0);
 
   // Loop on the character string
 
-  int idim = 0;
-  int ind = 0;
-  int length = (int) string.size();
+  int idim   = 0;
+  int ind    = 0;
+  int length = (int)string.size();
 
   while (ind < length)
   {
     int orient = 0;
-    if (string[ind] == '-' && (string[ind+1] == 'x' && isdigit(string[ind+2])))
+    if (string[ind] == '-' && (string[ind + 1] == 'x' && isdigit(string[ind + 2])))
       orient = -1;
-    else if (string[ind] == '+' && (string[ind+1] == 'x' && isdigit(string[ind+2])))
+    else if (string[ind] == '+' && (string[ind + 1] == 'x' && isdigit(string[ind + 2])))
       orient = 1;
     else
       orient = 0;
@@ -827,13 +821,13 @@ VectorInt decodeGridSorting(const String& string,
       int num = string[ind] - '0';
       if (idim >= ndim)
       {
-        messerr("'order' contains more terms (%d) than the space dimension (%d)", idim+1, ndim);
+        messerr("'order' contains more terms (%d) than the space dimension (%d)", idim + 1, ndim);
         return VectorInt();
       }
       order[idim] = orient * num;
       if (num > ndim)
       {
-        messerr("'order' refers to 'x%d' while space dimension is %d", num,ndim);
+        messerr("'order' refers to 'x%d' while space dimension is %d", num, ndim);
         return VectorInt();
       }
       ranks[num - 1] = orient;
@@ -875,4 +869,4 @@ VectorInt decodeGridSorting(const String& string,
   }
   return (order);
 }
-}
+} // namespace gstlrn

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -10,15 +10,15 @@
 /******************************************************************************/
 #include "Basic/VectorHelper.hpp"
 #include "Basic/AException.hpp"
-#include "Basic/Utilities.hpp"
 #include "Basic/Law.hpp"
+#include "Basic/Utilities.hpp"
 #include "geoslib_define.h"
 
-#include <string.h>
 #include <algorithm>
-#include <ctime>
+#include <cmath>
 #include <cstdlib>
-#include <math.h>
+#include <cstring>
+#include <ctime>
 #include <vector>
 
 namespace gstlrn
@@ -99,7 +99,7 @@ void VectorHelper::dump(const String& title, const VectorInt& vect, bool skipLin
   messageFlush(VH::toStringAsVI(vect));
 }
 
-void VectorHelper::dump(const String &title, const VectorDouble &vect, bool skipLine)
+void VectorHelper::dump(const String& title, const VectorDouble& vect, bool skipLine)
 {
   if (vect.empty()) return;
   if (!title.empty())
@@ -113,7 +113,7 @@ void VectorHelper::dump(const String &title, const VectorDouble &vect, bool skip
   messageFlush(VH::toStringAsVD(vect));
 }
 
-void VectorHelper::dump(const String &title, const VectorString &vect, bool skipLine)
+void VectorHelper::dump(const String& title, const VectorString& vect, bool skipLine)
 {
   if (vect.empty()) return;
   if (!title.empty())
@@ -127,7 +127,7 @@ void VectorHelper::dump(const String &title, const VectorString &vect, bool skip
   messageFlush(VH::toStringAsVS(vect));
 }
 
-void VectorHelper::dump(const String &title, const VectorVectorInt &vect, bool skipLine)
+void VectorHelper::dump(const String& title, const VectorVectorInt& vect, bool skipLine)
 {
   if (vect.empty()) return;
   if (!title.empty())
@@ -149,7 +149,7 @@ void VectorHelper::dump(const String& title, const VectorVectorDouble& vect, boo
   messageFlush(VH::toStringAsVVD(vect));
 }
 
-String VectorHelper::toStringAsVD(const VectorDouble &vec)
+String VectorHelper::toStringAsVD(const VectorDouble& vec)
 {
   return toVector(String(), vec);
 }
@@ -157,7 +157,7 @@ String VectorHelper::toStringAsSpan(constvect vec)
 {
   return toVector(String(), vec);
 }
-String VectorHelper::toStringAsVVD(const VectorVectorDouble &vec)
+String VectorHelper::toStringAsVVD(const VectorVectorDouble& vec)
 {
   return toVector(String(), vec);
 }
@@ -171,14 +171,14 @@ String VectorHelper::toStringAsVS(const VectorString& vec)
   return toVector(String(), vec);
 }
 
-String VectorHelper::toStringAsVI(const VectorInt &vec)
+String VectorHelper::toStringAsVI(const VectorInt& vec)
 {
   return toVector(String(), vec);
 }
 
 void VectorHelper::dumpStats(const String& title, constvect vect, int nmax)
 {
-  int ntotal  = (int)vect.size();
+  int ntotal = (int)vect.size();
   if (nmax > 0 && nmax < ntotal) ntotal = nmax;
   int number  = 0;
   double mean = 0.;
@@ -222,7 +222,7 @@ void VectorHelper::dumpStats(const String& title, const VectorDouble& vectin, in
   dumpStats(title, vect, nmax);
 }
 
-void VectorHelper::dumpRange(const String& title, const VectorDouble&  vectin, int nmax)
+void VectorHelper::dumpRange(const String& title, const VectorDouble& vectin, int nmax)
 {
   constvect vect(vectin);
   dumpRange(title, vect, nmax);
@@ -232,7 +232,7 @@ void VectorHelper::dumpRange(const String& title, constvect vect, int nmax)
 {
   int ntotal = (int)vect.size();
   if (nmax > 0 && nmax < ntotal) ntotal = nmax;
-  int number = 0;
+  int number  = 0;
   double mini = MAXIMUM_BIG;
   double maxi = MINIMUM_BIG;
 
@@ -258,12 +258,12 @@ void VectorHelper::dumpRange(const String& title, constvect vect, int nmax)
   }
 }
 
-void VectorHelper::dumpRange(const String &title, const VectorInt &vect)
+void VectorHelper::dumpRange(const String& title, const VectorInt& vect)
 {
-  int ntotal = (int) vect.size();
+  int ntotal = (int)vect.size();
   int number = 0;
-  int mini =  100000000;
-  int maxi = -100000000;
+  int mini   = 100000000;
+  int maxi   = -100000000;
 
   for (int i = 0; i < ntotal; i++)
   {
@@ -287,16 +287,16 @@ void VectorHelper::dumpRange(const String &title, const VectorInt &vect)
   }
 }
 
-void VectorHelper::dumpNNZ(const String &title, const VectorDouble &vect, int nclass)
+void VectorHelper::dumpNNZ(const String& title, const VectorDouble& vect, int nclass)
 {
-  int ntotal = (int) vect.size();
+  int ntotal = (int)vect.size();
   VectorInt total(nclass);
   for (int ic = 0; ic < nclass; ic++) total[ic] = 0.;
 
   for (int i = 0; i < ntotal; i++)
   {
     double value = ABS(vect[i]);
-    double tol = 1.;
+    double tol   = 1.;
     for (int ic = 0; ic < nclass; ic++)
     {
       tol /= 10.;
@@ -307,21 +307,21 @@ void VectorHelper::dumpNNZ(const String &title, const VectorDouble &vect, int nc
 
   if (!title.empty()) message("%s\n", title.c_str());
   for (int ic = 0; ic < nclass; ic++)
-    message("Count below 10.e-%d = %d\n", ic+1, total[ic]);
+    message("Count below 10.e-%d = %d\n", ic + 1, total[ic]);
 }
 
 bool VectorHelper::hasUndefined(const VectorDouble& vec)
 {
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
     if (FFFF(vec[i])) return true;
   return false;
 }
 
-int VectorHelper::maximum(const VectorInt &vec, bool flagAbs)
+int VectorHelper::maximum(const VectorInt& vec, bool flagAbs)
 {
   if (vec.size() <= 0) return 0;
   int max = -10000000;
-  for (auto v : vec)
+  for (auto v: vec)
   {
     if (IFFFF(v)) continue;
     if (flagAbs) v = ABS(v);
@@ -330,27 +330,27 @@ int VectorHelper::maximum(const VectorInt &vec, bool flagAbs)
   return (max);
 }
 
-double VectorHelper::maximum(const std::vector<std::vector<double>> &vec, bool flagAbs)
+double VectorHelper::maximum(const std::vector<std::vector<double>>& vec, bool flagAbs)
 {
   double val = VH::maximum(vec[0]);
-  for (int i = 1, n = (int) vec.size(); i < n; i++)
-    val = MAX(val,  VH::maximum(vec[i], flagAbs));
+  for (int i = 1, n = (int)vec.size(); i < n; i++)
+    val = MAX(val, VH::maximum(vec[i], flagAbs));
   return val;
 }
 
 double VectorHelper::maximum(const VectorVectorDouble& vect, bool flagAbs)
 {
   double val = VH::maximum(vect[0]);
-  for (int i = 1, n = (int) vect.size(); i < n; i++)
-    val = MAX(val,  VH::maximum(vect[i], flagAbs));
+  for (int i = 1, n = (int)vect.size(); i < n; i++)
+    val = MAX(val, VH::maximum(vect[i], flagAbs));
   return val;
 }
 
-int VectorHelper::minimum(const VectorInt &vec, bool flagAbs)
+int VectorHelper::minimum(const VectorInt& vec, bool flagAbs)
 {
   if (vec.size() <= 0) return 0;
   int min = 10000000;
-  for (auto v : vec)
+  for (auto v: vec)
   {
     if (IFFFF(v)) continue;
     if (flagAbs) v = ABS(v);
@@ -372,16 +372,16 @@ int VectorHelper::minimum(const VectorInt &vec, bool flagAbs)
  * @remarks - mode>0: statistics calculated only when 'vec' > 'aux'
  * @remarks - mode<0: statistics calculated only when 'vec' < 'aux'
  */
-double VectorHelper::maximum(const VectorDouble &vec, bool flagAbs, const VectorDouble& aux, int mode)
+double VectorHelper::maximum(const VectorDouble& vec, bool flagAbs, const VectorDouble& aux, int mode)
 {
   if (vec.empty()) return TEST;
-  int size = (int) vec.size();
-  bool flagAux = (! aux.empty() && (int) aux.size() == size);
-  double max = MINIMUM_BIG;
+  int size     = (int)vec.size();
+  bool flagAux = (!aux.empty() && (int)aux.size() == size);
+  double max   = MINIMUM_BIG;
 
-  if (! flagAux)
+  if (!flagAux)
   {
-    for (auto v : vec)
+    for (auto v: vec)
     {
       if (FFFF(v)) continue;
       if (flagAbs) v = ABS(v);
@@ -390,16 +390,16 @@ double VectorHelper::maximum(const VectorDouble &vec, bool flagAbs, const Vector
   }
   else
   {
-    const double *ptrv = vec.data();
+    const double* ptrv = vec.data();
     double val_vec;
-    const double *ptra = aux.data();
+    const double* ptra = aux.data();
     double val_aux;
 
     for (int i = 0; i < size; i++)
     {
       val_vec = (*ptrv);
       val_aux = (*ptra);
-      if (! FFFF(val_vec) && ! FFFF(val_aux))
+      if (!FFFF(val_vec) && !FFFF(val_aux))
       {
         if (flagAbs) val_vec = ABS(val_vec);
 
@@ -433,16 +433,16 @@ double VectorHelper::maximum(const VectorDouble &vec, bool flagAbs, const Vector
  * @remarks - mode>0: statistics calculated only when 'vec' > 'aux'
  * @remarks - mode<0: statistics calculated only when 'vec' < 'aux'
  */
-double VectorHelper::minimum(const VectorDouble &vec, bool flagAbs, const VectorDouble& aux, int mode)
+double VectorHelper::minimum(const VectorDouble& vec, bool flagAbs, const VectorDouble& aux, int mode)
 {
   if (vec.empty()) return TEST;
-  int size = (int) vec.size();
-  bool flagAux = (! aux.empty() && (int) aux.size() == size);
-  double min = MAXIMUM_BIG;
+  int size     = (int)vec.size();
+  bool flagAux = (!aux.empty() && (int)aux.size() == size);
+  double min   = MAXIMUM_BIG;
 
-  if (! flagAux)
+  if (!flagAux)
   {
-    for (auto v : vec)
+    for (auto v: vec)
     {
       if (FFFF(v)) continue;
       if (flagAbs) v = ABS(v);
@@ -451,16 +451,16 @@ double VectorHelper::minimum(const VectorDouble &vec, bool flagAbs, const Vector
   }
   else
   {
-    const double *ptrv = vec.data();
+    const double* ptrv = vec.data();
     double val_vec;
-    const double *ptra = aux.data();
+    const double* ptra = aux.data();
     double val_aux;
 
     for (int i = 0; i < size; i++)
     {
       val_vec = (*ptrv);
       val_aux = (*ptra);
-      if (! FFFF(val_vec) && ! FFFF(val_aux))
+      if (!FFFF(val_vec) && !FFFF(val_aux))
       {
         if (flagAbs) val_vec = ABS(val_vec);
 
@@ -484,31 +484,31 @@ double VectorHelper::minimum(const VectorDouble &vec, bool flagAbs, const Vector
 double VectorHelper::minimum(const VectorVectorDouble& vect, bool flagAbs)
 {
   double val = VH::minimum(vect[0]);
-  for (int i = 1, n = (int) vect.size(); i < n; i++)
-    val = MAX(val,  VH::minimum(vect[i], flagAbs));
+  for (int i = 1, n = (int)vect.size(); i < n; i++)
+    val = MAX(val, VH::minimum(vect[i], flagAbs));
   return val;
 }
 
-double VectorHelper::mean(const VectorDouble &vec)
+double VectorHelper::mean(const VectorDouble& vec)
 {
   if (vec.size() <= 0) return 0.;
   double mean = 0.;
-  int number = 0;
-  for (const auto &v : vec)
+  int number  = 0;
+  for (const auto& v: vec)
   {
     if (FFFF(v)) continue;
     mean += v;
     number++;
   }
   if (number > 0)
-    return (mean / (double) number);
+    return (mean / (double)number);
   return TEST;
 }
 
 int VectorHelper::cumul(const VectorInt& vec)
 {
   int total = 0.;
-  for (const auto &v : vec)
+  for (const auto& v: vec)
   {
     total += v;
   }
@@ -518,7 +518,7 @@ int VectorHelper::cumul(const VectorInt& vec)
 int VectorHelper::cumul(const VectorVectorInt& vec)
 {
   int total = 0.;
-  for (const auto &v : vec)
+  for (const auto& v: vec)
   {
     total += cumul(v);
   }
@@ -528,9 +528,9 @@ int VectorHelper::cumul(const VectorVectorInt& vec)
 int VectorHelper::count(const VectorVectorInt& vec)
 {
   int total = 0.;
-  for (const auto &v : vec)
+  for (const auto& v: vec)
   {
-    total += (int) v.size();
+    total += (int)v.size();
   }
   return total;
 }
@@ -538,7 +538,7 @@ int VectorHelper::count(const VectorVectorInt& vec)
 double VectorHelper::cumul(const VectorDouble& vec)
 {
   double total = 0.;
-  for (const auto &v : vec)
+  for (const auto& v: vec)
   {
     if (!FFFF(v)) total += v;
   }
@@ -557,7 +557,7 @@ double VectorHelper::cumulLog(const VectorDouble& vec)
 
 VectorInt VectorHelper::cumulIncrement(const VectorVectorInt& vec)
 {
-  int nvar = (int) vec.size();
+  int nvar = (int)vec.size();
   VectorInt cumul(nvar, 0);
   int number = 0;
   for (int ivar = 0; ivar < nvar; ivar++)
@@ -568,13 +568,13 @@ VectorInt VectorHelper::cumulIncrement(const VectorVectorInt& vec)
   return cumul;
 }
 
-double VectorHelper::variance(const VectorDouble &vec, bool scaleByN)
+double VectorHelper::variance(const VectorDouble& vec, bool scaleByN)
 {
   if (vec.size() <= 0) return 0.;
   double mean = 0.;
-  double var = 0.;
-  int number = 0;
-  for (const auto &v : vec)
+  double var  = 0.;
+  int number  = 0;
+  for (const auto& v: vec)
   {
     if (FFFF(v)) continue;
     var += v * v;
@@ -582,15 +582,15 @@ double VectorHelper::variance(const VectorDouble &vec, bool scaleByN)
     number++;
   }
   if (number <= 1) return TEST;
-  mean /= (double) number;
+  mean /= (double)number;
   if (scaleByN)
-    var = var / (double) number - mean * mean;
+    var = var / (double)number - mean * mean;
   else
-    var = (var - (double) number * mean * mean) / (double) (number-1);
+    var = (var - (double)number * mean * mean) / (double)(number - 1);
   return var;
 }
 
-double VectorHelper::correlation(const VectorDouble &veca, const VectorDouble& vecb)
+double VectorHelper::correlation(const VectorDouble& veca, const VectorDouble& vecb)
 {
   if (veca.size() <= 0 || vecb.size() <= 0 || veca.size() != vecb.size()) return 0.;
 
@@ -600,7 +600,7 @@ double VectorHelper::correlation(const VectorDouble &veca, const VectorDouble& v
   double v22 = 0.;
   double v12 = 0.;
   int number = 0;
-  for (int i = 0; i < (int) veca.size(); i++)
+  for (int i = 0; i < (int)veca.size(); i++)
   {
     double z1 = veca[i];
     double z2 = vecb[i];
@@ -613,11 +613,11 @@ double VectorHelper::correlation(const VectorDouble &veca, const VectorDouble& v
     number++;
   }
   if (number <= 0) return TEST;
-  m1 /= (double) number;
-  m2 /= (double) number;
-  v11 = v11 / (double) number - m1 * m1;
-  v22 = v22 / (double) number - m2 * m2;
-  v12 = v12 / (double) number - m1 * m2;
+  m1 /= (double)number;
+  m2 /= (double)number;
+  v11 = v11 / (double)number - m1 * m1;
+  v22 = v22 / (double)number - m2 * m2;
+  v12 = v12 / (double)number - m1 * m2;
   if (v11 <= 0.) return TEST;
   if (v22 <= 0.) return TEST;
   double corr = v12 / sqrt(v11 * v22);
@@ -630,11 +630,11 @@ double VectorHelper::correlation(const VectorDouble &veca, const VectorDouble& v
  * @param probas Array of probabilities (sorted by ascending order)
  * @return Vector of data values for the different probabilities
  */
-VectorDouble VectorHelper::quantiles(const VectorDouble &vec,
-                                     const VectorDouble &probas)
+VectorDouble VectorHelper::quantiles(const VectorDouble& vec,
+                                     const VectorDouble& probas)
 {
-  int nproba = (int) probas.size();
-  int nech   = (int) vec.size();
+  int nproba = (int)probas.size();
+  int nech   = (int)vec.size();
   if (nech <= 0 || nproba <= 0) return VectorDouble();
 
   VectorDouble retval(nproba, TEST);
@@ -645,7 +645,7 @@ VectorDouble VectorHelper::quantiles(const VectorDouble &vec,
   for (int ip = 0; ip < nproba; ip++)
   {
     double proba = probas[ip];
-    int rank = (int) (proba * (double) nech);
+    int rank     = (int)(proba * (double)nech);
 
     double value = TEST;
     if (rank < 0)
@@ -656,41 +656,41 @@ VectorDouble VectorHelper::quantiles(const VectorDouble &vec,
     {
       double v1 = sorted[rank];
       double v2 = sorted[rank + 1];
-      double p1 = (double) rank / (double) nech;
-      double p2 = (double) (1 + rank) / (double) nech;
-      value = v1 + (proba - p1) * (v2 - v1) / (p2 - p1);
+      double p1 = (double)rank / (double)nech;
+      double p2 = (double)(1 + rank) / (double)nech;
+      value     = v1 + (proba - p1) * (v2 - v1) / (p2 - p1);
     }
     else
     {
-      value = sorted[nech-1];
+      value = sorted[nech - 1];
     }
     retval[ip] = value;
   }
   return retval;
 }
 
-double VectorHelper::stdv(const VectorDouble &vec, bool scaleByN)
+double VectorHelper::stdv(const VectorDouble& vec, bool scaleByN)
 {
   double var = variance(vec, scaleByN);
   if (!FFFF(var)) return (sqrt(var));
   return TEST;
 }
 
-double VectorHelper::norm(const VectorDouble &vec)
+double VectorHelper::norm(const VectorDouble& vec)
 {
   double ip = innerProduct(vec, vec);
   return sqrt(ip);
 }
 
-double VectorHelper::norm(const std::vector<double> &vec)
+double VectorHelper::norm(const std::vector<double>& vec)
 {
   double ip = innerProduct(vec, vec);
   return sqrt(ip);
 }
 
-double VectorHelper::normL1(const VectorDouble &vec)
+double VectorHelper::normL1(const VectorDouble& vec)
 {
-  int nval = (int) vec.size();
+  int nval      = (int)vec.size();
   double normL1 = 0.;
   for (int i = 0; i < nval; i++)
   {
@@ -700,10 +700,10 @@ double VectorHelper::normL1(const VectorDouble &vec)
   return (normL1);
 }
 
-double VectorHelper::norminf(const VectorDouble &vec)
+double VectorHelper::norminf(const VectorDouble& vec)
 {
   double norminf = 0.;
-  for (int i = 0, nval = (int) vec.size(); i < nval; i++)
+  for (int i = 0, nval = (int)vec.size(); i < nval; i++)
   {
     double value = ABS(vec[i]);
     if (value > norminf) norminf = value;
@@ -711,30 +711,30 @@ double VectorHelper::norminf(const VectorDouble &vec)
   return norminf;
 }
 
-double VectorHelper::median(const VectorDouble &vec)
+double VectorHelper::median(const VectorDouble& vec)
 {
   VectorDouble med;
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
-    if (! FFFF(vec[i])) med.push_back(vec[i]);
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
+    if (!FFFF(vec[i])) med.push_back(vec[i]);
 
   // Sort the values
   med = sort(med);
 
   // Return the median value
-  int number = (int) med.size();
+  int number = (int)med.size();
   if (number <= 0) return TEST;
   if (isOdd(number)) return med[number / 2];
   return (med[number / 2] + med[number / 2 - 1]) / 2.;
 }
 
-double VectorHelper::normDistance(const VectorDouble &veca,
-                                  const VectorDouble &vecb)
+double VectorHelper::normDistance(const VectorDouble& veca,
+                                  const VectorDouble& vecb)
 {
-  double prod = 0.;
-  double delta = 0.;
-  const double *ptra = veca.data();
-  const double *ptrb = vecb.data();
-  for (int i = 0, n = (int) veca.size(); i < n; i++)
+  double prod        = 0.;
+  double delta       = 0.;
+  const double* ptra = veca.data();
+  const double* ptrb = vecb.data();
+  for (int i = 0, n = (int)veca.size(); i < n; i++)
   {
     delta = (*ptra) - (*ptrb);
     prod += delta * delta;
@@ -747,9 +747,9 @@ double VectorHelper::normDistance(const VectorDouble &veca,
 int VectorHelper::product(const VectorInt& vec)
 {
   if (vec.empty()) return 0;
-  int nprod = 1;
+  int nprod       = 1;
   const int* iptr = vec.data();
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
   {
     nprod *= (*iptr);
     iptr++;
@@ -760,9 +760,9 @@ int VectorHelper::product(const VectorInt& vec)
 double VectorHelper::product(const VectorDouble& vec)
 {
   if (vec.empty()) return 0;
-  double nprod = 1.;
+  double nprod       = 1.;
   const double* iptr = vec.data();
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
   {
     nprod *= (*iptr);
     iptr++;
@@ -770,7 +770,7 @@ double VectorHelper::product(const VectorDouble& vec)
   return nprod;
 }
 
-void VectorHelper::normalize(VectorDouble &vec, int norm)
+void VectorHelper::normalize(VectorDouble& vec, int norm)
 {
   double ratio;
   if (norm == 2)
@@ -778,11 +778,11 @@ void VectorHelper::normalize(VectorDouble &vec, int norm)
   else
     ratio = VH::normL1(vec);
   if (ratio <= 0.) return;
-  for (auto &v : vec)
-     v /= ratio;
+  for (auto& v: vec)
+    v /= ratio;
 }
 
-void VectorHelper::normalize(double *tab, int ntab)
+void VectorHelper::normalize(double* tab, int ntab)
 {
   int i;
   double norme;
@@ -797,14 +797,14 @@ void VectorHelper::normalize(double *tab, int ntab)
     tab[i] /= norme;
 }
 
-void VectorHelper::normalizeFromGaussianDistribution(VectorDouble &vec,
+void VectorHelper::normalizeFromGaussianDistribution(VectorDouble& vec,
                                                      double mini,
                                                      double maxi)
 {
   double* iptr = vec.data();
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
   {
-    if (! FFFF(*iptr))
+    if (!FFFF(*iptr))
       (*iptr) = mini + (maxi - mini) * law_cdf_gaussian(*iptr);
     iptr++;
   }
@@ -812,7 +812,7 @@ void VectorHelper::normalizeFromGaussianDistribution(VectorDouble &vec,
 
 VectorDouble VectorHelper::qnormVec(const VectorDouble& vec)
 {
-  int number = (int) vec.size();
+  int number = (int)vec.size();
   VectorDouble retvec(number, TEST);
   for (int i = 0; i < number; i++)
     retvec[i] = law_invcdf_gaussian(vec[i]);
@@ -821,33 +821,33 @@ VectorDouble VectorHelper::qnormVec(const VectorDouble& vec)
 
 VectorDouble VectorHelper::pnormVec(const VectorDouble& vec)
 {
-  int number = (int) vec.size();
+  int number = (int)vec.size();
   VectorDouble retvec(number, TEST);
   for (int i = 0; i < number; i++)
     retvec[i] = law_cdf_gaussian(vec[i]);
   return retvec;
 }
 
-VectorDouble VectorHelper::normalScore(const VectorDouble &data,
-                                       const VectorDouble &wt)
+VectorDouble VectorHelper::normalScore(const VectorDouble& data,
+                                       const VectorDouble& wt)
 {
-  int nech = (int) data.size();
+  int nech = (int)data.size();
   VectorDouble vec(nech, TEST);
   if (nech <= 0) return vec;
 
   // Check dimension of vector
-  if (! wt.empty() && nech != (int) wt.size())
+  if (!wt.empty() && nech != (int)wt.size())
   {
     messerr("Arguments 'data' and 'wt' should have the same dimension");
     return VectorDouble();
   }
 
   // Check that weights of active samples are positive
-  double wtotal = 0.;
+  double wtotal  = 0.;
   double nechtot = 0.;
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! FFFF(data[iech]))
+    if (!FFFF(data[iech]))
     {
       double wtloc = 1.;
       if (!wt.empty()) wtloc = wt[iech];
@@ -875,7 +875,7 @@ VectorDouble VectorHelper::normalScore(const VectorDouble &data,
   for (int iech = 0; iech < nech; iech++)
   {
     int jech = idx[iech];
-    if (! FFFF(data[jech]))
+    if (!FFFF(data[jech]))
     {
       double wtloc = (wt.empty()) ? 1. : wt[jech];
       wpartial += wtloc;
@@ -900,7 +900,7 @@ bool VectorHelper::isConstant(const VectorDouble& vect, double refval)
   if (vect.empty()) return false;
   if (FFFF(refval)) refval = vect[0];
   const double* iptr = vect.data();
-  for (int i = 0, n = (int) vect.size(); i < n; i++)
+  for (int i = 0, n = (int)vect.size(); i < n; i++)
   {
     if ((*iptr) != refval) return false;
     iptr++;
@@ -919,7 +919,7 @@ bool VectorHelper::isConstant(const VectorInt& vect, int refval)
   if (vect.empty()) return false;
   if (IFFFF(refval)) refval = vect[0];
   const int* iptr = vect.data();
-  for (int i = 0, n = (int) vect.size(); i < n; i++)
+  for (int i = 0, n = (int)vect.size(); i < n; i++)
   {
     if ((*iptr) != refval) return false;
     iptr++;
@@ -927,7 +927,7 @@ bool VectorHelper::isConstant(const VectorInt& vect, int refval)
   return true;
 }
 
-bool VectorHelper::isEqual(const VectorDouble &v1, const VectorDouble &v2, double eps)
+bool VectorHelper::isEqual(const VectorDouble& v1, const VectorDouble& v2, double eps)
 {
   if (v1.size() != v2.size()) return false;
   VectorDouble::const_iterator it1(v1.begin());
@@ -941,7 +941,7 @@ bool VectorHelper::isEqual(const VectorDouble &v1, const VectorDouble &v2, doubl
   return true;
 }
 
-bool VectorHelper::isEqual(const VectorInt &v1, const VectorInt &v2)
+bool VectorHelper::isEqual(const VectorInt& v1, const VectorInt& v2)
 {
   if (v1.size() != v2.size()) return false;
   VectorInt::const_iterator it1(v1.begin());
@@ -955,21 +955,21 @@ bool VectorHelper::isEqual(const VectorInt &v1, const VectorInt &v2)
   return true;
 }
 
-void VectorHelper::fill(VectorDouble &vec, double value, int size)
+void VectorHelper::fill(VectorDouble& vec, double value, int size)
 {
   if (size > 0) vec.resize(size);
   std::fill(vec.begin(), vec.end(), value);
 }
 
-void VectorHelper::fill(VectorInt &vec, int value, int size)
+void VectorHelper::fill(VectorInt& vec, int value, int size)
 {
   if (size > 0) vec.resize(size);
   std::fill(vec.begin(), vec.end(), value);
 }
 
-void VectorHelper::fill(VectorVectorDouble &vec, double value)
+void VectorHelper::fill(VectorVectorDouble& vec, double value)
 {
-  for (auto &e : vec)
+  for (auto& e: vec)
   {
     VH::fill(e, value);
   }
@@ -1059,7 +1059,7 @@ VectorDouble VectorHelper::simulateBernoulli(int n, double proba, double vone, d
   {
     double rand = law_uniform(0., 1.);
     if (rand < proba)
-      *it= vone;
+      *it = vone;
     else
       *it = velse;
     it++;
@@ -1070,11 +1070,11 @@ VectorDouble VectorHelper::simulateBernoulli(int n, double proba, double vone, d
 VectorDouble VectorHelper::simulateGaussian(int n, double mean, double sigma)
 {
   VectorDouble vec(n);
-  simulateGaussianInPlace(vec,mean,sigma);
+  simulateGaussianInPlace(vec, mean, sigma);
   return vec;
 }
 
-void VectorHelper::simulateGaussianInPlace(VectorDouble &vec,
+void VectorHelper::simulateGaussianInPlace(VectorDouble& vec,
                                            double mean,
                                            double sigma)
 {
@@ -1086,20 +1086,20 @@ void VectorHelper::simulateGaussianInPlace(VectorDouble &vec,
   }
 }
 
-void VectorHelper::simulateGaussianInPlace(std::vector<double> &vec,
+void VectorHelper::simulateGaussianInPlace(std::vector<double>& vec,
                                            double mean,
                                            double sigma)
 {
   std::vector<double>::iterator it(vec.begin());
   while (it < vec.end())
   {
-    *it= mean + sigma * law_gaussian();
+    *it = mean + sigma * law_gaussian();
     it++;
   }
 }
 
-VectorDouble VectorHelper::concatenate(const VectorDouble &veca,
-                                       const VectorDouble &vecb)
+VectorDouble VectorHelper::concatenate(const VectorDouble& veca,
+                                       const VectorDouble& vecb)
 {
   VectorDouble res = veca;
   for (const auto& e: vecb) res.push_back(e);
@@ -1123,7 +1123,7 @@ void VectorHelper::cumulateInPlace(VectorDouble& vec)
   }
 }
 
-VectorDouble VectorHelper::cumsum(const VectorDouble &vecin, bool flagAddZero, bool revert)
+VectorDouble VectorHelper::cumsum(const VectorDouble& vecin, bool flagAddZero, bool revert)
 {
   VectorDouble vecout;
   if (flagAddZero)
@@ -1138,7 +1138,7 @@ VectorDouble VectorHelper::cumsum(const VectorDouble &vecin, bool flagAddZero, b
 
   if (revert)
   {
-    int size = (int) vecout.size();
+    int size       = (int)vecout.size();
     double lastval = vecout[size - 1];
     for (int i = 0; i < size; i++)
       vecout[i] = lastval - vecout[i];
@@ -1146,8 +1146,8 @@ VectorDouble VectorHelper::cumsum(const VectorDouble &vecin, bool flagAddZero, b
   return vecout;
 }
 
-void VectorHelper::cumulate(VectorDouble &veca,
-                            const VectorDouble &vecb,
+void VectorHelper::cumulate(VectorDouble& veca,
+                            const VectorDouble& vecb,
                             double coeff,
                             double addval)
 {
@@ -1177,7 +1177,7 @@ void VectorHelper::cumulate(VectorDouble &veca,
  */
 void VectorHelper::getMostSignificant(const VectorDouble& vec, double tol, int nmax)
 {
-  int nsize = (int) vec.size();
+  int nsize = (int)vec.size();
   VectorDouble absval(nsize, 0.);
   int ninvalid = 0;
   for (int i = 0; i < nsize; i++)
@@ -1193,7 +1193,7 @@ void VectorHelper::getMostSignificant(const VectorDouble& vec, double tol, int n
   if (ninvalid <= 0) return;
 
   VectorInt ranks = orderRanks(absval, false);
-  int nend = ninvalid;
+  int nend        = ninvalid;
   if (nmax > 0) nend = MIN(ninvalid, nmax);
   for (int i = 0; i < nend; i++)
   {
@@ -1230,7 +1230,7 @@ VectorInt VectorHelper::sampleRanks(int ntotal,
   if (proportion <= 0. && number <= 0)
     count = ntotal;
   else if (proportion > 0.)
-    count = (int) (ntotal * proportion);
+    count = (int)(ntotal * proportion);
   else
     count = number;
   count = MIN(ntotal, MAX(1, count));
@@ -1247,12 +1247,12 @@ VectorInt VectorHelper::sampleRanks(int ntotal,
 
   std::vector<int>::iterator it;
   it = std::unique(ranks.begin(), ranks.end());
-  ranks.resize(distance(ranks.begin(),it));
+  ranks.resize(distance(ranks.begin(), it));
 
   return ranks;
 }
 
-VectorDouble VectorHelper::add(const VectorDouble &veca, const VectorDouble &vecb)
+VectorDouble VectorHelper::add(const VectorDouble& veca, const VectorDouble& vecb)
 {
   if (veca.size() != vecb.size())
   {
@@ -1280,7 +1280,7 @@ VectorDouble VectorHelper::add(const VectorDouble &veca, const VectorDouble &vec
  * @param dest Input/Output vector
  * @param src Auxiliary vector
  */
-void VectorHelper::addInPlace(VectorDouble &dest, const VectorDouble &src)
+void VectorHelper::addInPlace(VectorDouble& dest, const VectorDouble& src)
 {
   if (dest.size() != src.size())
   {
@@ -1320,15 +1320,15 @@ void VectorHelper::addInPlace(VectorInt& dest, const VectorInt& src)
 void VectorHelper::addInPlace(constvect in, vect dest)
 {
   const double* inp = in.data();
-  double * outp = dest.data();
-  for (int i = 0; i < (int)in.size();i++)
+  double* outp      = dest.data();
+  for (int i = 0; i < (int)in.size(); i++)
   {
-      *(outp++) +=  *(inp++);
+    *(outp++) += *(inp++);
   }
 }
-void VectorHelper::addInPlace(std::vector<double>& dest, const std::vector<double> &src)
+void VectorHelper::addInPlace(std::vector<double>& dest, const std::vector<double>& src)
 {
-   if (dest.size() != src.size())
+  if (dest.size() != src.size())
   {
     messerr("Arguments 'dest' and 'src' should have the same dimension. Nothing is done");
     return;
@@ -1341,16 +1341,15 @@ void VectorHelper::addInPlace(std::vector<double>& dest, const std::vector<doubl
     *itd += *its;
     itd++;
     its++;
-  } 
+  }
 }
-
 
 /**
  * Performs: veca += vecb**2
  * @param dest Input/Output vector
  * @param src Auxiliary vector
  */
-void VectorHelper::addSquareInPlace(VectorDouble &dest, const VectorDouble &src)
+void VectorHelper::addSquareInPlace(VectorDouble& dest, const VectorDouble& src)
 {
   if (dest.size() != src.size())
   {
@@ -1368,19 +1367,19 @@ void VectorHelper::addSquareInPlace(VectorDouble &dest, const VectorDouble &src)
   }
 }
 
-void VectorHelper::addInPlace(const VectorDouble &veca,
-                              const VectorDouble &vecb,
-                              VectorDouble &res,
+void VectorHelper::addInPlace(const VectorDouble& veca,
+                              const VectorDouble& vecb,
+                              VectorDouble& res,
                               int size)
 {
-  if (size <= 0) size = (int) veca.size();
-  if (size != (int) vecb.size())
+  if (size <= 0) size = (int)veca.size();
+  if (size != (int)vecb.size())
     my_throw("Wrong size");
-  if ((int) res.size() != size) res.resize(size);
+  if ((int)res.size() != size) res.resize(size);
 
   const double* iptra = veca.data();
   const double* iptrb = vecb.data();
-  double* iptrv = res.data();
+  double* iptrv       = res.data();
   for (int i = 0; i < size; i++)
   {
     (*iptrv) = (*iptra) + (*iptrb);
@@ -1420,13 +1419,13 @@ void VectorHelper::addInPlace(const double* veca,
     res[i] = veca[i] + vecb[i];
 }
 
-void VectorHelper::addInPlace(const VectorVectorDouble &in1,
-                              const VectorVectorDouble &in2,
-                              VectorVectorDouble &outv)
+void VectorHelper::addInPlace(const VectorVectorDouble& in1,
+                              const VectorVectorDouble& in2,
+                              VectorVectorDouble& outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) in1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)in1[is].size(); i < n; i++)
     {
       outv[is][i] = in2[is][i] + in1[is][i];
     }
@@ -1450,13 +1449,13 @@ VectorDouble VectorHelper::subtract(constvect veca,
   return res;
 }
 
-void VectorHelper::addInPlace(const std::vector<std::vector<double>> &in1,
-                              const std::vector<std::vector<double>> &in2,
-                              std::vector<std::vector<double>> &outv)
+void VectorHelper::addInPlace(const std::vector<std::vector<double>>& in1,
+                              const std::vector<std::vector<double>>& in2,
+                              std::vector<std::vector<double>>& outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) in1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)in1[is].size(); i < n; i++)
     {
       outv[is][i] = in2[is][i] + in1[is][i];
     }
@@ -1465,8 +1464,8 @@ void VectorHelper::addInPlace(const std::vector<std::vector<double>> &in1,
 /**
  ** @overload
  */
-VectorDouble VectorHelper::subtract(const VectorDouble &veca,
-                                    const VectorDouble &vecb)
+VectorDouble VectorHelper::subtract(const VectorDouble& veca,
+                                    const VectorDouble& vecb)
 {
   if (veca.size() != vecb.size())
     my_throw("Wrong size");
@@ -1491,8 +1490,8 @@ VectorDouble VectorHelper::subtract(const VectorDouble &veca,
  * @param vecb Input Vector
  * @return
  */
-VectorInt VectorHelper::subtract(const VectorInt &veca,
-                                 const VectorInt &vecb)
+VectorInt VectorHelper::subtract(const VectorInt& veca,
+                                 const VectorInt& vecb)
 {
   if (veca.size() != vecb.size())
     my_throw("Wrong size");
@@ -1516,7 +1515,7 @@ VectorInt VectorHelper::subtract(const VectorInt &veca,
  * @param dest Input/Output vector
  * @param src Auxiliary vector
  */
-void VectorHelper::subtractInPlace(VectorDouble &dest, const VectorDouble &src)
+void VectorHelper::subtractInPlace(VectorDouble& dest, const VectorDouble& src)
 {
   VectorDouble res;
   if (dest.size() != src.size())
@@ -1532,7 +1531,7 @@ void VectorHelper::subtractInPlace(VectorDouble &dest, const VectorDouble &src)
   }
 }
 
-void VectorHelper::subtractInPlace(VectorInt &dest, const VectorInt &src)
+void VectorHelper::subtractInPlace(VectorInt& dest, const VectorInt& src)
 {
   VectorInt res;
   if (dest.size() != src.size())
@@ -1550,21 +1549,21 @@ void VectorHelper::subtractInPlace(VectorInt &dest, const VectorInt &src)
 
 void VectorHelper::subtractInPlace(const constvect in1,
                                    const constvect in2,
-                                   vect  outv)
+                                   vect outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
     outv[is] = in2[is] - in1[is];
   }
 }
 
-void VectorHelper::subtractInPlace(const VectorVectorDouble &in1,
-                                   const VectorVectorDouble &in2,
-                                   VectorVectorDouble &outv)
+void VectorHelper::subtractInPlace(const VectorVectorDouble& in1,
+                                   const VectorVectorDouble& in2,
+                                   VectorVectorDouble& outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) in1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)in1[is].size(); i < n; i++)
     {
       outv[is][i] = in2[is][i] - in1[is][i];
     }
@@ -1573,19 +1572,19 @@ void VectorHelper::subtractInPlace(const VectorVectorDouble &in1,
 
 // TODO: check why we cannot replace std::vector<std::vecot<double>> by VectorVectorDouble
 void VectorHelper::subtractInPlace(const std::vector<std::vector<double>>& in1,
-                                    const std::vector<std::vector<double>>& in2,
-                                    std::vector<std::vector<double>>& outv)
+                                   const std::vector<std::vector<double>>& in2,
+                                   std::vector<std::vector<double>>& outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) in1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)in1[is].size(); i < n; i++)
     {
       outv[is][i] = in2[is][i] - in1[is][i];
     }
   }
 }
 
-void VectorHelper::multiplyInPlace(VectorDouble &vec, const VectorDouble &v)
+void VectorHelper::multiplyInPlace(VectorDouble& vec, const VectorDouble& v)
 {
   if (vec.size() != v.size())
     my_throw("Arguments 'vec' and 'v' should have same dimension");
@@ -1644,7 +1643,7 @@ void VectorHelper::multiplyInPlace(const VectorDouble& veca,
   }
 }
 
-void VectorHelper::divideInPlace(VectorDouble &vec, const VectorDouble &v)
+void VectorHelper::divideInPlace(VectorDouble& vec, const VectorDouble& v)
 {
   if (vec.size() != v.size())
     my_throw("Arguments 'vec' and 'v' should have same dimension");
@@ -1660,7 +1659,7 @@ void VectorHelper::divideInPlace(VectorDouble &vec, const VectorDouble &v)
   }
 }
 
-void VectorHelper::divideInPlace(std::vector<double> &vec, const std::vector<double> &v)
+void VectorHelper::divideInPlace(std::vector<double>& vec, const std::vector<double>& v)
 {
   if (vec.size() != v.size())
     my_throw("Arguments 'vec' and 'v' should have same dimension");
@@ -1737,13 +1736,13 @@ void VectorHelper::multiplyComplexInPlace(const VectorDouble& vecaRe,
   VH::addInPlace(resIm, temp);
 }
 
-void VectorHelper::multiplyConstant(VectorDouble &vec, double v)
+void VectorHelper::multiplyConstant(VectorDouble& vec, double v)
 {
-  std::for_each(vec.begin(), vec.end(), [v](double &d)
-  { d *= v;});
+  std::for_each(vec.begin(), vec.end(), [v](double& d)
+                { d *= v; });
 }
 
-void VectorHelper::multiplyConstantInPlace(const VectorDouble &vecin, double v, VectorDouble& vecout)
+void VectorHelper::multiplyConstantInPlace(const VectorDouble& vecin, double v, VectorDouble& vecout)
 {
   VectorDouble::iterator itout(vecout.begin());
   VectorDouble::const_iterator itin(vecin.begin());
@@ -1755,7 +1754,7 @@ void VectorHelper::multiplyConstantInPlace(const VectorDouble &vecin, double v, 
   }
 }
 
-void VectorHelper::multiplyConstantSelfInPlace(VectorDouble &vec, double v)
+void VectorHelper::multiplyConstantSelfInPlace(VectorDouble& vec, double v)
 {
   VectorDouble::iterator it(vec.begin());
   while (it < vec.end())
@@ -1766,29 +1765,29 @@ void VectorHelper::multiplyConstantSelfInPlace(VectorDouble &vec, double v)
 }
 
 void VectorHelper::addMultiplyConstantInPlace(double val1,
-                                              const VectorDouble &in,
-                                              VectorDouble &out,
+                                              const VectorDouble& in,
+                                              VectorDouble& out,
                                               int iad)
 {
-    double * outp = out.data() + iad;
-    const double* inp = in.data();
-    for (int i = 0; i < (int)in.size();i++)
-    {
-      *(outp++) += val1 * *(inp++);
-    }
+  double* outp      = out.data() + iad;
+  const double* inp = in.data();
+  for (int i = 0; i < (int)in.size(); i++)
+  {
+    *(outp++) += val1 * *(inp++);
+  }
 }
 void VectorHelper::addMultiplyVectVectInPlace(const constvect in1,
                                               const constvect in2,
                                               vect out,
                                               int iad)
-{ //TODO check if one can use eigen operators
-    double * outp = out.data() + iad;
-    const double* inp1 = in1.data();
-    const double* inp2 = in2.data();
-    for (int i = 0; i < (int)in1.size(); i++)
-    {
-      *(outp++) += *(inp1++)* *(inp2++);
-    }
+{ // TODO check if one can use eigen operators
+  double* outp       = out.data() + iad;
+  const double* inp1 = in1.data();
+  const double* inp2 = in2.data();
+  for (int i = 0; i < (int)in1.size(); i++)
+  {
+    *(outp++) += *(inp1++) * *(inp2++);
+  }
 }
 
 void VectorHelper::addMultiplyConstantInPlace(double val1,
@@ -1796,38 +1795,38 @@ void VectorHelper::addMultiplyConstantInPlace(double val1,
                                               vect out,
                                               int iad)
 {
-    double * outp = out.data() + iad;
-    const double* inp = in.data();
-    for (int i = 0; i < (int)in.size();i++)
-    {
-      *(outp++) += val1 * *(inp++);
-    }
+  double* outp      = out.data() + iad;
+  const double* inp = in.data();
+  for (int i = 0; i < (int)in.size(); i++)
+  {
+    *(outp++) += val1 * *(inp++);
+  }
 }
 void VectorHelper::addMultiplyConstantInPlace(double val1,
-                                              const VectorVectorDouble &in1,
-                                              VectorVectorDouble &outv)
+                                              const VectorVectorDouble& in1,
+                                              VectorVectorDouble& outv)
 {
-  for (int is = 0, ns = (int) in1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)in1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) in1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)in1[is].size(); i < n; i++)
     {
       outv[is][i] += val1 * in1[is][i];
     }
   }
 }
 
-void VectorHelper::divideConstant(VectorDouble &vec, double v)
+void VectorHelper::divideConstant(VectorDouble& vec, double v)
 {
   if (isZero(v))
-  my_throw("division by 0");
-  std::for_each(vec.begin(), vec.end(), [v](double &d)
-  { d /= v; });
+    my_throw("division by 0");
+  std::for_each(vec.begin(), vec.end(), [v](double& d)
+                { d /= v; });
 }
 
-void VectorHelper::copy(const VectorDouble &vecin, VectorDouble &vecout, int size)
+void VectorHelper::copy(const VectorDouble& vecin, VectorDouble& vecout, int size)
 {
-  if (size < 0) size = (int) vecin.size();
-  if (size > (int) vecout.size())
+  if (size < 0) size = (int)vecin.size();
+  if (size > (int)vecout.size())
     my_throw("Wrong size");
 
   VectorDouble::iterator itout(vecout.begin());
@@ -1840,10 +1839,10 @@ void VectorHelper::copy(const VectorDouble &vecin, VectorDouble &vecout, int siz
   }
 }
 
-void VectorHelper::copy(const VectorInt &vecin, VectorInt &vecout, int size)
+void VectorHelper::copy(const VectorInt& vecin, VectorInt& vecout, int size)
 {
-  if (size < 0) size = (int) vecin.size();
-  if (size > (int) vecout.size())
+  if (size < 0) size = (int)vecin.size();
+  if (size > (int)vecout.size())
     my_throw("Wrong size");
 
   VectorInt::iterator itout(vecout.begin());
@@ -1855,56 +1854,56 @@ void VectorHelper::copy(const VectorInt &vecin, VectorInt &vecout, int size)
     itout++;
   }
 }
-void VectorHelper::copy(const std::vector<std::vector<double>> &inv, std::vector<std::vector<double>> &outv)
+void VectorHelper::copy(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv)
 {
-  for (int is = 0, ns = (int) inv.size(); is < ns; is++)
+  for (int is = 0, ns = (int)inv.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) inv[is].size(); i < n; i++)
+    for (int i = 0, n = (int)inv[is].size(); i < n; i++)
     {
       outv[is][i] = inv[is][i];
     }
   }
 }
-void VectorHelper::copy(const VectorVectorDouble &inv, VectorVectorDouble &outv)
+void VectorHelper::copy(const VectorVectorDouble& inv, VectorVectorDouble& outv)
 {
-  for (int is = 0, ns = (int) inv.size(); is < ns; is++)
+  for (int is = 0, ns = (int)inv.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) inv[is].size(); i < n; i++)
+    for (int i = 0, n = (int)inv[is].size(); i < n; i++)
     {
       outv[is][i] = inv[is][i];
     }
   }
 }
 
-void VectorHelper::addConstant(VectorDouble &vec, double v)
+void VectorHelper::addConstant(VectorDouble& vec, double v)
 {
-  std::for_each(vec.begin(), vec.end(), [v](double &d)
-  { d += v;});
+  std::for_each(vec.begin(), vec.end(), [v](double& d)
+                { d += v; });
 }
 
-void VectorHelper::addConstant(VectorInt &vec, int v)
+void VectorHelper::addConstant(VectorInt& vec, int v)
 {
-  std::for_each(vec.begin(), vec.end(), [v](int &d)
-  { d += v;});
+  std::for_each(vec.begin(), vec.end(), [v](int& d)
+                { d += v; });
 }
 
-void VectorHelper::mean1AndMean2ToStdev(const VectorDouble &mean1,
-                                        const VectorDouble &mean2,
-                                        VectorDouble &std,
+void VectorHelper::mean1AndMean2ToStdev(const VectorDouble& mean1,
+                                        const VectorDouble& mean2,
+                                        VectorDouble& std,
                                         int number)
 {
-  double dnumber = (double) number;
-  int size = (int) mean1.size();
-  if ((int) mean2.size() != size)
+  double dnumber = (double)number;
+  int size       = (int)mean1.size();
+  if ((int)mean2.size() != size)
   {
     messerr("Arguments 'mean1'(%d) and 'mean2'(%d) should have same dimension",
-            size, (int) mean2.size());
+            size, (int)mean2.size());
     return;
   }
-  if ((int) std.size() != size)
+  if ((int)std.size() != size)
   {
     messerr("Arguments 'mean1'(%d) and 'std'(%d) should have same dimension",
-            size, (int) std.size());
+            size, (int)std.size());
     return;
   }
 
@@ -1916,8 +1915,8 @@ void VectorHelper::mean1AndMean2ToStdev(const VectorDouble &mean1,
     {
       double dmean1 = mean1[i] / dnumber;
       double dmean2 = mean2[i] / dnumber;
-      double value = dmean2 - dmean1 * dmean1;
-      std[i] = (value > 0) ? sqrt(value) : 0.;
+      double value  = dmean2 - dmean1 * dmean1;
+      std[i]        = (value > 0) ? sqrt(value) : 0.;
     }
   }
 }
@@ -1936,7 +1935,7 @@ VectorDouble VectorHelper::inverse(const VectorDouble& vec)
   return res;
 }
 
-void VectorHelper::power(VectorDouble &res, const constvect vec, double power)
+void VectorHelper::power(VectorDouble& res, const constvect vec, double power)
 {
   res.resize(vec.size());
   for (size_t i = 0; i < vec.size(); ++i)
@@ -1954,7 +1953,7 @@ void VectorHelper::inverse(VectorDouble& res, const constvect vec)
   }
 }
 
-int VectorHelper::countUndefined(const VectorDouble &vec)
+int VectorHelper::countUndefined(const VectorDouble& vec)
 {
   int count = 0;
   VectorDouble::const_iterator it(vec.begin());
@@ -1966,13 +1965,13 @@ int VectorHelper::countUndefined(const VectorDouble &vec)
   return count;
 }
 
-int VectorHelper::countDefined(const VectorDouble &vec)
+int VectorHelper::countDefined(const VectorDouble& vec)
 {
   int count = 0;
   VectorDouble::const_iterator it(vec.begin());
   while (it < vec.end())
   {
-    if (! FFFF(*it)) count++;
+    if (!FFFF(*it)) count++;
     it++;
   }
   return count;
@@ -1985,12 +1984,12 @@ int VectorHelper::countDefined(const VectorDouble &vec)
  * @return
  * @remark If one coordinate is undefined, TEST is returned.
  */
-double VectorHelper::extensionDiagonal(const VectorDouble &mini,
-                                       const VectorDouble &maxi)
+double VectorHelper::extensionDiagonal(const VectorDouble& mini,
+                                       const VectorDouble& maxi)
 {
-  double diag = 0.;
+  double diag        = 0.;
   VectorDouble delta = VH::subtract(mini, maxi);
-  int ndim = (int) delta.size();
+  int ndim           = (int)delta.size();
   for (int idim = 0; idim < ndim; idim++)
   {
     double dval = delta[idim];
@@ -2003,7 +2002,7 @@ double VectorHelper::extensionDiagonal(const VectorDouble &mini,
 
 VectorInt VectorHelper::unique(const VectorInt& vecin, int size)
 {
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
 
   VectorInt vecout = vecin;
   vecout.resize(size);
@@ -2015,7 +2014,7 @@ VectorInt VectorHelper::unique(const VectorInt& vecin, int size)
 
 VectorDouble VectorHelper::unique(const VectorDouble& vecin, int size)
 {
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
 
   VectorDouble vecout = vecin;
   vecout.resize(size);
@@ -2033,11 +2032,11 @@ bool VectorHelper::isInList(const VectorInt& vec, int item)
 VectorInt VectorHelper::sort(const VectorInt& vecin, bool ascending, int size)
 {
   if (vecin.empty()) return VectorInt();
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorInt vecout = vecin;
   vecout.resize(size);
   std::sort(vecout.begin(), vecout.end());
-  if (! ascending)
+  if (!ascending)
     std::reverse(vecout.begin(), vecout.end());
   return vecout;
 }
@@ -2045,11 +2044,11 @@ VectorInt VectorHelper::sort(const VectorInt& vecin, bool ascending, int size)
 VectorDouble VectorHelper::sort(const VectorDouble& vecin, bool ascending, int size)
 {
   if (vecin.empty()) return VectorDouble();
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorDouble vecout = vecin;
   vecout.resize(size);
   std::sort(vecout.begin(), vecout.end());
-  if (! ascending)
+  if (!ascending)
     std::reverse(vecout.begin(), vecout.end());
   return vecout;
 }
@@ -2070,7 +2069,7 @@ void VectorHelper::sortInPlace(VectorDouble& vecin, bool ascending, int size)
 
 bool VectorHelper::isSorted(const VectorDouble& vec, bool ascending)
 {
-  int nval = (int) vec.size();
+  int nval = (int)vec.size();
 
   if (ascending)
   {
@@ -2108,16 +2107,16 @@ VectorInt VectorHelper::filter(const VectorInt& vecin, int vmin, int vmax, bool 
 
   // Sort the vector
   std::sort(vecout.begin(), vecout.end());
-  if (! ascending)
+  if (!ascending)
     std::reverse(vecout.begin(), vecout.end());
 
   // Unique occurrence
   std::vector<int>::iterator it;
   it = std::unique(vecout.begin(), vecout.end());
-  vecout.resize(distance(vecout.begin(),it));
+  vecout.resize(distance(vecout.begin(), it));
 
   // Filter out the irrelevant values
-  int nech = (int) vecout.size();
+  int nech = (int)vecout.size();
   for (int j = 0; j < nech; j++)
   {
     int i = nech - j - 1;
@@ -2125,7 +2124,7 @@ VectorInt VectorHelper::filter(const VectorInt& vecin, int vmin, int vmax, bool 
     {
       if (vecout[i] < vmin)
       {
-        vecout.erase(vecout.begin()+i);
+        vecout.erase(vecout.begin() + i);
         continue;
       }
     }
@@ -2133,7 +2132,7 @@ VectorInt VectorHelper::filter(const VectorInt& vecin, int vmin, int vmax, bool 
     {
       if (vecout[i] >= vmax)
       {
-        vecout.erase(vecout.begin()+i);
+        vecout.erase(vecout.begin() + i);
         continue;
       }
     }
@@ -2162,18 +2161,18 @@ VectorInt VectorHelper::complement(const VectorInt& vec, const VectorInt& sel)
   std::sort(offVec.begin(), offVec.end());
 
   int j, k, idx;
-  int nvec = (int) allVec.size();
-  int noff = (int) offVec.size();
+  int nvec = (int)allVec.size();
+  int noff = (int)offVec.size();
   for (int i = 0; i < nvec; i++)
   {
     j = allVec.at(i);
 
     // I go through offVec as long as element is strictly less than j
-    k = 0;
+    k   = 0;
     idx = offVec.at(k);
     while (idx < j && k < noff)
     {
-        idx = offVec.at(k++);
+      idx = offVec.at(k++);
     }
 
     if (idx != j) // idx not in offElemsVec
@@ -2195,7 +2194,7 @@ VectorInt VectorHelper::orderRanks(const VectorInt& vecin, bool ascending, int s
 {
   if (vecin.empty()) return VectorInt();
 
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorInt idx(size);
   for (int i = 0; i < size; i++) idx[i] = i;
 
@@ -2205,12 +2204,14 @@ VectorInt VectorHelper::orderRanks(const VectorInt& vecin, bool ascending, int s
   if (ascending)
   {
     stable_sort(idx.begin(), last,
-                [&vecin](size_t i1, size_t i2) {return vecin[i1] < vecin[i2];});
+                [&vecin](size_t i1, size_t i2)
+                { return vecin[i1] < vecin[i2]; });
   }
   else
   {
     stable_sort(idx.begin(), last,
-                [&vecin](size_t i1, size_t i2) {return vecin[i1] > vecin[i2];});
+                [&vecin](size_t i1, size_t i2)
+                { return vecin[i1] > vecin[i2]; });
   }
 
   return idx;
@@ -2222,7 +2223,7 @@ VectorInt VectorHelper::orderRanks(const VectorInt& vecin, bool ascending, int s
 VectorInt VectorHelper::orderRanks(const VectorDouble& vecin, bool ascending, int size)
 {
   if (vecin.empty()) return VectorInt();
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorInt idx(size);
   for (int i = 0; i < size; i++) idx[i] = i;
 
@@ -2232,12 +2233,14 @@ VectorInt VectorHelper::orderRanks(const VectorDouble& vecin, bool ascending, in
   if (ascending)
   {
     stable_sort(idx.begin(), last,
-                [&vecin](size_t i1, size_t i2) {return vecin[i1] < vecin[i2];});
+                [&vecin](size_t i1, size_t i2)
+                { return vecin[i1] < vecin[i2]; });
   }
   else
   {
     stable_sort(idx.begin(), last,
-                [&vecin](size_t i1, size_t i2) {return vecin[i1] > vecin[i2];});
+                [&vecin](size_t i1, size_t i2)
+                { return vecin[i1] > vecin[i2]; });
   }
 
   return idx;
@@ -2246,7 +2249,7 @@ VectorInt VectorHelper::orderRanks(const VectorDouble& vecin, bool ascending, in
 VectorInt VectorHelper::sortRanks(const VectorDouble& vecin, bool ascending, int size)
 {
   if (vecin.empty()) return VectorInt();
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorInt order = orderRanks(vecin, ascending, size);
   VectorInt idx(size);
   for (int i = 0; i < size; i++) idx[order[i]] = i;
@@ -2256,31 +2259,33 @@ VectorInt VectorHelper::sortRanks(const VectorDouble& vecin, bool ascending, int
 
 VectorInt VectorHelper::reorder(const VectorInt& vecin, const VectorInt& order, int size)
 {
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorInt vecout(size);
-  for (int i = 0; i< size; i++)
+  for (int i = 0; i < size; i++)
     vecout[i] = vecin[order[i]];
   return vecout;
 }
 
 VectorDouble VectorHelper::reorder(const VectorDouble& vecin, const VectorInt& order, int size)
 {
-  if (size < 0) size = (int) vecin.size();
+  if (size < 0) size = (int)vecin.size();
   VectorDouble vecout(size);
-  for (int i = 0; i< size; i++)
+  for (int i = 0; i < size; i++)
     vecout[i] = vecin[order[i]];
   return vecout;
 }
 
-VectorDouble VectorHelper::revert(const VectorDouble &vecin) {
+VectorDouble VectorHelper::revert(const VectorDouble& vecin)
+{
   int nech = (int)vecin.size();
   VectorDouble vecout(nech);
   for (int iech = 0; iech < nech; iech++)
-    vecout[nech - 1 -iech] = vecin[iech];
+    vecout[nech - 1 - iech] = vecin[iech];
   return vecout;
 }
 
-VectorInt VectorHelper::revert(const VectorInt &vecin) {
+VectorInt VectorHelper::revert(const VectorInt& vecin)
+{
   int nech = (int)vecin.size();
   VectorInt vecout(nech);
   for (int iech = 0; iech < nech; iech++)
@@ -2305,14 +2310,14 @@ VectorInt VectorHelper::revert(const VectorInt &vecin) {
  **
  *****************************************************************************/
 void VectorHelper::arrangeInPlace(int safe,
-                                  VectorInt &ranks,
-                                  VectorDouble &values,
+                                  VectorInt& ranks,
+                                  VectorDouble& values,
                                   bool ascending,
                                   int size)
 {
   VectorInt order = orderRanks(values, ascending, size);
 
-  if (! ranks.empty())
+  if (!ranks.empty())
   {
     VectorInt newranks = reorder(ranks, order, size);
     copy(newranks, ranks, size);
@@ -2331,44 +2336,44 @@ void VectorHelper::arrangeInPlace(int safe,
  ** @overload
  **/
 void VectorHelper::arrangeInPlace(int safe,
-                                  VectorInt &ranks,
-                                  VectorInt &values,
+                                  VectorInt& ranks,
+                                  VectorInt& values,
                                   bool ascending,
                                   int size)
 {
   VectorInt order = orderRanks(values, ascending, size);
 
-  if (! ranks.empty())
+  if (!ranks.empty())
   {
     VectorInt newranks = reorder(ranks, order, size);
-    ranks = newranks;
+    ranks              = newranks;
   }
 
   if (safe == 0)
   {
     VectorInt newval = reorder(values, order, size);
-    values = newval;
+    values           = newval;
   }
 }
 
-std::pair<double,double> VectorHelper::rangeVals(const VectorDouble& vec)
+std::pair<double, double> VectorHelper::rangeVals(const VectorDouble& vec)
 {
-  std::pair<double,double> res(vec[0],vec[0]);
+  std::pair<double, double> res(vec[0], vec[0]);
   for (int i = 1; i < (int)vec.size(); i++)
   {
-    res.first  = MIN(res.first ,vec[i]);
-    res.second = MAX(res.second,vec[i]);
+    res.first  = MIN(res.first, vec[i]);
+    res.second = MAX(res.second, vec[i]);
   }
   return res;
 }
 
-double VectorHelper::innerProduct(const std::vector<double> &veca, const std::vector<double> &vecb, int size)
+double VectorHelper::innerProduct(const std::vector<double>& veca, const std::vector<double>& vecb, int size)
 {
-  if (size < 0) size = (int) veca.size();
-  if (size > (int) veca.size() || size > (int) vecb.size())
+  if (size < 0) size = (int)veca.size();
+  if (size > (int)veca.size() || size > (int)vecb.size())
     my_throw("Incompatible sizes");
 
-  return innerProduct(veca.data(), vecb.data(), size);  
+  return innerProduct(veca.data(), vecb.data(), size);
 }
 
 double VectorHelper::innerProduct(const constvect veca, const constvect vecb)
@@ -2376,12 +2381,12 @@ double VectorHelper::innerProduct(const constvect veca, const constvect vecb)
   return innerProduct(veca.data(), vecb.data(), (int)veca.size());
 }
 
-double VectorHelper::innerProduct(const VectorDouble &veca,
-                                  const VectorDouble &vecb,
+double VectorHelper::innerProduct(const VectorDouble& veca,
+                                  const VectorDouble& vecb,
                                   int size)
 {
-  if (size < 0) size = (int) veca.size();
-  if (size > (int) veca.size() || size > (int) vecb.size())
+  if (size < 0) size = (int)veca.size();
+  if (size > (int)veca.size() || size > (int)vecb.size())
     my_throw("Incompatible sizes");
 
   return innerProduct(veca.data(), vecb.data(), size);
@@ -2391,9 +2396,9 @@ double VectorHelper::innerProduct(const double* veca,
                                   const double* vecb,
                                   int size)
 {
-  double prod = 0.;
-  const double *ptra = &veca[0];
-  const double *ptrb = &vecb[0];
+  double prod        = 0.;
+  const double* ptra = &veca[0];
+  const double* ptrb = &vecb[0];
   for (int i = 0; i < size; i++)
   {
     prod += (*ptra) * (*ptrb);
@@ -2403,19 +2408,19 @@ double VectorHelper::innerProduct(const double* veca,
   return prod;
 }
 
-double VectorHelper::innerProduct(const std::vector<std::vector<double>> &x,
-                                  const std::vector<std::vector<double>> &y)
+double VectorHelper::innerProduct(const std::vector<std::vector<double>>& x,
+                                  const std::vector<std::vector<double>>& y)
 {
   double s = 0.;
-  for (int i = 0, n = (int) x.size(); i < n; i++)
+  for (int i = 0, n = (int)x.size(); i < n; i++)
     s += VH::innerProduct(x[i], y[i]);
   return s;
 }
-double VectorHelper::innerProduct(const VectorVectorDouble &x,
-                                  const VectorVectorDouble &y)
+double VectorHelper::innerProduct(const VectorVectorDouble& x,
+                                  const VectorVectorDouble& y)
 {
   double s = 0.;
-  for (int i = 0, n = (int) x.size(); i < n; i++)
+  for (int i = 0, n = (int)x.size(); i < n; i++)
     s += VH::innerProduct(x[i], y[i]);
   return s;
 }
@@ -2426,8 +2431,8 @@ double VectorHelper::innerProduct(const VectorVectorDouble &x,
  * @param vecb Second Vector
  * @return
  */
-VectorDouble VectorHelper::crossProduct3D(const VectorDouble &veca,
-                                          const VectorDouble &vecb)
+VectorDouble VectorHelper::crossProduct3D(const VectorDouble& veca,
+                                          const VectorDouble& vecb)
 {
   if (veca.size() != vecb.size())
     my_throw("Wrong size");
@@ -2436,7 +2441,7 @@ VectorDouble VectorHelper::crossProduct3D(const VectorDouble &veca,
   return res;
 }
 
-void VectorHelper::crossProduct3DInPlace(const double *a, const double *b, double *v)
+void VectorHelper::crossProduct3DInPlace(const double* a, const double* b, double* v)
 {
   v[0] = a[1] * b[2] - a[2] * b[1];
   v[1] = a[2] * b[0] - a[0] * b[2];
@@ -2452,8 +2457,8 @@ VectorDouble VectorHelper::flatten(const VectorVectorDouble& vvd)
 {
   VectorDouble vd;
 
-  for (int i = 0; i < (int) vvd.size(); i++)
-    for (int j = 0; j < (int) vvd[i].size(); j++)
+  for (int i = 0; i < (int)vvd.size(); i++)
+    for (int j = 0; j < (int)vvd[i].size(); j++)
       vd.push_back(vvd[i][j]);
 
   return vd;
@@ -2462,8 +2467,8 @@ VectorDouble VectorHelper::flatten(const VectorVectorDouble& vvd)
 void VectorHelper::flattenInPlace(const VectorVectorDouble& vvd, VectorDouble& vd)
 {
   int ecr = 0;
-  for (int i = 0; i < (int) vvd.size(); i++)
-    for (int j = 0; j < (int) vvd[i].size(); j++)
+  for (int i = 0; i < (int)vvd.size(); i++)
+    for (int j = 0; j < (int)vvd[i].size(); j++)
       vd[ecr++] = (vvd[i][j]);
 }
 
@@ -2472,7 +2477,7 @@ VectorVectorDouble VectorHelper::unflatten(const VectorDouble& vd, const VectorI
   VectorVectorDouble vvd;
 
   int lec = 0;
-  for (int i = 0, n = (int) sizes.size(); i < n; i++)
+  for (int i = 0, n = (int)sizes.size(); i < n; i++)
   {
     int lng = sizes[i];
     VectorDouble local(lng);
@@ -2486,16 +2491,16 @@ VectorVectorDouble VectorHelper::unflatten(const VectorDouble& vd, const VectorI
 void VectorHelper::flattenInPlace(const std::vector<std::vector<double>>& vvd, std::vector<double>& vd)
 {
   int ecr = 0;
-  for (int i = 0; i < (int) vvd.size(); i++)
-    for (int j = 0; j < (int) vvd[i].size(); j++)
+  for (int i = 0; i < (int)vvd.size(); i++)
+    for (int j = 0; j < (int)vvd[i].size(); j++)
       vd[ecr++] = (vvd[i][j]);
 }
 
 void VectorHelper::unflattenInPlace(const std::vector<double>& vd, std::vector<std::vector<double>>& vvd)
 {
   int lec = 0;
-  for (int i = 0, n = (int) vvd.size(); i < n; i++)
-    for (int j = 0; j < (int) vvd[i].size(); j++)
+  for (int i = 0, n = (int)vvd.size(); i < n; i++)
+    for (int j = 0; j < (int)vvd[i].size(); j++)
       vvd[i][j] = vd[lec++];
 }
 
@@ -2503,20 +2508,19 @@ std::vector<double> VectorHelper::flatten(const std::vector<std::vector<double>>
 {
   std::vector<double> vd;
 
-  for (int i = 0; i < (int) vvd.size(); i++)
-    for (int j = 0; j < (int) vvd[i].size(); j++)
+  for (int i = 0; i < (int)vvd.size(); i++)
+    for (int j = 0; j < (int)vvd[i].size(); j++)
       vd.push_back(vvd[i][j]);
 
   return vd;
-
 }
 
 std::vector<std::vector<double>> VectorHelper::unflatten(const std::vector<double>& vd, const VectorInt& sizes)
 {
- std::vector<std::vector<double>> vvd;
+  std::vector<std::vector<double>> vvd;
 
   int lec = 0;
-  for (int i = 0, n = (int) sizes.size(); i < n; i++)
+  for (int i = 0, n = (int)sizes.size(); i < n; i++)
   {
     int lng = sizes[i];
     VectorDouble local(lng);
@@ -2525,26 +2529,25 @@ std::vector<std::vector<double>> VectorHelper::unflatten(const std::vector<doubl
     vvd.push_back(local);
   }
   return vvd;
-
 }
 VectorDouble VectorHelper::suppressTest(const VectorDouble& vecin)
 {
   VectorDouble vecout;
-  for (int i = 0, n = (int) vecin.size(); i < n; i++)
+  for (int i = 0, n = (int)vecin.size(); i < n; i++)
   {
-    if (! FFFF(vecin[i])) vecout.push_back(vecin[i]);
+    if (!FFFF(vecin[i])) vecout.push_back(vecin[i]);
   }
   return vecout;
 }
 
 void VectorHelper::linearCombinationInPlace(double val1,
-                                            const VectorDouble &vd1,
+                                            const VectorDouble& vd1,
                                             double val2,
-                                            const VectorDouble &vd2,
-                                            VectorDouble &outv)
+                                            const VectorDouble& vd2,
+                                            VectorDouble& outv)
 {
   if (vd1.empty() || vd2.empty()) return;
-  for (int i = 0, n = (int) vd1.size(); i < n; i++)
+  for (int i = 0, n = (int)vd1.size(); i < n; i++)
   {
     double value = 0.;
     if (val1 != 0. && !vd1.empty()) value += val1 * vd1[i];
@@ -2553,40 +2556,39 @@ void VectorHelper::linearCombinationInPlace(double val1,
   }
 }
 void VectorHelper::linearCombinationVVDInPlace(double val1,
-                                          const std::vector<std::vector<double>> &vvd1,
-                                          double val2,
-                                          const std::vector<std::vector<double>> &vvd2,
-                                          std::vector<std::vector<double>> &outv)
-{
-if (vvd1.empty() || vvd2.empty()) return;
-
-  for (int is = 0, ns = (int) vvd1.size(); is < ns; is++)
-  {
-    for (int i = 0, n = (int) vvd1[is].size(); i < n; i++)
-    {
-      double value = 0.;
-      if (val1 != 0. && ! vvd1.empty()) value += val1 * vvd1[is][i];
-      if (val2 != 0. && ! vvd2.empty()) value += val2 * vvd2[is][i];
-      outv[is][i] = value;
-    }
-  }
-
-}
-void VectorHelper::linearCombinationVVDInPlace(double val1,
-                                               const VectorVectorDouble &vvd1,
+                                               const std::vector<std::vector<double>>& vvd1,
                                                double val2,
-                                               const VectorVectorDouble &vvd2,
-                                               VectorVectorDouble &outv)
+                                               const std::vector<std::vector<double>>& vvd2,
+                                               std::vector<std::vector<double>>& outv)
 {
   if (vvd1.empty() || vvd2.empty()) return;
 
-  for (int is = 0, ns = (int) vvd1.size(); is < ns; is++)
+  for (int is = 0, ns = (int)vvd1.size(); is < ns; is++)
   {
-    for (int i = 0, n = (int) vvd1[is].size(); i < n; i++)
+    for (int i = 0, n = (int)vvd1[is].size(); i < n; i++)
     {
       double value = 0.;
-      if (val1 != 0. && ! vvd1.empty()) value += val1 * vvd1[is][i];
-      if (val2 != 0. && ! vvd2.empty()) value += val2 * vvd2[is][i];
+      if (val1 != 0. && !vvd1.empty()) value += val1 * vvd1[is][i];
+      if (val2 != 0. && !vvd2.empty()) value += val2 * vvd2[is][i];
+      outv[is][i] = value;
+    }
+  }
+}
+void VectorHelper::linearCombinationVVDInPlace(double val1,
+                                               const VectorVectorDouble& vvd1,
+                                               double val2,
+                                               const VectorVectorDouble& vvd2,
+                                               VectorVectorDouble& outv)
+{
+  if (vvd1.empty() || vvd2.empty()) return;
+
+  for (int is = 0, ns = (int)vvd1.size(); is < ns; is++)
+  {
+    for (int i = 0, n = (int)vvd1[is].size(); i < n; i++)
+    {
+      double value = 0.;
+      if (val1 != 0. && !vvd1.empty()) value += val1 * vvd1[is][i];
+      if (val2 != 0. && !vvd2.empty()) value += val2 * vvd2[is][i];
       outv[is][i] = value;
     }
   }
@@ -2623,7 +2625,7 @@ void VectorHelper::mergeInPlace(const VectorDouble& vecin, VectorDouble& vecout,
 void VectorHelper::transformVD(VectorDouble& tab, int oper_choice)
 {
   operate_function oper_func = operate_Identify(oper_choice);
-  int number = (int) tab.size();
+  int number                 = (int)tab.size();
   for (int i = 0; i < number; i++)
     tab[i] = oper_func(tab[i]);
 }
@@ -2637,7 +2639,7 @@ void VectorHelper::transformVD(VectorDouble& tab, int oper_choice)
  ** \param[in,out]  codir Input/Output Direction coefficients
  **
  *****************************************************************************/
-void VectorHelper::normalizeCodir(int ndim, VectorDouble &codir)
+void VectorHelper::normalizeCodir(int ndim, VectorDouble& codir)
 {
   double norme;
 
@@ -2670,15 +2672,15 @@ void VectorHelper::normalizeCodir(int ndim, VectorDouble &codir)
  * @remarks in the structural system. The purpose is to sample the relevant sub-information
  * @remarks (between 'top' and 'bot') densely in 'vecout'
  */
-void VectorHelper::squeezeAndStretchInPlaceForward(const VectorDouble &vecin,
-                                                   VectorDouble &vecout,
+void VectorHelper::squeezeAndStretchInPlaceForward(const VectorDouble& vecin,
+                                                   VectorDouble& vecout,
                                                    double origin,
                                                    double mesh,
                                                    double top,
                                                    double bot)
 {
-  int nzin  = (int) vecin.size();
-  int nzout = (int) vecout.size();
+  int nzin     = (int)vecin.size();
+  int nzout    = (int)vecout.size();
   double thick = top - bot;
   double ratio = thick / nzout;
 
@@ -2686,10 +2688,10 @@ void VectorHelper::squeezeAndStretchInPlaceForward(const VectorDouble &vecin,
   for (int iz = 0; iz < nzout; iz++)
   {
     // Corresponding coordinate of the sample in the structural system
-    double zzin = bot + (double) iz * ratio;
+    double zzin = bot + (double)iz * ratio;
 
     // Find the index in the input vector
-    int izin = (int) ((zzin - origin) / mesh);
+    int izin = (int)((zzin - origin) / mesh);
     if (izin < 0 || izin >= nzin) continue;
 
     // Assign the value
@@ -2711,15 +2713,15 @@ void VectorHelper::squeezeAndStretchInPlaceForward(const VectorDouble &vecin,
  * @remarks Extend the relevant information, lying between 'bot' and 'top' in order to fill
  * @remarks the whole vector 'vecout'
  */
-void VectorHelper::squeezeAndStretchInPlaceBackward(const VectorDouble &vecin,
-                                                    VectorDouble &vecout,
+void VectorHelper::squeezeAndStretchInPlaceBackward(const VectorDouble& vecin,
+                                                    VectorDouble& vecout,
                                                     double origin,
                                                     double mesh,
                                                     double top,
                                                     double bot)
 {
-  int nzin  = (int) vecin.size();
-  int nzout = (int) vecout.size();
+  int nzin  = (int)vecin.size();
+  int nzout = (int)vecout.size();
 
   // Blank out the output vector
   vecout.fill(TEST);
@@ -2729,10 +2731,10 @@ void VectorHelper::squeezeAndStretchInPlaceBackward(const VectorDouble &vecin,
   // Get the top and bottom indices in the output vector
   int indbot = floor((bot - origin) / mesh);
   if (indbot < 0) indbot = 0;
-  int indtop = ceil((top - origin)  / mesh);
+  int indtop = ceil((top - origin) / mesh);
   if (indtop >= nzout) indtop = nzout - 1;
 
-  double ratio = (double) nzin / thick;
+  double ratio = (double)nzin / thick;
 
   // Loop on the positions of the pile in the structural system
   for (int izout = indbot; izout <= indtop; izout++)
@@ -2760,9 +2762,9 @@ void VectorHelper::squeezeAndStretchInPlaceBackward(const VectorDouble &vecin,
  *****************************************************************************/
 int VectorHelper::whereMinimum(const VectorDouble& tab)
 {
-  int ibest = -1;
+  int ibest    = -1;
   double vbest = MAXIMUM_BIG;
-  for (int i = 0, ntab = (int) tab.size(); i < ntab; i++)
+  for (int i = 0, ntab = (int)tab.size(); i < ntab; i++)
   {
     if (FFFF(tab[i])) continue;
     if (tab[i] > vbest) continue;
@@ -2783,9 +2785,9 @@ int VectorHelper::whereMinimum(const VectorDouble& tab)
  *****************************************************************************/
 int VectorHelper::whereMaximum(const VectorDouble& tab)
 {
-  int ibest = -1;
+  int ibest    = -1;
   double vbest = MINIMUM_BIG;
-  for (int i = 0, ntab = (int) tab.size(); i < ntab; i++)
+  for (int i = 0, ntab = (int)tab.size(); i < ntab; i++)
   {
     if (FFFF(tab[i])) continue;
     if (tab[i] < vbest) continue;
@@ -2805,7 +2807,7 @@ int VectorHelper::whereMaximum(const VectorDouble& tab)
  */
 int VectorHelper::whereElement(const VectorInt& tab, int target)
 {
-  for (int i = 0, ntab = (int) tab.size(); i < ntab; i++)
+  for (int i = 0, ntab = (int)tab.size(); i < ntab; i++)
   {
     if (tab[i] == target) return i;
   }
@@ -2818,7 +2820,7 @@ int VectorHelper::whereElement(const VectorInt& tab, int target)
  * @param vecin Input vector (double)
  * @param index Index to be suppressed
  */
-VectorDouble VectorHelper::reduceOne(const VectorDouble &vecin, int index)
+VectorDouble VectorHelper::reduceOne(const VectorDouble& vecin, int index)
 {
   VectorInt vindex(1);
   vindex[0] = index;
@@ -2831,7 +2833,7 @@ VectorDouble VectorHelper::reduceOne(const VectorDouble &vecin, int index)
  * @param vecin Input vector (double)
  * @param vindex Vector of indices to be suppressed
  */
-VectorDouble VectorHelper::reduce(const VectorDouble &vecin, const VectorInt& vindex)
+VectorDouble VectorHelper::reduce(const VectorDouble& vecin, const VectorInt& vindex)
 {
   VectorDouble vecout = vecin;
 
@@ -2839,11 +2841,11 @@ VectorDouble VectorHelper::reduce(const VectorDouble &vecin, const VectorInt& vi
   VectorInt indexLocal = vindex;
   std::sort(indexLocal.begin(), indexLocal.end());
 
-  int nsel = (int) indexLocal.size();
+  int nsel = (int)indexLocal.size();
   for (int j = 0; j < nsel; j++)
   {
     int i = indexLocal[nsel - j - 1];
-    vecout.erase(vecout.begin()+i);
+    vecout.erase(vecout.begin() + i);
   }
   return vecout;
 }
@@ -2854,10 +2856,10 @@ VectorDouble VectorHelper::reduce(const VectorDouble &vecin, const VectorInt& vi
  * @param vecin Input vector (double)
  * @param vindex Vector of indices to be kept
  */
-VectorDouble VectorHelper::compress(const VectorDouble &vecin, const VectorInt& vindex)
+VectorDouble VectorHelper::compress(const VectorDouble& vecin, const VectorInt& vindex)
 {
   VectorDouble vecout;
-  for (int j = 0, nsel = (int) vindex.size(); j < nsel; j++)
+  for (int j = 0, nsel = (int)vindex.size(); j < nsel; j++)
   {
     int i = vindex[j];
     vecout.push_back(vecin[i]);
@@ -2867,7 +2869,7 @@ VectorDouble VectorHelper::compress(const VectorDouble &vecin, const VectorInt& 
 
 void VectorHelper::truncateDecimalsInPlace(VectorDouble& vec, int ndec)
 {
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
   {
     if (FFFF(vec[i])) continue;
     vec[i] = truncateDecimals(vec[i], ndec);
@@ -2876,7 +2878,7 @@ void VectorHelper::truncateDecimalsInPlace(VectorDouble& vec, int ndec)
 
 void VectorHelper::truncateDigitsInPlace(VectorDouble& vec, int ndec)
 {
-  for (int i = 0, n = (int) vec.size(); i < n; i++)
+  for (int i = 0, n = (int)vec.size(); i < n; i++)
   {
     if (FFFF(vec[i])) continue;
     vec[i] = truncateDigits(vec[i], ndec);
@@ -2941,10 +2943,10 @@ bool VectorHelper::isEqualExtended(const VectorDouble& v1,
     message("Impossible to compare vectors of different dimensions\n");
     return false;
   }
-  int size = (int)v1.size();
+  int size          = (int)v1.size();
   VectorDouble vec1 = v1;
   VectorDouble vec2 = v2;
-  
+
   // Check is performed on the absolute value of each term of each vector
   if (flagAbsolute)
   {
@@ -2985,4 +2987,4 @@ bool VectorHelper::isIsotropic(const VectorVectorInt& sampleRanks)
   return true;
 }
 
-}
+} // namespace gstlrn

--- a/src/Boolean/ShapeHalfSinusoid.cpp
+++ b/src/Boolean/ShapeHalfSinusoid.cpp
@@ -11,7 +11,8 @@
 #include "Boolean/ShapeHalfSinusoid.hpp"
 #include "Simulation/BooleanObject.hpp"
 
-#include <math.h>
+#include <cmath>
+
 namespace gstlrn
 {
 ShapeHalfSinusoid::ShapeHalfSinusoid(double proportion,
@@ -21,7 +22,7 @@ ShapeHalfSinusoid::ShapeHalfSinusoid(double proportion,
                                      double xext,
                                      double zext,
                                      double theta)
-    : AShape()
+  : AShape()
 {
   initParams(getNParams());
   setParamDefault(0, "Period", period);
@@ -33,16 +34,16 @@ ShapeHalfSinusoid::ShapeHalfSinusoid(double proportion,
   setProportion(proportion);
 }
 
-ShapeHalfSinusoid::ShapeHalfSinusoid(const ShapeHalfSinusoid &r)
-    : AShape(r)
+ShapeHalfSinusoid::ShapeHalfSinusoid(const ShapeHalfSinusoid& r)
+  : AShape(r)
 {
 }
 
-ShapeHalfSinusoid& ShapeHalfSinusoid::operator=(const ShapeHalfSinusoid &r)
+ShapeHalfSinusoid& ShapeHalfSinusoid::operator=(const ShapeHalfSinusoid& r)
 {
   if (this != &r)
   {
-    AShape::operator =(r);
+    AShape::operator=(r);
   }
   return *this;
 }
@@ -82,12 +83,12 @@ BooleanObject* ShapeHalfSinusoid::generateObject(int ndim)
 bool ShapeHalfSinusoid::belongObject(const VectorDouble& coor,
                                      const BooleanObject* object) const
 {
-  int ndim = (int) coor.size();
-  double dx = (ndim >= 1) ? coor[0] / object->getValue(0) : 0.;
-  double dz = (ndim >= 3) ? coor[2] / object->getExtension(2) : 0.;
+  int ndim    = (int)coor.size();
+  double dx   = (ndim >= 1) ? coor[0] / object->getValue(0) : 0.;
+  double dz   = (ndim >= 3) ? coor[2] / object->getExtension(2) : 0.;
   double yloc = object->getValue(1) * cos(2. * GV_PI * dx) / 2.;
-  double dy = (ndim >= 2) ? (coor[1] - yloc) / (object->getValue(2) / 2.) :  0.;
+  double dy   = (ndim >= 2) ? (coor[1] - yloc) / (object->getValue(2) / 2.) : 0.;
 
   return (dx * dx + dy * dy + dz * dz <= 1);
 }
-}
+} // namespace gstlrn

--- a/src/Calculators/CalcStatistics.cpp
+++ b/src/Calculators/CalcStatistics.cpp
@@ -8,33 +8,32 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Enum/ELoc.hpp"
-
-#include "Basic/NamingConvention.hpp"
 #include "Calculators/CalcStatistics.hpp"
+#include "Basic/NamingConvention.hpp"
 #include "Calculators/ACalcDbToDb.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Enum/ELoc.hpp"
 #include "Stats/Classical.hpp"
 #include "Stats/Regression.hpp"
-#include "Db/DbGrid.hpp"
-#include "Db/Db.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 CalcStatistics::CalcStatistics()
-    : ACalcDbToDb(),
-      _iattOut(-1),
-      _dboutMustBeGrid(false),
-      _flagStats(false),
-      _oper(EStatOption::UNKNOWN),
-      _radius(0),
-      _flagRegr(false),
-      _flagCst(false),
-      _regrMode(0),
-      _nameResp(),
-      _nameAux(),
-      _model(nullptr)
+  : ACalcDbToDb()
+  , _iattOut(-1)
+  , _dboutMustBeGrid(false)
+  , _flagStats(false)
+  , _oper(EStatOption::UNKNOWN)
+  , _radius(0)
+  , _flagRegr(false)
+  , _flagCst(false)
+  , _regrMode(0)
+  , _nameResp()
+  , _nameAux()
+  , _model(nullptr)
 {
 }
 
@@ -44,10 +43,10 @@ CalcStatistics::~CalcStatistics()
 
 bool CalcStatistics::_check()
 {
-  if (! ACalcDbToDb::_check()) return false;
+  if (!ACalcDbToDb::_check()) return false;
 
-  if (! hasDbin()) return false;
-  if (! hasDbout()) return false;
+  if (!hasDbin()) return false;
+  if (!hasDbout()) return false;
 
   int nvar = getDbin()->getNLoc(ELoc::Z);
   if (nvar <= 0)
@@ -58,7 +57,7 @@ bool CalcStatistics::_check()
 
   if (getDboutMustBeGrid())
   {
-    if (! getDbout()->isGrid())
+    if (!getDbout()->isGrid())
     {
       messerr("This method requires 'dbout' to be a Grid");
       return false;
@@ -67,7 +66,7 @@ bool CalcStatistics::_check()
 
   if (_flagRegr)
   {
-    if (! _flagCst && _nameAux.empty())
+    if (!_flagCst && _nameAux.empty())
     {
       messerr("This method requires Explanatory variables and/or constant term");
       return false;
@@ -80,7 +79,7 @@ bool CalcStatistics::_check()
 bool CalcStatistics::_preprocess()
 {
   if (!ACalcDbToDb::_preprocess()) return false;
-  
+
   if (_flagStats)
     _iattOut = _addVariableDb(2, 1, ELoc::UNKNOWN, 0, _getNVar(), 0.);
 
@@ -120,7 +119,7 @@ bool CalcStatistics::_run()
 {
   if (_flagStats)
   {
-    DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
+    DbGrid* dbgrid     = dynamic_cast<DbGrid*>(getDbout());
     VectorString names = getDbin()->getNamesByLocator(ELoc::Z);
     if (dbStatisticsInGridTool(getDbin(), dbgrid, names, _oper, _radius, _iattOut))
       return false;
@@ -148,11 +147,11 @@ bool CalcStatistics::_run()
  ** \param[in]  namconv Naming convention
  **
  *****************************************************************************/
-int dbStatisticsOnGrid(Db *db,
-                       DbGrid *dbgrid,
-                       const EStatOption &oper,
+int dbStatisticsOnGrid(Db* db,
+                       DbGrid* dbgrid,
+                       const EStatOption& oper,
                        int radius,
-                       const NamingConvention &namconv)
+                       const NamingConvention& namconv)
 {
   CalcStatistics stats;
   stats.setDbin(db);
@@ -169,14 +168,14 @@ int dbStatisticsOnGrid(Db *db,
   return error;
 }
 
-int dbRegression(Db *db1,
+int dbRegression(Db* db1,
                  const String& nameResp,
                  const VectorString& nameAux,
                  int mode,
                  bool flagCst,
-                 Db *db2,
+                 Db* db2,
                  const Model* model,
-                 const NamingConvention &namconv)
+                 const NamingConvention& namconv)
 {
   if (db2 == nullptr) db2 = db1;
 
@@ -196,4 +195,4 @@ int dbRegression(Db *db1,
   int error = (stats.run()) ? 0 : 1;
   return error;
 }
-}
+} // namespace gstlrn

--- a/src/Core/cluster.cpp
+++ b/src/Core/cluster.cpp
@@ -24,7 +24,7 @@ License: BSD 3-clause
 
 #include "Basic/Law.hpp"
 #include "geoslib_old_f.h"
-#include <limits.h>
+#include <climits>
 
 #define DATA(iech, ivar)  (data[(iech) * nvar + (ivar)])
 #define DATA1(iech, ivar) (data1[(iech) * nvar + (ivar)])

--- a/src/Core/convert.cpp
+++ b/src/Core/convert.cpp
@@ -30,9 +30,10 @@
 #include "OutputFormat/GridZycor.hpp"
 #include "OutputFormat/vtk.h"
 #include "geoslib_define.h"
+
+#include <cstdio>
+#include <cstring>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
 #include <string>
 
 /*! \cond */
@@ -627,5 +628,4 @@ int csv_table_read(const String& filename,
 
   return 0;
 }
-
-}
+} // namespace gstlrn

--- a/src/Core/db.cpp
+++ b/src/Core/db.cpp
@@ -9,13 +9,14 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Db/Db.hpp"
+
 #include "Basic/Grid.hpp"
-#include "Basic/Memory.hpp"
 #include "Basic/Utilities.hpp"
 #include "Db/DbGrid.hpp"
 #include "Polygon/Polygons.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -1497,23 +1498,23 @@ int db_prop_write(DbGrid* db, int ix, int iy, double* props)
  ** \param[out] dmax    Maximum distance
  **
  ** \remarks The returned array must be freed by calling routine
- ** \remarks When the two Dbs coincide, the distance calculation
- *excludes
+ ** \remarks When the two Dbs coincide, the distance calculation excludes
  ** \remarks the comparison between one sample and itself
  **
  *****************************************************************************/
-double* db_distances_general(Db* db1,
-                             Db* db2,
-                             int niso,
-                             int mode,
-                             int flag_same,
-                             int* n1,
-                             int* n2,
-                             double* dmin,
-                             double* dmax)
+VectorDouble db_distances_general(Db* db1,
+                                  Db* db2,
+                                  int niso,
+                                  int mode,
+                                  int flag_same,
+                                  int* n1,
+                                  int* n2,
+                                  double* dmin,
+                                  double* dmax)
 {
   int nech1, nech2, iech1, iech2, ecr, max_all, nvalid;
-  double *dist, dlocmin, dloc, dist_min, dist_max;
+  double dlocmin, dloc, dist_min, dist_max;
+  VectorDouble dist;
 
   /* Preliminary calculations */
 
@@ -1521,7 +1522,6 @@ double* db_distances_general(Db* db1,
   *n2     = 0;
   nech1   = db1->getNSample(true);
   nech2   = db2->getNSample(true);
-  dist    = nullptr;
   max_all = nech1 * nech2;
 
   /* Preliminary checks */
@@ -1532,15 +1532,14 @@ double* db_distances_general(Db* db1,
             niso);
     messerr("But the input 'Db' have %d and %d variables defined",
             db1->getNLoc(ELoc::Z), db2->getNLoc(ELoc::Z));
-    return (dist);
+    return dist;
   }
 
   /* Core allocation */
 
   if (mode > 0)
   {
-    dist = (double*)mem_alloc(sizeof(double) * max_all, 0);
-    if (dist == nullptr) return (dist);
+    dist.resize(max_all);
     for (int i = 0; i < max_all; i++) dist[i] = 0.;
   }
 
@@ -1586,10 +1585,7 @@ double* db_distances_general(Db* db1,
   /* Reallocate the distance array */
 
   if (mode > 0 && ecr < max_all)
-  {
-    dist = (double*)mem_realloc((char*)dist, sizeof(double) * ecr, 0);
-    if (dist == nullptr) return (dist);
-  }
+    dist.resize(ecr);
 
   /* Returned arguments */
 
@@ -1605,7 +1601,7 @@ double* db_distances_general(Db* db1,
     *n1 = nvalid;
     *n2 = nvalid;
   }
-  return (dist);
+  return dist;
 }
 
 /****************************************************************************/
@@ -2422,4 +2418,4 @@ VectorInt grid_iterator_next(Grid* grid)
   VectorInt indices = grid->iteratorNext();
   return (indices);
 }
-}
+} // namespace gstlrn

--- a/src/Core/dbtools.cpp
+++ b/src/Core/dbtools.cpp
@@ -1786,8 +1786,8 @@ label_end:
  ** \param[in]  nmini       Minimum number of nodes before drawing
  **
  ** \param[out] nech_ret    Number of selected samples
- ** \param[out] coor_ret    Array of coordinates
- ** \param[out] data_ret    Array of variables
+ ** \param[out] coor        Array of coordinates
+ ** \param[out] data        Array of variables
  **
  ** \remarks The returned arrays 'coor' and 'data' must be freed by
  ** \remarks the calling function

--- a/src/Core/fft.cpp
+++ b/src/Core/fft.cpp
@@ -54,9 +54,9 @@ License: BSD 3-clause
 */
 #include "Basic/AStringable.hpp"
 #include "Core/fftn.hpp"
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 
 /*! \cond */
 #define MD_PI      3.14159265358979323846264338327950288 /* Pi with many decimals */
@@ -1012,4 +1012,4 @@ Dimension_Error:
   fft_free(); /* free-up memory */
   return -1;
 }
-}
+} // namespace gstlrn

--- a/src/Core/foxleg.cpp
+++ b/src/Core/foxleg.cpp
@@ -14,7 +14,7 @@
 #include "Basic/VectorHelper.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+#include <cmath>
 
 /*! \cond */
 #define IAD(ic, ipar)              ((ipar) + NPAR * (ic))
@@ -34,9 +34,8 @@ static int NPAR, NPAR2, NPARAC, NPARAC2, NDAT, NCONT, NPCT, NPCT2;
 static int ITERATION, SOUSITER;
 static void (*FUNC_EVALUATE)(int ndat,
                              int npar,
-                             VectorDouble &param,
-                             VectorDouble &work);
-
+                             VectorDouble& param,
+                             VectorDouble& work);
 
 /****************************************************************************/
 /*!
@@ -1362,4 +1361,4 @@ label_ok:
   }
 }
 
-}
+} // namespace gstlrn

--- a/src/Core/geophy.cpp
+++ b/src/Core/geophy.cpp
@@ -12,7 +12,7 @@
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
@@ -4128,4 +4128,4 @@ static int scan_z_fb(int x_start,
 }
 /*--------------------------------------------END_Z_SIDE()--------------------*/
 /*********************************************END_TIME_3D**********************/
-}
+} // namespace gstlrn

--- a/src/Core/io.cpp
+++ b/src/Core/io.cpp
@@ -14,9 +14,9 @@
 #include "Basic/String.hpp"
 #include "Basic/Utilities.hpp"
 #include "geoslib_io.h"
-#include <math.h>
-#include <stdarg.h>
-#include <string.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstring>
 
 /*! \cond */
 #define OLD 0
@@ -48,7 +48,6 @@ static char* cur = NULL;
 #  define strncasecmp _strnicmp
 #  define strcasecmp  _stricmp
 #endif
-
 
 /****************************************************************************/
 /*!
@@ -1153,4 +1152,4 @@ int _record_read(FILE* file, const char* format, ...)
   return (error);
 }
 
-}
+} // namespace gstlrn

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -35,10 +35,10 @@
 #include "geoslib_f.h"
 #include "geoslib_f_private.h"
 #include "geoslib_old_f.h"
-#include <limits.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 
 /*! \cond */
 #define NBYPAS                  5
@@ -96,9 +96,7 @@ static int INH_FLAG_VERBOSE = 0;
 static int INH_FLAG_LIMIT   = 1;
 static char string[100];
 
-
 static CovInternal COVINT;
-
 
 typedef struct
 {
@@ -5172,4 +5170,4 @@ void _image_smoother(DbGrid* dbgrid,
     dbgrid->setArray(iech_out, iptr0, estim);
   }
 }
-}
+} // namespace gstlrn

--- a/src/Core/math.cpp
+++ b/src/Core/math.cpp
@@ -18,6 +18,9 @@
 #define INTRESX(ic, i)        (ctables->CT[ic]->res[(i)])
 #define COVAL(ctables, iconf) (ctables->cmin + iconf * ctables->dc)
 #define NELEM(ctables)        ((ctables->flag_cumul) ? ctables->ndisc + 1 : ctables->ndisc)
+#define INTRESX(ic, i)        (ctables->CT[ic]->res[(i)])
+#define COVAL(ctables, iconf) (ctables->cmin + iconf * ctables->dc)
+#define NELEM(ctables)        ((ctables->flag_cumul) ? ctables->ndisc + 1 : ctables->ndisc)
 /*! \endcond */
 
 namespace gstlrn
@@ -66,8 +69,8 @@ static void st_tableone_manage(CTables* ctables,
     {
       if (ctables->CT[rank] == NULL)
       {
-        ctables->CT[rank]      = (CTable*)mem_alloc(sizeof(CTable), 1);
-        ctables->CT[rank]->res = (double*)mem_alloc(sizeof(double) * size, 1);
+        ctables->CT[rank] = (CTable*)mem_alloc(sizeof(CTable), 1);
+        ctables->CT[rank]->res.resize(size);
         for (int i = 0; i < size; i++)
           INTRESX(rank, i) = TEST;
         return;
@@ -81,8 +84,7 @@ static void st_tableone_manage(CTables* ctables,
       number = 0;
       for (int i = 0; i < size; i++)
         if (FFFF(INTRESX(rank, i))) number++;
-      ctables->CT[rank]->res = (double*)mem_free(
-        (char*)ctables->CT[rank]->res);
+      ctables->CT[rank]->res.clear();
       *nb_used          = number;
       ctables->CT[rank] = (CTable*)mem_alloc(sizeof(CTable), 1);
       return;
@@ -364,7 +366,7 @@ void ct_tables_print(CTables* ctables, int flag_print)
                 COVAL(ctables, iconf));
 
       if (flag_print == 2)
-        print_matrix(NULL, 0, 1, nelem, nelem, NULL, &INTRESX(iconf, 0));
+        print_matrix(NULL, 0, 1, nelem, nelem, NULL, ctables->CT[iconf]->res.data());
     }
     message("\n");
   }
@@ -674,4 +676,4 @@ int ct_tableone_getrank_from_proba(CTables* ctables,
 
   return (iad);
 }
-}
+} // namespace gstlrn

--- a/src/Core/matrix.cpp
+++ b/src/Core/matrix.cpp
@@ -12,7 +12,6 @@
 #include "Basic/Utilities.hpp"
 #include "geoslib_old_f.h"
 #include <cmath>
-#include <math.h>
 
 /*! \cond */
 #define TRI(i)        (((i) * ((i) + 1)) / 2)
@@ -873,4 +872,4 @@ int matrix_eigen_tridiagonal(const double* vecdiag,
   mem_free((char*)e);
   return (0);
 }
-}
+} // namespace gstlrn

--- a/src/Core/memory.cpp
+++ b/src/Core/memory.cpp
@@ -12,7 +12,8 @@
 #include "Basic/AStringable.hpp"
 #include "Basic/String.hpp"
 #include "Core/Keypair.hpp"
-#include <string.h>
+
+#include <cstring>
 
 /*! \cond */
 #define STORE_NAME_LENGTH 10

--- a/src/Core/model.cpp
+++ b/src/Core/model.cpp
@@ -31,7 +31,8 @@
 #include "Space/SpaceRN.hpp"
 #include "Variogram/Vario.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 /*! \cond */
 #define AD(ivar, jvar)        (ivar) + nvar*(jvar)
@@ -47,7 +48,7 @@
 
 namespace gstlrn
 {
-int NDIM_LOCAL = 0;
+int NDIM_LOCAL        = 0;
 VectorDouble X1_LOCAL = VectorDouble();
 VectorDouble X2_LOCAL = VectorDouble();
 
@@ -727,5 +728,4 @@ label_end:
   mem_free((char*)G);
   return (error);
 }
-
-}
+} // namespace gstlrn

--- a/src/Core/model_auto.cpp
+++ b/src/Core/model_auto.cpp
@@ -33,7 +33,7 @@
 #include "Variogram/Vario.hpp"
 #include "geoslib_f.h"
 #include "geoslib_old_f.h"
-#include <math.h>
+#include <cmath>
 
 /*! \cond */
 #define TAKE_ROT ((optvar.getLockSamerot() && first_covrot < 0) || \
@@ -4986,4 +4986,4 @@ label_end:
   st_model_auto_strmod_free(strmod);
   return (error);
 }
-}
+} // namespace gstlrn

--- a/src/Core/potential.cpp
+++ b/src/Core/potential.cpp
@@ -23,8 +23,9 @@
 #include "Neigh/ANeigh.hpp"
 #include "Simulation/CalcSimuTurningBands.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
-#include <string.h>
+
+#include <cmath>
+#include <cstring>
 
 /*! \cond */
 
@@ -3671,4 +3672,4 @@ int potential_cov(Model* model,
 
   return (0);
 }
-}
+} // namespace gstlrn

--- a/src/Core/seismic.cpp
+++ b/src/Core/seismic.cpp
@@ -1766,25 +1766,25 @@ static void st_seismic_contrast(int nz, double* tab)
  ** \param[in]  db            Db structure
  ** \param[in]  flag_operate  1 to perform the convolution; 0 otherwise
  ** \param[in]  flag_contrast 1 to perform contrast; 0 otherwise
- ** \param[in]  type          Type of the wavelet (ENUM_WAVELETS)
- ** \param[in]  ntw           half-length of the wavelet excluding center (samples)
- ** \param[in]  option        option used to perform the convolution
- ** \li                       -1 : erode the edge (on ntw pixels)
- ** \li                        0 : truncate the wavelet on the edge
- ** \li                       +1 : extend the trace with padding before convolution
- ** \li                       +2 : extend the trace with the last informed values
- ** \param[in]  tindex        time index to locate the spike (Spike)
- ** \param[in]  fpeak         peak frequency of the Ricker wavelet
- ** \param[in]  period        wavelet period (s) (Ricker)
- ** \param[in]  amplitude     wavelet amplitude (Ricker)
- ** \param[in]  distort       wavelet distortion factor (Ricker)
- ** \param[in]  val_before    Replacement value for undefined element
- **                           before first defined sample
- ** \param[in]  val_middle    Replacement value for undefined element
- **                           between defined samples
- ** \param[in]  val_after     Replacement value for undefined element
- **                           after last defined sample
- ** \param[in]  wavelet       Wavelet defined as input (Dimension: 2*ntw+1)
+ ** \param[in]  type        Type of the wavelet (ENUM_WAVELETS)
+ ** \param[in]  ntw         half-length of the wavelet excluding center (samples)
+ ** \param[in]  option      option used to perform the convolution
+ ** \li                     -1 : erode the edge (on ntw pixels)
+ ** \li                      0 : truncate the wavelet on the edge
+ ** \li                     +1 : extend the trace with padding before convolution
+ ** \li                     +2 : extend the trace with the last informed values
+ ** \param[in]  tindex      time index to locate the spike (Spike)
+ ** \param[in]  fpeak       peak frequency of the Ricker wavelet
+ ** \param[in]  period      wavelet period (s) (Ricker)
+ ** \param[in]  amplitude   wavelet amplitude (Ricker)
+ ** \param[in]  distort     wavelet distortion factor (Ricker)
+ ** \param[in]  val_before  Replacement value for undefined element
+ **                         before first defined sample
+ ** \param[in]  val_middle  Replacement value for undefined element
+ **                         between defined samples
+ ** \param[in]  val_after   Replacement value for undefined element
+ **                         after last defined sample
+ ** \param[in]  wavelet     Wavelet defined as input (Dimension: 2*ntw+1)
  **
  *****************************************************************************/
 int seismic_convolve(DbGrid* db,

--- a/src/Core/seismic.cpp
+++ b/src/Core/seismic.cpp
@@ -8,35 +8,35 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
 #include "geoslib_enum.h"
+#include "geoslib_old_f.h"
 
 #include "Enum/EJustify.hpp"
 
 #include "Basic/Law.hpp"
+#include "Basic/Memory.hpp"
+#include "Basic/OptDbg.hpp"
+#include "Basic/String.hpp"
+#include "Basic/Utilities.hpp"
+#include "Core/Seismic.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "Model/Model.hpp"
-#include "Basic/Utilities.hpp"
-#include "Basic/String.hpp"
-#include "Basic/OptDbg.hpp"
-#include "Basic/Memory.hpp"
-#include "Core/Seismic.hpp"
 
-#include <math.h>
+#include <cmath>
 
 /*! \cond */
 #define LTABLE 8
 #define NTABLE 513
 
-#define ARRAY(ix,iy)      (array[(iy) * NX + (ix)])
-#define LIMIT(ix,iy)      (limit[(iy) * NX + (ix)])
-#define VV(itr,iz)        (db_v->getArray(iatt_v,NTRACE * (iz) + itr) / VFACT)
-#define C00(ivar,jvar)    (c00   [(jvar) * NVAR + (ivar)])
-#define LB(ivar,jvar)     (lb    [(jvar) * NVAR + (ivar)])
-#define IND(iech,ivar)    ((iech) + (ivar) * nech)
-#define LHS(i,iv,j,jv)    (lhs [IND(i,iv) + neqmax * IND(j,jv)])
-#define RHS(i,iv,jv)      (rhs [IND(i,iv) + neqmax * (jv)])
+#define ARRAY(ix, iy)     (array[(iy) * NX + (ix)])
+#define LIMIT(ix, iy)     (limit[(iy) * NX + (ix)])
+#define VV(itr, iz)       (db_v->getArray(iatt_v, NTRACE * (iz) + itr) / VFACT)
+#define C00(ivar, jvar)   (c00[(jvar) * NVAR + (ivar)])
+#define LB(ivar, jvar)    (lb[(jvar) * NVAR + (ivar)])
+#define IND(iech, ivar)   ((iech) + (ivar) * nech)
+#define LHS(i, iv, j, jv) (lhs[IND(i, iv) + neqmax * IND(j, jv)])
+#define RHS(i, iv, jv)    (rhs[IND(i, iv) + neqmax * (jv)])
 /*! \endcond */
 
 namespace gstlrn
@@ -74,17 +74,17 @@ typedef struct
  **
  *****************************************************************************/
 static int st_velocity_minmax(int nech,
-                              double *vv,
-                              double *v0,
-                              double *v1,
-                              double *vmin,
-                              double *vmax)
+                              double* vv,
+                              double* v0,
+                              double* v1,
+                              double* vmin,
+                              double* vmax)
 {
   int i, number;
   double vvdef, delta;
 
-  (*v0) = MAXIMUM_BIG;
-  (*v1) = MAXIMUM_BIG;
+  (*v0)   = MAXIMUM_BIG;
+  (*v1)   = MAXIMUM_BIG;
   (*vmin) = MAXIMUM_BIG;
   (*vmax) = MINIMUM_BIG;
 
@@ -151,13 +151,13 @@ static int st_velocity_minmax(int nech,
 static void st_yxtoxy(int nx,
                       double dx,
                       double x0,
-                      const double *y,
+                      const double* y,
                       int ny,
                       double dy,
                       double y0,
                       double xylo,
                       double xyhi,
-                      double *x)
+                      double* x)
 {
   int nxi, nyo, jxi1, jxi2, jyo;
   double dxi, fxi, dyo, fyo, fyi, yo, xi1, yi1, yi2;
@@ -185,7 +185,7 @@ static void st_yxtoxy(int nx,
   }
   jxi1 = 0;
   jxi2 = 1;
-  xi1 = fxi;
+  xi1  = fxi;
   while (jxi2 < nxi && jyo < nyo)
   {
     yi1 = y[jxi1];
@@ -245,7 +245,7 @@ static double dsinc(double x)
  ** \remark assumed symmetric.
  **
  *****************************************************************************/
-static void stoepd(int n, const double *r, const double *g, double *f, double *a)
+static void stoepd(int n, const double* r, const double* g, double* f, double* a)
 {
   int i, j;
   double v, e, c, w, bot;
@@ -253,7 +253,7 @@ static void stoepd(int n, const double *r, const double *g, double *f, double *a
   if (r[0] == 0.0) return;
 
   a[0] = 1.0;
-  v = r[0];
+  v    = r[0];
   f[0] = g[0] / r[0];
 
   for (j = 1; j < n; j++)
@@ -309,13 +309,13 @@ static void stoepd(int n, const double *r, const double *g, double *f, double *a
  ** \remark than fmax, the error should be less than 1.0 percent.
 
  *****************************************************************************/
-static void st_mksinc(double d, int lsinc, double *sinc)
+static void st_mksinc(double d, int lsinc, double* sinc)
 {
   int j;
   double s[20], a[20], c[20], work[20], fmax;
 
   /* compute auto-correlation and cross-correlation arrays */
-  fmax = 0.066 + 0.265 * log((double) lsinc);
+  fmax = 0.066 + 0.265 * log((double)lsinc);
   fmax = (fmax < 1.0) ? fmax : 1.0;
   for (j = 0; j < lsinc; j++)
   {
@@ -372,46 +372,39 @@ static void st_intt8r(int ntable,
                       int nxin,
                       double dxin,
                       double fxin,
-                      const double *yin,
+                      const double* yin,
                       double yinl,
                       double yinr,
                       int nxout,
-                      const double *xout,
-                      double *yout)
+                      const double* xout,
+                      double* yout)
 {
   int ioutb, nxinm8, ixout, ixoutn, kyin, ktable, itable;
   double xoutb, xoutf, xoutn, frac, fntablem1, yini, sum;
 
   /* compute constants */
-  ioutb = -3 - 8;
-  xoutf = fxin;
-  xoutb = 8.0 - xoutf / dxin;
-  fntablem1 = (double) (ntable - 1);
-  nxinm8 = nxin - 8;
+  ioutb     = -3 - 8;
+  xoutf     = fxin;
+  xoutb     = 8.0 - xoutf / dxin;
+  fntablem1 = (double)(ntable - 1);
+  nxinm8    = nxin - 8;
 
   /* loop over output samples */
   for (ixout = 0; ixout < nxout; ixout++)
   {
 
     /* determine pointers into table and yin */
-    sum = 0.;
-    xoutn = xoutb + xout[ixout] / dxin;
-    ixoutn = (int) xoutn;
-    kyin = ioutb + ixoutn;
-    frac = xoutn - (double) ixoutn;
-    ktable = (int) ((frac >= 0.0) ? frac * fntablem1 + 0.5 :
-                                    (frac + 1.0) * fntablem1 - 0.5);
+    sum    = 0.;
+    xoutn  = xoutb + xout[ixout] / dxin;
+    ixoutn = (int)xoutn;
+    kyin   = ioutb + ixoutn;
+    frac   = xoutn - (double)ixoutn;
+    ktable = (int)((frac >= 0.0) ? frac * fntablem1 + 0.5 : (frac + 1.0) * fntablem1 - 0.5);
 
     /* if totally within input array, use fast method */
     if (kyin >= 0 && kyin <= nxinm8)
     {
-      sum = yin[kyin + 0] * table[ktable][0] + yin[kyin + 1] * table[ktable][1]
-            + yin[kyin + 2] * table[ktable][2]
-            + yin[kyin + 3] * table[ktable][3]
-            + yin[kyin + 4] * table[ktable][4]
-            + yin[kyin + 5] * table[ktable][5]
-            + yin[kyin + 6] * table[ktable][6]
-            + yin[kyin + 7] * table[ktable][7];
+      sum = yin[kyin + 0] * table[ktable][0] + yin[kyin + 1] * table[ktable][1] + yin[kyin + 2] * table[ktable][2] + yin[kyin + 3] * table[ktable][3] + yin[kyin + 4] * table[ktable][4] + yin[kyin + 5] * table[ktable][5] + yin[kyin + 6] * table[ktable][6] + yin[kyin + 7] * table[ktable][7];
 
       /* else handle end effects with care */
     }
@@ -452,15 +445,15 @@ static void st_weights(double table[][LTABLE])
 
   for (jtable = 1; jtable < NTABLE - 1; jtable++)
   {
-    frac = (double) jtable / (double) (NTABLE - 1);
+    frac = (double)jtable / (double)(NTABLE - 1);
     st_mksinc(frac, LTABLE, &table[jtable][0]);
   }
   for (jtable = 0; jtable < LTABLE; jtable++)
   {
-    table[0][jtable] = 0.0;
+    table[0][jtable]          = 0.0;
     table[NTABLE - 1][jtable] = 0.0;
   }
-  table[0][LTABLE / 2 - 1] = 1.0;
+  table[0][LTABLE / 2 - 1]      = 1.0;
   table[NTABLE - 1][LTABLE / 2] = 1.0;
 }
 
@@ -541,18 +534,18 @@ static void st_seismic_debug(int rankz,
  **
  *****************************************************************************/
 int seismic_z2t_grid(int verbose,
-                     DbGrid *db_z,
+                     DbGrid* db_z,
                      int iatt_v,
-                     int *nx,
-                     double *x0,
-                     double *dx)
+                     int* nx,
+                     double* x0,
+                     double* dx)
 {
   double z0, t0, v0, v1, dz, dt, vmin, vmax;
   int ndim, nech, nt, nz, i;
 
   /* Initializations */
 
-  if (! db_z->isGrid())
+  if (!db_z->isGrid())
   {
     messerr("This procedure requires an input Grid Db");
     return 1;
@@ -581,7 +574,7 @@ int seismic_z2t_grid(int verbose,
   dz = db_z->getDX(ndim - 1);
   dt = 2. * dz / vmin;
   t0 = 2. * z0 / v0;
-  nt = (int) (1 + (nz - 1) * (2. * dz) / (dt * vmax));
+  nt = (int)(1 + (nz - 1) * (2. * dz) / (dt * vmax));
   dt *= VFACT;
   t0 *= VFACT;
   dx[ndim - 1] = dt;
@@ -611,18 +604,18 @@ int seismic_z2t_grid(int verbose,
  **
  *****************************************************************************/
 int seismic_t2z_grid(int verbose,
-                     DbGrid *db_t,
+                     DbGrid* db_t,
                      int iatt_v,
-                     int *nx,
-                     double *x0,
-                     double *dx)
+                     int* nx,
+                     double* x0,
+                     double* dx)
 {
   double z0, t0, v0, v1, dz, dt, vmin, vmax;
   int ndim, nech, nt, nz, i;
 
   /* Initializations */
 
-  if (! db_t->isGrid())
+  if (!db_t->isGrid())
   {
     messerr("This procedure requires an input Grid Db");
     return (1);
@@ -651,7 +644,7 @@ int seismic_t2z_grid(int verbose,
   dt = db_t->getDX(ndim - 1);
   dz = vmin * dt / 2.;
   z0 = v0 * t0 / 2.;
-  nz = (int) (1 + (nt - 1) * (dt * vmax) / (2. * dz));
+  nz = (int)(1 + (nt - 1) * (dt * vmax) / (2. * dz));
   dz /= VFACT;
   z0 /= VFACT;
   dx[ndim - 1] = dz;
@@ -678,12 +671,12 @@ int seismic_t2z_grid(int verbose,
  ** \param[in]  tab   Array containing the column of values
  **
  *****************************************************************************/
-static void st_copy(int mode, DbGrid *db, int iatt, int ival, double *tab)
+static void st_copy(int mode, DbGrid* db, int iatt, int ival, double* tab)
 {
   int ndim = db->getNDim();
   int nech = db->getNSample();
   int nval = db->getNX(ndim - 1);
-  int nby = nech / nval;
+  int nby  = nech / nval;
 
   /* Dispatch */
 
@@ -713,17 +706,17 @@ static void st_copy(int mode, DbGrid *db, int iatt, int ival, double *tab)
  ** \remark  In case of error, a message is displayed
  **
  *****************************************************************************/
-static int st_match(DbGrid *db_z, DbGrid *db_t)
+static int st_match(DbGrid* db_z, DbGrid* db_t)
 {
   int idim, ndim, nech, nz, error;
 
   /* Initializations */
 
   NTRACE = 0;
-  error = 1;
-  nech = db_z->getNSample();
-  ndim = db_z->getNDim();
-  nz = db_z->getNX(ndim - 1);
+  error  = 1;
+  nech   = db_z->getNSample();
+  ndim   = db_z->getNDim();
+  nz     = db_z->getNX(ndim - 1);
 
   /* Check the grid characteristics */
 
@@ -786,25 +779,25 @@ label_end:
 ** \remark determine interval velocities at times not specified.
 **
 *****************************************************************************/
-static void st_seismic_z2t_convert(DbGrid *db_z,
-                                   int    iatt_z,
-                                   int    nz,
+static void st_seismic_z2t_convert(DbGrid* db_z,
+                                   int iatt_z,
+                                   int nz,
                                    double z0,
                                    double /*z1*/,
                                    double dz,
-                                   DbGrid *db_t,
+                                   DbGrid* db_t,
                                    int iatt_t,
                                    int nt,
                                    double t0,
                                    double t1,
                                    double dt,
-                                   DbGrid *db_v,
+                                   DbGrid* db_v,
                                    int iatt_v,
                                    int natt,
-                                   double *tz,
-                                   double *zt,
-                                   double *at,
-                                   double *az)
+                                   double* tz,
+                                   double* zt,
+                                   double* at,
+                                   double* az)
 {
   double t, vz0, vz1, table[NTABLE][LTABLE];
   int itrace, iz, it, iatt;
@@ -878,25 +871,25 @@ static void st_seismic_z2t_convert(DbGrid *db_z,
  ** \remark determine interval velocities at times not specified.
  **
  *****************************************************************************/
-static void st_seismic_t2z_convert(DbGrid *db_t,
+static void st_seismic_t2z_convert(DbGrid* db_t,
                                    int iatt_t,
                                    int nt,
                                    double t0,
                                    double t1,
                                    double dt,
-                                   DbGrid *db_z,
+                                   DbGrid* db_z,
                                    int iatt_z,
                                    int nz,
                                    double z0,
                                    double z1,
                                    double dz,
-                                   DbGrid *db_v,
+                                   DbGrid* db_v,
                                    int iatt_v,
                                    int natt,
-                                   double *tz,
-                                   double *zt,
-                                   double *at,
-                                   double *az)
+                                   double* tz,
+                                   double* zt,
+                                   double* at,
+                                   double* az)
 {
   double z, vt0, vt1, table[NTABLE][LTABLE];
   int itrace, it, iz, iatt;
@@ -954,7 +947,7 @@ static void st_seismic_t2z_convert(DbGrid *db_t,
  ** \param[in]  it        Rank of the sample on the trace
  **
  *****************************************************************************/
-static double TR_IN(Db *db, int iatt_in, int iatt, int itrace, int it)
+static double TR_IN(Db* db, int iatt_in, int iatt, int itrace, int it)
 {
   return (db->getArray(iatt_in + iatt, NTRACE * (it) + (itrace)));
 }
@@ -971,7 +964,7 @@ static double TR_IN(Db *db, int iatt_in, int iatt, int itrace, int it)
  ** \param[in]  value     Value to be stored
  **
  *****************************************************************************/
-static void TR_OUT(Db *db,
+static void TR_OUT(Db* db,
                    int iatt_out,
                    int iatt,
                    int itr,
@@ -999,7 +992,7 @@ static void TR_OUT(Db *db,
  ** \remark the input contains 0 values, 0 values are returned.
  **
  *****************************************************************************/
-static int st_seismic_operate(Db *db,
+static int st_seismic_operate(Db* db,
                               int oper,
                               int natt,
                               int nt,
@@ -1364,9 +1357,9 @@ static double* st_seismic_wavelet(int verbose,
 
   /* Initializations */
 
-  ntw2 = 2 * ntw + 1;
-  t0 = ntw * dt;
-  wavelet = (double*) mem_alloc(sizeof(double) * ntw2, 0);
+  ntw2    = 2 * ntw + 1;
+  t0      = ntw * dt;
+  wavelet = (double*)mem_alloc(sizeof(double) * ntw2, 0);
   if (wavelet == nullptr) return (wavelet);
   for (it = 0; it < ntw2; it++)
     wavelet[it] = 0.;
@@ -1382,9 +1375,9 @@ static double* st_seismic_wavelet(int verbose,
     case WAVELET_RICKER1:
       for (it = 0; it < ntw2; it++)
       {
-        t1 = it * dt;
-        value = GV_PI * fpeak * (t1 - t0);
-        value = value * value;
+        t1          = it * dt;
+        value       = GV_PI * fpeak * (t1 - t0);
+        value       = value * value;
         wavelet[it] = (1. - 2. * value) * exp(-value);
       }
       break;
@@ -1393,9 +1386,9 @@ static double* st_seismic_wavelet(int verbose,
       t = 0.;
       for (it = 0; it <= ntw; it++, t += dt)
       {
-        tnorm = t / period;
-        value = (2.5 * tnorm) * (2.5 * tnorm);
-        wsym = amplitude * (1. - 2. * value) * exp(-value);
+        tnorm             = t / period;
+        value             = (2.5 * tnorm) * (2.5 * tnorm);
+        wsym              = amplitude * (1. - 2. * value) * exp(-value);
         wavelet[ntw + it] = wsym * (1. - 2. * distort * tnorm);
         wavelet[ntw - it] = wsym * (1. + 2. * distort * tnorm);
       }
@@ -1404,9 +1397,9 @@ static double* st_seismic_wavelet(int verbose,
     case WAVELET_AKB:
       for (it = 0; it < ntw2; it++)
       {
-        t1 = it * dt;
-        value = fpeak * (t1 - t0);
-        value = value * value;
+        t1          = it * dt;
+        value       = fpeak * (t1 - t0);
+        value       = value * value;
         wavelet[it] = -amplitude * (t1 - t0) * exp(-2. * value);
       }
       break;
@@ -1465,13 +1458,13 @@ static double* st_seismic_wavelet(int verbose,
  *****************************************************************************/
 static void st_seismic_convolve(int nx,
                                 int ix0,
-                                const double *x,
+                                const double* x,
                                 int ny,
                                 int iy0,
-                                const double *y,
+                                const double* y,
                                 int nz,
                                 int iz0,
-                                double *z)
+                                double* z)
 {
   int ix1, iy1, iz1, i, j, j0, j1;
   double sum;
@@ -1511,10 +1504,10 @@ static void st_seismic_convolve(int nx,
  ** \remark determine interval velocities at times not specified.
  **
  *****************************************************************************/
-int seismic_z2t_convert(DbGrid *db_z, int iatt_v, DbGrid *db_t)
+int seismic_z2t_convert(DbGrid* db_z, int iatt_v, DbGrid* db_t)
 {
-  DbGrid *db_v;
-  double  z0, z1, t0, t1, dz, dt;
+  DbGrid* db_v;
+  double z0, z1, t0, t1, dz, dt;
   int nz, nt, ndim, natt, iatt_t, iatt_z, error;
   VectorDouble zt;
   VectorDouble tz;
@@ -1525,17 +1518,17 @@ int seismic_z2t_convert(DbGrid *db_z, int iatt_v, DbGrid *db_t)
 
   if (st_match(db_z, db_t)) return (1);
   error = 1;
-  db_v = db_z;
-  ndim = db_z->getNDim();
-  natt = db_z->getNLoc(ELoc::Z);
-  nz = db_z->getNX(ndim - 1);
-  nt = db_t->getNX(ndim - 1);
-  z0 = db_z->getX0(ndim - 1);
-  t0 = db_t->getX0(ndim - 1);
-  dz = db_z->getDX(ndim - 1);
-  dt = db_t->getDX(ndim - 1);
-  t1 = t0 + (nt - 1) * dt;
-  z1 = z0 + (nz - 1) * dz;
+  db_v  = db_z;
+  ndim  = db_z->getNDim();
+  natt  = db_z->getNLoc(ELoc::Z);
+  nz    = db_z->getNX(ndim - 1);
+  nt    = db_t->getNX(ndim - 1);
+  z0    = db_z->getX0(ndim - 1);
+  t0    = db_t->getX0(ndim - 1);
+  dz    = db_z->getDX(ndim - 1);
+  dt    = db_t->getDX(ndim - 1);
+  t1    = t0 + (nt - 1) * dt;
+  z1    = z0 + (nz - 1) * dz;
 
   /* Create the output variables */
 
@@ -1553,15 +1546,15 @@ int seismic_z2t_convert(DbGrid *db_z, int iatt_v, DbGrid *db_t)
   /* Perform the conversion from Depth to Time */
 
   st_seismic_z2t_convert(db_z, iatt_z, nz, z0, z1, dz, db_t, iatt_t, nt, t0, t1,
-                         dt, db_v, iatt_v, natt, 
-                         tz.data(), zt.data(), 
+                         dt, db_v, iatt_v, natt,
+                         tz.data(), zt.data(),
                          at.data(), az.data());
 
   /* Set the error return code */
 
   error = 0;
 
-  label_end:
+label_end:
   return (error);
 }
 
@@ -1580,10 +1573,10 @@ int seismic_z2t_convert(DbGrid *db_z, int iatt_v, DbGrid *db_t)
  ** \remark determine interval velocities at times not specified.
  **
  *****************************************************************************/
-int seismic_t2z_convert(DbGrid *db_t, int iatt_v, DbGrid *db_z)
+int seismic_t2z_convert(DbGrid* db_t, int iatt_v, DbGrid* db_z)
 {
-  DbGrid *db_v;
-  double  z0, z1, t0, t1, dz, dt;
+  DbGrid* db_v;
+  double z0, z1, t0, t1, dz, dt;
   int nz, nt, ndim, natt, iatt_z, iatt_t, error;
   VectorDouble zt;
   VectorDouble tz;
@@ -1594,17 +1587,17 @@ int seismic_t2z_convert(DbGrid *db_t, int iatt_v, DbGrid *db_z)
 
   if (st_match(db_z, db_t)) return (1);
   error = 1;
-  db_v = db_t;
-  ndim = db_t->getNDim();
-  natt = db_t->getNLoc(ELoc::Z);
-  nz = db_z->getNX(ndim - 1);
-  nt = db_t->getNX(ndim - 1);
-  z0 = db_z->getX0(ndim - 1);
-  t0 = db_t->getX0(ndim - 1);
-  dz = db_z->getDX(ndim - 1);
-  dt = db_t->getDX(ndim - 1);
-  t1 = t0 + (nt - 1) * dt;
-  z1 = z0 + (nz - 1) * dz;
+  db_v  = db_t;
+  ndim  = db_t->getNDim();
+  natt  = db_t->getNLoc(ELoc::Z);
+  nz    = db_z->getNX(ndim - 1);
+  nt    = db_t->getNX(ndim - 1);
+  z0    = db_z->getX0(ndim - 1);
+  t0    = db_t->getX0(ndim - 1);
+  dz    = db_z->getDX(ndim - 1);
+  dt    = db_t->getDX(ndim - 1);
+  t1    = t0 + (nt - 1) * dt;
+  z1    = z0 + (nz - 1) * dz;
 
   /* Create the output variables */
 
@@ -1622,15 +1615,15 @@ int seismic_t2z_convert(DbGrid *db_t, int iatt_v, DbGrid *db_z)
   /* Perform the conversion from Time to Depth */
 
   st_seismic_t2z_convert(db_t, iatt_t, nt, t0, t1, dt, db_z, iatt_z, nz, z0, z1,
-                         dz, db_v, iatt_v, natt, 
-                         tz.data(), zt.data(), 
+                         dz, db_v, iatt_v, natt,
+                         tz.data(), zt.data(),
                          at.data(), az.data());
 
   /* Set the error return code */
 
   error = 0;
 
-  label_end:
+label_end:
   return (error);
 }
 
@@ -1647,7 +1640,7 @@ int seismic_t2z_convert(DbGrid *db_t, int iatt_v, DbGrid *db_z)
  ** \remark the input contains 0 values, 0 values are returned.
  **
  *****************************************************************************/
-int seismic_operate(DbGrid *db, int oper)
+int seismic_operate(DbGrid* db, int oper)
 {
   int ndim, natt, nt, iatt_in, iatt_out;
   double dt;
@@ -1657,8 +1650,8 @@ int seismic_operate(DbGrid *db, int oper)
   if (st_match(db, nullptr)) return (1);
   ndim = db->getNDim();
   natt = db->getNLoc(ELoc::Z);
-  nt = db->getNX(ndim - 1);
-  dt = db->getDX(ndim - 1);
+  nt   = db->getNX(ndim - 1);
+  dt   = db->getDX(ndim - 1);
 
   /* Create the output variables */
 
@@ -1690,14 +1683,14 @@ int seismic_operate(DbGrid *db, int oper)
 ** \param[out] tab1        Output array (Dimension: nz)
 **
 *****************************************************************************/
-static void st_seismic_affect(Db     * /*db*/,
-                              int     nz,
-                              int     shift,
-                              double  val_before,
-                              double  val_middle,
-                              double  val_after,
-                              const double *tab0,
-                              double *tab1)
+static void st_seismic_affect(Db* /*db*/,
+                              int nz,
+                              int shift,
+                              double val_before,
+                              double val_middle,
+                              double val_after,
+                              const double* tab0,
+                              double* tab1)
 {
   int iz, flag_already;
   double value;
@@ -1717,8 +1710,7 @@ static void st_seismic_affect(Db     * /*db*/,
     value = tab0[iz];
     if (FFFF(value))
     {
-      value = (flag_already) ? val_middle :
-                               val_before;
+      value = (flag_already) ? val_middle : val_before;
     }
     else
     {
@@ -1737,7 +1729,7 @@ static void st_seismic_affect(Db     * /*db*/,
  ** \param[out] tab      Output array (Dimension: nz)
  **
  *****************************************************************************/
-static void st_seismic_contrast(int nz, double *tab)
+static void st_seismic_contrast(int nz, double* tab)
 {
   int iz;
   double denom, x, y;
@@ -1752,9 +1744,8 @@ static void st_seismic_contrast(int nz, double *tab)
       tab[iz] = TEST;
     else
     {
-      denom = (x + y);
-      tab[iz] = (denom == 0.) ? TEST :
-                                (x - y) / denom;
+      denom   = (x + y);
+      tab[iz] = (denom == 0.) ? TEST : (x - y) / denom;
     }
   }
   tab[0] = TEST;
@@ -1790,7 +1781,7 @@ static void st_seismic_contrast(int nz, double *tab)
  ** \param[in]  wavelet       Wavelet defined as input (Dimension: 2*ntw+1)
  **
  *****************************************************************************/
-int seismic_convolve(DbGrid *db,
+int seismic_convolve(DbGrid* db,
                      int flag_operate,
                      int flag_contrast,
                      int type,
@@ -1804,7 +1795,7 @@ int seismic_convolve(DbGrid *db,
                      double val_before,
                      double val_middle,
                      double val_after,
-                     double *wavelet)
+                     double* wavelet)
 {
   int ndim, iatt, natt, itrace, iz, nz, iatt_in, iatt_out, error, size, shift;
   double dz;
@@ -1815,10 +1806,10 @@ int seismic_convolve(DbGrid *db,
   /* Initializations */
 
   if (st_match(db, nullptr)) return (1);
-  ndim = db->getNDim();
-  natt = db->getNLoc(ELoc::Z);
-  nz = db->getNX(ndim - 1);
-  dz = db->getDX(ndim - 1);
+  ndim  = db->getNDim();
+  natt  = db->getNLoc(ELoc::Z);
+  nz    = db->getNX(ndim - 1);
+  dz    = db->getDX(ndim - 1);
   error = 0;
 
   /* Generation of the wavelet */
@@ -1833,7 +1824,7 @@ int seismic_convolve(DbGrid *db,
 
   /* Create the output variables */
 
-  error = 1;
+  error   = 1;
   iatt_in = db->getUIDByLocator(ELoc::Z, 0);
   if (iatt_in < 0) return (1);
   iatt_out = db->addColumnsByConstant(natt, 0.);
@@ -1841,9 +1832,8 @@ int seismic_convolve(DbGrid *db,
 
   /* Core allocation */
 
-  shift = (option > 0) ? ntw :
-                         0;
-  size = nz + 2 * shift;
+  shift = (option > 0) ? ntw : 0;
+  size  = nz + 2 * shift;
   tab0.resize(size);
   tab1.resize(size);
   tab2.resize(size);
@@ -1867,7 +1857,7 @@ int seismic_convolve(DbGrid *db,
       if (option == 2)
       {
         val_before = tab0[0];
-        val_after = tab0[nz - 1];
+        val_after  = tab0[nz - 1];
       }
 
       /* Load the input attribute */
@@ -1882,8 +1872,9 @@ int seismic_convolve(DbGrid *db,
 
       /* In case of edge erosion, set the edge to FFFF */
 
-      if (option < 0) for (iz = 0; iz < ntw; iz++)
-        tab2[iz] = tab2[nz - iz - 1] = TEST;
+      if (option < 0)
+        for (iz = 0; iz < ntw; iz++)
+          tab2[iz] = tab2[nz - iz - 1] = TEST;
 
       /* Save the output attribute */
 
@@ -1897,8 +1888,8 @@ int seismic_convolve(DbGrid *db,
 
   error = 0;
 
-  label_end:
-  if (type >= 0) mem_free((char* ) wavelet);
+label_end:
+  if (type >= 0) mem_free((char*)wavelet);
   return (error);
 }
 
@@ -1913,10 +1904,10 @@ int seismic_convolve(DbGrid *db,
  ** \param[in]  iz        Rank of the target sample within the target trace
  **
  *****************************************************************************/
-static int st_absolute_index(DbGrid *db, int ix, int iz)
+static int st_absolute_index(DbGrid* db, int ix, int iz)
 {
   int ndim = db->getNDim();
-  VectorInt indg(ndim,0);
+  VectorInt indg(ndim, 0);
 
   indg[0] = ix;
   indg[1] = 0;
@@ -1932,7 +1923,7 @@ static int st_absolute_index(DbGrid *db, int ix, int iz)
  ** \param[in,out]  ngh        ST_Seismic_Neigh structure
  **
  *****************************************************************************/
-static void st_sample_remove_central(ST_Seismic_Neigh *ngh)
+static void st_sample_remove_central(ST_Seismic_Neigh* ngh)
 
 {
   int lec, ecr;
@@ -1968,13 +1959,13 @@ static void st_sample_remove_central(ST_Seismic_Neigh *ngh)
  ** \param[in,out] ngh     ST_Seismic_Neigh structure
  **
  *****************************************************************************/
-static void st_sample_add(DbGrid *db,
+static void st_sample_add(DbGrid* db,
                           int iatt_z1,
                           int iatt_z2,
                           int flag_test,
                           int ix,
                           int iz,
-                          ST_Seismic_Neigh *ngh)
+                          ST_Seismic_Neigh* ngh)
 {
   int iech, i, found;
   double v1, v2;
@@ -2022,10 +2013,10 @@ static void st_sample_add(DbGrid *db,
  ** \param[out] presence  Array giving the number of valid samples per trace
  **
  *****************************************************************************/
-static void st_estimate_check_presence(DbGrid *db,
+static void st_estimate_check_presence(DbGrid* db,
                                        int ivar,
-                                       int *npres,
-                                       int *presence)
+                                       int* npres,
+                                       int* presence)
 {
   int ix, iz, iech;
 
@@ -2054,14 +2045,14 @@ static void st_estimate_check_presence(DbGrid *db,
  ** \param[in]  ngh      ST_Seismic_Neigh structure to be freed (if mode<0)
  **
  *****************************************************************************/
-static void st_estimate_neigh_init(ST_Seismic_Neigh *ngh)
+static void st_estimate_neigh_init(ST_Seismic_Neigh* ngh)
 
 {
   int i;
 
   ngh->nactive = 0;
-  ngh->n_v1 = 0;
-  ngh->n_v2 = 0;
+  ngh->n_v1    = 0;
+  ngh->n_v2    = 0;
   for (i = 0; i < ngh->nvois; i++)
   {
     ngh->ix_ngh[i] = ITEST;
@@ -2086,7 +2077,7 @@ static void st_estimate_neigh_init(ST_Seismic_Neigh *ngh)
  *****************************************************************************/
 static ST_Seismic_Neigh* st_estimate_neigh_management(int mode,
                                                       int nvois,
-                                                      ST_Seismic_Neigh *ngh)
+                                                      ST_Seismic_Neigh* ngh)
 {
   /* Dispatch */
 
@@ -2095,12 +2086,12 @@ static ST_Seismic_Neigh* st_estimate_neigh_management(int mode,
 
     /* Allocation */
 
-    ngh = (ST_Seismic_Neigh*) mem_alloc(sizeof(ST_Seismic_Neigh), 0);
+    ngh = (ST_Seismic_Neigh*)mem_alloc(sizeof(ST_Seismic_Neigh), 0);
     if (ngh == nullptr) return (ngh);
-    ngh->nvois = nvois;
+    ngh->nvois   = nvois;
     ngh->nactive = 0;
-    ngh->n_v1 = 0;
-    ngh->n_v2 = 0;
+    ngh->n_v1    = 0;
+    ngh->n_v2    = 0;
 
     ngh->ix_ngh.resize(nvois);
     ngh->iz_ngh.resize(nvois);
@@ -2116,7 +2107,7 @@ static ST_Seismic_Neigh* st_estimate_neigh_management(int mode,
     ngh->iz_ngh.clear();
     ngh->v1_ngh.clear();
     ngh->v2_ngh.clear();
-    mem_free((char* ) ngh);
+    mem_free((char*)ngh);
   }
   return (ngh);
 }
@@ -2131,8 +2122,8 @@ static ST_Seismic_Neigh* st_estimate_neigh_management(int mode,
  ** \param[in]  ngh_cur   Current ST_Seismic_Neigh structure
  **
  *****************************************************************************/
-static int st_estimate_neigh_unchanged(ST_Seismic_Neigh *ngh_old,
-                                       ST_Seismic_Neigh *ngh_cur)
+static int st_estimate_neigh_unchanged(ST_Seismic_Neigh* ngh_old,
+                                       ST_Seismic_Neigh* ngh_cur)
 {
   int i, flag_unchanged;
 
@@ -2145,15 +2136,14 @@ static int st_estimate_neigh_unchanged(ST_Seismic_Neigh *ngh_old,
 
   for (i = 0; i < ngh_old->nactive; i++)
   {
-    if (ngh_cur->ix_ngh[i] != ngh_old->ix_ngh[i] || ngh_cur->iz_ngh[i]
-        != ngh_old->iz_ngh[i]) goto label_end;
+    if (ngh_cur->ix_ngh[i] != ngh_old->ix_ngh[i] || ngh_cur->iz_ngh[i] != ngh_old->iz_ngh[i]) goto label_end;
   }
 
   /* The neighborhood is unchanged */
 
   flag_unchanged = 1;
 
-  label_end:
+label_end:
 
   /* Optional printout */
 
@@ -2172,8 +2162,8 @@ static int st_estimate_neigh_unchanged(ST_Seismic_Neigh *ngh_old,
  ** \param[out]  ngh_old  Old ST_Seismic_Neigh structure
  **
  *****************************************************************************/
-static void st_estimate_neigh_copy(ST_Seismic_Neigh *ngh_cur,
-                                   ST_Seismic_Neigh *ngh_old)
+static void st_estimate_neigh_copy(ST_Seismic_Neigh* ngh_cur,
+                                   ST_Seismic_Neigh* ngh_old)
 {
   int i;
 
@@ -2202,7 +2192,7 @@ static void st_estimate_neigh_copy(ST_Seismic_Neigh *ngh_cur,
  ** \param[in]  iz0       Rank of the target sample within the target trace
  **
  *****************************************************************************/
-static void st_estimate_neigh_print(ST_Seismic_Neigh *ngh, int ix0, int iz0)
+static void st_estimate_neigh_print(ST_Seismic_Neigh* ngh, int ix0, int iz0)
 {
   int i;
 
@@ -2251,7 +2241,7 @@ static void st_estimate_neigh_print(ST_Seismic_Neigh *ngh, int ix0, int iz0)
  ** \param[out]  ngh      Current ST_Seismic_Neigh structure
  **
  *****************************************************************************/
-static int st_estimate_neigh_create(DbGrid *db,
+static int st_estimate_neigh_create(DbGrid* db,
                                     int flag_exc,
                                     int iatt_z1,
                                     int iatt_z2,
@@ -2260,8 +2250,8 @@ static int st_estimate_neigh_create(DbGrid *db,
                                     int nbench,
                                     int nv2max,
                                     int /*npres*/[2],
-                                    int *presence[2],
-                                    ST_Seismic_Neigh *ngh)
+                                    int* presence[2],
+                                    ST_Seismic_Neigh* ngh)
 {
   int i, idx, ix, iz, jz, count, flag_valid;
 
@@ -2373,17 +2363,17 @@ static int st_estimate_neigh_create(DbGrid *db,
  ** \param[out] nred      Reduced number of equations
  **
  *****************************************************************************/
-static void st_estimate_flag(ST_Seismic_Neigh *ngh,
+static void st_estimate_flag(ST_Seismic_Neigh* ngh,
                              int nfeq,
-                             int *flag,
-                             int *nred)
+                             int* flag,
+                             int* nred)
 {
   double value;
   int i, ivar, nech, neqmax, nvalid;
 
   /* Initializations */
 
-  nech = ngh->nactive;
+  nech   = ngh->nactive;
   neqmax = NVAR * (nech + nfeq);
 
   /* Initialize the flag array */
@@ -2396,8 +2386,7 @@ static void st_estimate_flag(ST_Seismic_Neigh *ngh,
   for (ivar = 0; ivar < NVAR; ivar++)
     for (i = 0; i < nech; i++)
     {
-      value = (ivar == 0) ? ngh->v1_ngh[i] :
-                            ngh->v2_ngh[i];
+      value = (ivar == 0) ? ngh->v1_ngh[i] : ngh->v2_ngh[i];
       if (FFFF(value)) flag[ivar * nech + i] = 0;
     }
 
@@ -2429,7 +2418,7 @@ static void st_estimate_flag(ST_Seismic_Neigh *ngh,
  ** \param[out] var0      Array containing the C00 terms (Dimension: NVAR)
  **
  *****************************************************************************/
-static void st_estimate_var0(Model *model, double *var0)
+static void st_estimate_var0(Model* model, double* var0)
 {
   VectorDouble d1(model->getNDim());
   CovCalcMode mode(ECalcMember::VAR);
@@ -2448,7 +2437,7 @@ static void st_estimate_var0(Model *model, double *var0)
  ** \param[out] c00      Array containing the C00 terms (Dimension: NVAR * NVAR)
  **
  *****************************************************************************/
-static void st_estimate_c00(Model *model, double *c00)
+static void st_estimate_c00(Model* model, double* c00)
 {
   VectorDouble d1(model->getNDim());
   CovCalcMode mode(ECalcMember::VAR);
@@ -2456,7 +2445,7 @@ static void st_estimate_c00(Model *model, double *c00)
 
   for (int ivar = 0; ivar < NVAR; ivar++)
     for (int jvar = 0; jvar < NVAR; jvar++)
-      C00(ivar,jvar) = covtab.getValue(ivar, jvar);
+      C00(ivar, jvar) = covtab.getValue(ivar, jvar);
 }
 
 /****************************************************************************/
@@ -2472,12 +2461,12 @@ static void st_estimate_c00(Model *model, double *c00)
  ** \param[out] lhs       Array containing the Kriging L.H.S.
  **
  *****************************************************************************/
-static void st_estimate_lhs(ST_Seismic_Neigh *ngh,
-                            Model *model,
+static void st_estimate_lhs(ST_Seismic_Neigh* ngh,
+                            Model* model,
                             int nfeq,
                             int nred,
-                            int *flag,
-                            double *lhs)
+                            int* flag,
+                            double* lhs)
 {
   int iech, jech, ivar, jvar, nech, neqmax, i, j, lec, ecr;
   VectorDouble d1;
@@ -2485,7 +2474,7 @@ static void st_estimate_lhs(ST_Seismic_Neigh *ngh,
   /* Initializations */
 
   d1.resize(3, 0.);
-  nech = ngh->nactive;
+  nech   = ngh->nactive;
   neqmax = NVAR * (nech + nfeq);
 
   /* Initialize the L.H.S. array */
@@ -2504,7 +2493,7 @@ static void st_estimate_lhs(ST_Seismic_Neigh *ngh,
 
       for (ivar = 0; ivar < NVAR; ivar++)
         for (jvar = 0; jvar < NVAR; jvar++)
-          LHS(iech,ivar,jech,jvar) = covtab.getValue(ivar, jvar);
+          LHS(iech, ivar, jech, jvar) = covtab.getValue(ivar, jvar);
     }
 
   /* Establish the drift part */
@@ -2515,8 +2504,8 @@ static void st_estimate_lhs(ST_Seismic_Neigh *ngh,
       for (ivar = 0; ivar < NVAR; ivar++)
         for (jvar = 0; jvar < NVAR; jvar++)
         {
-          LHS(iech,ivar,jvar,NVAR) = (ivar == jvar);
-          LHS(jvar,NVAR,iech,ivar) = (ivar == jvar);
+          LHS(iech, ivar, jvar, NVAR) = (ivar == jvar);
+          LHS(jvar, NVAR, iech, ivar) = (ivar == jvar);
         }
   }
 
@@ -2543,12 +2532,12 @@ static void st_estimate_lhs(ST_Seismic_Neigh *ngh,
  ** \param[out] rhs       Array containing the Kriging R.H.S.
  **
  *****************************************************************************/
-static void st_estimate_rhs(ST_Seismic_Neigh *ngh,
-                            Model *model,
+static void st_estimate_rhs(ST_Seismic_Neigh* ngh,
+                            Model* model,
                             int nfeq,
                             int nred,
-                            int *flag,
-                            double *rhs)
+                            int* flag,
+                            double* rhs)
 {
   int iech, nech, ivar, jvar, neqmax, lec, ecr, i;
   VectorDouble d1;
@@ -2557,7 +2546,7 @@ static void st_estimate_rhs(ST_Seismic_Neigh *ngh,
   /* Initializations */
 
   d1.resize(3, 0.);
-  nech = ngh->nactive;
+  nech   = ngh->nactive;
   neqmax = NVAR * (nech + nfeq);
   mode.setMember(ECalcMember::RHS);
 
@@ -2576,7 +2565,7 @@ static void st_estimate_rhs(ST_Seismic_Neigh *ngh,
 
     for (ivar = 0; ivar < NVAR; ivar++)
       for (jvar = 0; jvar < NVAR; jvar++)
-        RHS(iech,ivar,jvar) = covtab.getValue(ivar, jvar);
+        RHS(iech, ivar, jvar) = covtab.getValue(ivar, jvar);
   }
 
   /* Establish the drift part */
@@ -2585,7 +2574,7 @@ static void st_estimate_rhs(ST_Seismic_Neigh *ngh,
   {
     for (ivar = 0; ivar < NVAR; ivar++)
       for (jvar = 0; jvar < NVAR; jvar++)
-        RHS(jvar,NVAR,ivar) = (ivar == jvar);
+        RHS(jvar, NVAR, ivar) = (ivar == jvar);
   }
 
   /* Compress from isotopic to heterotopic */
@@ -2611,12 +2600,12 @@ static void st_estimate_rhs(ST_Seismic_Neigh *ngh,
  ** \param[in]  wgt     Array of Kriging weights
  **
  *****************************************************************************/
-static void st_wgt_print(ST_Seismic_Neigh *ngh,
+static void st_wgt_print(ST_Seismic_Neigh* ngh,
                          int nvar,
                          int nech,
                          int nred,
-                         const int *flag,
-                         const double *wgt)
+                         const int* flag,
+                         const double* wgt)
 {
   double sum[2], value;
   int iwgt, ivar, jvar, iech, lec, cumflag;
@@ -2634,7 +2623,7 @@ static void st_wgt_print(ST_Seismic_Neigh *ngh,
   tab_prints(NULL, "Data");
   for (ivar = 0; ivar < nvar; ivar++)
   {
-    (void) gslSPrintf(string, "Z%d*", ivar + 1);
+    (void)gslSPrintf(string, "Z%d*", ivar + 1);
     tab_prints(NULL, string);
   }
   message("\n");
@@ -2661,9 +2650,8 @@ static void st_wgt_print(ST_Seismic_Neigh *ngh,
 
       for (ivar = 0; ivar < nvar; ivar++)
       {
-        iwgt = nred * ivar + cumflag;
-        value = (flag[lec]) ? wgt[iwgt] :
-                              TEST;
+        iwgt  = nred * ivar + cumflag;
+        value = (flag[lec]) ? wgt[iwgt] : TEST;
         if (!FFFF(value)) sum[ivar] += value;
         tab_printg(NULL, value);
       }
@@ -2693,13 +2681,13 @@ static void st_wgt_print(ST_Seismic_Neigh *ngh,
 ** \param[out] wgt       Array containing the Kriging Weights
 **
 *****************************************************************************/
-static int st_estimate_wgt(ST_Seismic_Neigh *ngh,
-                           Model  * /*model*/,
-                           int     nred,
-                           int    *flag,
-                           double *lhs,
-                           double *rhs,
-                           double *wgt)
+static int st_estimate_wgt(ST_Seismic_Neigh* ngh,
+                           Model* /*model*/,
+                           int nred,
+                           int* flag,
+                           double* lhs,
+                           double* rhs,
+                           double* wgt)
 {
   int nech;
 
@@ -2734,17 +2722,17 @@ static int st_estimate_wgt(ST_Seismic_Neigh *ngh,
 ** \param[in]  iatt_std  Array of pointers to the variance of estimation
 **
 *****************************************************************************/
-static void st_estimate_result(Db     *db,
-                               ST_Seismic_Neigh *ngh,
-                               int     flag_std,
-                               int     /*nfeq*/,
-                               int     nred,
-                               const int    *flag,
-                               const double *wgt,
-                               const double *rhs,
-                               const double *var0,
-                               int *iatt_est,
-                               int *iatt_std)
+static void st_estimate_result(Db* db,
+                               ST_Seismic_Neigh* ngh,
+                               int flag_std,
+                               int /*nfeq*/,
+                               int nred,
+                               const int* flag,
+                               const double* wgt,
+                               const double* rhs,
+                               const double* var0,
+                               int* iatt_est,
+                               int* iatt_std)
 {
   int i, ivar, jvar, nech, lec;
   double result, value, stdev;
@@ -2762,13 +2750,12 @@ static void st_estimate_result(Db     *db,
     /* Estimation */
 
     result = stdev = 0.;
-    lec = ivar * nred;
+    lec            = ivar * nred;
     for (jvar = 0; jvar < NVAR; jvar++)
       for (i = 0; i < nech; i++)
       {
         if (!flag[jvar * nech + i]) continue;
-        value = (jvar == 0) ? ngh->v1_ngh[i] :
-                              ngh->v2_ngh[i];
+        value = (jvar == 0) ? ngh->v1_ngh[i] : ngh->v2_ngh[i];
         result += wgt[lec++] * value;
       }
     db->setArray(IECH_OUT, iatt_est[ivar], result);
@@ -2778,11 +2765,10 @@ static void st_estimate_result(Db     *db,
     if (flag_std)
     {
       stdev = var0[ivar];
-      lec = ivar * nred;
+      lec   = ivar * nred;
       for (i = 0; i < nred; i++)
         stdev -= rhs[lec + i] * wgt[lec + i];
-      stdev = (stdev > 0) ? sqrt(stdev) :
-                            0.;
+      stdev = (stdev > 0) ? sqrt(stdev) : 0.;
       db->setArray(IECH_OUT, iatt_std[ivar], stdev);
     }
 
@@ -2813,18 +2799,18 @@ static void st_estimate_result(Db     *db,
 ** \param[in]  iatt_sim  Array of pointers to the simulated results
 **
 *****************************************************************************/
-static void st_simulate_result(DbGrid *db,
-                               int     ix0,
-                               int     iz0,
-                               ST_Seismic_Neigh *ngh,
-                               int     nbsimu,
-                               int     /*nfeq*/,
-                               int     nred,
-                               const int    *flag,
-                               const double *wgt,
-                               const double *rhs,
-                               const double *c00,
-                               int *iatt_sim)
+static void st_simulate_result(DbGrid* db,
+                               int ix0,
+                               int iz0,
+                               ST_Seismic_Neigh* ngh,
+                               int nbsimu,
+                               int /*nfeq*/,
+                               int nred,
+                               const int* flag,
+                               const double* wgt,
+                               const double* rhs,
+                               const double* c00,
+                               int* iatt_sim)
 {
   int i, ivar, jvar, nech, lec, isimu, iech;
   double result[2], value, sigma0, sigma1, sigma2, z1, z2, l0, lb[4];
@@ -2842,7 +2828,7 @@ static void st_simulate_result(DbGrid *db,
       value = 0.;
       for (i = 0; i < nred; i++)
         value += wgt[nred * ivar + i] * rhs[nred * jvar + i];
-      LB(ivar,jvar) = value;
+      LB(ivar, jvar) = value;
     }
 
   /* Loop on the simulations */
@@ -2858,13 +2844,13 @@ static void st_simulate_result(DbGrid *db,
       /* Estimation */
 
       result[ivar] = 0.;
-      lec = ivar * nred;
+      lec          = ivar * nred;
       for (jvar = 0; jvar < NVAR; jvar++)
         for (i = 0; i < nech; i++)
         {
           if (!flag[jvar * nech + i]) continue;
-          iech = st_absolute_index(db, ix0 + ngh->ix_ngh[i],
-                                   iz0 + ngh->iz_ngh[i]);
+          iech  = st_absolute_index(db, ix0 + ngh->ix_ngh[i],
+                                    iz0 + ngh->iz_ngh[i]);
           value = db->getArray(iech, iatt_sim[jvar] + isimu);
           result[ivar] += wgt[lec++] * value;
         }
@@ -2872,18 +2858,18 @@ static void st_simulate_result(DbGrid *db,
 
     /* Link the two variables */
 
-    sigma1 = C00(0,0) - LB(0, 0);
-    sigma2 = C00(1,1) - LB(1, 1);
+    sigma1 = C00(0, 0) - LB(0, 0);
+    sigma2 = C00(1, 1) - LB(1, 1);
 
     z2 = db->getArray(IECH_OUT, iatt_sim[1] + isimu);
     if (FFFF(z2)) z2 = result[1] + sqrt(MAX(0, sigma2)) * law_gaussian();
     z1 = db->getArray(IECH_OUT, iatt_sim[0] + isimu);
     if (FFFF(z1) && sigma2 > 0)
     {
-      l0 = (C00(0,1) - LB(0, 1)) / sigma2;
-      sigma0 = sigma1 - l0 * (C00(0,1) - LB(1, 0));
+      l0     = (C00(0, 1) - LB(0, 1)) / sigma2;
+      sigma0 = sigma1 - l0 * (C00(0, 1) - LB(1, 0));
       sigma0 = sqrt(MAX(0, sigma0));
-      z1 = result[0] + (z2 - result[1]) * l0 + sigma0 * law_gaussian();
+      z1     = result[0] + (z2 - result[1]) * l0 + sigma0 * law_gaussian();
     }
     result[0] = z1;
     result[1] = z2;
@@ -2915,7 +2901,7 @@ static void st_simulate_result(DbGrid *db,
  ** \param[out] rank     Array giving the order of the traces
  **
  *****************************************************************************/
-static int st_estimate_sort(const int *presence, int *rank)
+static int st_estimate_sort(const int* presence, int* rank)
 {
   double distmin, distval;
   int ix, jx;
@@ -2925,7 +2911,7 @@ static int st_estimate_sort(const int *presence, int *rank)
   for (ix = 0; ix < NX; ix++)
   {
     rank[ix] = ix;
-    distmin = MAXIMUM_BIG;
+    distmin  = MAXIMUM_BIG;
     for (jx = 0; jx < NX; jx++)
     {
       if (presence[jx] <= 0) continue;
@@ -2958,8 +2944,8 @@ static int st_estimate_sort(const int *presence, int *rank)
  ** \param[in]  flag_stat  1 for producing final statistics
  **
  *****************************************************************************/
-int seismic_estimate_XZ(DbGrid *db,
-                        Model *model,
+int seismic_estimate_XZ(DbGrid* db,
+                        Model* model,
                         int nbench,
                         int nv2max,
                         int flag_ks,
@@ -2982,30 +2968,30 @@ int seismic_estimate_XZ(DbGrid *db,
 
   error = 1;
   nvois = nred = nb_total = nb_process = nb_calcul = 0;
-  nfeq = (flag_ks) ? 0 : 1;
+  nfeq                                             = (flag_ks) ? 0 : 1;
   ngh_cur = ngh_old = nullptr;
   for (i = 0; i < 2; i++)
   {
     iatt_est[i] = -1;
     iatt_std[i] = -1;
     presence[i] = nullptr;
-    npres[i] = 0;
+    npres[i]    = 0;
   }
   if (krige_koption_manage(1, 1, EKrigOpt::POINT, 1, VectorInt())) goto label_end;
 
   /* Check that the grid is XZ */
 
-  if (! db->isGrid())
+  if (!db->isGrid())
   {
     messerr("The Db structure must be a Grid Db");
     return (1);
   }
-  NX = db->getNX(0);
-  NY = db->getNX(1);
-  NZ = db->getNX(2);
-  DX = db->getDX(0);
-  DZ = db->getDX(2);
-  NVAR = db->getNLoc(ELoc::Z);
+  NX      = db->getNX(0);
+  NY      = db->getNX(1);
+  NZ      = db->getNX(2);
+  DX      = db->getDX(0);
+  DZ      = db->getDX(2);
+  NVAR    = db->getNLoc(ELoc::Z);
   iatt_z1 = db->getUIDByLocator(ELoc::Z, 0);
   iatt_z2 = db->getUIDByLocator(ELoc::Z, 1);
 
@@ -3024,7 +3010,7 @@ int seismic_estimate_XZ(DbGrid *db,
 
   for (i = 0; i < 2; i++)
   {
-    presence[i] = (int*) mem_alloc(sizeof(int) * NX, 0);
+    presence[i] = (int*)mem_alloc(sizeof(int) * NX, 0);
     if (presence[i] == nullptr) goto label_end;
   }
 
@@ -3036,7 +3022,7 @@ int seismic_estimate_XZ(DbGrid *db,
   /* Maximum dimension of the neighborhood */
 
   nvois = (2 * nbench + 1) * (npres[0] + 2 * nv2max + 1);
-  size = NVAR * (nvois + nfeq);
+  size  = NVAR * (nvois + nfeq);
 
   /* Core allocation (second) */
 
@@ -3060,11 +3046,12 @@ int seismic_estimate_XZ(DbGrid *db,
     iatt_est[i] = db->addColumnsByConstant(1, TEST);
     if (iatt_est[i] < 0) goto label_end;
   }
-  if (flag_std) for (i = 0; i < 2; i++)
-  {
-    iatt_std[i] = db->addColumnsByConstant(1, TEST);
-    if (iatt_std[i] < 0) goto label_end;
-  }
+  if (flag_std)
+    for (i = 0; i < 2; i++)
+    {
+      iatt_std[i] = db->addColumnsByConstant(1, TEST);
+      if (iatt_std[i] < 0) goto label_end;
+    }
 
   /* Calculate the constant terms for the variances */
 
@@ -3132,7 +3119,8 @@ int seismic_estimate_XZ(DbGrid *db,
 
   error = 0;
 
-  label_end: OptDbg::setCurrentIndex(0);
+label_end:
+  OptDbg::setCurrentIndex(0);
   if (flag_stat)
   {
     message("Statistics on the number of nodes:\n");
@@ -3142,11 +3130,11 @@ int seismic_estimate_XZ(DbGrid *db,
   }
   for (i = 0; i < 2; i++)
   {
-    presence[i] = (int*) mem_free((char* ) presence[i]);
+    presence[i] = (int*)mem_free((char*)presence[i]);
     if (error && iatt_est[i] >= 0) db->deleteColumnByUID(iatt_est[i]);
     if (error && iatt_std[i] >= 0) db->deleteColumnByUID(iatt_std[i]);
   }
-  (void) krige_koption_manage(-1, 1, EKrigOpt::POINT, 1, VectorInt());
+  (void)krige_koption_manage(-1, 1, EKrigOpt::POINT, 1, VectorInt());
   st_estimate_neigh_management(-1, nvois, ngh_cur);
   st_estimate_neigh_management(-1, nvois, ngh_old);
 
@@ -3162,7 +3150,7 @@ int seismic_estimate_XZ(DbGrid *db,
  ** \param[in]  iatt     Address of the first item for each variable
  **
  *****************************************************************************/
-static void st_copy_attribute(Db *db, int nbsimu, int *iatt)
+static void st_copy_attribute(Db* db, int nbsimu, int* iatt)
 {
   int ivar, isimu, iech, nech;
   double value;
@@ -3210,8 +3198,8 @@ static void st_copy_attribute(Db *db, int nbsimu, int *iatt)
  ** \param[in]  flag_stat  1 for producing final statistics
  **
  *****************************************************************************/
-int seismic_simulate_XZ(DbGrid *db,
-                        Model *model,
+int seismic_simulate_XZ(DbGrid* db,
+                        Model* model,
                         int nbench,
                         int nv2max,
                         int nbsimu,
@@ -3235,27 +3223,27 @@ int seismic_simulate_XZ(DbGrid *db,
 
   error = 1;
   nvois = nred = nb_total = nb_process = nb_calcul = 0;
-  nfeq = (flag_ks) ? 0 : 1;
+  nfeq                                             = (flag_ks) ? 0 : 1;
   ngh_cur = ngh_old = nullptr;
   for (i = 0; i < 2; i++)
   {
     iatt_sim[i] = -1;
     presence[i] = nullptr;
-    npres[i] = 0;
+    npres[i]    = 0;
   }
 
   /* Check that the grid is XZ */
 
-  if (! db->isGrid())
+  if (!db->isGrid())
   {
     messerr("The Db structure must be a Grid Db");
     return (1);
   }
-  NX = db->getNX(0);
-  NY = db->getNX(1);
-  NZ = db->getNX(2);
-  DX = db->getDX(0);
-  DZ = db->getDX(2);
+  NX   = db->getNX(0);
+  NY   = db->getNX(1);
+  NZ   = db->getNX(2);
+  DX   = db->getDX(0);
+  DZ   = db->getDX(2);
   NVAR = db->getNLoc(ELoc::Z);
 
   if (NX <= 1 || NY != 1 || NZ <= 1)
@@ -3273,7 +3261,7 @@ int seismic_simulate_XZ(DbGrid *db,
 
   for (i = 0; i < 2; i++)
   {
-    presence[i] = (int*) mem_alloc(sizeof(int) * NX, 0);
+    presence[i] = (int*)mem_alloc(sizeof(int) * NX, 0);
     if (presence[i] == nullptr) goto label_end;
   }
 
@@ -3286,7 +3274,7 @@ int seismic_simulate_XZ(DbGrid *db,
   /* Maximum dimension of the neighborhood */
 
   nvois = (2 * nbench + 1) * (npres[0] + 2 * nv2max + 1);
-  size = NVAR * (nvois + nfeq);
+  size  = NVAR * (nvois + nfeq);
 
   /* Core allocation (second) */
 
@@ -3382,7 +3370,8 @@ int seismic_simulate_XZ(DbGrid *db,
 
   error = 0;
 
-  label_end: OptDbg::setCurrentIndex(0);
+label_end:
+  OptDbg::setCurrentIndex(0);
   if (flag_stat)
   {
     message("Statistics on the number of nodes:\n");
@@ -3392,13 +3381,14 @@ int seismic_simulate_XZ(DbGrid *db,
   }
   for (i = 0; i < 2; i++)
   {
-    mem_free((char* ) presence[i]);
-    if (error) for (isimu = 0; isimu < nbsimu; isimu++)
-      db->deleteColumnByUID(iatt_sim[i] + isimu);
+    mem_free((char*)presence[i]);
+    if (error)
+      for (isimu = 0; isimu < nbsimu; isimu++)
+        db->deleteColumnByUID(iatt_sim[i] + isimu);
   }
   st_estimate_neigh_management(-1, nvois, ngh_cur);
   st_estimate_neigh_management(-1, nvois, ngh_old);
 
   return (error);
 }
-}
+} // namespace gstlrn

--- a/src/Core/simtub.cpp
+++ b/src/Core/simtub.cpp
@@ -41,8 +41,9 @@
 #include "Simulation/SimuSphericalParam.hpp"
 #include "geoslib_f.h"
 #include "geoslib_old_f.h"
-#include <math.h>
-#include <string.h>
+
+#include <cmath>
+#include <cstring>
 
 /*! \cond */
 #define DATA   0
@@ -55,7 +56,8 @@
 
 /*! \endcond */
 
-namespace gstlrn{
+namespace gstlrn
+{
 
 static double GIBBS_RHO, GIBBS_SQR;
 static Modif_Categorical ModCat = {0, {0, 0}, NULL, NULL};
@@ -2931,4 +2933,4 @@ MatrixDense fluid_extract(DbGrid* dbgrid,
   }
   return tab;
 }
-}
+} // namespace gstlrn

--- a/src/Core/spill.cpp
+++ b/src/Core/spill.cpp
@@ -14,7 +14,8 @@
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "geoslib_old_f.h"
-#include <string.h>
+
+#include <cstring>
 
 namespace gstlrn
 {

--- a/src/Core/stats.cpp
+++ b/src/Core/stats.cpp
@@ -20,8 +20,9 @@
 #include "Morpho/Morpho.hpp"
 #include "Stats/Classical.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
-#include <string.h>
+
+#include <cmath>
+#include <cstring>
 
 /*! \cond */
 #define G_ADDRESS(ix, iy, iz, nxyz) ((ix) + nxyz[0] * ((iy) + nxyz[1] * (iz)))
@@ -1502,4 +1503,4 @@ int stats_residuals(int verbose,
   (*mean)    = moyenne;
   return (0);
 }
-}
+} // namespace gstlrn

--- a/src/Core/surface.cpp
+++ b/src/Core/surface.cpp
@@ -16,7 +16,8 @@
 #include "Model/Model.hpp"
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -782,4 +783,4 @@ label_end:
 
   return (error);
 }
-}
+} // namespace gstlrn

--- a/src/Core/util.cpp
+++ b/src/Core/util.cpp
@@ -16,8 +16,9 @@
 #include "Space/ASpaceObject.hpp"
 #include "Space/SpaceSN.hpp"
 #include "geoslib_old_f.h"
+
 #include <cmath>
-#include <string.h>
+#include <cstring>
 
 /*! \cond */
 #define TAB(ix, iy)  (tab[(ix) * ny + (iy)])

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -34,11 +34,12 @@
 #include "Space/SpacePoint.hpp"
 #include "Variogram/Vario.hpp"
 #include "geoslib_define.h"
+
+#include <cmath>
 #include <cstddef>
-#include <math.h>
 #include <vector>
 
-namespace gstlrn 
+namespace gstlrn
 {
 
 ACov::ACov(const CovContext& ctxt)
@@ -2481,4 +2482,4 @@ void ACov::setContext(const CovContext& ctxt)
   _ctxt = ctxt;
   _setContext(ctxt);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/ACovFunc.cpp
+++ b/src/Covariances/ACovFunc.cpp
@@ -12,7 +12,8 @@
 #include "Basic/AException.hpp"
 #include "Basic/FFT.hpp"
 #include "Basic/Utilities.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -345,4 +346,4 @@ void ACovFunc::computeCorrec(int ndim)
   setCorrec(correc);
 }
 
-}
+} // namespace gstlrn

--- a/src/Covariances/ACovGradient.cpp
+++ b/src/Covariances/ACovGradient.cpp
@@ -9,7 +9,8 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Covariances/ACovGradient.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -41,4 +42,4 @@ ACovGradient& ACovGradient::operator=(const ACovGradient& r)
 ACovGradient::~ACovGradient()
 {
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -36,11 +36,11 @@
 #include "Space/ASpaceObject.hpp"
 #include "Space/SpacePoint.hpp"
 #include "Space/SpaceSN.hpp"
-
 #include "geoslib_define.h"
+
 #include <algorithm>
+#include <cmath>
 #include <functional>
-#include <math.h>
 #include <vector>
 
 static int NWGT[4]      = {2, 3, 4, 5};
@@ -1671,4 +1671,4 @@ void CorAniso::updateCov()
     }
   }
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovAniso.cpp
+++ b/src/Covariances/CovAniso.cpp
@@ -30,492 +30,491 @@
 #include "Space/SpaceRN.hpp"
 #include "Space/SpaceSN.hpp"
 
+#include <cmath>
 #include <functional>
-#include <math.h>
-#include <math.h>
 #include <ostream>
 
 namespace gstlrn
 {
 
-  CovAniso::CovAniso(const ECov& type, const CovContext& ctxt)
-    : CovProportional(nullptr, MatrixSymmetric(ctxt.getNVar()))
+CovAniso::CovAniso(const ECov& type, const CovContext& ctxt)
+  : CovProportional(nullptr, MatrixSymmetric(ctxt.getNVar()))
+{
+  auto tempcor = CorAniso(type, ctxt);
+  CovProportional::setCor(&tempcor);
+  _initFromContext();
+}
+
+CovAniso::CovAniso(const String& symbol, const CovContext& ctxt)
+  : CovProportional(new CorAniso(symbol, ctxt))
+{
+  ECov covtype = CovFactory::identifyCovariance(symbol, ctxt);
+  _initFromContext();
+}
+
+CovAniso::CovAniso(const ECov& type,
+                   double range,
+                   double param,
+                   double sill,
+                   const CovContext& ctxt,
+                   bool flagRange)
+  : CovProportional(nullptr, MatrixSymmetric(ctxt.getNVar()))
+{
+  auto temp = CorAniso(type, range, param, ctxt, flagRange);
+  setCor(&temp);
+  _initFromContext();
+
+  // Sill
+  if (ctxt.getNVar() == 1)
+    _sillCur.setValue(0, 0, sill);
+  else
   {
-    auto tempcor = CorAniso(type, ctxt);
-    CovProportional::setCor(&tempcor);
-    _initFromContext();
+    int nvar = ctxt.getNVar();
+    _sillCur.fill(0);
+    for (int ivar = 0; ivar < nvar; ivar++)
+      _sillCur.setValue(ivar, ivar, sill);
   }
 
-  CovAniso::CovAniso(const String& symbol, const CovContext& ctxt)
-    : CovProportional(new CorAniso(symbol, ctxt))
+  // Param
+  setParam(param);
+
+  // Range
+  if (flagRange)
+    setRangeIsotropic(range);
+  else
+    setScale(range);
+}
+
+CovAniso::CovAniso(const CovAniso& r)
+  : CovProportional(r)
+{
+  _ctxt.setNVar(r.getNVar());
+}
+
+CovAniso& CovAniso::operator=(const CovAniso& r)
+{
+  if (this != &r)
   {
-    ECov covtype = CovFactory::identifyCovariance(symbol, ctxt);
-    _initFromContext();
+    setCor(new CorAniso(*r.getCorAniso()));
+    _ctxt    = r._ctxt;
+    _sillCur = r._sillCur;
   }
+  return *this;
+}
 
-  CovAniso::CovAniso(const ECov& type,
-                     double range,
-                     double param,
-                     double sill,
-                     const CovContext& ctxt,
-                     bool flagRange)
-    : CovProportional(nullptr, MatrixSymmetric(ctxt.getNVar()))
+CovAniso::~CovAniso()
+{
+}
+
+CorAniso* CovAniso::getCorAniso()
+{
+  return (CorAniso*)getCor();
+}
+
+double CovAniso::_getSillValue(int ivar, int jvar, const CovCalcMode* mode) const
+{
+  if (mode != nullptr && mode->getUnitary()) return 1.;
+  return getSill(ivar, jvar);
+}
+
+double CovAniso::eval0(int ivar, int jvar, const CovCalcMode* mode) const
+{
+  double cov = getCorAniso()->evalCorFromH(0, mode);
+  return cov * _getSillValue(ivar, jvar, mode);
+}
+
+double CovAniso::_eval(const SpacePoint& p1,
+                       const SpacePoint& p2,
+                       int ivar,
+                       int jvar,
+                       const CovCalcMode* mode) const
+{
+  double cov = getCorAniso()->evalCor(p1, p2, mode);
+  return cov * _getSillValue(ivar, jvar, mode);
+}
+
+double CovAniso::evalCovOnSphere(double alpha,
+                                 int degree,
+                                 bool flagScaleDistance,
+                                 const CovCalcMode* mode) const
+{
+  double value = getCorAniso()->evalCovOnSphere(alpha, degree, flagScaleDistance, mode);
+  return value * _getSillValue(0, 0, mode);
+}
+
+VectorDouble CovAniso::evalSpectrumOnSphere(int n, bool flagNormDistance, bool flagCumul) const
+{
+  return getCorAniso()->evalSpectrumOnSphere(n, flagNormDistance, flagCumul);
+}
+
+double CovAniso::evalSpectrum(const VectorDouble& freq, int ivar, int jvar) const
+{
+  if (!getCorAniso()->hasSpectrumOnRn()) return TEST;
+  return _sillCur.getValue(ivar, jvar) * getCorAniso()->evalSpectrum(freq, ivar, jvar);
+}
+
+VectorDouble CovAniso::evalCovOnSphereVec(const VectorDouble& alpha,
+                                          int degree,
+                                          bool flagScaleDistance,
+                                          const CovCalcMode* mode) const
+{
+  int n = (int)alpha.size();
+  VectorDouble vec(n);
+  for (int i = 0; i < n; i++)
+    vec[i] = evalCovOnSphere(alpha[i], degree, flagScaleDistance, mode);
+  return vec;
+}
+
+String CovAniso::toString(const AStringFormat* strfmt) const
+{
+  std::stringstream sstr;
+
+  sstr << getCorAniso()->getCorFunc()->toString();
+
+  // Sill - Factor / Slope information
+  if (getCorAniso()->hasRange() >= 0)
   {
-    auto temp = CorAniso(type, range, param, ctxt, flagRange);
-    setCor(&temp);
-    _initFromContext();
+    // A sill is defined
 
-    // Sill
-    if (ctxt.getNVar() == 1)
-      _sillCur.setValue(0, 0, sill);
-    else
+    if (getNVar() > 1)
     {
-      int nvar = ctxt.getNVar();
-      _sillCur.fill(0);
-      for (int ivar = 0; ivar < nvar; ivar++)
-        _sillCur.setValue(ivar, ivar, sill);
-    }
-
-    // Param
-    setParam(param);
-
-    // Range
-    if (flagRange)
-      setRangeIsotropic(range);
-    else
-      setScale(range);
-  }
-
-  CovAniso::CovAniso(const CovAniso& r)
-    : CovProportional(r)
-  {
-    _ctxt.setNVar(r.getNVar());
-  }
-
-  CovAniso& CovAniso::operator=(const CovAniso& r)
-  {
-    if (this != &r)
-    {
-      setCor(new CorAniso(*r.getCorAniso()));
-      _ctxt    = r._ctxt;
-      _sillCur = r._sillCur;
-    }
-    return *this;
-  }
-
-  CovAniso::~CovAniso()
-  {
-  }
-
-  CorAniso* CovAniso::getCorAniso()
-  {
-    return (CorAniso*)getCor();
-  }
-
-  double CovAniso::_getSillValue(int ivar, int jvar, const CovCalcMode* mode) const
-  {
-    if (mode != nullptr && mode->getUnitary()) return 1.;
-    return getSill(ivar, jvar);
-  }
-
-  double CovAniso::eval0(int ivar, int jvar, const CovCalcMode* mode) const
-  {
-    double cov = getCorAniso()->evalCorFromH(0, mode);
-    return cov * _getSillValue(ivar, jvar, mode);
-  }
-
-  double CovAniso::_eval(const SpacePoint& p1,
-                         const SpacePoint& p2,
-                         int ivar,
-                         int jvar,
-                         const CovCalcMode* mode) const
-  {
-    double cov = getCorAniso()->evalCor(p1, p2, mode);
-    return cov * _getSillValue(ivar, jvar, mode);
-  }
-
-  double CovAniso::evalCovOnSphere(double alpha,
-                                   int degree,
-                                   bool flagScaleDistance,
-                                   const CovCalcMode* mode) const
-  {
-    double value = getCorAniso()->evalCovOnSphere(alpha, degree, flagScaleDistance, mode);
-    return value * _getSillValue(0, 0, mode);
-  }
-
-  VectorDouble CovAniso::evalSpectrumOnSphere(int n, bool flagNormDistance, bool flagCumul) const
-  {
-    return getCorAniso()->evalSpectrumOnSphere(n, flagNormDistance, flagCumul);
-  }
-
-  double CovAniso::evalSpectrum(const VectorDouble& freq, int ivar, int jvar) const
-  {
-    if (!getCorAniso()->hasSpectrumOnRn()) return TEST;
-    return _sillCur.getValue(ivar, jvar) * getCorAniso()->evalSpectrum(freq, ivar, jvar);
-  }
-
-  VectorDouble CovAniso::evalCovOnSphereVec(const VectorDouble& alpha,
-                                            int degree,
-                                            bool flagScaleDistance,
-                                            const CovCalcMode* mode) const
-  {
-    int n = (int)alpha.size();
-    VectorDouble vec(n);
-    for (int i = 0; i < n; i++)
-      vec[i] = evalCovOnSphere(alpha[i], degree, flagScaleDistance, mode);
-    return vec;
-  }
-
-  String CovAniso::toString(const AStringFormat* strfmt) const
-  {
-    std::stringstream sstr;
-
-    sstr << getCorAniso()->getCorFunc()->toString();
-
-    // Sill - Factor / Slope information
-    if (getCorAniso()->hasRange() >= 0)
-    {
-      // A sill is defined
-
-      if (getNVar() > 1)
-      {
-        sstr << toMatrix("- Sill matrix:", VectorString(), VectorString(), 0,
-                         getNVar(), getNVar(), _sillCur.getValues());
-      }
-      else
-      {
-        sstr << "- Sill         = " << toDouble(_sillCur.getValue(0, 0)) << std::endl;
-      }
+      sstr << toMatrix("- Sill matrix:", VectorString(), VectorString(), 0,
+                       getNVar(), getNVar(), _sillCur.getValues());
     }
     else
     {
-      // The sill is not defined: use slope instead
-
-      if (getNVar() > 1)
-      {
-        MatrixSquare slopes = _sillCur;
-        double range        = getRange(0);
-        for (int ivar = 0; ivar < getNVar(); ivar++)
-          for (int jvar = 0; jvar < getNVar(); jvar++)
-            slopes.setValue(ivar, jvar, _sillCur.getValue(ivar, jvar) / range);
-        sstr << toMatrix("- Slope matrix:", VectorString(), VectorString(), 0,
-                         getNVar(), getNVar(), slopes.getValues());
-      }
-      else
-      {
-        sstr << "- Slope        = " << toDouble(getSlope(0, 0)) << std::endl;
-      }
+      sstr << "- Sill         = " << toDouble(_sillCur.getValue(0, 0)) << std::endl;
     }
+  }
+  else
+  {
+    // The sill is not defined: use slope instead
 
-    // Covariance Parameters
-    sstr << getCorAniso()->toStringParams(strfmt);
-
-    // Non-stationary parameters
-
-    if (isNoStat())
+    if (getNVar() > 1)
     {
-      sstr << toTitle(1, "Non-Stationary Parameters");
-      sstr << _tabNoStat->toString(strfmt);
-      int i = getTabNoStatSills()->getNSills();
-      sstr << getCorAniso()->toStringNoStat(strfmt, i);
+      MatrixSquare slopes = _sillCur;
+      double range        = getRange(0);
+      for (int ivar = 0; ivar < getNVar(); ivar++)
+        for (int jvar = 0; jvar < getNVar(); jvar++)
+          slopes.setValue(ivar, jvar, _sillCur.getValue(ivar, jvar) / range);
+      sstr << toMatrix("- Slope matrix:", VectorString(), VectorString(), 0,
+                       getNVar(), getNVar(), slopes.getValues());
     }
-    return sstr.str();
+    else
+    {
+      sstr << "- Slope        = " << toDouble(getSlope(0, 0)) << std::endl;
+    }
   }
 
-  /**
-   * Return the Slope calculated as the sill / range(idim=0)
-   * @param ivar Rank of the first variable
-   * @param jvar Rank of the second variable
-   * @return
-   */
-  double CovAniso::getSlope(int ivar, int jvar) const
+  // Covariance Parameters
+  sstr << getCorAniso()->toStringParams(strfmt);
+
+  // Non-stationary parameters
+
+  if (isNoStat())
   {
-    if (hasRange() == 0) return TEST;
-    double range = getRange(0);
-    return _sillCur.getValue(ivar, jvar) / range;
+    sstr << toTitle(1, "Non-Stationary Parameters");
+    sstr << _tabNoStat->toString(strfmt);
+    int i = getTabNoStatSills()->getNSills();
+    sstr << getCorAniso()->toStringNoStat(strfmt, i);
   }
+  return sstr.str();
+}
 
-  /**
-   * Calculate the Integral Range in various Space Dimension (1, 2 or 3)
-   * @return
-   */
-  double CovAniso::getIntegralRange(int ndisc, double hmax) const
+/**
+ * Return the Slope calculated as the sill / range(idim=0)
+ * @param ivar Rank of the first variable
+ * @param jvar Rank of the second variable
+ * @return
+ */
+double CovAniso::getSlope(int ivar, int jvar) const
+{
+  if (hasRange() == 0) return TEST;
+  double range = getRange(0);
+  return _sillCur.getValue(ivar, jvar) / range;
+}
+
+/**
+ * Calculate the Integral Range in various Space Dimension (1, 2 or 3)
+ * @return
+ */
+double CovAniso::getIntegralRange(int ndisc, double hmax) const
+{
+  return _sillCur.getValue(0, 0) * getCorAniso()->getIntegralRange(ndisc, hmax);
+}
+
+CovAniso* CovAniso::createIsotropic(const CovContext& ctxt,
+                                    const ECov& type,
+                                    double range,
+                                    double sill,
+                                    double param,
+                                    bool flagRange)
+{
+  if (ctxt.getNVar() != 1)
   {
-    return _sillCur.getValue(0, 0) * getCorAniso()->getIntegralRange(ndisc, hmax);
+    messerr("This function is dedicated to the Monovariate case");
+    return nullptr;
   }
+  return new CovAniso(type, range, param, sill, ctxt, flagRange);
+}
 
-  CovAniso* CovAniso::createIsotropic(const CovContext& ctxt,
+CovAniso* CovAniso::createAnisotropic(const CovContext& ctxt,
                                       const ECov& type,
-                                      double range,
+                                      const VectorDouble& ranges,
                                       double sill,
                                       double param,
+                                      const VectorDouble& angles,
                                       bool flagRange)
+{
+  if (ctxt.getNVar() != 1)
   {
-    if (ctxt.getNVar() != 1)
-    {
-      messerr("This function is dedicated to the Monovariate case");
-      return nullptr;
-    }
-    return new CovAniso(type, range, param, sill, ctxt, flagRange);
+    messerr("This function is dedicated to the Monovariate case");
+    return nullptr;
+  }
+  int ndim = (int)ranges.size();
+  if ((int)ctxt.getNDim() != ndim)
+  {
+    messerr("Mismatch in Space Dimension between 'ranges'(%d) and 'ctxt'(%d)",
+            ndim, ctxt.getNDim());
+    return nullptr;
   }
 
-  CovAniso* CovAniso::createAnisotropic(const CovContext& ctxt,
-                                        const ECov& type,
-                                        const VectorDouble& ranges,
-                                        double sill,
-                                        double param,
-                                        const VectorDouble& angles,
-                                        bool flagRange)
-  {
-    if (ctxt.getNVar() != 1)
-    {
-      messerr("This function is dedicated to the Monovariate case");
-      return nullptr;
-    }
-    int ndim = (int)ranges.size();
-    if ((int)ctxt.getNDim() != ndim)
-    {
-      messerr("Mismatch in Space Dimension between 'ranges'(%d) and 'ctxt'(%d)",
-              ndim, ctxt.getNDim());
-      return nullptr;
-    }
+  CovAniso* cov = new CovAniso(type, ctxt);
+  if (flagRange)
+    cov->setRanges(ranges);
+  else
+    cov->setScales(ranges);
+  cov->setSill(sill);
+  cov->setParam(param);
+  if (!angles.empty()) cov->setAnisoAngles(angles);
+  return cov;
+}
 
-    CovAniso* cov = new CovAniso(type, ctxt);
+CovAniso* CovAniso::createIsotropicMulti(const CovContext& ctxt,
+                                         const ECov& type,
+                                         double range,
+                                         const MatrixSymmetric& sills,
+                                         double param,
+                                         bool flagRange)
+{
+  CovAniso* cov = new CovAniso(type, ctxt);
+  int nvar      = sills.getNSize();
+  if (ctxt.getNVar() != nvar)
+  {
+    messerr(
+      "Mismatch in the number of variables between 'sills'(%d) and 'ctxt'(%d)",
+      nvar, ctxt.getNVar());
+    return nullptr;
+  }
+  if (flagRange)
+    cov->setRangeIsotropic(range);
+  else
+    cov->setScale(range);
+  cov->setSill(sills);
+  cov->setParam(param);
+  return cov;
+}
+
+CovAniso* CovAniso::createAnisotropicMulti(const CovContext& ctxt,
+                                           const ECov& type,
+                                           const VectorDouble& ranges,
+                                           const MatrixSymmetric& sills,
+                                           double param,
+                                           const VectorDouble& angles,
+                                           bool flagRange)
+{
+
+  int nvar = sills.getNSize();
+  if (ctxt.getNVar() != nvar)
+  {
+    messerr(
+      "Mismatch in the number of variables between 'sills'(%d) and 'ctxt'(%d)",
+      nvar, ctxt.getNVar());
+    return nullptr;
+  }
+  int ndim = (int)ranges.size();
+  if ((int)ctxt.getNDim() != ndim)
+  {
+    messerr("Mismatch in Space Dimension between 'ranges'(%d) and 'ctxt'(%d)",
+            ndim, ctxt.getNDim());
+    return nullptr;
+  }
+
+  CovAniso* cov = new CovAniso(type, ctxt);
+  if (flagRange)
+    cov->setRanges(ranges);
+  else
+    cov->setScales(ranges);
+  cov->setSill(sills);
+  cov->setParam(param);
+  if (!angles.empty()) cov->setAnisoAngles(angles);
+  return cov;
+}
+
+CovAniso* CovAniso::createFromParam(const ECov& type,
+                                    double range,
+                                    double sill,
+                                    double param,
+                                    const VectorDouble& ranges,
+                                    const MatrixSymmetric& sills,
+                                    const VectorDouble& angles,
+                                    const ASpaceSharedPtr& space,
+                                    bool flagRange)
+{
+  // Check consistency with parameters of the model
+
+  int ndim = 0;
+  if (!ranges.empty())
+  {
+    if (ndim > 0 && (int)ranges.size() != ndim)
+    {
+      messerr("Mismatch between the dimension of 'ranges' (%d)",
+              (int)ranges.size());
+      messerr("and the Space dimension stored in the Model (%d)", ndim);
+      messerr("Operation is cancelled");
+      return nullptr;
+    }
+    ndim = (int)ranges.size();
+  }
+  if (!angles.empty())
+  {
+    if (ndim > 0 && (int)angles.size() != ndim)
+    {
+      messerr("Mismatch between the dimension of 'angles' (%d)",
+              (int)angles.size());
+      messerr("and the Space dimension stored in the Model (%d)", ndim);
+      messerr("Operation is cancelled");
+      return nullptr;
+    }
+    ndim = (int)angles.size();
+  }
+  if (space != nullptr)
+  {
+    if (ndim > 0 && (int)space->getNDim() != ndim)
+    {
+      messerr("Mismatch between the space dimension in 'space' (%d)",
+              (int)space->getNDim());
+      messerr("and the Space dimension stored in the Model (%d)", ndim);
+      messerr("Operation is cancelled");
+      return nullptr;
+    }
+    ndim = (int)space->getNDim();
+  }
+  if (ndim <= 0)
+  {
+    messerr("You must define the SPace dimension");
+    return nullptr;
+  }
+
+  int nvar = 0;
+  if (!sills.empty())
+  {
+    if (nvar > 0 && nvar != sills.getNCols())
+    {
+      messerr("Mismatch between the number of rows 'sills' (%d)", sills.getNRows());
+      messerr("and the Number of variables stored in the Model (%d)", nvar);
+      messerr("Operation is cancelled");
+      return nullptr;
+    }
+    nvar = (int)sqrt((double)sills.size());
+  }
+  if (nvar <= 0) nvar = 1;
+
+  // Define the covariance
+
+  const CovContext& ctxt = CovContext(nvar, space);
+  CovAniso* cov          = new CovAniso(type, ctxt);
+
+  // Define the Third parameter
+  double parmax = cov->getParMax();
+  if (param > parmax) param = parmax;
+  cov->setParam(param);
+
+  // Define the range
+  if (!ranges.empty())
+  {
     if (flagRange)
       cov->setRanges(ranges);
     else
       cov->setScales(ranges);
-    cov->setSill(sill);
-    cov->setParam(param);
-    if (!angles.empty()) cov->setAnisoAngles(angles);
-    return cov;
   }
-
-  CovAniso* CovAniso::createIsotropicMulti(const CovContext& ctxt,
-                                           const ECov& type,
-                                           double range,
-                                           const MatrixSymmetric& sills,
-                                           double param,
-                                           bool flagRange)
+  else
   {
-    CovAniso* cov = new CovAniso(type, ctxt);
-    int nvar      = sills.getNSize();
-    if (ctxt.getNVar() != nvar)
-    {
-      messerr(
-        "Mismatch in the number of variables between 'sills'(%d) and 'ctxt'(%d)",
-        nvar, ctxt.getNVar());
-      return nullptr;
-    }
     if (flagRange)
       cov->setRangeIsotropic(range);
     else
       cov->setScale(range);
+  }
+
+  // Define the sill
+  if (!sills.empty())
     cov->setSill(sills);
-    cov->setParam(param);
-    return cov;
-  }
-
-  CovAniso* CovAniso::createAnisotropicMulti(const CovContext& ctxt,
-                                             const ECov& type,
-                                             const VectorDouble& ranges,
-                                             const MatrixSymmetric& sills,
-                                             double param,
-                                             const VectorDouble& angles,
-                                             bool flagRange)
+  else
   {
-
-    int nvar = sills.getNSize();
-    if (ctxt.getNVar() != nvar)
-    {
-      messerr(
-        "Mismatch in the number of variables between 'sills'(%d) and 'ctxt'(%d)",
-        nvar, ctxt.getNVar());
-      return nullptr;
-    }
-    int ndim = (int)ranges.size();
-    if ((int)ctxt.getNDim() != ndim)
-    {
-      messerr("Mismatch in Space Dimension between 'ranges'(%d) and 'ctxt'(%d)",
-              ndim, ctxt.getNDim());
-      return nullptr;
-    }
-
-    CovAniso* cov = new CovAniso(type, ctxt);
-    if (flagRange)
-      cov->setRanges(ranges);
-    else
-      cov->setScales(ranges);
-    cov->setSill(sills);
-    cov->setParam(param);
-    if (!angles.empty()) cov->setAnisoAngles(angles);
-    return cov;
-  }
-
-  CovAniso* CovAniso::createFromParam(const ECov& type,
-                                      double range,
-                                      double sill,
-                                      double param,
-                                      const VectorDouble& ranges,
-                                      const MatrixSymmetric& sills,
-                                      const VectorDouble& angles,
-                                      const ASpaceSharedPtr& space,
-                                      bool flagRange)
-  {
-    // Check consistency with parameters of the model
-
-    int ndim = 0;
-    if (!ranges.empty())
-    {
-      if (ndim > 0 && (int)ranges.size() != ndim)
-      {
-        messerr("Mismatch between the dimension of 'ranges' (%d)",
-                (int)ranges.size());
-        messerr("and the Space dimension stored in the Model (%d)", ndim);
-        messerr("Operation is cancelled");
-        return nullptr;
-      }
-      ndim = (int)ranges.size();
-    }
-    if (!angles.empty())
-    {
-      if (ndim > 0 && (int)angles.size() != ndim)
-      {
-        messerr("Mismatch between the dimension of 'angles' (%d)",
-                (int)angles.size());
-        messerr("and the Space dimension stored in the Model (%d)", ndim);
-        messerr("Operation is cancelled");
-        return nullptr;
-      }
-      ndim = (int)angles.size();
-    }
-    if (space != nullptr)
-    {
-      if (ndim > 0 && (int)space->getNDim() != ndim)
-      {
-        messerr("Mismatch between the space dimension in 'space' (%d)",
-                (int)space->getNDim());
-        messerr("and the Space dimension stored in the Model (%d)", ndim);
-        messerr("Operation is cancelled");
-        return nullptr;
-      }
-      ndim = (int)space->getNDim();
-    }
-    if (ndim <= 0)
-    {
-      messerr("You must define the SPace dimension");
-      return nullptr;
-    }
-
-    int nvar = 0;
-    if (!sills.empty())
-    {
-      if (nvar > 0 && nvar != sills.getNCols())
-      {
-        messerr("Mismatch between the number of rows 'sills' (%d)", sills.getNRows());
-        messerr("and the Number of variables stored in the Model (%d)", nvar);
-        messerr("Operation is cancelled");
-        return nullptr;
-      }
-      nvar = (int)sqrt((double)sills.size());
-    }
-    if (nvar <= 0) nvar = 1;
-
-    // Define the covariance
-
-    const CovContext& ctxt = CovContext(nvar, space);
-    CovAniso* cov          = new CovAniso(type, ctxt);
-
-    // Define the Third parameter
-    double parmax = cov->getParMax();
-    if (param > parmax) param = parmax;
-    cov->setParam(param);
-
-    // Define the range
-    if (!ranges.empty())
-    {
-      if (flagRange)
-        cov->setRanges(ranges);
-      else
-        cov->setScales(ranges);
-    }
+    if (nvar <= 1)
+      cov->setSill(sill);
     else
     {
-      if (flagRange)
-        cov->setRangeIsotropic(range);
-      else
-        cov->setScale(range);
+      MatrixSymmetric locsills(nvar);
+      locsills.setIdentity(sill);
+      cov->setSill(locsills);
     }
-
-    // Define the sill
-    if (!sills.empty())
-      cov->setSill(sills);
-    else
-    {
-      if (nvar <= 1)
-        cov->setSill(sill);
-      else
-      {
-        MatrixSymmetric locsills(nvar);
-        locsills.setIdentity(sill);
-        cov->setSill(locsills);
-      }
-    }
-
-    if (!angles.empty()) cov->setAnisoAngles(angles);
-    return cov;
   }
 
-  Array CovAniso::evalCovFFT(const VectorDouble& hmax,
-                             int N,
-                             int ivar,
-                             int jvar) const
+  if (!angles.empty()) cov->setAnisoAngles(angles);
+  return cov;
+}
+
+Array CovAniso::evalCovFFT(const VectorDouble& hmax,
+                           int N,
+                           int ivar,
+                           int jvar) const
+{
+  if (!hasSpectrumOnRn()) return Array();
+
+  std::function<double(const VectorDouble&)> funcSpectrum;
+  funcSpectrum = [this, ivar, jvar](const VectorDouble& freq)
   {
-    if (!hasSpectrumOnRn()) return Array();
+    return evalSpectrum(freq, ivar, jvar) * getDetTensor();
+  };
+  return evalCovFFTSpatial(hmax, N, funcSpectrum);
+}
 
-    std::function<double(const VectorDouble&)> funcSpectrum;
-    funcSpectrum = [this, ivar, jvar](const VectorDouble& freq)
-    {
-      return evalSpectrum(freq, ivar, jvar) * getDetTensor();
-    };
-    return evalCovFFTSpatial(hmax, N, funcSpectrum);
-  }
+const CorAniso* CovAniso::getCorAniso() const
+{
+  return dynamic_cast<const CorAniso*>(getCor());
+}
 
-  const CorAniso* CovAniso::getCorAniso() const
-  {
-    return dynamic_cast<const CorAniso*>(getCor());
-  }
-  
-  CovAniso* CovAniso::createReduce(const VectorInt& validVars) const
-  {
-    CovAniso* newCovAniso = this->clone();
+CovAniso* CovAniso::createReduce(const VectorInt& validVars) const
+{
+  CovAniso* newCovAniso = this->clone();
 
-    // Modify the CovContext
-    int nvar        = (int)validVars.size();
-    CovContext ctxt = CovContext(nvar);
+  // Modify the CovContext
+  int nvar        = (int)validVars.size();
+  CovContext ctxt = CovContext(nvar);
 
-    // Modify the Matrix of sills
-    newCovAniso->setContext(ctxt);
-    MatrixSymmetric* newsill = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&_sillCur, validVars, validVars));
-    newCovAniso->setSill(*newsill);
-    return newCovAniso;
-  }
+  // Modify the Matrix of sills
+  newCovAniso->setContext(ctxt);
+  MatrixSymmetric* newsill = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&_sillCur, validVars, validVars));
+  newCovAniso->setSill(*newsill);
+  return newCovAniso;
+}
 
-  double scale2range(const ECov& type, double scale, double param)
-  {
-    CovContext ctxt = CovContext(1, 1);
-    ACovFunc* cova  = CovFactory::createCovFunc(type, ctxt);
-    cova->setParam(param);
-    double scadef = cova->getScadef();
-    return scale * scadef;
-  }
+double scale2range(const ECov& type, double scale, double param)
+{
+  CovContext ctxt = CovContext(1, 1);
+  ACovFunc* cova  = CovFactory::createCovFunc(type, ctxt);
+  cova->setParam(param);
+  double scadef = cova->getScadef();
+  return scale * scadef;
+}
 
-  double range2scale(const ECov& type, double range, double param)
-  {
-    CovContext ctxt = CovContext(1, 1);
-    ACovFunc* cova  = CovFactory::createCovFunc(type, ctxt);
-    cova->setParam(param);
-    double scadef = cova->getScadef();
-    return range / scadef;
-  }
+double range2scale(const ECov& type, double range, double param)
+{
+  CovContext ctxt = CovContext(1, 1);
+  ACovFunc* cova  = CovFactory::createCovFunc(type, ctxt);
+  cova->setParam(param);
+  double scadef = cova->getScadef();
+  return range / scadef;
+}
 } // namespace gstlrn

--- a/src/Covariances/CovAnisoList.cpp
+++ b/src/Covariances/CovAnisoList.cpp
@@ -27,8 +27,8 @@
 #include "Space/ASpace.hpp"
 #include "geoslib_define.h"
 
+#include <cmath>
 #include <cstddef>
-#include <math.h>
 #include <vector>
 
 namespace gstlrn
@@ -600,4 +600,4 @@ void CovAnisoList::appendParams(ListParams& listParams,
     }
   }
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovBesselJ.cpp
+++ b/src/Covariances/CovBesselJ.cpp
@@ -13,7 +13,7 @@
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #define MAXTAB 100
 
@@ -73,4 +73,4 @@ double CovBesselJ::simulateTurningBand(double t0, TurningBandOperate& operTB) co
 {
   return operTB.cosineOne(t0);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovCauchy.cpp
+++ b/src/Covariances/CovCauchy.cpp
@@ -11,7 +11,7 @@
 #include "Covariances/CovCauchy.hpp"
 #include "Covariances/CovContext.hpp"
 
-#include "math.h"
+#include <cmath>
 
 namespace gstlrn
 {
@@ -54,4 +54,4 @@ String CovCauchy::getFormula() const
 {
   return "C(h)=\\frac{1}{\\left( 1+ \\frac{h^2}{a_t^2} \\right)^\\alpha";
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovCosExp.cpp
+++ b/src/Covariances/CovCosExp.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Covariances/CovCosExp.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -52,4 +53,4 @@ double CovCosExp::_evaluateCov(double h) const
   cov *= cos(2. * GV_PI * h2);
   return (cov);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovCosinus.cpp
+++ b/src/Covariances/CovCosinus.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Covariances/CovCosinus.hpp"
 #include "Covariances/CovContext.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -42,4 +43,4 @@ double CovCosinus::_evaluateCov(double h) const
   double cov = cos(2. * GV_PI * h);
   return (cov);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovExponential.cpp
+++ b/src/Covariances/CovExponential.cpp
@@ -14,7 +14,8 @@
 #include "Covariances/CovContext.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -94,4 +95,4 @@ VectorDouble CovExponential::_evaluateSpectrumOnSphere(int n, double scale) cons
 //   return (cov);
 // }
 
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGCspline.cpp
+++ b/src/Covariances/CovGCspline.cpp
@@ -11,7 +11,8 @@
 #include "Covariances/CovGCspline.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovGCspline2.cpp
+++ b/src/Covariances/CovGCspline2.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Covariances/CovGCspline2.hpp"
 #include "Covariances/CovContext.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -71,4 +72,4 @@ double CovGCspline2::_evaluateCovDerivative(int degree, double h) const
 
   return (cov);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGamma.cpp
+++ b/src/Covariances/CovGamma.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Covariances/CovGamma.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -57,4 +58,4 @@ String CovGamma::getFormula() const
 {
   return "C(h)=\\frac{1}{\\left( 1+ \\frac{h}{a_t} \\right)^\\alpha";
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGaussian.cpp
+++ b/src/Covariances/CovGaussian.cpp
@@ -13,7 +13,8 @@
 #include "Covariances/CovContext.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -100,4 +101,4 @@ MatrixDense CovGaussian::simulateSpectralOmega(int nb) const
       mat.setValue(irow, icol, law_gaussian());
   return mat;
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGeometric.cpp
+++ b/src/Covariances/CovGeometric.cpp
@@ -11,7 +11,8 @@
 #include "Covariances/CovGeometric.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -64,4 +65,4 @@ VectorDouble CovGeometric::_evaluateSpectrumOnSphere(int n, double scale) const
 
   return sp;
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGradientFunctional.cpp
+++ b/src/Covariances/CovGradientFunctional.cpp
@@ -12,7 +12,8 @@
 #include "Basic/VectorHelper.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Space/ASpace.hpp"
-#include <math.h>
+
+#include <cmath>
 
 #define TR(i, j) (Tr[3 * (i) + (j)])
 
@@ -203,4 +204,4 @@ void CovGradientFunctional::evalZAndGradients(const SpacePoint& p1,
     }
   }
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovGradientNumerical.cpp
+++ b/src/Covariances/CovGradientNumerical.cpp
@@ -12,7 +12,8 @@
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Covariances/CovFactory.hpp"
-#include <math.h>
+
+#include <cmath>
 
 #define TR(i, j) (Tr[(i) * 3 + (j)])
 

--- a/src/Covariances/CovLMCAnamorphosis.cpp
+++ b/src/Covariances/CovLMCAnamorphosis.cpp
@@ -21,7 +21,8 @@
 #include "Enum/ECalcMember.hpp"
 #include "Model/Model.hpp"
 #include "Space/ASpace.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovLMCConvolution.cpp
+++ b/src/Covariances/CovLMCConvolution.cpp
@@ -17,7 +17,8 @@
 #include "Matrix/MatrixDense.hpp"
 #include "Model/Model.hpp"
 #include "Space/ASpace.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -336,4 +337,4 @@ double CovLMCConvolution::_eval(const SpacePoint& p1,
   }
   return cov;
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovLMCTapering.cpp
+++ b/src/Covariances/CovLMCTapering.cpp
@@ -15,7 +15,8 @@
 #include "Enum/ETape.hpp"
 #include "Model/Model.hpp"
 #include "Space/ASpace.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -215,4 +216,4 @@ std::string_view CovLMCTapering::getName() const
 {
   return _tapeType.getDescr();
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovLinearSph.cpp
+++ b/src/Covariances/CovLinearSph.cpp
@@ -11,7 +11,8 @@
 #include "Covariances/CovLinearSph.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovList.cpp
+++ b/src/Covariances/CovList.cpp
@@ -26,7 +26,8 @@
 #include "Space/ASpace.hpp"
 #include "Space/SpacePoint.hpp"
 #include "geoslib_define.h"
-#include <math.h>
+
+#include <cmath>
 #include <memory>
 #include <vector>
 

--- a/src/Covariances/CovMarkov.cpp
+++ b/src/Covariances/CovMarkov.cpp
@@ -10,16 +10,17 @@
 /******************************************************************************/
 #include "Covariances/CovMarkov.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 #define MAXTAB 100
 
 namespace gstlrn
 {
-CovMarkov::CovMarkov(const CovContext &ctxt)
-    : ACovFunc(ECov::MARKOV, ctxt),
-      _markovCoeffs(),
-      _correc(1.)
+CovMarkov::CovMarkov(const CovContext& ctxt)
+  : ACovFunc(ECov::MARKOV, ctxt)
+  , _markovCoeffs()
+  , _correc(1.)
 {
   setParam(1);
   _markovCoeffs.push_back(1.);
@@ -104,6 +105,6 @@ double CovMarkov::evaluateSpectrum(double freq) const
   {
     s += _markovCoeffs[i] * pow(freq, i);
   }
-  return 1. /  s;
+  return 1. / s;
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovMatern.cpp
+++ b/src/Covariances/CovMatern.cpp
@@ -15,7 +15,8 @@
 #include "Covariances/CovContext.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "math.h"
+
+#include <cmath>
 
 #define MAXTAB 100
 namespace gstlrn

--- a/src/Covariances/CovPoisson.cpp
+++ b/src/Covariances/CovPoisson.cpp
@@ -13,7 +13,8 @@
 #include "Basic/MathFunc.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Covariances/CovContext.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovPower.cpp
+++ b/src/Covariances/CovPower.cpp
@@ -12,7 +12,8 @@
 #include "Basic/MathFunc.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovSincard.cpp
+++ b/src/Covariances/CovSincard.cpp
@@ -11,7 +11,8 @@
 #include "Covariances/CovSincard.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include "math.h"
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Covariances/CovStable.cpp
+++ b/src/Covariances/CovStable.cpp
@@ -11,7 +11,8 @@
 #include "Covariances/CovStable.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Simulation/TurningBandOperate.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -58,4 +59,4 @@ double CovStable::simulateTurningBand(double t0, TurningBandOperate& operTB) con
     return operTB.cosineOne(t0);
   return operTB.spectralOne(t0);
 }
-}
+} // namespace gstlrn

--- a/src/Covariances/CovStorkey.cpp
+++ b/src/Covariances/CovStorkey.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "Covariances/CovStorkey.hpp"
 #include "Covariances/CovContext.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -35,8 +35,9 @@
 #include "Stats/Classical.hpp"
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
-#include <math.h>
-#include <stdio.h>
+
+#include <cmath>
+#include <cstdio>
 #include <vector>
 
 namespace gstlrn
@@ -5890,4 +5891,4 @@ void Db::dumpGeometry(int iech, int jech) const
   VH::dump("- Angles (deg) = ", angles, false);
 }
 
-}
+} // namespace gstlrn

--- a/src/Db/DbGraphO.cpp
+++ b/src/Db/DbGraphO.cpp
@@ -18,7 +18,8 @@
 #include "Polygon/Polygons.hpp"
 #include "Stats/Classical.hpp"
 #include "geoslib_define.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -25,8 +25,9 @@
 #include "Space/SpaceTarget.hpp"
 #include "Stats/Classical.hpp"
 #include "geoslib_define.h"
+
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Db/DbLine.cpp
+++ b/src/Db/DbLine.cpp
@@ -24,7 +24,7 @@
 #include "Stats/Classical.hpp"
 #include "geoslib_define.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Db/PtrGeos.cpp
+++ b/src/Db/PtrGeos.cpp
@@ -12,8 +12,9 @@
 #include "Basic/AStringable.hpp"
 #include "Basic/String.hpp"
 #include "Basic/Utilities.hpp"
+
 #include <sstream>
-#include <string.h>
+#include <cstring>
 
 namespace gstlrn
 {

--- a/src/Estimation/CalcGlobal.cpp
+++ b/src/Estimation/CalcGlobal.cpp
@@ -17,7 +17,8 @@
 #include "Model/Model.hpp"
 #include "Neigh/NeighUnique.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Estimation/CalcKriging.cpp
+++ b/src/Estimation/CalcKriging.cpp
@@ -20,7 +20,8 @@
 #include "Model/Model.hpp"
 #include "Neigh/NeighBench.hpp"
 #include "Neigh/NeighUnique.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Estimation/CalcKrigingSimpleCase.cpp
+++ b/src/Estimation/CalcKrigingSimpleCase.cpp
@@ -18,7 +18,8 @@
 #include "Model/Model.hpp"
 #include "Neigh/ANeigh.hpp"
 #include "Neigh/NeighUnique.hpp"
-#include <math.h>
+
+#include <cmath>
 #include <omp.h>
 
 namespace gstlrn

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -35,7 +35,8 @@
 #include "Space/SpaceRN.hpp"
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 { 

--- a/src/Estimation/KrigingSystemSimpleCase.cpp
+++ b/src/Estimation/KrigingSystemSimpleCase.cpp
@@ -37,7 +37,8 @@
 #include "Space/SpaceRN.hpp"
 #include "geoslib_define.h"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 { 

--- a/src/Fractures/FracDesc.cpp
+++ b/src/Fractures/FracDesc.cpp
@@ -11,7 +11,8 @@
 #include "Fractures/FracDesc.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/Utilities.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Fractures/FracFault.cpp
+++ b/src/Fractures/FracFault.cpp
@@ -12,7 +12,9 @@
 #include "Basic/AStringable.hpp"
 #include "Basic/SerializeHDF5.hpp"
 #include "Basic/Utilities.hpp"
-#include <math.h>
+
+#include <cmath>
+
 namespace gstlrn
 {
 FracFault::FracFault(double coord, double orient)

--- a/src/Fractures/FracList.cpp
+++ b/src/Fractures/FracList.cpp
@@ -22,7 +22,8 @@
 #include "Fractures/FracFault.hpp"
 #include "Geometry/GeometryHelper.hpp"
 #include "Matrix/MatrixDense.hpp"
-#include <math.h>
+
+#include <cmath>
 
 #define FRACSEG(ifrac, i) (frac_segs[NBYFRAC * (ifrac) + (i)])
 #define WELL(iw, i)       (well[2 * (iw) + (i)])

--- a/src/Geometry/GeometryHelper.cpp
+++ b/src/Geometry/GeometryHelper.cpp
@@ -17,7 +17,8 @@
 #include "Matrix/MatrixSquare.hpp"
 #include "Space/ASpaceObject.hpp"
 #include "Space/SpaceSN.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {
@@ -1905,4 +1906,4 @@ VectorVectorDouble GeometryHelper::getEllipse(const VectorDouble& center,
   coords[1][count] = coords[1][0];
   return coords;
 }
-}
+} // namespace gstlrn

--- a/src/Gibbs/AGibbs.cpp
+++ b/src/Gibbs/AGibbs.cpp
@@ -16,7 +16,8 @@
 #include "Basic/VectorHelper.hpp"
 #include "Db/Db.hpp"
 #include "geoslib_define.h"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Gibbs/GibbsMMulti.cpp
+++ b/src/Gibbs/GibbsMMulti.cpp
@@ -18,7 +18,8 @@
 #include "Model/Model.hpp"
 #include <Eigen/Sparse>
 #include <Eigen/SparseCholesky>
-#include <math.h>
+
+#include <cmath>
 
 static bool storeSparse = true;
 

--- a/src/Gibbs/GibbsMulti.cpp
+++ b/src/Gibbs/GibbsMulti.cpp
@@ -17,7 +17,8 @@
 #include "Gibbs/AGibbs.hpp"
 #include "Model/Model.hpp"
 #include "geoslib_define.h"
-#include <math.h>
+
+#include <cmath>
 
 #define COVMAT(i, j) (covmat[(i) * neq + (j)])
 

--- a/src/Gibbs/GibbsMultiMono.cpp
+++ b/src/Gibbs/GibbsMultiMono.cpp
@@ -16,7 +16,8 @@
 #include "Db/Db.hpp"
 #include "Gibbs/AGibbs.hpp"
 #include "Model/Model.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Gibbs/GibbsUMulti.cpp
+++ b/src/Gibbs/GibbsUMulti.cpp
@@ -13,7 +13,8 @@
 #include "Db/Db.hpp"
 #include "Model/Model.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 #define COVMAT(i, j) (_covmat[(i) * neq + (j)])
 

--- a/src/Gibbs/GibbsUMultiMono.cpp
+++ b/src/Gibbs/GibbsUMultiMono.cpp
@@ -13,7 +13,8 @@
 #include "Db/Db.hpp"
 #include "Model/Model.hpp"
 #include "geoslib_old_f.h"
-#include <math.h>
+
+#include <cmath>
 
 #define COVMAT(ivar, i, j) (_covmat[ivar][(i) * nact + (j)])
 

--- a/src/Gibbs/GibbsUPropMono.cpp
+++ b/src/Gibbs/GibbsUPropMono.cpp
@@ -14,7 +14,8 @@
 #include "Db/Db.hpp"
 #include "Model/CovInternal.hpp"
 #include "Model/Model.hpp"
-#include <math.h>
+
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/LinearOp/AShiftOp.cpp
+++ b/src/LinearOp/AShiftOp.cpp
@@ -10,7 +10,8 @@
 /******************************************************************************/
 #include "LinearOp/AShiftOp.hpp"
 #include "Covariances/CovAniso.hpp"
-#include <math.h>
+
+#include <cmath>
 
 using namespace gstlrn;
 

--- a/src/LinearOp/HessianOp.cpp
+++ b/src/LinearOp/HessianOp.cpp
@@ -12,11 +12,9 @@
 #include "Basic/Utilities.hpp"
 #include "Basic/AException.hpp"
 #include "Basic/Law.hpp"
-
-#include "LinearOp/ALinearOp.hpp"
 #include "LinearOp/PrecisionOp.hpp"
 
-#include <math.h>
+#include <cmath>
 
 using namespace gstlrn;
 HessianOp::HessianOp()

--- a/src/LinearOp/OptimCostBinary.cpp
+++ b/src/LinearOp/OptimCostBinary.cpp
@@ -10,78 +10,78 @@
 /******************************************************************************/
 #include "LinearOp/LinearOpCGSolver.hpp"
 
-#include "LinearOp/OptimCostBinary.hpp"
+#include "Basic/AException.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/OptDbg.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "LinearOp/HessianOp.hpp"
 #include "LinearOp/IOptimCost.hpp"
+#include "LinearOp/OptimCostBinary.hpp"
 #include "LinearOp/PrecisionOp.hpp"
 #include "LinearOp/ProjMatrix.hpp"
-#include "Basic/Law.hpp"
-#include "Basic/Utilities.hpp"
-#include "Basic/AException.hpp"
-#include "Basic/OptDbg.hpp"
-#include "Basic/VectorHelper.hpp"
-#include <math.h>
 
-namespace gstlrn 
+#include <cmath>
+
+namespace gstlrn
 {
 OptimCostBinary::OptimCostBinary()
-    : IOptimCost(),
-      _isInitialized(false),
-      _flagSeismic(false),
-      _meanPropRaw(0.),
-      _meanPropGaus(0.),
-      _pMat(nullptr),
-      _projData(nullptr),
-      _projSeis(nullptr),
-      _propSeis(),
-      _varSeis(),
-      _grad(),
-      _workp(),
-      _workx(),
-      _workv(),
-      _lambdav(),
-      _works()
+  : IOptimCost()
+  , _isInitialized(false)
+  , _flagSeismic(false)
+  , _meanPropRaw(0.)
+  , _meanPropGaus(0.)
+  , _pMat(nullptr)
+  , _projData(nullptr)
+  , _projSeis(nullptr)
+  , _propSeis()
+  , _varSeis()
+  , _grad()
+  , _workp()
+  , _workx()
+  , _workv()
+  , _lambdav()
+  , _works()
 {
 }
 
-OptimCostBinary::OptimCostBinary(const OptimCostBinary &m)
-    : IOptimCost(),
-      _isInitialized(m._isInitialized),
-      _flagSeismic(m._flagSeismic),
-      _meanPropRaw(m._meanPropRaw),
-      _meanPropGaus(m._meanPropGaus),
-      _pMat(m._pMat),
-      _projData(m._projData),
-      _projSeis(m._projSeis),
-      _propSeis(m._propSeis),
-      _varSeis(m._varSeis),
-      _grad(),
-      _workp(),
-      _workx(),
-      _workv(),
-      _lambdav()
+OptimCostBinary::OptimCostBinary(const OptimCostBinary& m)
+  : IOptimCost()
+  , _isInitialized(m._isInitialized)
+  , _flagSeismic(m._flagSeismic)
+  , _meanPropRaw(m._meanPropRaw)
+  , _meanPropGaus(m._meanPropGaus)
+  , _pMat(m._pMat)
+  , _projData(m._projData)
+  , _projSeis(m._projSeis)
+  , _propSeis(m._propSeis)
+  , _varSeis(m._varSeis)
+  , _grad()
+  , _workp()
+  , _workx()
+  , _workv()
+  , _lambdav()
 {
-
 }
 
-OptimCostBinary& OptimCostBinary::operator = (const OptimCostBinary &m)
+OptimCostBinary& OptimCostBinary::operator=(const OptimCostBinary& m)
 {
   if (this != &m)
   {
     _isInitialized = m._isInitialized;
-    _flagSeismic = m._flagSeismic;
-    _meanPropRaw = m._meanPropRaw;
-    _meanPropGaus = m._meanPropGaus;
-    _pMat = m._pMat;
-    _projData = m._projData;
-    _projSeis = m._projSeis;
-    _propSeis = m._propSeis;
-    _varSeis = m._varSeis;
+    _flagSeismic   = m._flagSeismic;
+    _meanPropRaw   = m._meanPropRaw;
+    _meanPropGaus  = m._meanPropGaus;
+    _pMat          = m._pMat;
+    _projData      = m._projData;
+    _projSeis      = m._projSeis;
+    _propSeis      = m._propSeis;
+    _varSeis       = m._varSeis;
   }
   return *this;
 }
 
-OptimCostBinary::~OptimCostBinary() 
+OptimCostBinary::~OptimCostBinary()
 {
 }
 
@@ -108,14 +108,14 @@ void OptimCostBinary::reset(PrecisionOp* pmat,
   _projSeis = projseis;
   _propSeis = propseis;
   _varSeis  = varseis;
-  
+
   // Copy the memory chunks passed as arguments
   int nvertex = _projData->getNApex();
   int npoint  = _projData->getNPoint();
-  
+
   // Particular case of the Seismic
 
-  _flagSeismic = (projseis != (ProjMatrix *) NULL && projseis->getNPoint() > 0);
+  _flagSeismic = (projseis != (ProjMatrix*)NULL && projseis->getNPoint() > 0);
   if (_flagSeismic)
   {
     int nseis = _projSeis->getNPoint();
@@ -156,27 +156,27 @@ VectorDouble OptimCostBinary::minimize(VectorDouble& indic,
 {
   double normgrad, costv;
   bool flagContinue;
-  int  iter;
-  HessianOp *hess = nullptr;
+  int iter;
+  HessianOp* hess = nullptr;
   VectorDouble propfac;
   // Statistics on the input data (only for verbose option)
 
   if (verbose)
   {
-    message("Mean proportion (provided as input) = %lf\n",_meanPropRaw);
-    VH::dumpStats("Proportions calculated on Data",indic);
+    message("Mean proportion (provided as input) = %lf\n", _meanPropRaw);
+    VH::dumpStats("Proportions calculated on Data", indic);
   }
 
-  try 
+  try
   {
-    if (! _isInitialized) 
+    if (!_isInitialized)
       my_throw("'OptimCostBinary' must be initialized beforehand");
     int nvertex = _pMat->getSize();
 
     // Instantiate the Hessian
 
     hess = new HessianOp();
-    if (hess->init(_pMat, _projData, _projSeis, indic, _propSeis, _varSeis)) 
+    if (hess->init(_pMat, _projData, _projSeis, indic, _propSeis, _varSeis))
       my_throw("Problem in Hessian init() method");
 
     // Core allocation
@@ -185,22 +185,22 @@ VectorDouble OptimCostBinary::minimize(VectorDouble& indic,
     VectorDouble step(nvertex, 0.);
     propfac.resize(nvertex);
     propfac.fill(0.);
-  
+
     // Evaluate the reference cost value
 
-    costv = _evaluateCost(indic,propfac);
+    costv = _evaluateCost(indic, propfac);
 
     // Iterations to minimize the Cost function
 
-    iter = 0;
+    iter         = 0;
     flagContinue = true;
-    while(flagContinue)
+    while (flagContinue)
     {
       iter++;
-      _evaluateGrad(indic,propfac,&normgrad);
+      _evaluateGrad(indic, propfac, &normgrad);
       if (OptDbg::query(EDbg::CONVERGE))
         message("Iteration #%d (max=%d) - Cost=%lf - NormGrad=%lf (eps=%lg)\n",
-                iter,maxiter,costv,normgrad,eps);
+                iter, maxiter, costv, normgrad, eps);
 
       flagContinue = (normgrad > eps && iter < maxiter);
 
@@ -208,42 +208,42 @@ VectorDouble OptimCostBinary::minimize(VectorDouble& indic,
 
       hess->setLambda(propfac);
       LinearOpCGSolver<HessianOp> solver(hess);
-      solver.solve(_grad,step);
-      
+      solver.solve(_grad, step);
+
       bool flagSortie = false;
-      while (! flagSortie)
+      while (!flagSortie)
       {
-        for (int i=0; i<nvertex; i++) lambdat[i] = propfac[i] - step[i];
-        double costt = _evaluateCost(indic,lambdat);
+        for (int i = 0; i < nvertex; i++) lambdat[i] = propfac[i] - step[i];
+        double costt = _evaluateCost(indic, lambdat);
         if (costt < costv * 1.000001)
         {
           costv = costt;
-          for (int i=0; i<nvertex; i++) propfac[i] = lambdat[i];
+          for (int i = 0; i < nvertex; i++) propfac[i] = lambdat[i];
           flagSortie = true;
         }
-        for (int i=0; i<nvertex; i++) step[i] /= 2.;
+        for (int i = 0; i < nvertex; i++) step[i] /= 2.;
       }
     }
 
     // Final conversion from Gaussian to Proportion scale
 
-    for (int i=0; i<nvertex; i++)
+    for (int i = 0; i < nvertex; i++)
       propfac[i] = 1. - law_cdf_gaussian(propfac[i]);
 
     // Calculate the Proportion statistics (verbose option)
 
     if (verbose)
     {
-      VH::dumpStats("Calculated Proportions",propfac);
+      VH::dumpStats("Calculated Proportions", propfac);
     }
   }
-  catch(const std::string& str)
+  catch (const std::string& str)
   {
     // TODO : Check if std::exception can be used
     messerr("%s", str.c_str());
   }
 
-  delete(hess);
+  delete (hess);
   return propfac;
 }
 
@@ -264,9 +264,9 @@ void OptimCostBinary::calculateGradient(const VectorDouble& indic,
 {
   double normgrad;
 
-  _evaluateGrad(indic,lambda,&normgrad);
+  _evaluateGrad(indic, lambda, &normgrad);
 
-  for (int i=0; i<_projData->getNApex(); i++) out[i] = _grad[i];
+  for (int i = 0; i < _projData->getNApex(); i++) out[i] = _grad[i];
 }
 
 /*****************************************************************************/
@@ -276,19 +276,19 @@ void OptimCostBinary::calculateGradient(const VectorDouble& indic,
 *****************************************************************************/
 int OptimCostBinary::getNPoint() const
 {
-  if (! _isInitialized) 
+  if (!_isInitialized)
     my_throw("'OptimCostBinary' must be initialized beforehand");
   return _projData->getNPoint();
 }
 
 /*****************************************************************************/
 /*!
-**  Returns the Number of Meshing Vertices 
+**  Returns the Number of Meshing Vertices
 **
 *****************************************************************************/
 int OptimCostBinary::getNVertex() const
 {
-  if (! _isInitialized) 
+  if (!_isInitialized)
     my_throw("'OptimCostBinary' must be initialized beforehand");
   return _projData->getNApex();
 }
@@ -335,7 +335,7 @@ int OptimCostBinary::setMeanProportion(double meanprop)
 /*!
 **  Internal function to evaluate the Cost
 **
-** \param[in]  indic      Array containing the Facies indicators 
+** \param[in]  indic      Array containing the Facies indicators
 **                        (Dimension: npoint)
 ** \param[in]  lambda     Array of input values
 **
@@ -347,28 +347,28 @@ double OptimCostBinary::_evaluateCost(const VectorDouble& indic,
 
   // Contribution of the Data
 
-  _projData->mesh2point(lambda,_workp);
+  _projData->mesh2point(lambda, _workp);
 
   double sum_pos = 0.;
   double sum_neg = 0.;
-  for (int i=0; i<_projData->getNPoint(); i++)
+  for (int i = 0; i < _projData->getNPoint(); i++)
   {
     if (FFFF(indic[i])) continue;
     if (indic[i] > 0.)
       sum_pos -= log(1. - law_cdf_gaussian(_workp[i]));
     else
-      sum_neg -= log(     law_cdf_gaussian(_workp[i]));
+      sum_neg -= log(law_cdf_gaussian(_workp[i]));
   }
   result += sum_pos + sum_neg;
 
-  // Contribution of the spatial structure 
+  // Contribution of the spatial structure
 
-  for (int i=0; i<_projData->getNApex(); i++) 
+  for (int i = 0; i < _projData->getNApex(); i++)
     _lambdav[i] = lambda[i] - _meanPropGaus;
   _pMat->evalDirect(_lambdav, _workv);
 
   double sum_str = 0.;
-  for (int i=0; i<_projData->getNApex(); i++)
+  for (int i = 0; i < _projData->getNApex(); i++)
     sum_str += 0.5 * _lambdav[i] * _workv[i];
   result += sum_str;
 
@@ -379,7 +379,7 @@ double OptimCostBinary::_evaluateCost(const VectorDouble& indic,
     _contributeSeismic(lambda);
 
     double sum_seis = 0.;
-    for (int i=0; i<_projSeis->getNPoint(); i++) 
+    for (int i = 0; i < _projSeis->getNPoint(); i++)
       sum_seis += 0.5 * _works[i] * _varSeis[i] * _works[i];
 
     result += sum_seis;
@@ -406,35 +406,35 @@ void OptimCostBinary::_evaluateGrad(const VectorDouble& indic,
   // Contribution of the spatial structure
   // Array 'lambda' must be corrected from the contribution of the 'mean'
 
-  for (int i=0; i<_projData->getNApex(); i++) 
+  for (int i = 0; i < _projData->getNApex(); i++)
     _lambdav[i] = lambda[i] - _meanPropGaus;
-  _pMat->evalDirect(_lambdav,_grad);
+  _pMat->evalDirect(_lambdav, _grad);
 
   // Contribution of the Data
 
-  _projData->mesh2point(lambda,_workp);
-  for (int i=0; i<_projData->getNPoint(); i++)
+  _projData->mesh2point(lambda, _workp);
+  for (int i = 0; i < _projData->getNPoint(); i++)
   {
     if (FFFF(indic[i]))
-      _workp[i] = 0.;           // TODO: to be checked
+      _workp[i] = 0.; // TODO: to be checked
     else
-      _workp[i] = 
+      _workp[i] =
         law_df_gaussian(_workp[i]) / (indic[i] - law_cdf_gaussian(_workp[i]));
   }
   _projData->point2mesh(_workp, _workv);
-  for (int i=0; i<_projData->getNApex(); i++) _grad[i] += _workv[i];
-  
+  for (int i = 0; i < _projData->getNApex(); i++) _grad[i] += _workv[i];
+
   // Contribution of the Seismic
 
   if (_flagSeismic)
   {
     _contributeSeismicDerivative(lambda);
-    for (int i=0; i<_projData->getNApex(); i++) _grad[i] += _workv[i];
+    for (int i = 0; i < _projData->getNApex(); i++) _grad[i] += _workv[i];
   }
 
   // Evaluate the norm of the gradient
   (*normgrad) = 0.;
-  for (int i=0; i<_projData->getNApex(); i++)
+  for (int i = 0; i < _projData->getNApex(); i++)
     (*normgrad) += _grad[i] * _grad[i];
 }
 
@@ -447,10 +447,10 @@ void OptimCostBinary::_evaluateGrad(const VectorDouble& indic,
 *****************************************************************************/
 void OptimCostBinary::_contributeSeismic(const VectorDouble& lambda)
 {
-  for (int i=0; i<_projSeis->getNApex(); i++) 
+  for (int i = 0; i < _projSeis->getNApex(); i++)
     _workv[i] = law_cdf_gaussian(lambda[i]);
   _projSeis->mesh2point(_workv, _works);
-  for (int i=0; i<_projSeis->getNPoint(); i++) 
+  for (int i = 0; i < _projSeis->getNPoint(); i++)
     _works[i] -= _propSeis[i];
 }
 
@@ -465,10 +465,10 @@ void OptimCostBinary::_contributeSeismicDerivative(const VectorDouble& lambda)
 {
   _contributeSeismic(lambda);
 
-  for (int i=0; i<_projSeis->getNPoint(); i++)
+  for (int i = 0; i < _projSeis->getNPoint(); i++)
     _works[i] *= _varSeis[i];
   _projSeis->point2mesh(_works, _workv);
-  for (int i=0; i<_projSeis->getNApex(); i++) 
+  for (int i = 0; i < _projSeis->getNApex(); i++)
     _workv[i] *= law_df_gaussian(lambda[i]);
 }
-}
+} // namespace gstlrn

--- a/src/LinearOp/PrecisionOpMultiConditionalCs.cpp
+++ b/src/LinearOp/PrecisionOpMultiConditionalCs.cpp
@@ -12,19 +12,18 @@
 #include "LinearOp/PrecisionOpMatrix.hpp"
 
 #include "Basic/VectorHelper.hpp"
-#include "Matrix/MatrixSparse.hpp"
 #include "Matrix/MatrixFactory.hpp"
+#include "Matrix/MatrixSparse.hpp"
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 
 namespace gstlrn
 {
 PrecisionOpMultiConditionalCs::PrecisionOpMultiConditionalCs()
-    : _QpAtA(nullptr)
-    , _chol(nullptr)
+  : _QpAtA(nullptr)
+  , _chol(nullptr)
 {
-
 }
 
 PrecisionOpMultiConditionalCs::~PrecisionOpMultiConditionalCs()
@@ -64,7 +63,7 @@ double PrecisionOpMultiConditionalCs::computeLogDetOp(int nbsimu) const
 MatrixSparse* PrecisionOpMultiConditionalCs::_buildQmult() const
 {
   MatrixSparse* Qmult = nullptr;
-  int number = sizes();
+  int number          = sizes();
 
   if (number <= 0)
   {
@@ -81,14 +80,14 @@ MatrixSparse* PrecisionOpMultiConditionalCs::_buildQmult() const
   else
   {
     const PrecisionOpMatrix* pmat1 = dynamic_cast<const PrecisionOpMatrix*>(getMultiPrecisionOp(0));
-    const MatrixSparse* Qref = pmat1->getQ();
+    const MatrixSparse* Qref       = pmat1->getQ();
 
     for (int is = 1; is < number; is++)
     {
       const PrecisionOpMatrix* pmataux = dynamic_cast<const PrecisionOpMatrix*>(getMultiPrecisionOp(is));
       delete Qmult;
       Qmult = dynamic_cast<MatrixSparse*>(MatrixFactory::createGlue(Qref, pmataux->getQ(), true, true));
-      Qref = Qmult;
+      Qref  = Qmult;
     }
   }
   return Qmult;
@@ -97,7 +96,7 @@ MatrixSparse* PrecisionOpMultiConditionalCs::_buildQmult() const
 ProjMatrix* PrecisionOpMultiConditionalCs::_buildAmult() const
 {
   ProjMatrix* Pmult = nullptr;
-  int number = sizes();
+  int number        = sizes();
   if (number <= 0)
   {
     messerr("This method requires at least one registered projection matrix");
@@ -112,14 +111,14 @@ ProjMatrix* PrecisionOpMultiConditionalCs::_buildAmult() const
   }
   else
   {
-    MatrixSparse* mstemp = nullptr;
+    MatrixSparse* mstemp      = nullptr;
     const MatrixSparse* msref = dynamic_cast<const MatrixSparse*>(getProjMatrix(0));
     for (int is = 1; is < number; is++)
     {
       const MatrixSparse* msaux = dynamic_cast<const MatrixSparse*>(getProjMatrix(is));
       delete mstemp;
       mstemp = dynamic_cast<MatrixSparse*>(MatrixFactory::createGlue(msref, msaux, false, true));
-      msref = mstemp;
+      msref  = mstemp;
     }
     Pmult = new ProjMatrix(mstemp);
     delete mstemp;
@@ -142,7 +141,7 @@ int PrecisionOpMultiConditionalCs::_buildQpAtA()
   // Create the conditional multiple precision matrix 'Q'
   VectorDouble invsigma = VectorHelper::inverse(getAllVarianceData());
   MatrixSparse* AtAsVar = prodNormMat(Amult, invsigma, true);
-  _QpAtA = MatrixSparse::addMatMat(Qmult, AtAsVar, 1., 1.);
+  _QpAtA                = MatrixSparse::addMatMat(Qmult, AtAsVar, 1., 1.);
 
   // Free core allocated
   delete Amult;
@@ -152,8 +151,8 @@ int PrecisionOpMultiConditionalCs::_buildQpAtA()
   return 0;
 }
 
-void PrecisionOpMultiConditionalCs::evalInverse(const std::vector<std::vector<double>> &vecin,
-                                                std::vector<std::vector<double>> &vecout) const
+void PrecisionOpMultiConditionalCs::evalInverse(const std::vector<std::vector<double>>& vecin,
+                                                std::vector<std::vector<double>>& vecout) const
 {
   if (_chol == nullptr)
     _chol = new CholeskySparse(_QpAtA);
@@ -168,4 +167,4 @@ void PrecisionOpMultiConditionalCs::makeReady()
   // Perform Cholesky decomposition (if not already performed)
   _buildQpAtA();
 }
-}
+} // namespace gstlrn

--- a/src/LinearOp/ShiftOpMatrix.cpp
+++ b/src/LinearOp/ShiftOpMatrix.cpp
@@ -10,24 +10,24 @@
 /******************************************************************************/
 #include "LinearOp/ShiftOpMatrix.hpp"
 
-#include "Enum/EConsElem.hpp"
-#include "LinearOp/AShiftOp.hpp"
-#include "Matrix/MatrixSparse.hpp"
-#include "Matrix/MatrixSquare.hpp"
-#include "Matrix/MatrixDense.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
-#include "Matrix/MatrixFactory.hpp"
-#include "Matrix/NF_Triplet.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/AException.hpp"
+#include "Basic/AStringable.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Covariances/CovAniso.hpp"
+#include "Enum/EConsElem.hpp"
 #include "Geometry/GeometryHelper.hpp"
-#include "Space/SpaceSN.hpp"
+#include "LinearOp/AShiftOp.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixFactory.hpp"
+#include "Matrix/MatrixSparse.hpp"
+#include "Matrix/MatrixSquare.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
+#include "Matrix/NF_Triplet.hpp"
 #include "Space/ASpaceObject.hpp"
+#include "Space/SpaceSN.hpp"
 #include "geoslib_define.h"
 
-#include <math.h>
+#include <cmath>
 #include <memory>
 
 namespace gstlrn
@@ -99,7 +99,7 @@ ShiftOpMatrix::ShiftOpMatrix(const ShiftOpMatrix& shift)
   _reallocate(shift);
 }
 
-ShiftOpMatrix& ShiftOpMatrix::operator=(const ShiftOpMatrix &shift)
+ShiftOpMatrix& ShiftOpMatrix::operator=(const ShiftOpMatrix& shift)
 {
   if (this != &shift)
   {
@@ -114,19 +114,19 @@ ShiftOpMatrix::~ShiftOpMatrix()
   _reset();
 }
 
-ShiftOpMatrix* ShiftOpMatrix::create(const AMesh *amesh,
-                             const CovAniso *cova,
-                             const Db *dbout,
-                             bool verbose)
+ShiftOpMatrix* ShiftOpMatrix::create(const AMesh* amesh,
+                                     const CovAniso* cova,
+                                     const Db* dbout,
+                                     bool verbose)
 {
   return new ShiftOpMatrix(amesh, cova, dbout, verbose);
 }
 
-ShiftOpMatrix* ShiftOpMatrix::createFromSparse(const MatrixSparse *S,
-                                       const VectorDouble &TildeC,
-                                       const VectorDouble &Lambda,
-                                       const CovAniso *cova,
-                                       bool verbose)
+ShiftOpMatrix* ShiftOpMatrix::createFromSparse(const MatrixSparse* S,
+                                               const VectorDouble& TildeC,
+                                               const VectorDouble& Lambda,
+                                               const CovAniso* cova,
+                                               bool verbose)
 {
   return new ShiftOpMatrix(S, TildeC, Lambda, cova, verbose);
 }
@@ -141,12 +141,12 @@ ShiftOpMatrix* ShiftOpMatrix::createFromSparse(const MatrixSparse *S,
  * @return Error return code
  */
 int ShiftOpMatrix::initFromMesh(const AMesh* amesh,
-                            const CovAniso* cova,
-                            const Db* /*dbout*/,
-                            bool flagAdvection,
-                            bool verbose)
+                                const CovAniso* cova,
+                                const Db* /*dbout*/,
+                                bool flagAdvection,
+                                bool verbose)
 {
-  DECLARE_UNUSED(flagAdvection,verbose);
+  DECLARE_UNUSED(flagAdvection, verbose);
 
   // Initializations
 
@@ -177,15 +177,15 @@ int ShiftOpMatrix::initFromMesh(const AMesh* amesh,
     _buildLambda(amesh);
   }
 
-  catch(const AException& e)
+  catch (const AException& e)
   {
-    messerr("initFromMesh has failed: %s",e.what());
+    messerr("initFromMesh has failed: %s", e.what());
     _reset();
     return 1;
   }
-  catch(const std::exception& e)
+  catch (const std::exception& e)
   {
-    messerr("initFromMesh has failed: %s",e.what());
+    messerr("initFromMesh has failed: %s", e.what());
     _reset();
     return 1;
   }
@@ -201,9 +201,9 @@ int ShiftOpMatrix::initFromMesh(const AMesh* amesh,
  * @return Error return code
  */
 int ShiftOpMatrix::initGradFromMesh(const AMesh* amesh,
-                                const CovAniso* cova,
-                                bool verbose,
-                                double tol)
+                                    const CovAniso* cova,
+                                    bool verbose,
+                                    double tol)
 {
   // Initializations
   DECLARE_UNUSED(verbose)
@@ -221,15 +221,15 @@ int ShiftOpMatrix::initGradFromMesh(const AMesh* amesh,
       my_throw("Problem when buildLambdaGrad");
   }
 
-  catch(const AException& e)
+  catch (const AException& e)
   {
-    messerr("initGradFromMesh has failed: %s",e.what());
+    messerr("initGradFromMesh has failed: %s", e.what());
     _reset();
     return 1;
   }
-  catch(const std::exception& e)
+  catch (const std::exception& e)
   {
-    messerr("initGradFromMesh has failed: %s",e.what());
+    messerr("initGradFromMesh has failed: %s", e.what());
     _reset();
     return 1;
   }
@@ -268,18 +268,18 @@ int ShiftOpMatrix::initFromCS(const MatrixSparse* S,
 
     // Duplicate the Shift Operator sparse matrix
 
-    _S = S->clone();
+    _S       = S->clone();
     _napices = S->getNCols();
   }
 
-  catch(const AException& e)
+  catch (const AException& e)
   {
-    messerr("initFromCS has failed: %s",e.what());
+    messerr("initFromCS has failed: %s", e.what());
     return 1;
   }
-  catch(const std::exception& e)
+  catch (const std::exception& e)
   {
-    messerr("initFromCS has failed: %s",e.what());
+    messerr("initFromCS has failed: %s", e.what());
     return 1;
   }
   return 0;
@@ -299,8 +299,8 @@ int ShiftOpMatrix::initFromCS(const MatrixSparse* S,
  **
  *****************************************************************************/
 void ShiftOpMatrix::prodTildeC(const VectorDouble& x,
-                           VectorDouble& y,
-                           const EPowerPT& power) const
+                               VectorDouble& y,
+                               const EPowerPT& power) const
 {
   if (power == EPowerPT::ONE)
   {
@@ -340,34 +340,29 @@ void ShiftOpMatrix::normalizeLambdaBySills(const AMesh* mesh)
   if (_cova->isNoStatForVariance())
   {
     _cova->informMeshByApexForSills(mesh);
-    int number = (int) _Lambda.size();
-                       
-    
+    int number = (int)_Lambda.size();
+
     for (int imesh = 0; imesh < number; imesh++)
     {
-      _cova->updateCovByMesh(imesh,false);
-      double sill = _cova->getSill(0,0);
+      _cova->updateCovByMesh(imesh, false);
+      double sill      = _cova->getSill(0, 0);
       double invsillsq = 1. / sqrt(sill);
       _Lambda[imesh] *= invsillsq;
     }
   }
-  else 
+  else
   {
-    double invsillsq = 1. / sqrt(_getCovAniso()->getSill(0,0));
-    for (auto &e:_Lambda)
+    double invsillsq = 1. / sqrt(_getCovAniso()->getSill(0, 0));
+    for (auto& e: _Lambda)
     {
       e *= invsillsq;
     }
   }
 }
 
-
-
-
-
 void ShiftOpMatrix::prodLambdaOnSqrtTildeC(const VectorDouble& inv,
-                                     VectorDouble& outv,
-                                     double puis) const
+                                           VectorDouble& outv,
+                                           double puis) const
 {
   for (int i = 0; i < getSize(); i++)
     outv[i] = inv[i] * pow(_Lambda[i] / sqrt(_TildeC[i]), puis);
@@ -392,10 +387,10 @@ int ShiftOpMatrix::_addToDest(const constvect inv, vect outv) const
 int ShiftOpMatrix::_resetGrad()
 {
   if (_SGrad.empty()) return 1;
-  for (int i = 0; i < (int) _SGrad.size(); i++)
+  for (int i = 0; i < (int)_SGrad.size(); i++)
   {
-     delete _SGrad[i];
-     _SGrad[i] = nullptr;
+    delete _SGrad[i];
+    _SGrad[i] = nullptr;
   }
   return 0;
 }
@@ -409,18 +404,18 @@ void ShiftOpMatrix::_reset()
 
 void ShiftOpMatrix::_reallocate(const ShiftOpMatrix& shift)
 {
-  _TildeC = shift._TildeC;
-  _Lambda = shift._Lambda;
-  _S = shift._S->clone();
+  _TildeC             = shift._TildeC;
+  _Lambda             = shift._Lambda;
+  _S                  = shift._S->clone();
   _nCovAnisoGradParam = shift._nCovAnisoGradParam;
-  for (int i = 0; i < (int) _SGrad.size(); i++)
+  for (int i = 0; i < (int)_SGrad.size(); i++)
     _SGrad[i] = shift._SGrad[i]->clone();
-  for (int i = 0; i < (int) _LambdaGrad.size(); i++)
+  for (int i = 0; i < (int)_LambdaGrad.size(); i++)
     _LambdaGrad[i] = shift._LambdaGrad[i];
   _flagNoStatByHH = shift._flagNoStatByHH;
 
-  _cova = shift._cova;
-  _ndim = shift._ndim;
+  _cova    = shift._cova;
+  _ndim    = shift._ndim;
   _napices = shift._napices;
 }
 
@@ -428,14 +423,14 @@ MatrixSparse* ShiftOpMatrix::getTildeCGrad(int iapex, int igparam) const
 {
 
   if (_TildeCGrad.empty())
-    {
-      messerr("You must initialize the Gradients with 'initGradFromMesh' beforehand");
-      return nullptr;
-    }
-    int iad = getSGradAddress(iapex, igparam);
-    if (iad < 0) return nullptr;
+  {
+    messerr("You must initialize the Gradients with 'initGradFromMesh' beforehand");
+    return nullptr;
+  }
+  int iad = getSGradAddress(iapex, igparam);
+  if (iad < 0) return nullptr;
 
-    return _TildeCGrad[iad];
+  return _TildeCGrad[iad];
 }
 
 MatrixSparse* ShiftOpMatrix::getSGrad(int iapex, int igparam) const
@@ -456,23 +451,22 @@ MatrixSparse* ShiftOpMatrix::getSGrad(int iapex, int igparam) const
  * @param cova Local CovAniso structure (updated here)
  * @param imesh Rank of the active mesh
  */
-void ShiftOpMatrix::_updateCova(std::shared_ptr<CovAniso> &cova, int imesh)
+void ShiftOpMatrix::_updateCova(std::shared_ptr<CovAniso>& cova, int imesh)
 {
-  cova->updateCovByMesh(imesh,true);
-
+  cova->updateCovByMesh(imesh, true);
 }
 
 void ShiftOpMatrix::_updateHH(MatrixSymmetric& hh, int imesh)
 {
   DECLARE_UNUSED(imesh)
-  if (! _isNoStat()) return;
+  if (!_isNoStat()) return;
   int ndim = getNDim();
 
   for (int idim = 0; idim < ndim; idim++)
     for (int jdim = idim; jdim < ndim; jdim++)
     {
-      double value = 0.; //TODO repare
-    //  double value = nostat->getValue(EConsElem::TENSOR, 0, imesh, idim, jdim);
+      double value = 0.; // TODO repare
+      //  double value = nostat->getValue(EConsElem::TENSOR, 0, imesh, idim, jdim);
       hh.setValue(idim, jdim, value);
     }
 }
@@ -484,20 +478,19 @@ void ShiftOpMatrix::_updateHH(MatrixSymmetric& hh, int imesh)
  * @param hh Output Array
  * @param imesh Rank of the active mesh
  */
-void ShiftOpMatrix::_loadHHRegular(MatrixSymmetric &hh, int imesh)
+void ShiftOpMatrix::_loadHHRegular(MatrixSymmetric& hh, int imesh)
 {
   int ndim = getNDim();
   // Locally update the covariance for non-stationarity (if necessary)
   _updateCova(_getCovAniso(), imesh);
 
   // Calculate the current HH matrix (using local covariance parameters)
-  const MatrixSquare &rotmat = _getCovAniso()->getAnisoInvMat();
+  const MatrixSquare& rotmat = _getCovAniso()->getAnisoInvMat();
 
   VH::power(_diag, _getCovAniso()->getScales(), 2.);
   MatrixSymmetric temp(ndim);
   temp.setDiagonal(_diag);
   hh.normMatrix(rotmat, temp);
-
 }
 
 void ShiftOpMatrix::_loadHHVariety(MatrixSymmetric& hh, int imesh)
@@ -527,10 +520,10 @@ void ShiftOpMatrix::_loadHHVariety(MatrixSymmetric& hh, int imesh)
  * @details: - ndim:ngparam : rotation angles (=ndim or 1 in 2-D)
  */
 
-void ShiftOpMatrix::_loadHHGrad(const AMesh *amesh,
-                            MatrixSymmetric &hh,
-                            int igparam,
-                            int ipref)
+void ShiftOpMatrix::_loadHHGrad(const AMesh* amesh,
+                                MatrixSymmetric& hh,
+                                int igparam,
+                                int ipref)
 {
   int ndim = getNDim();
 
@@ -551,12 +544,11 @@ void ShiftOpMatrix::_loadHHGrad(const AMesh *amesh,
   {
     // Case where the derivation is performed on ranges and angles
 
-
     // Locally update the covariance for non-stationarity (if necessary)
 
     _updateCova(_getCovAniso(), ipref);
-    const MatrixSquare &rotmat = _getCovAniso()->getAnisoRotMat();
-    VectorDouble diag = VH::power(_getCovAniso()->getScales(), 2.);
+    const MatrixSquare& rotmat = _getCovAniso()->getAnisoRotMat();
+    VectorDouble diag          = VH::power(_getCovAniso()->getScales(), 2.);
 
     MatrixSymmetric temp(ndim);
     if (igparam < ndim)
@@ -569,12 +561,12 @@ void ShiftOpMatrix::_loadHHGrad(const AMesh *amesh,
     else
     {
       // Derivation with respect to the Angle 'igparam'-ndim
-      int ir = igparam - ndim;
-      auto covini = _getCovAniso();
+      int ir         = igparam - ndim;
+      auto covini    = _getCovAniso();
       auto covaderiv = cloneAndCast(covini);
       _updateCova(covaderiv, ipref);
       _getCovAniso()->setAnisoAngle(ir, covaderiv->getAnisoAngle(ir) + 90.);
-      const MatrixSquare &drotmat = covaderiv->getAnisoRotMat();
+      const MatrixSquare& drotmat = covaderiv->getAnisoRotMat();
 
       VH::divideConstant(diag, 180. / GV_PI); // Necessary as angles are provided in degrees. Factor 2 is for derivative
       temp.setDiagonal(diag);
@@ -586,20 +578,20 @@ void ShiftOpMatrix::_loadHHGrad(const AMesh *amesh,
   hh.prodScalar(1. / number);
 }
 
-double ShiftOpMatrix::_computeGradLogDetHH(const AMesh *amesh,
-                                       int igparam,
-                                       int ipref,
-                                       const MatrixSymmetric &invHH,
-                                       MatrixSymmetric &work,
-                                       MatrixSymmetric &work2)
+double ShiftOpMatrix::_computeGradLogDetHH(const AMesh* amesh,
+                                           int igparam,
+                                           int ipref,
+                                           const MatrixSymmetric& invHH,
+                                           MatrixSymmetric& work,
+                                           MatrixSymmetric& work2)
 {
-  int ndim = getNDim();
+  int ndim   = getNDim();
   int number = amesh->getNApexPerMesh();
 
   if (igparam < ndim)
   {
     _updateCova(_getCovAniso(), ipref);
-    const MatrixSquare &rotmat = _getCovAniso()->getAnisoRotMat();
+    const MatrixSquare& rotmat = _getCovAniso()->getAnisoRotMat();
     MatrixSymmetric temp(ndim);
     temp.setDiagonal(_getCovAniso()->getScales());
     for (int idim = 0; idim < ndim; idim++)
@@ -628,9 +620,9 @@ double ShiftOpMatrix::_computeGradLogDetHH(const AMesh *amesh,
  * @param amesh Pointer to the meshing
  * @param imesh Rank of the mesh
  */
-void ShiftOpMatrix::_loadHH(const AMesh *amesh,
-                        MatrixSymmetric &hh,
-                        int imesh)
+void ShiftOpMatrix::_loadHH(const AMesh* amesh,
+                            MatrixSymmetric& hh,
+                            int imesh)
 {
   if (_flagNoStatByHH)
   {
@@ -645,9 +637,9 @@ void ShiftOpMatrix::_loadHH(const AMesh *amesh,
   }
 }
 
-void ShiftOpMatrix::_loadAux(VectorDouble &tab, const EConsElem &type, int imesh)
+void ShiftOpMatrix::_loadAux(VectorDouble& tab, const EConsElem& type, int imesh)
 {
-  DECLARE_UNUSED(tab,type,imesh)
+  DECLARE_UNUSED(tab, type, imesh)
   // TODO Repare
   // if (! _isNoStat()) return;
   // if (tab.empty()) return;
@@ -662,12 +654,12 @@ void ShiftOpMatrix::_loadAux(VectorDouble &tab, const EConsElem &type, int imesh
   //     tab[i] = nostat->getValue(type, 0, imesh, i, -1);
 }
 
-int ShiftOpMatrix::_preparMatrices(const AMesh *amesh,
-                               int imesh,
-                               MatrixSquare& matu,
-                               MatrixDense& matw) const
+int ShiftOpMatrix::_preparMatrices(const AMesh* amesh,
+                                   int imesh,
+                                   MatrixSquare& matu,
+                                   MatrixDense& matw) const
 {
-  int ndim = _ndim;
+  int ndim    = _ndim;
   int ncorner = amesh->getNApexPerMesh();
 
   for (int icorn = 0; icorn < ncorner; icorn++)
@@ -691,7 +683,7 @@ int ShiftOpMatrix::_preparMatrices(const AMesh *amesh,
   return 0;
 }
 
-MatrixSparse* ShiftOpMatrix::_BuildTildeCGradfromMap(std::map< int, double> &tab) const
+MatrixSparse* ShiftOpMatrix::_BuildTildeCGradfromMap(std::map<int, double>& tab) const
 {
   std::map<int, double>::iterator it;
 
@@ -716,15 +708,15 @@ MatrixSparse* ShiftOpMatrix::_BuildTildeCGradfromMap(std::map< int, double> &tab
   return MatrixSparse::createFromTriplet(NF_T, getSize(), getSize(), -1);
 }
 
-int ShiftOpMatrix::_prepareMatricesSVariety(const AMesh *amesh,
-                                        int imesh,
-                                        VectorVectorDouble &coords,
-                                        MatrixDense& matM,
-                                        MatrixSymmetric &matMtM,
-                                        AMatrix &matP,
-                                        double *deter) const
+int ShiftOpMatrix::_prepareMatricesSVariety(const AMesh* amesh,
+                                            int imesh,
+                                            VectorVectorDouble& coords,
+                                            MatrixDense& matM,
+                                            MatrixSymmetric& matMtM,
+                                            AMatrix& matP,
+                                            double* deter) const
 {
-  int ndim = getNDim();
+  int ndim    = getNDim();
   int ncorner = amesh->getNApexPerMesh();
 
   amesh->getEmbeddedCoordinatesPerMeshInPlace(imesh, coords);
@@ -757,13 +749,13 @@ int ShiftOpMatrix::_prepareMatricesSVariety(const AMesh *amesh,
   return 0;
 }
 
-int ShiftOpMatrix::_prepareMatricesSphere(const AMesh *amesh,
-                                      int imesh,
-                                      VectorVectorDouble &coords,
-                                      MatrixSquare &matMs,
-                                      double *deter) const
+int ShiftOpMatrix::_prepareMatricesSphere(const AMesh* amesh,
+                                          int imesh,
+                                          VectorVectorDouble& coords,
+                                          MatrixSquare& matMs,
+                                          double* deter) const
 {
-  int ndim = getNDim();
+  int ndim    = getNDim();
   int ncorner = amesh->getNApexPerMesh();
 
   amesh->getEmbeddedCoordinatesPerMeshInPlace(imesh, coords);
@@ -778,7 +770,7 @@ int ShiftOpMatrix::_prepareMatricesSphere(const AMesh *amesh,
   }
 
   double detM = matMs.determinant();
-  *deter = detM * detM;
+  *deter      = detM * detM;
   if (matMs.invert())
   {
     messerr("Problem for Mesh #%d", imesh + 1);
@@ -796,11 +788,11 @@ int ShiftOpMatrix::_prepareMatricesSphere(const AMesh *amesh,
  *
  * @remark TildeC is calculated at the same time
  */
-int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
+int ShiftOpMatrix::_buildS(const AMesh* amesh, double tol)
 {
   DECLARE_UNUSED(tol);
-  int error = 1;
-  int ndim = getNDim();
+  int error   = 1;
+  int ndim    = getNDim();
   int ncorner = amesh->getNApexPerMesh();
   int napices = amesh->getNApices();
   int nmeshes = amesh->getNMeshes();
@@ -812,25 +804,24 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
 
   VectorDouble srot(2);
   MatrixSymmetric hh(ndim);
-  MatrixSymmetric matMtM(ncorner-1);
-  MatrixDense matP(ncorner-1,ndim);
+  MatrixSymmetric matMtM(ncorner - 1);
+  MatrixDense matP(ncorner - 1, ndim);
   MatrixDense matM(ndim, ncorner - 1);
   MatrixSquare matMs(ndim);
-  MatrixSymmetric matPinvHPt(ncorner-1);
+  MatrixSymmetric matPinvHPt(ncorner - 1);
   VectorVectorDouble coords = amesh->getEmbeddedCoordinatesPerMesh();
-  double detMtM = 0.;
-  double dethh = 0.;
+  double detMtM             = 0.;
+  double dethh              = 0.;
 
   // Define the global matrices
-
 
   if (_isGlobalHH())
   {
     _loadHH(amesh, hh, 0);
     dethh = 1. / hh.determinant();
   }
-  
-  //TODO : repare shpere
+
+  // TODO : repare shpere
   /* if (! _isNoStat())
     _loadAux(srot, EConsElem::SPHEROT, 0); */
 
@@ -838,7 +829,7 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
   if (_S == nullptr) goto label_end;
 
   /* Loop on the active meshes */
-  
+
   for (int imesh = 0; imesh < nmeshes; imesh++)
   {
     OptDbg::setCurrentIndex(imesh + 1);
@@ -847,17 +838,17 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
 
     if (_cova->isNoStatForAnisotropy())
     {
-        _loadHH(amesh, hh, imesh);
-        dethh = 1. / hh.determinant();
+      _loadHH(amesh, hh, imesh);
+      dethh = 1. / hh.determinant();
     }
-     // if (nostat->isDefined(EConsElem::SPHEROT, -1, -1))
-     //   _loadAux(srot, EConsElem::SPHEROT, imesh);
+    // if (nostat->isDefined(EConsElem::SPHEROT, -1, -1))
+    //   _loadAux(srot, EConsElem::SPHEROT, imesh);
 
     // Prepare M matrix
 
     bool flagSphere = (amesh->getVariety() != 0);
-    flagSphere = false; // Modif DR a valider
-    if (! flagSphere)
+    flagSphere      = false; // Modif DR a valider
+    if (!flagSphere)
     {
       if (_prepareMatricesSVariety(amesh, imesh, coords, matM, matMtM, matP, &detMtM))
         my_throw("Matrix inversion");
@@ -873,16 +864,16 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
     // Storing in the Element of the Sparse Matrix
 
     double ratio = sqrt(dethh * detMtM);
-    double S = 0.;
-    for (int j0 = 0; j0 < ncorner-1; j0++)
+    double S     = 0.;
+    for (int j0 = 0; j0 < ncorner - 1; j0++)
     {
       int ip0 = amesh->getApex(imesh, j0);
       _TildeC[ip0] += ratio / 6.;
 
       double s = 0.;
-      for (int j1 = 0; j1 < ncorner-1; j1++)
+      for (int j1 = 0; j1 < ncorner - 1; j1++)
       {
-        int ip1 = amesh->getApex(imesh, j1);
+        int ip1     = amesh->getApex(imesh, j1);
         double vald = matPinvHPt.getValue(j0, j1) * ratio / 2.;
         s += vald;
         _S->addValue(ip0, ip1, vald);
@@ -905,7 +896,7 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
 
   error = 0;
 
-  label_end:
+label_end:
   if (error)
   {
     delete _S;
@@ -914,12 +905,12 @@ int ShiftOpMatrix::_buildS(const AMesh *amesh, double tol)
   return error;
 }
 
-MatrixSparse* ShiftOpMatrix::_prepareSparse(const AMesh *amesh)
+MatrixSparse* ShiftOpMatrix::_prepareSparse(const AMesh* amesh)
 {
   MatrixSparse* Sret = nullptr;
-  MatrixSparse* Sl = nullptr;
-  int nmeshes = amesh->getNMeshes();
-  int ncorner = amesh->getNApexPerMesh();
+  MatrixSparse* Sl   = nullptr;
+  int nmeshes        = amesh->getNMeshes();
+  int ncorner        = amesh->getNApexPerMesh();
 
   // Define Sl as the sparse matrix giving the clutter of apices among vertices
   NF_Triplet NF_T;
@@ -954,15 +945,15 @@ bool ShiftOpMatrix::_cond(int indref, int igparam, int ipref)
  * @param tol Tolerance beyond which elements are not stored in S matrix
  * @return Error return code
  */
-int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
+int ShiftOpMatrix::_buildSGrad(const AMesh* amesh, double tol)
 {
-  auto cova = _getCovAniso();
+  auto cova           = _getCovAniso();
   _nCovAnisoGradParam = cova->getNGradParam();
-  int number = _nCovAnisoGradParam * getSize();
-  VectorT<std::map<int, double> > tab(number);
-  std::vector<std::map<std::pair<int, int>, double> > Mtab(number);
+  int number          = _nCovAnisoGradParam * getSize();
+  VectorT<std::map<int, double>> tab(number);
+  std::vector<std::map<std::pair<int, int>, double>> Mtab(number);
 
-  int ndim = getNDim();
+  int ndim    = getNDim();
   int ncorner = amesh->getNApexPerMesh();
   int ngparam = _nCovAnisoGradParam;
 
@@ -973,14 +964,14 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
   MatrixSymmetric work2(ndim);
   MatrixSymmetric hhGrad(ndim);
   MatrixDense matM(ndim, ncorner - 1);
-  MatrixSymmetric matMtM(ncorner-1);
-  MatrixDense matP(ncorner-1,ndim);
+  MatrixSymmetric matMtM(ncorner - 1);
+  MatrixDense matP(ncorner - 1, ndim);
   MatrixSquare matMs(ndim);
-  MatrixSymmetric matPGradHPt(ncorner-1);
-  MatrixSymmetric matPHHPt(ncorner-1);
+  MatrixSymmetric matPGradHPt(ncorner - 1);
+  MatrixSymmetric matPHHPt(ncorner - 1);
 
-  double detMtM = 0.;
-  double dethh = 0.;
+  double detMtM       = 0.;
+  double dethh        = 0.;
   double gradLogDetHH = 0.;
   // Define the global matrices
 
@@ -998,8 +989,8 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
     if (_cova->isNoStatForAnisotropy())
       _loadHH(amesh, hh, imesh);
     bool flagSphere = (amesh->getVariety() == 1);
-    flagSphere = false; // Modif DR a valider
-    if (! flagSphere)
+    flagSphere      = false; // Modif DR a valider
+    if (!flagSphere)
     {
       if (_prepareMatricesSVariety(amesh, imesh, coords, matM, matMtM, matP, &detMtM))
         my_throw("Matrix inversion");
@@ -1023,12 +1014,12 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
       for (int jref = 0; jref < ncorner; jref++)
       {
         int ipref = amesh->getApex(imesh, jref);
-        int iad = getSGradAddress(ipref, igparam);
+        int iad   = getSGradAddress(ipref, igparam);
 
         // Update HH matrix
 
         _loadHHGrad(amesh, hhGrad, igparam, ipref);
-        gradLogDetHH = _computeGradLogDetHH(amesh,igparam,ipref,hh,work,work2);
+        gradLogDetHH = _computeGradLogDetHH(amesh, igparam, ipref, hh, work, work2);
 
         if (amesh->getVariety() == 0)
           matPGradHPt.normMatrix(matP, hhGrad, true);
@@ -1037,30 +1028,30 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
 
         // Storing in the Map
 
-        double ratio = sqrt(dethh * detMtM);
-        double dratio = - 0.5 * gradLogDetHH * ratio;
-        double S = 0.;
-        for (int j0 = 0; j0 < ncorner-1; j0++)
+        double ratio  = sqrt(dethh * detMtM);
+        double dratio = -0.5 * gradLogDetHH * ratio;
+        double S      = 0.;
+        for (int j0 = 0; j0 < ncorner - 1; j0++)
         {
           int ip0 = amesh->getApex(imesh, j0);
-          _mapTildeCUpdate(tab[iad],ip0,dratio / 6.);
+          _mapTildeCUpdate(tab[iad], ip0, dratio / 6.);
           double s = 0.;
-          for (int j1 = 0; j1 < ncorner-1; j1++)
+          for (int j1 = 0; j1 < ncorner - 1; j1++)
           {
-            int ip1 = amesh->getApex(imesh, j1);
-            double vald  = matPGradHPt.getValue(j0, j1)  / 2.;
-            double valdS = matPHHPt.getValue(j0, j1)  / 2.;
-            vald = ratio * vald + dratio * valdS;
+            int ip1      = amesh->getApex(imesh, j1);
+            double vald  = matPGradHPt.getValue(j0, j1) / 2.;
+            double valdS = matPHHPt.getValue(j0, j1) / 2.;
+            vald         = ratio * vald + dratio * valdS;
             s += vald;
             _mapGradUpdate(Mtab[iad], ip0, ip1, vald, tol);
           }
           int ip1 = amesh->getApex(imesh, ncorner - 1);
-          _mapGradUpdate(Mtab[iad],ip0, ip1, -s, tol);
-          _mapGradUpdate(Mtab[iad],ip1, ip0, -s, tol);
+          _mapGradUpdate(Mtab[iad], ip0, ip1, -s, tol);
+          _mapGradUpdate(Mtab[iad], ip1, ip0, -s, tol);
           S += s;
         }
         int ip0 = amesh->getApex(imesh, ncorner - 1);
-        _mapTildeCUpdate(tab[iad],ip0,dratio / 6.);
+        _mapTildeCUpdate(tab[iad], ip0, dratio / 6.);
         _mapGradUpdate(Mtab[iad], ip0, ip0, S, tol);
       }
     }
@@ -1079,15 +1070,15 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
     if (_TildeCGrad[i] == nullptr) return 1;
   }
 
-  VectorDouble sqrtTildeC = VH::power(_TildeC, 0.5);
+  VectorDouble sqrtTildeC    = VH::power(_TildeC, 0.5);
   VectorDouble invSqrtTildeC = VH::power(_TildeC, -0.5);
-  VectorDouble tempVec = VH::inverse(_TildeC);
+  VectorDouble tempVec       = VH::inverse(_TildeC);
   VH::multiplyConstant(tempVec, -0.5);
 
-  int ind = 0;
+  int ind                     = 0;
   MatrixSparse* tildeCGradMat = nullptr;
-  MatrixSparse* A = nullptr;
-  MatrixSparse* At = nullptr;
+  MatrixSparse* A             = nullptr;
+  MatrixSparse* At            = nullptr;
   for (int ipar = 0; ipar < _nCovAnisoGradParam; ipar++)
   {
     for (int iap = 0; iap < getSize(); iap++)
@@ -1098,7 +1089,7 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
       _SGrad[ind]->prodNormDiagVecInPlace(invSqrtTildeC, 1);
 
       tildeCGradMat = MatrixSparse::diagVec(tildeCGrad);
-      A = MatrixFactory::prodMatMat<MatrixSparse>(_S, tildeCGradMat);
+      A             = MatrixFactory::prodMatMat<MatrixSparse>(_S, tildeCGradMat);
       delete tildeCGradMat;
       At = A->transpose();
       A->addMatInPlace(*At);
@@ -1112,25 +1103,25 @@ int ShiftOpMatrix::_buildSGrad(const AMesh *amesh, double tol)
   return 0;
 }
 
-void ShiftOpMatrix::_mapTildeCUpdate(std::map<int, double> &tab,
-                                 int ip0,
-                                 double value,
-                                 double tol)
+void ShiftOpMatrix::_mapTildeCUpdate(std::map<int, double>& tab,
+                                     int ip0,
+                                     double value,
+                                     double tol)
 {
-  std::pair<std::map<int,double>::iterator, bool> ret;
+  std::pair<std::map<int, double>::iterator, bool> ret;
 
   if (ABS(value) < tol) return;
   ret = tab.insert(std::pair<int, double>(ip0, value));
   if (!ret.second) ret.first->second += value;
 }
 
-VectorT<std::map<int,double>> ShiftOpMatrix::_mapTildeCCreate()const
+VectorT<std::map<int, double>> ShiftOpMatrix::_mapTildeCCreate() const
 {
   int number = _ndim * getSize();
-  VectorT<std::map<int,double>> tab(number);
+  VectorT<std::map<int, double>> tab(number);
   for (int i = 0; i < number; i++)
   {
-    tab.push_back(std::map<int,double>());
+    tab.push_back(std::map<int, double>());
   }
   return tab;
 }
@@ -1159,11 +1150,11 @@ VectorT<VectorT<std::map<int, double>>> ShiftOpMatrix::_mapVectorCreate() const
  * Construct the _Lambda vector (Dimension: _napices)
  * @param amesh Description of the Mesh
  */
-void ShiftOpMatrix::_buildLambda(const AMesh *amesh)
+void ShiftOpMatrix::_buildLambda(const AMesh* amesh)
 {
-  int ndim = getNDim();
+  int ndim    = getNDim();
   int nvertex = amesh->getNApices();
-  //int nmeshes = amesh->getNMeshes();
+  // int nmeshes = amesh->getNMeshes();
   auto cova = _getCovAniso();
 
   /* Load global matrices */
@@ -1172,19 +1163,19 @@ void ShiftOpMatrix::_buildLambda(const AMesh *amesh)
   _Lambda.resize(nvertex, 0.);
 
   MatrixSymmetric hh(ndim);
-  //double param = cova->getParam();
+  // double param = cova->getParam();
   bool flagSphere = (amesh->getVariety() == 1);
 
   double correc = cova->getCorrec();
   double factor = 1.;
- if (flagSphere)
+  if (flagSphere)
   {
-    const ASpace *space = getDefaultSpaceSh().get();
-    const SpaceSN *spaceSn = dynamic_cast<const SpaceSN*>(space);
-    double r = 1.;
+    const ASpace* space    = getDefaultSpaceSh().get();
+    const SpaceSN* spaceSn = dynamic_cast<const SpaceSN*>(space);
+    double r               = 1.;
     if (spaceSn != nullptr) r = spaceSn->getRadius();
-    double normalizing = cova->normalizeOnSphere(50); //useful only for Markov
-    correc = pow(r, -2.) * normalizing;
+    double normalizing = cova->normalizeOnSphere(50); // useful only for Markov
+    correc             = pow(r, -2.) * normalizing;
     if (_isGlobalHH())
     {
       _loadHH(amesh, hh, 0);
@@ -1203,10 +1194,10 @@ void ShiftOpMatrix::_buildLambda(const AMesh *amesh)
  * @param amesh Description of the Mesh (New class)
  * @return
  */
-bool ShiftOpMatrix::_buildLambdaGrad(const AMesh *amesh)
+bool ShiftOpMatrix::_buildLambdaGrad(const AMesh* amesh)
 {
   int nvertex = amesh->getNApices();
-  auto cova = cloneAndCast(_cova);
+  auto cova   = cloneAndCast(_cova);
 
   /* Core allocation */
 
@@ -1215,7 +1206,7 @@ bool ShiftOpMatrix::_buildLambdaGrad(const AMesh *amesh)
   {
     _LambdaGrad.clear();
     VectorDouble temp(nvertex);
-    for(int i = 0; i< number; i++)
+    for (int i = 0; i < number; i++)
       _LambdaGrad.push_back(temp);
   }
 
@@ -1241,20 +1232,20 @@ bool ShiftOpMatrix::_buildLambdaGrad(const AMesh *amesh)
  * @param imesh Rank of the mesh of interest
  * @param coeff Coordinates of the projected vertices
  */
-void ShiftOpMatrix::_projectMesh(const AMesh *amesh,
-                             const VectorDouble& srot,
-                             int imesh,
-                             double coeff[3][2])
+void ShiftOpMatrix::_projectMesh(const AMesh* amesh,
+                                 const VectorDouble& srot,
+                                 int imesh,
+                                 double coeff[3][2])
 {
   double xyz[3][3];
 
   // Calculate the Mesh Center
 
   VectorDouble center(3, 0.);
-  for (int icorn = 0; icorn < (int) amesh->getNApexPerMesh(); icorn++)
+  for (int icorn = 0; icorn < (int)amesh->getNApexPerMesh(); icorn++)
   {
     GH::convertSph2Cart(amesh->getCoor(imesh, icorn, 0),
-                        amesh->getCoor(imesh, icorn, 1), 
+                        amesh->getCoor(imesh, icorn, 1),
                         &xyz[icorn][0], &xyz[icorn][1], &xyz[icorn][2]);
     for (int i = 0; i < 3; i++)
       center[i] += xyz[icorn][i];
@@ -1321,18 +1312,16 @@ double ShiftOpMatrix::getMaxEigenValue() const
   return getS()->L1Norm();
 }
 
-
 int ShiftOpMatrix::getLambdaGradSize() const
 {
   return _ndim;
 }
 
-
 void ShiftOpMatrix::_mapGradUpdate(std::map<std::pair<int, int>, double>& tab,
-                               int ip0,
-                               int ip1,
-                               double value,
-                               double tol)
+                                   int ip0,
+                                   int ip1,
+                                   double value,
+                                   double tol)
 {
   std::pair<std::map<std::pair<int, int>, double>::iterator, bool> ret;
 
@@ -1347,7 +1336,7 @@ void ShiftOpMatrix::_mapGradUpdate(std::map<std::pair<int, int>, double>& tab,
  * @param tab   Input Map
  * @return
  */
-MatrixSparse* ShiftOpMatrix::_BuildSGradfromMap(std::map<std::pair<int, int>, double> &tab) const
+MatrixSparse* ShiftOpMatrix::_BuildSGradfromMap(std::map<std::pair<int, int>, double>& tab) const
 {
   std::map<std::pair<int, int>, double>::iterator it;
 
@@ -1378,7 +1367,7 @@ MatrixSparse* ShiftOpMatrix::_BuildSGradfromMap(std::map<std::pair<int, int>, do
 void ShiftOpMatrix::_determineFlagNoStatByHH()
 {
   _flagNoStatByHH = false;
-  if (! _isNoStat()) return;
+  if (!_isNoStat()) return;
   _flagNoStatByHH = _cova->isNoStatForTensor();
 }
 
@@ -1387,6 +1376,6 @@ void ShiftOpMatrix::_determineFlagNoStatByHH()
 //   MatrixSparse* T1 = MatrixSparse::diagConstant(getSize(), 1.);
 //   if (T1 == nullptr) my_throw("Problem in cs_eye");
 //   _S->addMatInPlace(*T1, v1, v2);
-//   delete T1;  
+//   delete T1;
 // }
-}
+} // namespace gstlrn

--- a/src/LinearOp/TurboOptimizer.cpp
+++ b/src/LinearOp/TurboOptimizer.cpp
@@ -9,18 +9,18 @@
 /*                                                                            */
 /******************************************************************************/
 #include "LinearOp/TurboOptimizer.hpp"
+
 #include <algorithm>
-#include <iostream>
-#include <string>
-#include <math.h>
 #include <cmath>
 #include <iomanip>
+#include <iostream>
+#include <string>
 
 #define GETADR(nrows, irow, icol) ((icol) * (nrows) + (irow))
-#define U(i,j)   (uu[GETADR(TO_ncorner,i,j)])
-#define V(i,j)   (vv[GETADR(TO_ncorner,i,j)])
-#define H(i,j)   (hh[GETADR(TO_ndim,i,j)])
-#define W(i,j)   (ww[GETADR(TO_ndim,i,j)])
+#define U(i, j)                   (uu[GETADR(TO_ncorner, i, j)])
+#define V(i, j)                   (vv[GETADR(TO_ncorner, i, j)])
+#define H(i, j)                   (hh[GETADR(TO_ndim, i, j)])
+#define W(i, j)                   (ww[GETADR(TO_ndim, i, j)])
 
 namespace gstlrn
 {
@@ -56,7 +56,7 @@ TurboOptimizer::TurboOptimizer(int nx,
 {
 }
 
-TurboOptimizer::TurboOptimizer(const TurboOptimizer &tbo)
+TurboOptimizer::TurboOptimizer(const TurboOptimizer& tbo)
   : _isCalculated(tbo._isCalculated)
   , _nx(tbo._nx)
   , _ny(tbo._ny)
@@ -79,29 +79,29 @@ TurboOptimizer::TurboOptimizer(const TurboOptimizer &tbo)
 {
 }
 
-TurboOptimizer& TurboOptimizer::operator=(const TurboOptimizer &tbo)
+TurboOptimizer& TurboOptimizer::operator=(const TurboOptimizer& tbo)
 {
   if (this != &tbo)
   {
     _isCalculated = tbo._isCalculated;
-    _nx = tbo._nx;
-    _ny = tbo._ny;
-    _dx = tbo._dx;
-    _dy = tbo._dy;
-    _x0 = tbo._x0;
-    _y0 = tbo._y0;
-    _scale = tbo._scale;
-    _sill  = tbo._sill;
-    _param = tbo._param;
-    _poncif = tbo._poncif;
-    _center = tbo._center;
-    _nxred = tbo._nxred;
-    _half = tbo._half;
-    _flagOne = tbo._flagOne;
-    _TildeC_T = tbo._TildeC_T;
-    _Lambda_T = tbo._Lambda_T;
-    _S_T = tbo._S_T;
-    _Q_T = tbo._Q_T;
+    _nx           = tbo._nx;
+    _ny           = tbo._ny;
+    _dx           = tbo._dx;
+    _dy           = tbo._dy;
+    _x0           = tbo._x0;
+    _y0           = tbo._y0;
+    _scale        = tbo._scale;
+    _sill         = tbo._sill;
+    _param        = tbo._param;
+    _poncif       = tbo._poncif;
+    _center       = tbo._center;
+    _nxred        = tbo._nxred;
+    _half         = tbo._half;
+    _flagOne      = tbo._flagOne;
+    _TildeC_T     = tbo._TildeC_T;
+    _Lambda_T     = tbo._Lambda_T;
+    _S_T          = tbo._S_T;
+    _Q_T          = tbo._Q_T;
   }
   return *this;
 }
@@ -142,7 +142,7 @@ void TurboOptimizer::setGrid(int nx,
  */
 void TurboOptimizer::setModelByRange(double range, double sill, int param)
 {
-  _sill = sill;
+  _sill  = sill;
   _param = param;
   _scale = _rangeToScale(range); // Performed after setting 'param'
 }
@@ -156,7 +156,7 @@ void TurboOptimizer::setModelByRange(double range, double sill, int param)
 void TurboOptimizer::setModelByScale(double scale, double sill, int param)
 {
   _scale = scale;
-  _sill = sill;
+  _sill  = sill;
   _param = param;
 }
 
@@ -178,26 +178,26 @@ double TurboOptimizer::_rangeToScale(double range) const
 int TurboOptimizer::_getVertex(int imesh, int rank) const
 {
   VectorInt indice(2);
-  int node,icas;
-  _fromMeshToIndex(imesh,&node,&icas);
-  _rankToIndice(node,indice,false);
+  int node, icas;
+  _fromMeshToIndex(imesh, &node, &icas);
+  _rankToIndice(node, indice, false);
   for (int idim = 0; idim < TO_ndim; idim++)
     indice[idim] += _MSS(icas, rank, idim);
   return _indiceToRank(indice);
 }
 
-void TurboOptimizer::_fromMeshToIndex(int imesh, int *node, int *icas) const
+void TurboOptimizer::_fromMeshToIndex(int imesh, int* node, int* icas) const
 {
   VectorInt indice(2);
   int rank = imesh / TO_npercell;
-  _rankToIndice(rank,indice,true);
+  _rankToIndice(rank, indice, true);
   *icas = imesh - rank * TO_npercell;
   *node = _indiceToRank(indice);
 }
 
 int TurboOptimizer::_MSS(int icas, int icorn, int idim0)
 {
-  static int S2D[2][3][2] = {{{0,0}, {1,0}, {0,1}}, {{0,1}, {1,0}, {1,1}}};
+  static int S2D[2][3][2] = {{{0, 0}, {1, 0}, {0, 1}}, {{0, 1}, {1, 0}, {1, 1}}};
   return S2D[icas][icorn][idim0];
 }
 
@@ -205,7 +205,7 @@ void TurboOptimizer::_rankToIndice(int rank, VectorInt& indice, bool minusOne) c
 {
   if ((int)indice.size() < 2)
     my_throw("Argument indice should have the correct size");
-  int nval = minusOne? (_ny - 1) : _ny;
+  int nval  = minusOne ? (_ny - 1) : _ny;
   indice[1] = rank / nval;
   rank -= indice[1] * nval;
   indice[0] = rank;
@@ -231,7 +231,6 @@ double TurboOptimizer::_indiceToCoordinate(int idim0,
   return (_y0 + indice[1] * _dy);
 }
 
-
 double TurboOptimizer::_getCoor(int node, int idim0) const
 {
   VectorInt indice(TO_ndim);
@@ -242,8 +241,8 @@ double TurboOptimizer::_getCoor(int node, int idim0) const
 double TurboOptimizer::_getCoorByMesh(int imesh, int rank, int idim0) const
 {
   VectorInt indice(TO_ndim);
-  int node = _getVertex(imesh,rank);
-  return _getCoor(node,idim0);
+  int node = _getVertex(imesh, rank);
+  return _getCoor(node, idim0);
 }
 
 void TurboOptimizer::_printVector(const std::string& title,
@@ -251,7 +250,7 @@ void TurboOptimizer::_printVector(const std::string& title,
                                   int width,
                                   int ndec)
 {
-  int nval = static_cast<int> (uu.size());
+  int nval = static_cast<int>(uu.size());
   std::cout << title << std::endl;
   for (int i = 0; i < nval; i++)
   {
@@ -273,25 +272,25 @@ void TurboOptimizer::_printMatrix(const std::string& title,
                                   int ndec)
 {
   // Initializations
-  int nbatch = 1 + (ncol-1) / nper_batch;
+  int nbatch = 1 + (ncol - 1) / nper_batch;
 
   // Printout
   std::cout << title << std::endl;
   for (int ibatch = 0; ibatch < nbatch; ibatch++)
   {
     int ncol_min = ibatch * nper_batch;
-    int ncol_max = std::min((ibatch+1) * nper_batch, ncol);
+    int ncol_max = std::min((ibatch + 1) * nper_batch, ncol);
 
     std::cout << "     ";
     for (int icol = ncol_min; icol < ncol_max; icol++)
     {
-      std::cout << std::setw(width-2) << "[," << icol+col_shift+1 << "]";
+      std::cout << std::setw(width - 2) << "[," << icol + col_shift + 1 << "]";
     }
     std::cout << std::endl;
 
     for (int irow = 0; irow < nrow; irow++)
     {
-      std::cout << "[" << std::setw(3) << irow+row_shift+1 << ",]";
+      std::cout << "[" << std::setw(3) << irow + row_shift + 1 << ",]";
       for (int icol = ncol_min; icol < ncol_max; icol++)
       {
         std::cout << " ";
@@ -309,23 +308,23 @@ void TurboOptimizer::_invert_3x3(VectorDouble& uu,
                                  VectorDouble& vv,
                                  double tol)
 {
-  double det00 = U(1,1) * U(2,2) - U(2,1) * U(1,2);
-  double det01 = U(1,0) * U(2,2) - U(2,0) * U(1,2);
-  double det02 = U(1,0) * U(2,1) - U(2,0) * U(1,1);
-  double det   = U(0,0) * det00 - U(0,1) * det01 + U(0,2) * det02;
+  double det00 = U(1, 1) * U(2, 2) - U(2, 1) * U(1, 2);
+  double det01 = U(1, 0) * U(2, 2) - U(2, 0) * U(1, 2);
+  double det02 = U(1, 0) * U(2, 1) - U(2, 0) * U(1, 1);
+  double det   = U(0, 0) * det00 - U(0, 1) * det01 + U(0, 2) * det02;
   double toto  = ABS(det);
   if (toto < tol) my_throw("Matrix is not invertible");
   if (ABS(det) < tol) my_throw("Matrix is not invertible");
 
-  V(0,0) =  (U(1,1) * U(2,2) - U(2,1) * U(1,2)) / det;
-  V(0,1) = -(U(0,1) * U(2,2) - U(2,1) * U(0,2)) / det;
-  V(0,2) =  (U(0,1) * U(1,2) - U(1,1) * U(0,2)) / det;
-  V(1,0) = -(U(1,0) * U(2,2) - U(2,0) * U(1,2)) / det;
-  V(1,1) =  (U(0,0) * U(2,2) - U(2,0) * U(0,2)) / det;
-  V(1,2) = -(U(0,0) * U(1,2) - U(1,0) * U(0,2)) / det;
-  V(2,0) =  (U(1,0) * U(2,1) - U(2,0) * U(1,1)) / det;
-  V(2,1) = -(U(0,0) * U(2,1) - U(2,0) * U(0,1)) / det;
-  V(2,2) =  (U(0,0) * U(1,1) - U(1,0) * U(0,1)) / det;
+  V(0, 0) = (U(1, 1) * U(2, 2) - U(2, 1) * U(1, 2)) / det;
+  V(0, 1) = -(U(0, 1) * U(2, 2) - U(2, 1) * U(0, 2)) / det;
+  V(0, 2) = (U(0, 1) * U(1, 2) - U(1, 1) * U(0, 2)) / det;
+  V(1, 0) = -(U(1, 0) * U(2, 2) - U(2, 0) * U(1, 2)) / det;
+  V(1, 1) = (U(0, 0) * U(2, 2) - U(2, 0) * U(0, 2)) / det;
+  V(1, 2) = -(U(0, 0) * U(1, 2) - U(1, 0) * U(0, 2)) / det;
+  V(2, 0) = (U(1, 0) * U(2, 1) - U(2, 0) * U(1, 1)) / det;
+  V(2, 1) = -(U(0, 0) * U(2, 1) - U(2, 0) * U(0, 1)) / det;
+  V(2, 2) = (U(0, 0) * U(1, 1) - U(1, 0) * U(0, 1)) / det;
 }
 
 /**
@@ -345,15 +344,15 @@ void TurboOptimizer::_prodMatrix(int size,
     {
       double value = 0.;
       for (int k = 0; k < size; k++)
-        value += aa[GETADR(size,i,k)] * bb[GETADR(size,k,j)];
-      cc[GETADR(size,i,j)] = value;
+        value += aa[GETADR(size, i, k)] * bb[GETADR(size, k, j)];
+      cc[GETADR(size, i, j)] = value;
     }
 }
 
 void TurboOptimizer::_prodMatrixVector(int size,
-                                       const VectorDouble &aa,
-                                       const VectorDouble &bb,
-                                       VectorDouble &cc)
+                                       const VectorDouble& aa,
+                                       const VectorDouble& bb,
+                                       VectorDouble& cc)
 {
   for (int i = 0; i < size; i++)
   {
@@ -367,11 +366,11 @@ void TurboOptimizer::_prodMatrixVector(int size,
 VectorDouble TurboOptimizer::_buildS(const VectorDouble& TildeC) const
 {
   int nvertex_red = _getNVertices_red();
-  VectorDouble ss(nvertex_red*nvertex_red,0.);
-  VectorDouble hh(TO_ndim    * TO_ndim);
+  VectorDouble ss(nvertex_red * nvertex_red, 0.);
+  VectorDouble hh(TO_ndim * TO_ndim);
   VectorDouble uu(TO_ncorner * TO_ncorner);
   VectorDouble vv(TO_ncorner * TO_ncorner);
-  VectorDouble ww(TO_ndim    * TO_ncorner);
+  VectorDouble ww(TO_ndim * TO_ncorner);
 
   // Load the matrix HH which accounts for the Model
 
@@ -385,17 +384,17 @@ VectorDouble TurboOptimizer::_buildS(const VectorDouble& TildeC) const
     {
       // Filling the 3x3 matrix
       for (int idim = 0; idim < TO_ndim; idim++)
-        V(idim,icorn) = _getCoorByMesh(imesh, icorn, idim);
-      V(TO_ndim,icorn) = 1.;
+        V(idim, icorn) = _getCoorByMesh(imesh, icorn, idim);
+      V(TO_ndim, icorn) = 1.;
     }
 
     // Inverting matrix
     _invert_3x3(vv, uu);
 
-      // Transposing and compressing the matrix
+    // Transposing and compressing the matrix
     for (int icorn = 0; icorn < TO_ncorner; icorn++)
       for (int idim = 0; idim < TO_ndim; idim++)
-        W(idim,icorn) = U(icorn,idim);
+        W(idim, icorn) = U(icorn, idim);
 
     for (int irow = 0; irow < TO_ncorner; irow++)
       for (int icol = 0; icol < TO_ncorner; icol++)
@@ -403,18 +402,18 @@ VectorDouble TurboOptimizer::_buildS(const VectorDouble& TildeC) const
         double value = 0.;
         for (int k = 0; k < TO_ndim; k++)
           for (int l = 0; l < TO_ndim; l++)
-            value += W(k,irow) * H(k,l) * W(l,icol);
+            value += W(k, irow) * H(k, l) * W(l, icol);
 
         int ip1 = _getVertex(imesh, irow);
         int ip2 = _getVertex(imesh, icol);
-        ss[GETADR(nvertex_red,ip1,ip2)] += _getMeshSize() * value;
+        ss[GETADR(nvertex_red, ip1, ip2)] += _getMeshSize() * value;
       }
   }
 
   // Normalize S matrix by TildeC
   for (int ip = 0; ip < nvertex_red; ip++)
     for (int jp = 0; jp < nvertex_red; jp++)
-      ss[GETADR(nvertex_red,ip,jp)] /= sqrt(TildeC[ip] * TildeC[jp]);
+      ss[GETADR(nvertex_red, ip, jp)] /= sqrt(TildeC[ip] * TildeC[jp]);
 
   return ss;
 }
@@ -429,7 +428,7 @@ int TurboOptimizer::_determineInternalGrid(bool verbose)
 
   if (verbose)
   {
-    std::cout << "Internal Grid Determination"<< std::endl;
+    std::cout << "Internal Grid Determination" << std::endl;
     std::cout << "- Matérn parameter = " << _param << std::endl;
     std::cout << "- Dimension of Internal Square Grid = " << _nxred << std::endl;
   }
@@ -437,7 +436,7 @@ int TurboOptimizer::_determineInternalGrid(bool verbose)
   if (_nx < _nxred || _ny < _nxred)
   {
     std::cout << "The output grid must be larger than the internal one ("
-        << _nxred << ")" << std::endl;
+              << _nxred << ")" << std::endl;
     return 1;
   }
   return 0;
@@ -456,48 +455,48 @@ void TurboOptimizer::run(bool verbose)
 
   // Modify the Grid dimension to the Template one
   if (_determineInternalGrid(verbose)) my_throw("Incompatible Grid sizes");
-  _nx = _nxred;
-  _ny = _nxred;
+  _nx             = _nxred;
+  _ny             = _nxred;
   int nvertex_red = _getNVertices();
 
   if (verbose)
     std::cout << "Scale = " << _scale << std::endl;
 
   _Blin = _buildBlin();
-  if (verbose) _printVector("Template Blin Vector",_Blin);
+  if (verbose) _printVector("Template Blin Vector", _Blin);
 
   // Build TildeC template vector
   _TildeC_T = _buildTildeC();
-  if (verbose) _printVector("Template TildeC Vector",_TildeC_T);
+  if (verbose) _printVector("Template TildeC Vector", _TildeC_T);
 
   // Build Lambda template vector
   _Lambda_T = _buildLambda(_TildeC_T);
-  if (verbose) _printVector("Template Lambda Vector",_Lambda_T);
+  if (verbose) _printVector("Template Lambda Vector", _Lambda_T);
 
   // Build S template matrix
   _S_T = _buildS(_TildeC_T);
-  if (verbose) _printMatrix("Template S Matrix",nvertex_red,nvertex_red,_S_T,7);
+  if (verbose) _printMatrix("Template S Matrix", nvertex_red, nvertex_red, _S_T, 7);
 
   // Build Q matrix
   _Q_T = _buildQ(_S_T, _Blin, _Lambda_T);
-  if (verbose) _printMatrix("Template Q Matrix",nvertex_red,nvertex_red,_Q_T,6);
+  if (verbose) _printMatrix("Template Q Matrix", nvertex_red, nvertex_red, _Q_T, 6);
 
   // Restore the initial Grid dimensions
-  _nx = nx_memo;
-  _ny = ny_memo;
+  _nx           = nx_memo;
+  _ny           = ny_memo;
   _isCalculated = true;
 }
 
 VectorDouble TurboOptimizer::_buildTildeC() const
 {
   int nvertex = _getNVertices();
-  VectorDouble TildeC(nvertex,0.);
+  VectorDouble TildeC(nvertex, 0.);
 
   /* Loop on the meshes */
 
-  for (int imesh=0; imesh<_getNMeshes(); imesh++)
+  for (int imesh = 0; imesh < _getNMeshes(); imesh++)
   {
-    for (int icorn=0; icorn<TO_ncorner; icorn++)
+    for (int icorn = 0; icorn < TO_ncorner; icorn++)
     {
       int jp = _getVertex(imesh, icorn);
       TildeC[jp] += _getMeshSize();
@@ -506,7 +505,7 @@ VectorDouble TurboOptimizer::_buildTildeC() const
 
   /* Scaling */
 
-  for (int ip=0; ip<nvertex; ip++)
+  for (int ip = 0; ip < nvertex; ip++)
     TildeC[ip] /= TO_ncorner;
 
   return TildeC;
@@ -515,7 +514,7 @@ VectorDouble TurboOptimizer::_buildTildeC() const
 VectorDouble TurboOptimizer::_buildLambda(const VectorDouble& TildeC) const
 {
   int nvertex = _getNVertices();
-  VectorDouble Lambda(nvertex,0);
+  VectorDouble Lambda(nvertex, 0);
   double value = _scale * _scale;
   for (int ip = 0; ip < _getNVertices(); ip++)
     Lambda[ip] = sqrt(TildeC[ip] / (value * _sill));
@@ -528,19 +527,19 @@ VectorDouble TurboOptimizer::_buildBlin() const
   double PI = 3.14159265358979323846;
   double v1, v2;
 
-  int ndims2 = static_cast<int> (TO_ndim / 2.);
-  int p = _param + ndims2;
+  int ndims2 = static_cast<int>(TO_ndim / 2.);
+  int p      = _param + ndims2;
 
   double gammap = 0.;
   for (int i = 1; i < _param; i++)
-    gammap += log((double) i);
-  gammap = exp(gammap);
+    gammap += log((double)i);
+  gammap        = exp(gammap);
   double gammaa = 0.;
-  for (int i = 1; i< _param + ndims2; i++)
-    gammaa += log((double) i);
+  for (int i = 1; i < _param + ndims2; i++)
+    gammaa += log((double)i);
   gammaa = exp(gammaa);
 
-  double g0 = pow(4. * PI, ndims2);
+  double g0     = pow(4. * PI, ndims2);
   double correc = gammap / (g0 * gammaa);
 
   VectorDouble blin(p + 1, 0.);
@@ -554,7 +553,7 @@ VectorDouble TurboOptimizer::_buildBlin() const
       v2 += log(j + 1);
     }
     double cnp = exp(v1 - v2);
-    blin[i] = cnp * correc;
+    blin[i]    = cnp * correc;
   }
   return blin;
 }
@@ -564,7 +563,7 @@ VectorDouble TurboOptimizer::_buildQ(const VectorDouble& ss,
                                      const VectorDouble& lambda) const
 {
   int nvertex = _getNVertices();
-  int nblin = static_cast<int> (blin.size());
+  int nblin   = static_cast<int>(blin.size());
   VectorDouble qq(nvertex * nvertex, 0.);
   VectorDouble bi(nvertex * nvertex, 0.);
   VectorDouble be(nvertex * nvertex, 0.);
@@ -598,10 +597,10 @@ VectorDouble TurboOptimizer::_buildQ(const VectorDouble& ss,
 void TurboOptimizer::_loadHH(VectorDouble& hh) const
 {
   double value = _scale * _scale;
-  H(0,0) = value;
-  H(0,1) = 0.;
-  H(1,0) = 0.;
-  H(1,1) = value;
+  H(0, 0)      = value;
+  H(0, 1)      = 0.;
+  H(1, 0)      = 0.;
+  H(1, 1)      = value;
 }
 
 /**
@@ -617,9 +616,9 @@ void TurboOptimizer::printClass() const
   std::cout << "X0 = " << _x0 << std::endl;
   std::cout << "Y0 = " << _y0 << std::endl;
   std::cout << std::endl;
-  std::cout << "Model Definition"   << std::endl;
+  std::cout << "Model Definition" << std::endl;
   std::cout << "Scale = " << _scale << std::endl;
-  std::cout << "Sill  = " << _sill  << std::endl;
+  std::cout << "Sill  = " << _sill << std::endl;
   std::cout << "Param = " << _param << std::endl;
   std::cout << "Triplet Numbering starting value = " << _flagOne << std::endl;
 }
@@ -629,23 +628,23 @@ void TurboOptimizer::printClass() const
  */
 void TurboOptimizer::printMeshes() const
 {
-  std::cout << "Number of Meshes   '       = " << _getNMeshes()     << std::endl;
-  std::cout << "Number of Corners per Mesh = " << TO_ncorner      << std::endl;
+  std::cout << "Number of Meshes   '       = " << _getNMeshes() << std::endl;
+  std::cout << "Number of Corners per Mesh = " << TO_ncorner << std::endl;
   std::cout << "Number of Vertices         = " << _getNVertices() << std::endl;
-  std::cout << "Number of Coordinates      = " << TO_ndim         << std::endl;
+  std::cout << "Number of Coordinates      = " << TO_ndim << std::endl;
 
   for (int imesh = 0; imesh < _getNMeshes(); imesh++)
   {
-    std::cout << "Mesh #" << imesh+1 << " : ";
+    std::cout << "Mesh #" << imesh + 1 << " : ";
     for (int ic = 0; ic < TO_ncorner; ic++)
       std::cout << _getVertex(imesh, ic) << " ";
     std::cout << std::endl;
   }
-  std::cout<<std::endl;
+  std::cout << std::endl;
 
   for (int node = 0; node < _getNVertices(); node++)
   {
-    std::cout << "Vertex #" << node+1 << " : ";
+    std::cout << "Vertex #" << node + 1 << " : ";
     for (int idim = 0; idim < TO_ndim; idim++)
       std::cout << _getCoor(node, idim) << " ";
     std::cout << std::endl;
@@ -671,10 +670,10 @@ void TurboOptimizer::_getRankInTemplate(VectorInt& indice1,
 {
   int decalx = indice2[0] - indice1[0];
   int decaly = indice2[1] - indice1[1];
-  _updateMargin(0,indice1);
-  _updateMargin(1,indice1);
-  _updateMargin(0,indice2);
-  _updateMargin(1,indice2);
+  _updateMargin(0, indice1);
+  _updateMargin(1, indice1);
+  _updateMargin(0, indice2);
+  _updateMargin(1, indice2);
   indice2[0] = indice1[0] + decalx;
   indice2[1] = indice1[1] + decaly;
 }
@@ -682,21 +681,21 @@ void TurboOptimizer::_getRankInTemplate(VectorInt& indice1,
 VectorDouble TurboOptimizer::_getVectorFromTemplate(const VectorDouble& vecin) const
 {
   int nvertex = _getNVertices();
-  VectorDouble vecout(nvertex,0.);
-  if (! _isCalculated)
+  VectorDouble vecout(nvertex, 0.);
+  if (!_isCalculated)
     my_throw("You must use the method 'run' beforehand");
 
-  VectorInt indice(TO_ndim,0);
+  VectorInt indice(TO_ndim, 0);
 
-  for (int ix = 0; ix< _nx; ix++)
+  for (int ix = 0; ix < _nx; ix++)
     for (int iy = 0; iy < _ny; iy++)
     {
       indice[0] = ix;
       indice[1] = iy;
-      int ecr = _indiceToRank(indice);
-      _updateMargin(0,indice);
-      _updateMargin(1,indice);
-      int lec = _indiceToRank(indice, false);
+      int ecr   = _indiceToRank(indice);
+      _updateMargin(0, indice);
+      _updateMargin(1, indice);
+      int lec     = _indiceToRank(indice, false);
       vecout[ecr] = vecin[lec];
     }
   return vecout;
@@ -705,8 +704,8 @@ VectorDouble TurboOptimizer::_getVectorFromTemplate(const VectorDouble& vecin) c
 TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
                                                  int nperline) const
 {
-  VectorInt indice1(TO_ndim,0);
-  VectorInt indice2(TO_ndim,0);
+  VectorInt indice1(TO_ndim, 0);
+  VectorInt indice2(TO_ndim, 0);
 
   // Pre-dimensioning of TripletND structure (to avoid iterative concatenations
   // Trying to guess the number of non-zero terms in matrices
@@ -716,7 +715,7 @@ TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
   triplet.rows.resize(estimated_size);
   triplet.cols.resize(estimated_size);
   triplet.values.resize(estimated_size);
-  if (! _isCalculated)
+  if (!_isCalculated)
     my_throw("You must use the method 'run' beforehand");
 
   // Loop on the vertices (first point)
@@ -728,9 +727,9 @@ TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
 
       // Loop on the vertices (second point)
 
-      int ix2min = MAX(0,   ix1 - _poncif);
+      int ix2min = MAX(0, ix1 - _poncif);
       int ix2max = MIN(_nx, ix1 + _poncif);
-      int iy2min = MAX(0,   iy1 - _poncif);
+      int iy2min = MAX(0, iy1 - _poncif);
       int iy2max = MIN(_ny, iy1 + _poncif);
 
       for (int iy2 = iy2min; iy2 < iy2max; iy2++)
@@ -745,13 +744,13 @@ TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
           indice1[1] = iy1;
           indice2[0] = ix2;
           indice2[1] = iy2;
-          int ecr1 = _indiceToRank(indice1, true);
-          int ecr2 = _indiceToRank(indice2, true);
+          int ecr1   = _indiceToRank(indice1, true);
+          int ecr2   = _indiceToRank(indice2, true);
           _getRankInTemplate(indice1, indice2);
           int lec1 = _indiceToRank(indice1, false);
           int lec2 = _indiceToRank(indice2, false);
 
-          double value = matin[GETADR(_getNVertices_red(),lec1,lec2)];
+          double value = matin[GETADR(_getNVertices_red(), lec1, lec2)];
           if (value != 0.)
           {
             triplet.rows[added_element]   = (ecr1 + _flagOne);
@@ -762,13 +761,13 @@ TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
               my_throw("Reconsider the pre-estimation of matrix dimensions");
           }
         }
-  }
+    }
 
   // Final resizing
   if (estimated_size != added_element)
   {
-    triplet.rows.resize  (added_element);
-    triplet.cols.resize  (added_element);
+    triplet.rows.resize(added_element);
+    triplet.cols.resize(added_element);
     triplet.values.resize(added_element);
   }
   return triplet;
@@ -780,7 +779,7 @@ TripletND TurboOptimizer::_getMatrixFromTemplate(const VectorDouble& matin,
  */
 VectorDouble TurboOptimizer::getBlin() const
 {
-  if (! _isCalculated)
+  if (!_isCalculated)
     my_throw("You must use the method 'run' beforehand");
   return _Blin;
 }
@@ -820,7 +819,7 @@ TripletND TurboOptimizer::getS() const
  */
 TripletND TurboOptimizer::getQ() const
 {
-  int nbp1 = static_cast<int> (_Blin.size()) - 1;
+  int nbp1     = static_cast<int>(_Blin.size()) - 1;
   int nperline = 4 * nbp1 * nbp1;
   return _getMatrixFromTemplate(_Q_T, nperline);
 }
@@ -831,10 +830,10 @@ int TurboOptimizer::_coordinateToIndice(double x,
 {
   if ((int)indice.size() < 2)
     my_throw("Argument indice should have the correct size");
-  int ix = (int) floor((x - _x0) / _dx);
+  int ix = (int)floor((x - _x0) / _dx);
   if (ix < 0 || ix >= _nx) return 1;
   indice[0] = ix;
-  int iy = (int) floor((y - _y0) / _dy);
+  int iy    = (int)floor((y - _y0) / _dy);
   if (iy < 0 || iy >= _ny) return 1;
   indice[1] = iy;
   return 0;
@@ -850,21 +849,21 @@ int TurboOptimizer::_addWeights(int icas,
   VectorDouble lhs(TO_ncorner * TO_ncorner);
   VectorDouble lhsinv(TO_ncorner * TO_ncorner);
   VectorDouble rhs(TO_ncorner);
-  VectorInt    indgg(2);
+  VectorInt indgg(2);
 
-  for (int icorner=0; icorner<TO_ncorner; icorner++)
+  for (int icorner = 0; icorner < TO_ncorner; icorner++)
   {
     // Generate the indices of the mesh apex
-    for (int idim=0; idim<TO_ndim; idim++)
-      indgg[idim] = indg0[idim] + _MSS(icas,icorner,idim);
+    for (int idim = 0; idim < TO_ndim; idim++)
+      indgg[idim] = indg0[idim] + _MSS(icas, icorner, idim);
     if (indgg[0] < 0 || indgg[0] >= _nx) return 1;
     if (indgg[1] < 0 || indgg[1] >= _ny) return 1;
     indices[icorner] = _indiceToRank(indgg);
 
     // Update the LHS matrix
-    for (int idim=0; idim<TO_ndim; idim++)
-      lhs[GETADR(TO_ncorner,idim,icorner)] = _indiceToCoordinate(idim,indgg);
-    lhs[GETADR(TO_ncorner,TO_ndim,icorner)] = 1.;
+    for (int idim = 0; idim < TO_ndim; idim++)
+      lhs[GETADR(TO_ncorner, idim, icorner)] = _indiceToCoordinate(idim, indgg);
+    lhs[GETADR(TO_ncorner, TO_ndim, icorner)] = 1.;
   }
 
   // Generate the right-hand side
@@ -873,10 +872,10 @@ int TurboOptimizer::_addWeights(int icas,
   rhs[2] = 1.;
 
   // Invert the matrix
-  _invert_3x3(lhs,lhsinv);
+  _invert_3x3(lhs, lhsinv);
 
   // Calculate the weights
-  _prodMatrixVector(TO_ncorner,lhsinv,rhs,lambda);
+  _prodMatrixVector(TO_ncorner, lhsinv, rhs, lambda);
 
   // Check that all weights are positive
   for (int idim = 0; idim < TO_ndim; idim++)
@@ -901,28 +900,28 @@ TripletND TurboOptimizer::interpolate(const VectorDouble& x,
   VectorInt indg0(2);
   VectorInt indices(TO_ncorner);
   VectorDouble lambda(TO_ncorner);
-  int nech = static_cast<int> (x.size());
+  int nech = static_cast<int>(x.size());
 
   // Pre-allocate the triplet structure
 
   TripletND triplet;
   int size = TO_ncorner * nech;
-  triplet.rows.resize(size,-1);
-  triplet.cols.resize(size,-1);
-  triplet.values.resize(size,0.);
+  triplet.rows.resize(size, -1);
+  triplet.cols.resize(size, -1);
+  triplet.values.resize(size, 0.);
 
   /* Loop on the samples */
 
   int ecr = 0;
-  for (int iech=0; iech<nech; iech++)
+  for (int iech = 0; iech < nech; iech++)
   {
 
     /* Calculate the grid indices */
 
-    if (_coordinateToIndice(x[iech],y[iech],indg0) == 0)
+    if (_coordinateToIndice(x[iech], y[iech], indg0) == 0)
     {
 
-    /* Loop on the different meshes constituting the cell */
+      /* Loop on the different meshes constituting the cell */
 
       int found = -1;
       for (int icas = 0; icas < TO_npercell && found < 0; icas++)
@@ -963,7 +962,7 @@ VectorDouble TurboOptimizer::_expandTripletToMatrix(int row_begin,
   int nrows = row_end - row_begin + 1;
   int ncols = col_end - col_begin + 1;
   VectorDouble mat(nrows * ncols, 0.);
-  int size = static_cast<int> (triplet.rows.size());
+  int size = static_cast<int>(triplet.rows.size());
 
   for (int i = 0; i < size; i++)
   {
@@ -984,16 +983,16 @@ void TurboOptimizer::printS(int nper_batch,
 {
   // Convert from IHM to internal numbering
   if (row_begin > 0) row_begin--;
-  if (row_end   > 0) row_end--;
+  if (row_end > 0) row_end--;
   if (col_begin > 0) col_begin--;
-  if (col_end   > 0) col_end--;
+  if (col_end > 0) col_end--;
   if (row_end <= 0 || row_end >= _getNVertices()) row_end = _getNVertices() - 1;
   if (col_end <= 0 || col_end >= _getNVertices()) col_end = _getNVertices() - 1;
 
   VectorDouble temp = _expandTripletToMatrix(row_begin, row_end,
-                                                    col_begin, col_end, getS());
-  int nrows = row_end - row_begin + 1;
-  int ncols = col_end - col_begin + 1;
+                                             col_begin, col_end, getS());
+  int nrows         = row_end - row_begin + 1;
+  int ncols         = col_end - col_begin + 1;
   _printMatrix("Matrix S", nrows, ncols, temp, nper_batch, row_begin, col_begin);
 }
 
@@ -1005,17 +1004,16 @@ void TurboOptimizer::printQ(int nper_batch,
 {
   // Convert from IHM to internal numbering
   if (row_begin > 0) row_begin--;
-  if (row_end   > 0) row_end--;
+  if (row_end > 0) row_end--;
   if (col_begin > 0) col_begin--;
-  if (col_end   > 0) col_end--;
+  if (col_end > 0) col_end--;
   if (row_end <= 0 || row_end >= _getNVertices()) row_end = _getNVertices() - 1;
   if (col_end <= 0 || col_end >= _getNVertices()) col_end = _getNVertices() - 1;
 
   VectorDouble temp = _expandTripletToMatrix(row_begin, row_end,
-                                                    col_begin, col_end, getQ());
-  int nrows = row_end - row_begin + 1;
-  int ncols = col_end - col_begin + 1;
+                                             col_begin, col_end, getQ());
+  int nrows         = row_end - row_begin + 1;
+  int ncols         = col_end - col_begin + 1;
   _printMatrix("Matrix Q", nrows, ncols, temp, nper_batch, row_begin, col_begin);
-
 }
-}
+} // namespace gstlrn

--- a/src/LithoRule/RuleShadow.cpp
+++ b/src/LithoRule/RuleShadow.cpp
@@ -8,37 +8,37 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
 #include "geoslib_enum.h"
+#include "geoslib_old_f.h"
 
-#include "Basic/Utilities.hpp"
 #include "Basic/Law.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "Basic/SerializeHDF5.hpp"
-#include "LithoRule/RuleShadow.hpp"
-#include "LithoRule/Rule.hpp"
-#include "LithoRule/PropDef.hpp"
-#include "Model/Model.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
+#include "LithoRule/PropDef.hpp"
+#include "LithoRule/Rule.hpp"
+#include "LithoRule/RuleShadow.hpp"
+#include "Model/Model.hpp"
 
+#include <cmath>
 #include <sstream>
-#include <math.h>
 
 namespace gstlrn
 {
 RuleShadow::RuleShadow()
-    : Rule(),
-      _shDsup(0.),
-      _shDown(0.),
-      _slope(0.),
-      _shift(),
-      _dMax(TEST),
-      _tgte(TEST),
-      _incr(TEST),
-      _xyz(),
-      _ind1(),
-      _ind2()
+  : Rule()
+  , _shDsup(0.)
+  , _shDown(0.)
+  , _slope(0.)
+  , _shift()
+  , _dMax(TEST)
+  , _tgte(TEST)
+  , _incr(TEST)
+  , _xyz()
+  , _ind1()
+  , _ind2()
 {
   setModeRule(ERule::SHADOW);
 }
@@ -53,51 +53,49 @@ RuleShadow::RuleShadow()
 RuleShadow::RuleShadow(double slope,
                        double sh_dsup,
                        double sh_down,
-                       const VectorDouble &shift)
-    :
-    Rule(),
-    _shDsup(sh_dsup),
-    _shDown(sh_down),
-    _slope(slope),
-    _shift(shift),
-    _dMax(TEST),
-    _tgte(TEST),
-    _incr(TEST),
-    _xyz(),
-    _ind1(),
-    _ind2()
+                       const VectorDouble& shift)
+  : Rule()
+  , _shDsup(sh_dsup)
+  , _shDown(sh_down)
+  , _slope(slope)
+  , _shift(shift)
+  , _dMax(TEST)
+  , _tgte(TEST)
+  , _incr(TEST)
+  , _xyz()
+  , _ind1()
+  , _ind2()
 {
   setModeRule(ERule::SHADOW);
-  VectorString nodnames = { "S", "T", "F1", "F2", "F3" };
+  VectorString nodnames = {"S", "T", "F1", "F2", "F3"};
   setMainNodeFromNodNames(nodnames);
   _normalizeShift();
 }
 
-RuleShadow::RuleShadow(const RuleShadow &m)
-    :
-    Rule(m),
-    _shDsup(m._shDsup),
-    _shDown(m._shDown),
-    _slope(m._slope),
-    _shift(m._shift),
-    _dMax(m._dMax),
-    _tgte(m._tgte),
-    _incr(m._incr)
+RuleShadow::RuleShadow(const RuleShadow& m)
+  : Rule(m)
+  , _shDsup(m._shDsup)
+  , _shDown(m._shDown)
+  , _slope(m._slope)
+  , _shift(m._shift)
+  , _dMax(m._dMax)
+  , _tgte(m._tgte)
+  , _incr(m._incr)
 {
 }
 
-RuleShadow& RuleShadow::operator=(const RuleShadow &m)
+RuleShadow& RuleShadow::operator=(const RuleShadow& m)
 {
   if (this != &m)
   {
-    Rule::operator =(m);
+    Rule::operator=(m);
     _shDsup = m._shDsup;
     _shDown = m._shDown;
-    _slope = m._slope;
-    _shift = m._shift;
-    _dMax = m._dMax;
-    _tgte = m._tgte;
-    _incr = m._incr;
+    _slope  = m._slope;
+    _shift  = m._shift;
+    _dMax   = m._dMax;
+    _tgte   = m._tgte;
+    _incr   = m._incr;
   }
   return *this;
 }
@@ -124,9 +122,9 @@ bool RuleShadow::_deserializeAscii(std::istream& is, bool /*verbose*/)
 
 bool RuleShadow::_serializeAscii(std::ostream& os, bool /*verbose*/) const
 {
-  double slope  = (FFFF(_slope))  ? 0. : _slope;
-  double shdown = (FFFF(_shDown)) ? 0. : _shDown;
-  double shdsup = (FFFF(_shDsup)) ? 0. : _shDsup;
+  double slope          = (FFFF(_slope)) ? 0. : _slope;
+  double shdown         = (FFFF(_shDown)) ? 0. : _shDown;
+  double shdsup         = (FFFF(_shDsup)) ? 0. : _shDsup;
   VectorDouble shiftloc = _shift;
   shiftloc.resize(3);
 
@@ -176,9 +174,9 @@ String RuleShadow::displaySpecific() const
  ** \param[in]  flag_stat       1 for stationary; 0 otherwise
  **
  *****************************************************************************/
-int RuleShadow::particularities(Db *db,
-                                const Db *dbprop,
-                                Model *model,
+int RuleShadow::particularities(Db* db,
+                                const Db* dbprop,
+                                Model* model,
                                 int /*flag_grid_check*/,
                                 int flag_stat) const
 {
@@ -198,10 +196,10 @@ int RuleShadow::particularities(Db *db,
   return (0);
 }
 
-void RuleShadow::_st_shadow_max(const Db *dbprop,
+void RuleShadow::_st_shadow_max(const Db* dbprop,
                                 int flag_stat,
-                                double *sh_dsup_max,
-                                double *sh_down_max) const
+                                double* sh_dsup_max,
+                                double* sh_down_max) const
 {
   int iech;
   double val2, val3;
@@ -218,9 +216,9 @@ void RuleShadow::_st_shadow_max(const Db *dbprop,
     *sh_dsup_max = *sh_down_max = 0.;
     for (iech = 0; iech < dbprop->getNSample(); iech++)
     {
-      val2 = dbprop->getLocVariable(ELoc::P,iech, 1);
+      val2 = dbprop->getLocVariable(ELoc::P, iech, 1);
       if (val2 > (*sh_dsup_max)) (*sh_dsup_max) = val2;
-      val3 = dbprop->getLocVariable(ELoc::P,iech, 2);
+      val3 = dbprop->getLocVariable(ELoc::P, iech, 2);
       if (val3 > (*sh_down_max)) (*sh_down_max) = val3;
     }
   }
@@ -241,15 +239,15 @@ void RuleShadow::_st_shadow_max(const Db *dbprop,
  ** \param[out]  xyz0  Working array
  **
  *****************************************************************************/
-double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
+double RuleShadow::_st_grid_eval(DbGrid* dbgrid,
                                  int isimu,
                                  int icase,
                                  int nbsimu,
-                                 VectorDouble &xyz0) const
+                                 VectorDouble& xyz0) const
 {
   double top = 0.;
   double bot = 0.;
-  int ndim = dbgrid->getNDim();
+  int ndim   = dbgrid->getNDim();
 
   /* First point */
   int iech = dbgrid->indiceToRank(_ind2);
@@ -271,7 +269,7 @@ double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
   /* Second point */
   _ind2[0] += 1;
   iech = dbgrid->indiceToRank(_ind2);
-  z = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
+  z    = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
   if (!FFFF(z))
   {
     double d2 = 0.;
@@ -289,7 +287,7 @@ double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
   /* Third point */
   _ind2[1] += 1;
   iech = dbgrid->indiceToRank(_ind2);
-  z = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
+  z    = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
   if (!FFFF(z))
   {
     double d2 = 0.;
@@ -307,7 +305,7 @@ double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
   /* Fourth point */
   _ind2[0] -= 1;
   iech = dbgrid->indiceToRank(_ind2);
-  z = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
+  z    = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
   if (!FFFF(z))
   {
     double d2 = 0.;
@@ -324,8 +322,7 @@ double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
 
   /* Final interpolation */
   _ind2[1] -= 1;
-  z = (bot != 0) ? top / bot :
-                   TEST;
+  z = (bot != 0) ? top / bot : TEST;
   return (z);
 }
 
@@ -347,10 +344,10 @@ double RuleShadow::_st_grid_eval(DbGrid *dbgrid,
  ** \remark Attributes ELoc::FACIES are mandatory
  **
  *****************************************************************************/
-int RuleShadow::gaus2facData(PropDef *propdef,
-                             Db *dbin,
+int RuleShadow::gaus2facData(PropDef* propdef,
+                             Db* dbin,
                              Db* /*dbout*/,
-                             int *flag_used,
+                             int* flag_used,
                              int ipgs,
                              int isimu,
                              int nbsimu)
@@ -381,9 +378,9 @@ int RuleShadow::gaus2facData(PropDef *propdef,
     {
       int icase = get_rank_from_propdef(propdef, ipgs, igrf);
       y[igrf] =
-          (flag_used[igrf]) ? dbin->getSimvar(ELoc::GAUSFAC, iech, isimu, 0,
-                                              icase, nbsimu, 1) :
-                              0.;
+        (flag_used[igrf]) ? dbin->getSimvar(ELoc::GAUSFAC, iech, isimu, 0,
+                                            icase, nbsimu, 1)
+                          : 0.;
     }
     facies = getFaciesFromGaussian(y[0], y[1]);
 
@@ -410,8 +407,8 @@ int RuleShadow::gaus2facData(PropDef *propdef,
  ** \remark Attributes ELoc::FACIES and ELoc::SIMU are mandatory
  **
  *****************************************************************************/
-int RuleShadow::gaus2facResult(PropDef *propdef,
-                               Db *dbout,
+int RuleShadow::gaus2facResult(PropDef* propdef,
+                               Db* dbout,
                                int* /*flag_used*/,
                                int ipgs,
                                int isimu,
@@ -440,9 +437,9 @@ int RuleShadow::gaus2facResult(PropDef *propdef,
   /* Initializations */
 
   VectorDouble del(nech);
-  dinc = getIncr();
-  nstep = (int) floor(getDMax() / dinc);
-  dy = dinc * getTgte();
+  dinc  = getIncr();
+  nstep = (int)floor(getDMax() / dinc);
+  dy    = dinc * getTgte();
   for (idim = 0; idim < ndim; idim++)
     del[idim] = dinc * _shift[idim];
 
@@ -487,8 +484,8 @@ int RuleShadow::gaus2facResult(PropDef *propdef,
                                       isimu, nbsimu, &s1min, &s1max, &s2min,
                                       &s2max, &sh_dsup, &sh_down)) return (1);
         if (ys < s1max) continue; /* Upstream point not in island */
-        seuil = t1max - yc_down + dy * istep;
-        flag_shadow = (MIN(ys,s1max + sh_dsup) > seuil);
+        seuil       = t1max - yc_down + dy * istep;
+        flag_shadow = (MIN(ys, s1max + sh_dsup) > seuil);
       }
       facies = (flag_shadow) ? SHADOW_SHADOW : SHADOW_WATER;
     }
@@ -502,7 +499,7 @@ int RuleShadow::gaus2facResult(PropDef *propdef,
 
   error = 0;
 
-  label_end:
+label_end:
   return (error);
 }
 
@@ -521,9 +518,9 @@ int RuleShadow::gaus2facResult(PropDef *propdef,
  ** \param[in]  nbsimu     Number of simulations (if EProcessOper::CONDITIONAL)
  **
  *****************************************************************************/
-int RuleShadow::evaluateBounds(PropDef *propdef,
-                               Db *dbin,
-                               Db *dbout,
+int RuleShadow::evaluateBounds(PropDef* propdef,
+                               Db* dbin,
+                               Db* dbout,
                                int isimu,
                                int igrf,
                                int ipgs,
@@ -538,12 +535,12 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
 
   if (dbin == nullptr) return (0);
   nadd = jech = 0;
-  nech = dbin->getNSample();
-  dist = 0.;
-  dinc = getIncr();
-  nstep = (int) floor(getDMax() / dinc);
+  nech        = dbin->getNSample();
+  dist        = 0.;
+  dinc        = getIncr();
+  nstep       = (int)floor(getDMax() / dinc);
   seuil = s1min = s1max = s2min = s2max = TEST;
-  dbgrid = dynamic_cast<const DbGrid*>(dbout);
+  dbgrid                                = dynamic_cast<const DbGrid*>(dbout);
 
   /* Case of the shadow */
 
@@ -555,15 +552,15 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
     /* Convert the proportions into thresholds for data point */
     if (!dbin->isActive(iech)) continue;
     if (!point_inside_grid(dbin, iech, dbgrid)) continue;
-    facies = (int) dbin->getZVariable(iech, 0);
+    facies = (int)dbin->getZVariable(iech, 0);
     if (rule_thresh_define_shadow(propdef, dbin, this, facies, iech, isimu,
                                   nbsimu, &t1min, &t1max, &t2min, &t2max,
                                   &sh_dsup, &sh_down)) return (1);
     yc_down = sh_down;
-    dbin->setLocVariable(ELoc::L,iech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        t1min);
-    dbin->setLocVariable(ELoc::U,iech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        t1max);
+    dbin->setLocVariable(ELoc::L, iech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         t1min);
+    dbin->setLocVariable(ELoc::U, iech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         t1max);
 
     /* The data belongs to the island, no replicate */
 
@@ -582,7 +579,7 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
       /* - at a point where proportions are known */
       /* - after truncation, the point can create shadow at target */
 
-      alea = 1;
+      alea  = 1;
       valid = 0;
       while (!valid)
       {
@@ -601,7 +598,7 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
 
         if (replicateInvalid(dbin, dbout, jech))
         {
-          (void) dbin->deleteSample(jech);
+          (void)dbin->deleteSample(jech);
           continue;
         }
 
@@ -610,7 +607,7 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
                                       nbsimu, &s1min, &s1max, &s2min, &s2max,
                                       &sh_dsup, &sh_down))
         {
-          (void) dbin->deleteSample(jech);
+          (void)dbin->deleteSample(jech);
           return (1);
         }
         seuil = t1max - yc_down + dist * getTgte();
@@ -619,11 +616,11 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
       }
 
       /* Set the attributes of the replicate */
-      dbin->setLocVariable(ELoc::Z,jech, 0, SHADOW_ISLAND);
-      dbin->setLocVariable(ELoc::L,jech, get_rank_from_propdef(propdef, ipgs, igrf),
-                          MAX(seuil, s1max));
-      dbin->setLocVariable(ELoc::U,jech, get_rank_from_propdef(propdef, ipgs, igrf),
-      THRESH_SUP);
+      dbin->setLocVariable(ELoc::Z, jech, 0, SHADOW_ISLAND);
+      dbin->setLocVariable(ELoc::L, jech, get_rank_from_propdef(propdef, ipgs, igrf),
+                           MAX(seuil, s1max));
+      dbin->setLocVariable(ELoc::U, jech, get_rank_from_propdef(propdef, ipgs, igrf),
+                           THRESH_SUP);
       nadd++;
     }
 
@@ -653,7 +650,7 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
         /* Can the replicate be added */
         if (replicateInvalid(dbin, dbout, jech))
         {
-          (void) dbin->deleteSample(jech);
+          (void)dbin->deleteSample(jech);
           continue;
         }
 
@@ -662,7 +659,7 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
                                       nbsimu, &s1min, &s1max, &s2min, &s2max,
                                       &sh_dsup, &sh_down))
         {
-          (void) dbin->deleteSample(jech);
+          (void)dbin->deleteSample(jech);
           return (1);
         }
 
@@ -671,15 +668,15 @@ int RuleShadow::evaluateBounds(PropDef *propdef,
         if (seuil > s1max + sh_dsup)
         {
           /* The replicate is not necessary */
-          (void) dbin->deleteSample(jech);
+          (void)dbin->deleteSample(jech);
           continue;
         }
 
-        dbin->setLocVariable(ELoc::Z,jech, 0, SHADOW_IDLE);
-        dbin->setLocVariable(ELoc::L,jech, get_rank_from_propdef(propdef, ipgs, igrf),
+        dbin->setLocVariable(ELoc::Z, jech, 0, SHADOW_IDLE);
+        dbin->setLocVariable(ELoc::L, jech, get_rank_from_propdef(propdef, ipgs, igrf),
                              THRESH_INF);
-        dbin->setLocVariable(ELoc::U,jech, get_rank_from_propdef(propdef, ipgs, igrf),
-                            MAX(seuil, s1max));
+        dbin->setLocVariable(ELoc::U, jech, get_rank_from_propdef(propdef, ipgs, igrf),
+                             MAX(seuil, s1max));
         nadd++;
       }
     }
@@ -728,7 +725,7 @@ bool RuleShadow::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) con
 
   bool ret = true;
 
-  double slope          = (FFFF(_slope))  ? 0. : _slope;
+  double slope          = (FFFF(_slope)) ? 0. : _slope;
   double shdown         = (FFFF(_shDown)) ? 0. : _shDown;
   double shdsup         = (FFFF(_shDsup)) ? 0. : _shDsup;
   VectorDouble shiftloc = _shift;
@@ -744,4 +741,4 @@ bool RuleShadow::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) con
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/LithoRule/RuleShift.cpp
+++ b/src/LithoRule/RuleShift.cpp
@@ -8,47 +8,46 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
 #include "geoslib_enum.h"
+#include "geoslib_old_f.h"
 
 #include "Enum/ERule.hpp"
 
-#include "Basic/Utilities.hpp"
 #include "Basic/SerializeHDF5.hpp"
-#include "LithoRule/RuleShift.hpp"
-#include "LithoRule/Rule.hpp"
-#include "LithoRule/Node.hpp"
-#include "LithoRule/PropDef.hpp"
-#include "Model/Model.hpp"
+#include "Basic/Utilities.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
+#include "LithoRule/PropDef.hpp"
+#include "LithoRule/Rule.hpp"
+#include "LithoRule/RuleShift.hpp"
+#include "Model/Model.hpp"
 
+#include <cmath>
 #include <sstream>
-#include <math.h>
 
 namespace gstlrn
 {
 RuleShift::RuleShift()
-    : Rule(),
-      _shDsup(0.),
-      _shDown(0.),
-      _slope(0.),
-      _shift(),
-      _incr(TEST),
-      _xyz(),
-      _ind1(),
-      _ind2()
+  : Rule()
+  , _shDsup(0.)
+  , _shDown(0.)
+  , _slope(0.)
+  , _shift()
+  , _incr(TEST)
+  , _xyz()
+  , _ind1()
+  , _ind2()
 {
   setModeRule(ERule::SHIFT);
 }
 
 RuleShift::RuleShift(const RuleShift& m)
-    :  Rule(m),
-      _shDsup(m._shDsup),
-      _shDown(m._shDown),
-      _slope(m._slope),
-      _shift(m._shift),
-      _incr(m._incr)
+  : Rule(m)
+  , _shDsup(m._shDsup)
+  , _shDown(m._shDown)
+  , _slope(m._slope)
+  , _shift(m._shift)
+  , _incr(m._incr)
 {
 }
 
@@ -56,12 +55,12 @@ RuleShift& RuleShift::operator=(const RuleShift& m)
 {
   if (this != &m)
   {
-    Rule::operator =(m);
+    Rule::operator=(m);
     _shDsup = m._shDsup;
     _shDown = m._shDown;
-    _slope = m._slope;
-    _shift = m._shift;
-    _incr = m._incr;
+    _slope  = m._slope;
+    _shift  = m._shift;
+    _incr   = m._incr;
   }
   return *this;
 }
@@ -133,9 +132,9 @@ bool RuleShift::_deserializeAscii(std::istream& is, bool /*verbose*/)
 
 bool RuleShift::_serializeAscii(std::ostream& os, bool /*verbose*/) const
 {
-  double slope  = (FFFF(_slope)) ? 0. : _slope;
-  double shdown = (FFFF(_shDown)) ? 0. : _shDown;
-  double shdsup = (FFFF(_shDsup)) ? 0. : _shDsup;
+  double slope          = (FFFF(_slope)) ? 0. : _slope;
+  double shdown         = (FFFF(_shDown)) ? 0. : _shDown;
+  double shdsup         = (FFFF(_shDsup)) ? 0. : _shDsup;
   VectorDouble shiftloc = _shift;
   shiftloc.resize(3);
 
@@ -155,8 +154,8 @@ bool RuleShift::_serializeAscii(std::ostream& os, bool /*verbose*/) const
 String RuleShift::displaySpecific() const
 {
   std::stringstream sstr;
-  sstr << toTitle(2,"Shift Option");
-  sstr << toVector("Translation Vector",_shift);
+  sstr << toTitle(2, "Shift Option");
+  sstr << toVector("Translation Vector", _shift);
   sstr << "(With the 'Shift' option, only the first GRF is used)" << std::endl;
   return sstr.str();
 }
@@ -209,7 +208,7 @@ int RuleShift::particularities(Db* db,
   return (0);
 }
 
-int RuleShift::_st_shift_on_grid(Db *db, int ndim, int flag_grid_check) const
+int RuleShift::_st_shift_on_grid(Db* db, int ndim, int flag_grid_check) const
 {
   _xyz.resize(ndim);
   _ind1.resize(ndim);
@@ -217,28 +216,28 @@ int RuleShift::_st_shift_on_grid(Db *db, int ndim, int flag_grid_check) const
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(db);
   if (dbgrid == nullptr)
   {
-    if (! flag_grid_check) return(0);
+    if (!flag_grid_check) return (0);
     messerr("The shift Rule requires a Grid Db");
-    return(1);
+    return (1);
   }
 
-  for (int idim=0; idim<ndim; idim++)
+  for (int idim = 0; idim < ndim; idim++)
     _xyz[idim] = _shift[idim] + dbgrid->getX0(idim);
 
-  (void) point_to_grid(dbgrid,_xyz.data(),-1,_ind1.data());
+  (void)point_to_grid(dbgrid, _xyz.data(), -1, _ind1.data());
 
   /* Check that the translation is significant */
 
   int ntot = 0;
-  for (int idim=0; idim<ndim; idim++)
+  for (int idim = 0; idim < ndim; idim++)
     ntot += ABS(_ind1[idim]);
   if (ntot <= 0)
   {
     messerr("The shift of the Lithotype Rule cannot be rendered");
     messerr("using the Output Grid characteristics");
-    return(1);
+    return (1);
   }
-  return(0);
+  return (0);
 }
 
 bool RuleShift::checkModel(const Model* model, int nvar) const
@@ -281,30 +280,30 @@ int RuleShift::gaus2facResult(PropDef* propdef,
                               int isimu,
                               int nbsimu) const
 {
-  int    ndim,iech,jech,idim,igrf,icase;
-  double t1min,t1max,t2min,t2max,facies,y[2];
+  int ndim, iech, jech, idim, igrf, icase;
+  double t1min, t1max, t2min, t2max, facies, y[2];
 
   /* Initializations */
 
-  check_mandatory_attribute("rule_gaus2fac_result",dbout,ELoc::FACIES);
-  check_mandatory_attribute("rule_gaus2fac_result",dbout,ELoc::SIMU);
+  check_mandatory_attribute("rule_gaus2fac_result", dbout, ELoc::FACIES);
+  check_mandatory_attribute("rule_gaus2fac_result", dbout, ELoc::SIMU);
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(dbout);
   if (dbgrid == nullptr) return 1;
-  ndim   = dbgrid->getNDim();
+  ndim = dbgrid->getNDim();
   _xyz.resize(ndim);
   _ind1.resize(ndim);
   _ind2.resize(ndim);
 
   /* Processing the translation */
 
-  for (iech=0; iech<dbgrid->getNSample(); iech++)
+  for (iech = 0; iech < dbgrid->getNSample(); iech++)
   {
-    if (! dbgrid->isActive(iech)) continue;
+    if (!dbgrid->isActive(iech)) continue;
 
     facies = TEST;
-    for (igrf=0; igrf<2; igrf++) y[igrf] = TEST;
+    for (igrf = 0; igrf < 2; igrf++) y[igrf] = TEST;
     icase = get_rank_from_propdef(propdef, ipgs, 0);
-    y[0] = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
+    y[0]  = dbgrid->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu, 1);
     if (FFFF(y[0])) break;
 
     if (rule_thresh_define(propdef, dbgrid, this, ITEST, iech, isimu, nbsimu, 1,
@@ -321,7 +320,7 @@ int RuleShift::gaus2facResult(PropDef* propdef,
 
     /* Combine the underlying GRFs to derive Facies */
 
-    dbgrid->setSimvar(ELoc::FACIES,iech,isimu,0,ipgs,nbsimu,1,facies);
+    dbgrid->setSimvar(ELoc::FACIES, iech, isimu, 0, ipgs, nbsimu, 1, facies);
   }
   return 0;
 }
@@ -341,20 +340,20 @@ int RuleShift::gaus2facResult(PropDef* propdef,
 ** \param[in]  nbsimu     Number of simulations (if EProcessOper::CONDITIONAL)
 **
 *****************************************************************************/
-int RuleShift::evaluateBounds(PropDef *propdef,
-                              Db *dbin,
-                              Db *dbout,
+int RuleShift::evaluateBounds(PropDef* propdef,
+                              Db* dbin,
+                              Db* dbout,
                               int isimu,
                               int igrf,
                               int ipgs,
                               int nbsimu) const
 {
-  int    iech,jech,nadd,nech,idim,facies;
-  double t1min,t1max,t2min,t2max,s1min,s1max,s2min,s2max;
+  int iech, jech, nadd, nech, idim, facies;
+  double t1min, t1max, t2min, t2max, s1min, s1max, s2min, s2max;
 
   /* Initializations */
 
-  if (dbin == nullptr) return(0);
+  if (dbin == nullptr) return (0);
   nadd = 0;
   nech = dbin->getNSample();
 
@@ -367,13 +366,13 @@ int RuleShift::evaluateBounds(PropDef *propdef,
   {
     /* Convert the proportions into thresholds for data point */
     if (!dbin->isActive(iech)) continue;
-    facies = (int) dbin->getZVariable(iech, 0);
+    facies = (int)dbin->getZVariable(iech, 0);
     if (rule_thresh_define(propdef, dbin, this, facies, iech, isimu, nbsimu, 1,
                            &t1min, &t1max, &t2min, &t2max)) return (1);
-    dbin->setLocVariable(ELoc::L,iech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        t1min);
-    dbin->setLocVariable(ELoc::U,iech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        t1max);
+    dbin->setLocVariable(ELoc::L, iech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         t1min);
+    dbin->setLocVariable(ELoc::U, iech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         t1max);
     if (facies == SHADOW_ISLAND) continue;
 
     /* Add one replicate */
@@ -388,7 +387,7 @@ int RuleShift::evaluateBounds(PropDef *propdef,
     /* Can the replicate be added */
     if (replicateInvalid(dbin, dbout, jech))
     {
-      (void) dbin->deleteSample(jech);
+      (void)dbin->deleteSample(jech);
       return (1);
     }
 
@@ -396,17 +395,17 @@ int RuleShift::evaluateBounds(PropDef *propdef,
     if (rule_thresh_define(propdef, dbin, this, facies, jech, isimu, nbsimu, 1,
                            &s1min, &s1max, &s2min, &s2max))
     {
-      (void) dbin->deleteSample(jech);
+      (void)dbin->deleteSample(jech);
       return (1);
     }
 
     /* Set the attributes of the replicate */
-    if (facies == SHADOW_WATER) dbin->setLocVariable(ELoc::Z,jech, 0, SHADOW_WATER);
-    if (facies == SHADOW_SHADOW) dbin->setLocVariable(ELoc::Z,jech, 0, SHADOW_ISLAND);
-    dbin->setLocVariable(ELoc::L,jech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        s2min);
-    dbin->setLocVariable(ELoc::U,jech, get_rank_from_propdef(propdef, ipgs, igrf),
-                        s2max);
+    if (facies == SHADOW_WATER) dbin->setLocVariable(ELoc::Z, jech, 0, SHADOW_WATER);
+    if (facies == SHADOW_SHADOW) dbin->setLocVariable(ELoc::Z, jech, 0, SHADOW_ISLAND);
+    dbin->setLocVariable(ELoc::L, jech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         s2min);
+    dbin->setLocVariable(ELoc::U, jech, get_rank_from_propdef(propdef, ipgs, igrf),
+                         s2max);
     nadd++;
   }
 
@@ -496,7 +495,6 @@ bool RuleShift::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) cons
 
   bool ret = true;
 
-
   double slope          = (FFFF(_slope)) ? 0. : _slope;
   double shdown         = (FFFF(_shDown)) ? 0. : _shDown;
   double shdsup         = (FFFF(_shDsup)) ? 0. : _shDsup;
@@ -513,4 +511,4 @@ bool RuleShift::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) cons
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Matrix/MatrixDense.cpp
+++ b/src/Matrix/MatrixDense.cpp
@@ -9,15 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Matrix/MatrixDense.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Matrix/AMatrix.hpp"
+#include "Matrix/MatrixFactory.hpp"
 #include "Matrix/MatrixSquare.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
-#include "Matrix/MatrixFactory.hpp"
-#include "Matrix/AMatrix.hpp"
-#include "Basic/VectorHelper.hpp"
-#include "Basic/Utilities.hpp"
 #include "geoslib_define.h"
 
-#include <math.h>
+#include <cmath>
 #include <omp.h>
 
 namespace gstlrn
@@ -867,4 +867,4 @@ void MatrixDense::sum(const MatrixDense* mat1,
   mat3->getEigenMat().noalias() = mat1->getEigenMat() + mat2->getEigenMat();
 }
 
-}
+} // namespace gstlrn

--- a/src/Matrix/MatrixSquare.cpp
+++ b/src/Matrix/MatrixSquare.cpp
@@ -9,16 +9,16 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Matrix/MatrixSquare.hpp"
-#include "Matrix/MatrixFactory.hpp"
-#include "Matrix/AMatrix.hpp"
 #include "Basic/AException.hpp"
 #include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Matrix/AMatrix.hpp"
+#include "Matrix/MatrixFactory.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
-{ 
+{
 MatrixSquare::MatrixSquare(int nrow)
   : MatrixDense(nrow, nrow)
 {
@@ -89,8 +89,8 @@ double MatrixSquare::trace() const
  * \remarks The output matrix is square with dimension equal to the number of columns of Y
  */
 void MatrixSquare::innerMatrix(const MatrixSquare& x,
-                                const AMatrix& r1,
-                                const AMatrix& r2)
+                               const AMatrix& r1,
+                               const AMatrix& r2)
 {
   int n = x.getNSize();
   if (n != r1.getNRows())
@@ -265,9 +265,9 @@ MatrixSquare* MatrixSquare::createFromVVD(const VectorVectorDouble& X)
 }
 
 MatrixSquare* MatrixSquare::createFromVD(const VectorDouble& X,
-                                           int nrow,
-                                           bool byCol,
-                                           bool invertColumnOrder)
+                                         int nrow,
+                                         bool byCol,
+                                         bool invertColumnOrder)
 {
   int ncol = nrow;
   if (nrow * ncol != (int)X.size())
@@ -308,8 +308,8 @@ MatrixSquare* MatrixSquare::createFromVD(const VectorDouble& X,
  * @remarks The output matrices 'tus'  and 'tls' must be dimensioned beforehand
  */
 int MatrixSquare::decomposeLU(MatrixSquare& tls,
-                               MatrixSquare& tus,
-                               double eps)
+                              MatrixSquare& tus,
+                              double eps)
 {
   int neq = getNRows();
   tls.fill(0.);
@@ -388,9 +388,9 @@ int MatrixSquare::_invertLU()
 }
 
 int MatrixSquare::_solveLU(const MatrixSquare& tus,
-                            const MatrixSquare& tls,
-                            const double* b,
-                            double* x)
+                           const MatrixSquare& tls,
+                           const double* b,
+                           double* x)
 {
   int neq = getNRows();
   VectorDouble y(neq);
@@ -464,10 +464,10 @@ int MatrixSquare::_backwardLU(const MatrixSquare& tus, const double* b, double* 
 }
 
 MatrixSquare* prodNormMatMat(const MatrixDense* a,
-                              const MatrixDense* m,
-                              bool transpose)
+                             const MatrixDense* m,
+                             bool transpose)
 {
-  int nrow           = (transpose) ? a->getNCols() : a->getNRows();
+  int nrow          = (transpose) ? a->getNCols() : a->getNRows();
   MatrixSquare* mat = new MatrixSquare(nrow);
   mat->prodNormMatMatInPlace(a, m, transpose);
   return mat;
@@ -475,9 +475,9 @@ MatrixSquare* prodNormMatMat(const MatrixDense* a,
 
 MatrixSquare* prodNormMat(const MatrixDense& a, const VectorDouble& vec, bool transpose)
 {
-  int nsym           = (transpose) ? a.getNCols() : a.getNRows();
+  int nsym          = (transpose) ? a.getNCols() : a.getNRows();
   MatrixSquare* mat = new MatrixSquare(nsym);
   mat->prodNormMatVecInPlace(a, vec, transpose);
   return mat;
 }
-}
+} // namespace gstlrn

--- a/src/Mesh/Delaunay.cpp
+++ b/src/Mesh/Delaunay.cpp
@@ -8,22 +8,22 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Mesh/Delaunay.hpp"
 #include "Basic/Utilities.hpp"
+#include "Core/io.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "Mesh/AMesh.hpp"
 #include "Mesh/MeshEStandard.hpp"
-#include "Mesh/Delaunay.hpp"
-#include "Core/io.hpp"
 
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdio>
 
 /*! \cond */
-#define TRIANGLES(itri,j) (triangles[(itri) * 3 + (j)] - 1)
-#define MESHES(imesh,j)   (meshes[(imesh) * ncorner + (j)] - 1)
-#define POINTS(ip,idim)   (points[(ip) * ndim + (idim)])
-#define EXT(idim,ip)      (ext[(idim) * number + (ip)])
+#define TRIANGLES(itri, j) (triangles[(itri) * 3 + (j)] - 1)
+#define MESHES(imesh, j)   (meshes[(imesh) * ncorner + (j)] - 1)
+#define POINTS(ip, idim)   (points[(ip) * ndim + (idim)])
+#define EXT(idim, ip)      (ext[(idim) * number + (ip)])
 
 /*! \endcond */
 
@@ -52,35 +52,35 @@ int MSS(int ndim, int ipol, int icas, int icorn, int idim)
 {
   // Arrays S*D are provided for [ipol][icas][icorn][idim]
 
-  constexpr int S1D[1][1][2][1] = { { { { 0 }, { 1 } } } };
-  constexpr int S2D[2][2][3][2] = { { { { 0, 0 }, { 1, 0 }, { 0, 1 } },
-                                      { { 0, 1 }, { 1, 0 }, { 1, 1 } } },
-                                    { { { 0, 0 }, { 1, 0 }, { 1, 1 } },
-                                      { { 0, 0 }, { 0, 1 }, { 1, 1 } } } };
-  constexpr int S3D[1][6][4][3] = { { { { 0, 0, 0 },
-                                        { 1, 0, 0 },
-                                        { 1, 0, 1 },
-                                        { 1, 1, 1 } },
-                                      { { 0, 0, 0 },
-                                        { 0, 0, 1 },
-                                        { 1, 0, 1 },
-                                        { 1, 1, 1 } },
-                                      { { 0, 0, 0 },
-                                        { 0, 0, 1 },
-                                        { 0, 1, 1 },
-                                        { 1, 1, 1 } },
-                                      { { 0, 0, 0 },
-                                        { 0, 1, 0 },
-                                        { 0, 1, 1 },
-                                        { 1, 1, 1 } },
-                                      { { 0, 0, 0 },
-                                        { 1, 0, 0 },
-                                        { 1, 1, 0 },
-                                        { 1, 1, 1 } },
-                                      { { 0, 0, 0 },
-                                        { 0, 1, 0 },
-                                        { 1, 1, 0 },
-                                        { 1, 1, 1 } } } };
+  constexpr int S1D[1][1][2][1] = {{{{0}, {1}}}};
+  constexpr int S2D[2][2][3][2] = {{{{0, 0}, {1, 0}, {0, 1}},
+                                    {{0, 1}, {1, 0}, {1, 1}}},
+                                   {{{0, 0}, {1, 0}, {1, 1}},
+                                    {{0, 0}, {0, 1}, {1, 1}}}};
+  constexpr int S3D[1][6][4][3] = {{{{0, 0, 0},
+                                     {1, 0, 0},
+                                     {1, 0, 1},
+                                     {1, 1, 1}},
+                                    {{0, 0, 0},
+                                     {0, 0, 1},
+                                     {1, 0, 1},
+                                     {1, 1, 1}},
+                                    {{0, 0, 0},
+                                     {0, 0, 1},
+                                     {0, 1, 1},
+                                     {1, 1, 1}},
+                                    {{0, 0, 0},
+                                     {0, 1, 0},
+                                     {0, 1, 1},
+                                     {1, 1, 1}},
+                                    {{0, 0, 0},
+                                     {1, 0, 0},
+                                     {1, 1, 0},
+                                     {1, 1, 1}},
+                                    {{0, 0, 0},
+                                     {0, 1, 0},
+                                     {1, 1, 0},
+                                     {1, 1, 1}}}};
 
   int ival = 0;
   if (ipol < 0 || icorn < 0 || icas < 0 || idim < 0) return ival;
@@ -114,16 +114,16 @@ int MSS(int ndim, int ipol, int icas, int icorn, int idim)
  ** \remarks The returned array 'ext' must be freed by the calling function
  **
  *****************************************************************************/
-VectorDouble extend_grid(DbGrid *db, const VectorDouble& gext, int *nout)
+VectorDouble extend_grid(DbGrid* db, const VectorDouble& gext, int* nout)
 {
   int ndim, number, ndiv, ndiv0, rank, ival, delta;
 
   /* Initializations */
 
-  ndim = db->getNDim();
-  number = (int) pow(2., ndim);
-  ndiv0 = (int) pow(2., ndim - 1);
-  *nout = 0;
+  ndim   = db->getNDim();
+  number = (int)pow(2., ndim);
+  ndiv0  = (int)pow(2., ndim - 1);
+  *nout  = 0;
 
   /* Core allocation */
 
@@ -140,15 +140,15 @@ VectorDouble extend_grid(DbGrid *db, const VectorDouble& gext, int *nout)
     for (int idim = ndim - 1; idim >= 0; idim--)
     {
       delta = static_cast<int>((ceil)(gext[idim] / db->getDX(idim)));
-      ival = rank / ndiv;
-      rank = rank - ndiv * ival;
+      ival  = rank / ndiv;
+      rank  = rank - ndiv * ival;
       ndiv /= 2;
       indg[idim] = (ival == 0) ? -delta : db->getNX(idim) + delta;
     }
     db->indicesToCoordinateInPlace(indg, coor);
 
     for (int idim = 0; idim < ndim; idim++)
-      EXT(idim,corner) = coor[idim];
+      EXT(idim, corner) = coor[idim];
   }
 
   *nout = number;
@@ -169,11 +169,11 @@ VectorDouble extend_grid(DbGrid *db, const VectorDouble& gext, int *nout)
  ** \remarks The returned array 'ext' must be freed by the calling function
  **
  *****************************************************************************/
-VectorDouble extend_point(Db *db, const VectorDouble& gext, int *nout)
+VectorDouble extend_point(Db* db, const VectorDouble& gext, int* nout)
 {
-  int ndim = db->getNDim();
-  int number = (int) pow(2., ndim);
-  int ndiv0 = (int) pow(2., ndim - 1);
+  int ndim   = db->getNDim();
+  int number = (int)pow(2., ndim);
+  int ndiv0  = (int)pow(2., ndim - 1);
 
   /* Core allocation */
 
@@ -196,14 +196,13 @@ VectorDouble extend_point(Db *db, const VectorDouble& gext, int *nout)
     for (int idim = ndim - 1; idim >= 0; idim--)
     {
       int ival = rank / ndiv;
-      rank = rank - ndiv * ival;
+      rank     = rank - ndiv * ival;
       ndiv /= 2;
-      coor[idim] = (ival == 0) ? mini[idim] - gext[idim] :
-                                 maxi[idim] + gext[idim];
+      coor[idim] = (ival == 0) ? mini[idim] - gext[idim] : maxi[idim] + gext[idim];
     }
 
     for (int idim = 0; idim < ndim; idim++)
-      EXT(idim,corner) = coor[idim];
+      EXT(idim, corner) = coor[idim];
   }
 
   *nout = number;
@@ -225,13 +224,13 @@ VectorDouble extend_point(Db *db, const VectorDouble& gext, int *nout)
  ** \remarks with its dimension: ndim * 2^ndim
  **
  *****************************************************************************/
-VectorDouble get_db_extension(Db *dbin, Db *dbout, int *nout)
+VectorDouble get_db_extension(Db* dbin, Db* dbout, int* nout)
 {
   int ndim = 0;
   if (dbin != nullptr) ndim = dbin->getNDim();
   if (dbout != nullptr) ndim = dbout->getNDim();
-  int number = (int) pow(2., ndim);
-  int ndiv0 = (int) pow(2., ndim - 1);
+  int number = (int)pow(2., ndim);
+  int ndiv0  = (int)pow(2., ndim - 1);
 
   /* Core allocation */
 
@@ -240,8 +239,8 @@ VectorDouble get_db_extension(Db *dbin, Db *dbout, int *nout)
   VectorDouble coor(ndim);
   VectorDouble mini_abs;
   VectorDouble maxi_abs;
-  mini_abs.resize(ndim,TEST);
-  maxi_abs.resize(ndim,TEST);
+  mini_abs.resize(ndim, TEST);
+  maxi_abs.resize(ndim, TEST);
 
   /* Get the extension */
 
@@ -263,12 +262,12 @@ VectorDouble get_db_extension(Db *dbin, Db *dbout, int *nout)
     for (int idim = ndim - 1; idim >= 0; idim--)
     {
       int ival = rank / ndiv;
-      rank = rank - ndiv * ival;
+      rank     = rank - ndiv * ival;
       ndiv /= 2;
       coor[idim] = (ival == 0) ? mini_abs[idim] : maxi_abs[idim];
     }
     for (int idim = 0; idim < ndim; idim++)
-      EXT(idim,corner) = coor[idim];
+      EXT(idim, corner) = coor[idim];
   }
 
   *nout = number;
@@ -293,7 +292,7 @@ VectorDouble get_db_extension(Db *dbin, Db *dbout, int *nout)
  ** \remarks negative if the grid node is masked off
  **
  *****************************************************************************/
-static int st_load_segment(DbGrid *dbgrid,
+static int st_load_segment(DbGrid* dbgrid,
                            VectorInt& mesh,
                            VectorInt& order,
                            int ipos,
@@ -305,16 +304,16 @@ static int st_load_segment(DbGrid *dbgrid,
 
   int nactive = 0;
 
-  indg[0] = ix1;
-  iech1 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix1;
+  iech1          = dbgrid->indiceToRank(indg);
   mesh[ipos + 0] = iech1;
-  imask1 = dbgrid->isActive(iech1);
+  imask1         = dbgrid->isActive(iech1);
   nactive += imask1;
 
-  indg[0] = ix2;
-  iech2 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix2;
+  iech2          = dbgrid->indiceToRank(indg);
   mesh[ipos + 1] = iech2;
-  imask2 = dbgrid->isActive(iech2);
+  imask2         = dbgrid->isActive(iech2);
   nactive += imask2;
 
   if (nactive <= 0) return (0);
@@ -347,7 +346,7 @@ static int st_load_segment(DbGrid *dbgrid,
  ** \remarks negative if the grid node is masked off
  **
  *****************************************************************************/
-static int st_load_triangle(DbGrid *dbgrid,
+static int st_load_triangle(DbGrid* dbgrid,
                             VectorInt& mesh,
                             VectorInt& order,
                             int ipos,
@@ -363,25 +362,25 @@ static int st_load_triangle(DbGrid *dbgrid,
 
   int nactive = 0;
 
-  indg[0] = ix1;
-  indg[1] = iy1;
-  iech1 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix1;
+  indg[1]        = iy1;
+  iech1          = dbgrid->indiceToRank(indg);
   mesh[ipos + 0] = iech1;
-  imask1 = dbgrid->isActive(iech1);
+  imask1         = dbgrid->isActive(iech1);
   nactive += imask1;
 
-  indg[0] = ix2;
-  indg[1] = iy2;
-  iech2 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix2;
+  indg[1]        = iy2;
+  iech2          = dbgrid->indiceToRank(indg);
   mesh[ipos + 1] = iech2;
-  imask2 = dbgrid->isActive(iech2);
+  imask2         = dbgrid->isActive(iech2);
   nactive += imask2;
 
-  indg[0] = ix3;
-  indg[1] = iy3;
-  iech3 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix3;
+  indg[1]        = iy3;
+  iech3          = dbgrid->indiceToRank(indg);
   mesh[ipos + 2] = iech3;
-  imask3 = dbgrid->isActive(iech3);
+  imask3         = dbgrid->isActive(iech3);
   nactive += imask3;
 
   if (nactive <= 0) return (0);
@@ -420,7 +419,7 @@ static int st_load_triangle(DbGrid *dbgrid,
  ** \remarks negative if the grid node is masked off
  **
  *****************************************************************************/
-static int st_load_tetra(DbGrid *dbgrid,
+static int st_load_tetra(DbGrid* dbgrid,
                          VectorInt& mesh,
                          VectorInt& order,
                          int ipos,
@@ -442,36 +441,36 @@ static int st_load_tetra(DbGrid *dbgrid,
 
   int nactive = 0;
 
-  indg[0] = ix1;
-  indg[1] = iy1;
-  indg[2] = iz1;
-  iech1 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix1;
+  indg[1]        = iy1;
+  indg[2]        = iz1;
+  iech1          = dbgrid->indiceToRank(indg);
   mesh[ipos + 0] = iech1;
-  imask1 = dbgrid->isActive(iech1);
+  imask1         = dbgrid->isActive(iech1);
   nactive += imask1;
 
-  indg[0] = ix2;
-  indg[1] = iy2;
-  indg[2] = iz2;
-  iech2 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix2;
+  indg[1]        = iy2;
+  indg[2]        = iz2;
+  iech2          = dbgrid->indiceToRank(indg);
   mesh[ipos + 1] = iech2;
-  imask2 = dbgrid->isActive(iech2);
+  imask2         = dbgrid->isActive(iech2);
   nactive += imask1;
 
-  indg[0] = ix3;
-  indg[1] = iy3;
-  indg[2] = iz3;
-  iech3 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix3;
+  indg[1]        = iy3;
+  indg[2]        = iz3;
+  iech3          = dbgrid->indiceToRank(indg);
   mesh[ipos + 2] = iech3;
-  imask3 = dbgrid->isActive(iech3);
+  imask3         = dbgrid->isActive(iech3);
   nactive += imask1;
 
-  indg[0] = ix4;
-  indg[1] = iy4;
-  indg[2] = iz4;
-  iech4 = dbgrid->indiceToRank(indg);
+  indg[0]        = ix4;
+  indg[1]        = iy4;
+  indg[2]        = iz4;
+  iech4          = dbgrid->indiceToRank(indg);
   mesh[ipos + 3] = iech4;
-  imask4 = dbgrid->isActive(iech4);
+  imask4         = dbgrid->isActive(iech4);
   nactive += imask1;
 
   if (nactive <= 0) return (0);
@@ -498,7 +497,7 @@ static int st_load_tetra(DbGrid *dbgrid,
  ** \param[in] order    Array of relative ranks
  **
  *****************************************************************************/
-static MeshEStandard* st_ultimate_regular_grid(Db *dbgrid,
+static MeshEStandard* st_ultimate_regular_grid(Db* dbgrid,
                                                int ndim,
                                                int nmesh,
                                                int ncorner,
@@ -507,9 +506,9 @@ static MeshEStandard* st_ultimate_regular_grid(Db *dbgrid,
 {
   /* Count the number of active vertices */
 
-  int number = dbgrid->getNSample();
+  int number  = dbgrid->getNSample();
   int nvertex = 0;
-  int nin = 0;
+  int nin     = 0;
   for (int iech = 0; iech < number; iech++)
   {
     int local = order[iech];
@@ -520,7 +519,7 @@ static MeshEStandard* st_ultimate_regular_grid(Db *dbgrid,
 
   /* Define the addresses assigned to information */
 
-  int rank_in = 0;
+  int rank_in  = 0;
   int rank_out = nin;
   VectorInt ranks(number);
   for (int iech = 0; iech < number; iech++)
@@ -567,13 +566,13 @@ static MeshEStandard* st_ultimate_regular_grid(Db *dbgrid,
  ** \param[in]  dbgrid    Db structure
  **
  *****************************************************************************/
-AMesh* meshes_turbo_2D_grid_build(DbGrid *dbgrid)
+AMesh* meshes_turbo_2D_grid_build(DbGrid* dbgrid)
 {
-  int ndim = 2;
+  int ndim    = 2;
   int ncorner = 3;
-  int nx = dbgrid->getNX(0);
-  int ny = dbgrid->getNX(1);
-  int number = nx * ny;
+  int nx      = dbgrid->getNX(0);
+  int ny      = dbgrid->getNX(1);
+  int number  = nx * ny;
 
   /* Core allocation */
 
@@ -588,7 +587,7 @@ AMesh* meshes_turbo_2D_grid_build(DbGrid *dbgrid)
     {
       int ipol = ((ix + iy) % 2 == 1) ? 0 : 1;
       for (int i = 0; i < 2; i++)
-        if (st_load_triangle(dbgrid, meshes, order, nmesh*ncorner,
+        if (st_load_triangle(dbgrid, meshes, order, nmesh * ncorner,
                              ix + MSS(2, ipol, i, 0, 0),
                              iy + MSS(2, ipol, i, 0, 1),
                              ix + MSS(2, ipol, i, 1, 0),
@@ -601,7 +600,7 @@ AMesh* meshes_turbo_2D_grid_build(DbGrid *dbgrid)
 
   meshes.resize(nmesh * ncorner);
 
-  // Perform the ultimate tasks 
+  // Perform the ultimate tasks
 
   AMesh* amesh = st_ultimate_regular_grid(dbgrid, ndim, nmesh, ncorner, meshes, order);
 
@@ -625,8 +624,8 @@ AMesh* meshes_turbo_2D_grid_build(DbGrid *dbgrid)
  ** \param[in]  points    Array of 3-D coordinates for triangle vertices
  **
  *****************************************************************************/
-int meshes_2D_write(const char *file_name,
-                    const char *obj_name,
+int meshes_2D_write(const char* file_name,
+                    const char* obj_name,
                     int verbose,
                     int ndim,
                     int ncode,
@@ -636,7 +635,7 @@ int meshes_2D_write(const char *file_name,
                     const VectorInt& triangles,
                     const VectorDouble& points)
 {
-  FILE *file;
+  FILE* file;
   int i, itri, ntriloc;
   double normal[3];
 
@@ -771,14 +770,14 @@ void mesh_stats(int ndim, int ncorner, int nmesh, const int* meshes, const doubl
  ** \param[in]  dbgrid    Db structure
  **
  *****************************************************************************/
-AMesh* meshes_turbo_3D_grid_build(DbGrid *dbgrid)
+AMesh* meshes_turbo_3D_grid_build(DbGrid* dbgrid)
 {
-  int ndim = 3;
+  int ndim    = 3;
   int ncorner = 4;
-  int nx = dbgrid->getNX(0);
-  int ny = dbgrid->getNX(1);
-  int nz = dbgrid->getNX(2);
-  int number = nx * ny * nz;
+  int nx      = dbgrid->getNX(0);
+  int ny      = dbgrid->getNX(1);
+  int nz      = dbgrid->getNX(2);
+  int number  = nx * ny * nz;
 
   /* Core allocation */
 
@@ -793,7 +792,7 @@ AMesh* meshes_turbo_3D_grid_build(DbGrid *dbgrid)
       for (int iz = 0; iz < nz - 1; iz++)
         for (int i = 0; i < 6; i++)
         {
-          if (st_load_tetra(dbgrid, meshes, order, nmesh*ncorner,
+          if (st_load_tetra(dbgrid, meshes, order, nmesh * ncorner,
                             ix + MSS(3, 0, i, 0, 0), iy + MSS(3, 0, i, 0, 1),
                             iz + MSS(3, 0, i, 0, 2), ix + MSS(3, 0, i, 1, 0),
                             iy + MSS(3, 0, i, 1, 1), iz + MSS(3, 0, i, 1, 2),
@@ -807,7 +806,7 @@ AMesh* meshes_turbo_3D_grid_build(DbGrid *dbgrid)
 
   meshes.resize(nmesh * ncorner);
 
-  // Perform the ultimate tasks 
+  // Perform the ultimate tasks
 
   AMesh* amesh = st_ultimate_regular_grid(dbgrid, ndim, nmesh, ncorner, meshes, order);
 
@@ -823,12 +822,12 @@ AMesh* meshes_turbo_3D_grid_build(DbGrid *dbgrid)
  ** \param[in]  dbgrid    Db structure
  **
  *****************************************************************************/
-AMesh* meshes_turbo_1D_grid_build(DbGrid *dbgrid)
+AMesh* meshes_turbo_1D_grid_build(DbGrid* dbgrid)
 {
-  int ndim = 1;
+  int ndim    = 1;
   int ncorner = 2;
-  int nx = dbgrid->getNX(0);
-  int number = nx - 1;
+  int nx      = dbgrid->getNX(0);
+  int number  = nx - 1;
 
   /* Core allocation */
 
@@ -840,7 +839,7 @@ AMesh* meshes_turbo_1D_grid_build(DbGrid *dbgrid)
   int nmesh = 0;
   for (int ix = 0; ix < nx - 1; ix++)
   {
-    if (st_load_segment(dbgrid, meshes, order, nmesh*ncorner,
+    if (st_load_segment(dbgrid, meshes, order, nmesh * ncorner,
                         ix + MSS(1, 0, 1, 0, 0), ix + MSS(1, 0, 1, 1, 0)))
       nmesh++;
   }
@@ -849,11 +848,11 @@ AMesh* meshes_turbo_1D_grid_build(DbGrid *dbgrid)
 
   meshes.resize(nmesh * ncorner);
 
-  // Perform the ultimate tasks 
+  // Perform the ultimate tasks
 
   AMesh* amesh = st_ultimate_regular_grid(dbgrid, ndim, nmesh, ncorner, meshes, order);
 
   return amesh;
 }
 
-}
+} // namespace gstlrn

--- a/src/Mesh/LinkSphTriangle.cpp
+++ b/src/Mesh/LinkSphTriangle.cpp
@@ -10,20 +10,20 @@
 /******************************************************************************/
 #include "gmtsph.hpp"
 
-#include "Db/Db.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
+#include "Basic/Memory.hpp"
+#include "Core/Keypair.hpp"
+#include "Db/Db.hpp"
 #include "Geometry/GeometryHelper.hpp"
 #include "Mesh/AMesh.hpp"
 #include "Mesh/LinkSphTriangle.hpp"
-#include "Basic/Memory.hpp"
-#include "Core/Keypair.hpp"
 
-#include <math.h>
+#include <cmath>
 
 // External library
 
-#define COORD(i,j)  (coord[3 * (j) + (i)])
+#define COORD(i, j) (coord[3 * (j) + (i)])
 
 #define DEBUG 0
 
@@ -36,13 +36,13 @@ namespace gstlrn
  ** \param[in]  t      Pointer to the SphTriangle structure to be initialized
  **
  *****************************************************************************/
-void meshes_2D_sph_init(SphTriangle *t)
+void meshes_2D_sph_init(SphTriangle* t)
 {
-  t->n_nodes = 0;
+  t->n_nodes  = 0;
   t->sph_size = 0;
-  t->sph_x = nullptr;
-  t->sph_y = nullptr;
-  t->sph_z = nullptr;
+  t->sph_x    = nullptr;
+  t->sph_y    = nullptr;
+  t->sph_z    = nullptr;
   t->sph_list = nullptr;
   t->sph_lptr = nullptr;
   t->sph_lend = nullptr;
@@ -57,19 +57,19 @@ void meshes_2D_sph_init(SphTriangle *t)
  **                    0 for total deallocation
  **
  *****************************************************************************/
-void meshes_2D_sph_free(SphTriangle *t, int mode)
+void meshes_2D_sph_free(SphTriangle* t, int mode)
 {
-  if (t == (SphTriangle*) NULL) return;
+  if (t == (SphTriangle*)NULL) return;
   if (mode == 0)
   {
-    t->sph_x = (double*) mem_free((char* ) t->sph_x);
-    t->sph_y = (double*) mem_free((char* ) t->sph_y);
-    t->sph_z = (double*) mem_free((char* ) t->sph_z);
+    t->sph_x   = (double*)mem_free((char*)t->sph_x);
+    t->sph_y   = (double*)mem_free((char*)t->sph_y);
+    t->sph_z   = (double*)mem_free((char*)t->sph_z);
     t->n_nodes = 0;
   }
-  t->sph_list = (int*) mem_free((char* ) t->sph_list);
-  t->sph_lptr = (int*) mem_free((char* ) t->sph_lptr);
-  t->sph_lend = (int*) mem_free((char* ) t->sph_lend);
+  t->sph_list = (int*)mem_free((char*)t->sph_list);
+  t->sph_lptr = (int*)mem_free((char*)t->sph_lptr);
+  t->sph_lend = (int*)mem_free((char*)t->sph_lend);
   t->sph_size = 0;
 }
 
@@ -85,7 +85,7 @@ void meshes_2D_sph_free(SphTriangle *t, int mode)
  ** \remarks (longitude,latitude) into 3-D coordinates
  **
  *****************************************************************************/
-int meshes_2D_sph_from_db(Db *db, SphTriangle *t)
+int meshes_2D_sph_from_db(Db* db, SphTriangle* t)
 {
   int error, nech, ndim, neff, nold, ecr;
   double xx, yy, zz;
@@ -94,13 +94,13 @@ int meshes_2D_sph_from_db(Db *db, SphTriangle *t)
 
   if (db == nullptr) return (0);
   error = 1;
-  nech = db->getNSample();
-  ndim = db->getNDim();
+  nech  = db->getNSample();
+  ndim  = db->getNDim();
   if (ndim != 2)
   {
     messerr(
-        "In Spherical System, the Space Dimension of the data base Db must be 2 (%d)\n",
-        ndim);
+      "In Spherical System, the Space Dimension of the data base Db must be 2 (%d)\n",
+      ndim);
     return (1);
   }
 
@@ -110,16 +110,16 @@ int meshes_2D_sph_from_db(Db *db, SphTriangle *t)
 
   /* Core allocation */
 
-  nold = t->n_nodes;
-  ecr = nold;
-  t->sph_x = (double*) mem_realloc((char* ) t->sph_x,
-                                   sizeof(double) * (nold + neff), 0);
+  nold     = t->n_nodes;
+  ecr      = nold;
+  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
+                                  sizeof(double) * (nold + neff), 0);
   if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*) mem_realloc((char* ) t->sph_y,
-                                   sizeof(double) * (nold + neff), 0);
+  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
+                                  sizeof(double) * (nold + neff), 0);
   if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*) mem_realloc((char* ) t->sph_z,
-                                   sizeof(double) * (nold + neff), 0);
+  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
+                                  sizeof(double) * (nold + neff), 0);
   if (t->sph_z == nullptr) goto label_end;
 
   /* Load the points */
@@ -140,7 +140,8 @@ int meshes_2D_sph_from_db(Db *db, SphTriangle *t)
 
   error = 0;
 
-  label_end: if (error) meshes_2D_sph_free(t, 0);
+label_end:
+  if (error) meshes_2D_sph_free(t, 0);
   return (error);
 }
 
@@ -156,7 +157,7 @@ int meshes_2D_sph_from_db(Db *db, SphTriangle *t)
  ** \remarks SphTriangle structure
  **
  *****************************************************************************/
-int meshes_2D_sph_from_points(int nech, double *x, double *y, SphTriangle *t)
+int meshes_2D_sph_from_points(int nech, double* x, double* y, SphTriangle* t)
 {
   int error, ecr, nold;
   double xx, yy, zz;
@@ -167,16 +168,16 @@ int meshes_2D_sph_from_points(int nech, double *x, double *y, SphTriangle *t)
 
   /* List of points */
 
-  nold = t->n_nodes;
-  ecr = nold;
-  t->sph_x = (double*) mem_realloc((char* ) t->sph_x,
-                                   sizeof(double) * (nold + nech), 0);
+  nold     = t->n_nodes;
+  ecr      = nold;
+  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
+                                  sizeof(double) * (nold + nech), 0);
   if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*) mem_realloc((char* ) t->sph_y,
-                                   sizeof(double) * (nold + nech), 0);
+  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
+                                  sizeof(double) * (nold + nech), 0);
   if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*) mem_realloc((char* ) t->sph_z,
-                                   sizeof(double) * (nold + nech), 0);
+  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
+                                  sizeof(double) * (nold + nech), 0);
   if (t->sph_z == nullptr) goto label_end;
 
   /* Load the information */
@@ -195,7 +196,8 @@ int meshes_2D_sph_from_points(int nech, double *x, double *y, SphTriangle *t)
 
   error = 0;
 
-  label_end: if (error) meshes_2D_sph_free(t, 0);
+label_end:
+  if (error) meshes_2D_sph_free(t, 0);
   return (error);
 }
 
@@ -209,7 +211,7 @@ int meshes_2D_sph_from_points(int nech, double *x, double *y, SphTriangle *t)
  ** \remarks This function adds the vertices to an existing SphTriangle structure
  **
  *****************************************************************************/
-int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
+int meshes_2D_sph_from_auxiliary(const String& triswitch, SphTriangle* t)
 {
   int error, npoint, ecr, found_close, nech, nold, ndecode, flag_reg, flag_vdc;
   double c1[3], c2[3], dist;
@@ -219,7 +221,7 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
 
   error = 1;
   VectorDouble coord;
-  nold = t->n_nodes;
+  nold    = t->n_nodes;
   ndecode = flag_vdc = flag_reg = npoint = 0;
 
   // We set the random seed (for reproductible exemples)
@@ -231,13 +233,13 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
   if (triswitch[0] == '-' && triswitch[1] == 'n')
   {
     flag_vdc = 1;
-    ndecode = (int) strtod(&triswitch[2], nullptr);
+    ndecode  = (int)strtod(&triswitch[2], nullptr);
     if (ndecode <= 0) return (0);
   }
   if (triswitch[0] == '-' && triswitch[1] == 'r')
   {
     flag_reg = 1;
-    ndecode = (int) strtod(&triswitch[2], nullptr);
+    ndecode  = (int)strtod(&triswitch[2], nullptr);
     if (ndecode <= 0) return (0);
   }
   if (triswitch[0] == '-' && triswitch[1] == 'h')
@@ -262,14 +264,14 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
 
   /* Reallocate to maximum size */
 
-  t->sph_x = (double*) mem_realloc((char* ) t->sph_x,
-                                   sizeof(double) * (nold + npoint), 0);
+  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
+                                  sizeof(double) * (nold + npoint), 0);
   if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*) mem_realloc((char* ) t->sph_y,
-                                   sizeof(double) * (nold + npoint), 0);
+  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
+                                  sizeof(double) * (nold + npoint), 0);
   if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*) mem_realloc((char* ) t->sph_z,
-                                   sizeof(double) * (nold + npoint), 0);
+  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
+                                  sizeof(double) * (nold + npoint), 0);
   if (t->sph_z == nullptr) goto label_end;
 
   /* Check that random points are not too close from hard nodes */
@@ -307,12 +309,12 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
 
   /* Final resize */
 
-  nech = ecr;
-  t->sph_x = (double*) mem_realloc((char* ) t->sph_x, sizeof(double) * nech, 0);
+  nech     = ecr;
+  t->sph_x = (double*)mem_realloc((char*)t->sph_x, sizeof(double) * nech, 0);
   if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*) mem_realloc((char* ) t->sph_y, sizeof(double) * nech, 0);
+  t->sph_y = (double*)mem_realloc((char*)t->sph_y, sizeof(double) * nech, 0);
   if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*) mem_realloc((char* ) t->sph_z, sizeof(double) * nech, 0);
+  t->sph_z = (double*)mem_realloc((char*)t->sph_z, sizeof(double) * nech, 0);
   if (t->sph_z == nullptr) goto label_end;
   t->n_nodes = nech;
 
@@ -320,7 +322,7 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
 
   error = 0;
 
-  label_end:
+label_end:
   if (error) meshes_2D_sph_free(t, 0);
   return (error);
 }
@@ -333,14 +335,13 @@ int meshes_2D_sph_from_auxiliary(const String &triswitch, SphTriangle *t)
  ** \param[in]  brief     1 for a brief output; 0 otherwise
  **
  *****************************************************************************/
-void meshes_2D_sph_print(SphTriangle *t, int brief)
+void meshes_2D_sph_print(SphTriangle* t, int brief)
 {
   double rlong, rlat;
 
   message("- Number of nodes   = %d\n", t->n_nodes);
 
-  if (!brief && t->n_nodes > 0 && t->sph_x != nullptr && t->sph_y != nullptr
-      && t->sph_z != nullptr)
+  if (!brief && t->n_nodes > 0 && t->sph_x != nullptr && t->sph_y != nullptr && t->sph_z != nullptr)
   {
     message("\nCoordinates in Cartesian (R=1); then in Longitude - Latitude\n");
     for (int i = 0; i < t->n_nodes; i++)
@@ -364,45 +365,45 @@ void meshes_2D_sph_print(SphTriangle *t, int brief)
  ** \param[in]  t          SphTriangle structure
  **
  *****************************************************************************/
-int meshes_2D_sph_create(int verbose, SphTriangle *t)
+int meshes_2D_sph_create(int verbose, SphTriangle* t)
 {
   int *loc_near, *loc_next, *loc_lnew, error, skip_rnd, seed_memo;
   double *loc_dist, memo[3][3], ampli, value, cste;
 
   /* Initializations */
 
-  error = 1;
-  skip_rnd = (int) get_keypone("Skip_Random", 0);
+  error    = 1;
+  skip_rnd = (int)get_keypone("Skip_Random", 0);
   loc_near = loc_next = loc_lnew = nullptr;
-  loc_dist = nullptr;
-  if (t == (SphTriangle*) NULL || t->n_nodes < 3) return (1);
+  loc_dist                       = nullptr;
+  if (t == (SphTriangle*)NULL || t->n_nodes < 3) return (1);
 
   /* Re-allocate the arrays within the SphTriangle structure */
 
   meshes_2D_sph_free(t, 1);
   t->sph_size = 6 * t->n_nodes - 12;
-  t->sph_list = (int*) mem_alloc(sizeof(int) * t->sph_size, 0);
+  t->sph_list = (int*)mem_alloc(sizeof(int) * t->sph_size, 0);
   if (t->sph_list == nullptr) goto label_end;
   for (int i = 0; i < t->sph_size; i++)
     t->sph_list[i] = ITEST;
-  t->sph_lptr = (int*) mem_alloc(sizeof(int) * t->sph_size, 0);
+  t->sph_lptr = (int*)mem_alloc(sizeof(int) * t->sph_size, 0);
   if (t->sph_lptr == nullptr) goto label_end;
   for (int i = 0; i < t->sph_size; i++)
     t->sph_lptr[i] = ITEST;
-  t->sph_lend = (int*) mem_alloc(sizeof(int) * t->n_nodes, 0);
+  t->sph_lend = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
   if (t->sph_lend == nullptr) goto label_end;
   for (int i = 0; i < t->n_nodes; i++)
     t->sph_lend[i] = ITEST;
 
   /* Allocate local arrays */
 
-  loc_lnew = (int*) mem_alloc(sizeof(int) * t->sph_size, 0);
+  loc_lnew = (int*)mem_alloc(sizeof(int) * t->sph_size, 0);
   if (loc_lnew == nullptr) goto label_end;
-  loc_near = (int*) mem_alloc(sizeof(int) * t->n_nodes, 0);
+  loc_near = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
   if (loc_near == nullptr) goto label_end;
-  loc_next = (int*) mem_alloc(sizeof(int) * t->n_nodes, 0);
+  loc_next = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
   if (loc_next == nullptr) goto label_end;
-  loc_dist = (double*) mem_alloc(sizeof(double) * t->n_nodes, 0);
+  loc_dist = (double*)mem_alloc(sizeof(double) * t->n_nodes, 0);
   if (loc_dist == nullptr) goto label_end;
 
   /* Avoid having three first points colinear */
@@ -417,20 +418,19 @@ int meshes_2D_sph_create(int verbose, SphTriangle *t)
       memo[i][0] = t->sph_x[i];
       memo[i][1] = t->sph_y[i];
       memo[i][2] = t->sph_z[i];
-      cste = (t->sph_x[i] * t->sph_x[i] + t->sph_y[i] * t->sph_y[i]
-              + t->sph_z[i] * t->sph_z[i]);
+      cste       = (t->sph_x[i] * t->sph_x[i] + t->sph_y[i] * t->sph_y[i] + t->sph_z[i] * t->sph_z[i]);
       t->sph_x[i] += law_uniform(-ampli, ampli);
       t->sph_y[i] += law_uniform(-ampli, ampli);
       value = sqrt(
-          cste - t->sph_x[i] * t->sph_x[i] - t->sph_y[i] * t->sph_y[i]);
+        cste - t->sph_x[i] * t->sph_x[i] - t->sph_y[i] * t->sph_y[i]);
       t->sph_z[i] = (t->sph_z[i] > 0.) ? value : -value;
     }
     law_set_random_seed(seed_memo);
   }
 
-  (void) trmesh_(&t->n_nodes, t->sph_x, t->sph_y, t->sph_z, t->sph_list,
-                 t->sph_lptr, t->sph_lend, loc_lnew, loc_near, loc_next,
-                 loc_dist, &error);
+  (void)trmesh_(&t->n_nodes, t->sph_x, t->sph_y, t->sph_z, t->sph_list,
+                t->sph_lptr, t->sph_lend, loc_lnew, loc_near, loc_next,
+                loc_dist, &error);
 
   /* Restore the initial coordinates */
 
@@ -447,7 +447,7 @@ int meshes_2D_sph_create(int verbose, SphTriangle *t)
       if (verbose)
       {
         message("Spherical triangulation successfull\n");
-        meshes_2D_sph_print(t, ! DEBUG);
+        meshes_2D_sph_print(t, !DEBUG);
       }
       goto label_end;
 
@@ -469,12 +469,12 @@ int meshes_2D_sph_create(int verbose, SphTriangle *t)
 
   meshes_2D_sph_free(t, 1);
 
-  label_end:
-  mem_free((char* ) loc_near);
-  mem_free((char* ) loc_next);
-  mem_free((char* ) loc_lnew);
-  mem_free((char* ) loc_dist);
+label_end:
+  mem_free((char*)loc_near);
+  mem_free((char*)loc_next);
+  mem_free((char*)loc_lnew);
+  mem_free((char*)loc_dist);
   return (error);
 }
 
-}
+} // namespace gstlrn

--- a/src/Mesh/MeshETurbo.cpp
+++ b/src/Mesh/MeshETurbo.cpp
@@ -21,7 +21,7 @@
 #include "Mesh/AMesh.hpp"
 #include "Mesh/Delaunay.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
@@ -1138,4 +1138,4 @@ bool MeshETurbo::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) con
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/Model/Constraints.cpp
+++ b/src/Model/Constraints.cpp
@@ -9,26 +9,26 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Model/Constraints.hpp"
-#include "Model/ConsItem.hpp"
 #include "Basic/Utilities.hpp"
+#include "Model/ConsItem.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 Constraints::Constraints(double constantSillValue, const VectorDouble& constantSills)
-    : AStringable(),
-      _constantSillValue(constantSillValue),
-      _constantSills(constantSills),
-      _consItems()
+  : AStringable()
+  , _constantSillValue(constantSillValue)
+  , _constantSills(constantSills)
+  , _consItems()
 {
 }
 
-Constraints::Constraints(const Constraints &m)
-    : AStringable(m),
-      _constantSillValue(m._constantSillValue),
-      _constantSills(m._constantSills),
-      _consItems()
+Constraints::Constraints(const Constraints& m)
+  : AStringable(m)
+  , _constantSillValue(m._constantSillValue)
+  , _constantSills(m._constantSills)
+  , _consItems()
 {
   for (const auto& e: m._consItems)
   {
@@ -36,13 +36,13 @@ Constraints::Constraints(const Constraints &m)
   }
 }
 
-Constraints& Constraints::operator=(const Constraints &m)
+Constraints& Constraints::operator=(const Constraints& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
     _constantSillValue = m._constantSillValue;
-    _constantSills = m._constantSills;
+    _constantSills     = m._constantSills;
     for (const auto& e: m._consItems)
     {
       _consItems.push_back(e->clone());
@@ -62,11 +62,11 @@ void Constraints::addItem(const ConsItem* item)
   _consItems.push_back(item->clone());
 }
 
-void Constraints::addItemFromParamId(const EConsElem &elem,
+void Constraints::addItemFromParamId(const EConsElem& elem,
                                      int icov,
                                      int iv1,
                                      int iv2,
-                                     const EConsType &type,
+                                     const EConsType& type,
                                      double value)
 {
   ConsItem* item = ConsItem::createFromParamId(icov, elem, type, value, 0, iv1, iv2);
@@ -76,7 +76,7 @@ void Constraints::addItemFromParamId(const EConsElem &elem,
 String Constraints::toString(const AStringFormat* strfmt) const
 {
   std::stringstream sstr;
-  int nitem = static_cast<int> (_consItems.size());
+  int nitem = static_cast<int>(_consItems.size());
 
   if (nitem > 0)
     sstr << toTitle(0, "Constraints to be fulfilled in Fitting procedure");
@@ -87,7 +87,7 @@ String Constraints::toString(const AStringFormat* strfmt) const
     sstr << _consItems[i]->toString(strfmt);
   }
 
-  if (! FFFF(getConstantSillValue()))
+  if (!FFFF(getConstantSillValue()))
     sstr << "- Constraints on the sills =" << getConstantSillValue() << std::endl;
 
   return sstr.str();
@@ -95,21 +95,21 @@ String Constraints::toString(const AStringFormat* strfmt) const
 
 int Constraints::isDefinedForSill() const
 {
-  if (_consItems.size() <= 0) return(0);
-  for (int i=0; i<(int) _consItems.size(); i++)
+  if (_consItems.size() <= 0) return (0);
+  for (int i = 0; i < (int)_consItems.size(); i++)
   {
-    if (_consItems[i]->getType() == EConsElem::SILL) return(1);
+    if (_consItems[i]->getType() == EConsElem::SILL) return (1);
   }
-  return(0);
+  return (0);
 }
 
 void Constraints::modifyConstraintsForSill()
 {
-  for (int i=0; i<(int) getNConsItem(); i++)
+  for (int i = 0; i < (int)getNConsItem(); i++)
   {
     const ConsItem* consitem = getConsItems(i);
     if (consitem->getType() != EConsElem::SILL) continue;
-    if (consitem->getValue() > 0) setValue(i,sqrt(consitem->getValue()));
+    if (consitem->getValue() > 0) setValue(i, sqrt(consitem->getValue()));
   }
 }
 
@@ -120,13 +120,13 @@ void Constraints::setValue(int item, double value)
 
 void Constraints::expandConstantSill(int nvar)
 {
-  _constantSills.resize(nvar,_constantSillValue);
+  _constantSills.resize(nvar, _constantSillValue);
 }
 
 bool Constraints::isConstraintSillDefined() const
 {
-  if (! FFFF(_constantSillValue)) return true;
-  if (! _constantSills.empty()) return true;
+  if (!FFFF(_constantSillValue)) return true;
+  if (!_constantSills.empty()) return true;
   return false;
 }
 
@@ -257,4 +257,4 @@ int add_unit_sill_constraints(Constraints& constraints)
   constraints.setConstantSillValue(1.);
   return (0);
 }
-}
+} // namespace gstlrn

--- a/src/Model/Tapering.cpp
+++ b/src/Model/Tapering.cpp
@@ -8,38 +8,37 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Model/Tapering.hpp"
 #include "Enum/ECov.hpp"
 
-#include "Model/Tapering.hpp"
-
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 Tapering::Tapering()
-  : AStringable(),
-    _type(0)
+  : AStringable()
+  , _type(0)
   , _maxNDim(0)
   , _range(0)
 {
 }
 
-Tapering::Tapering(const Tapering &m)
-    : AStringable(m),
-      _type(m._type),
-      _maxNDim(m._maxNDim),
-      _range(m._range)
+Tapering::Tapering(const Tapering& m)
+  : AStringable(m)
+  , _type(m._type)
+  , _maxNDim(m._maxNDim)
+  , _range(m._range)
 {
 }
 
-Tapering& Tapering::operator=(const Tapering &m)
+Tapering& Tapering::operator=(const Tapering& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
-    _type = m._type;
+    _type    = m._type;
     _maxNDim = m._maxNDim;
-    _range = m._range;
+    _range   = m._range;
   }
   return (*this);
 }
@@ -48,7 +47,7 @@ Tapering::~Tapering()
 {
 }
 
-int Tapering::init(int tape_type,double tape_range)
+int Tapering::init(int tape_type, double tape_range)
 {
 
   /* Preliminary check */
@@ -79,15 +78,14 @@ int Tapering::getNTape()
 Def_Tapering& D_TAPE(int rank)
 {
   static Def_Tapering DEF_TAPES[] =
-  {
-   {"Spherical"    , ECov::E_SPHERICAL, 3, _tape_spherical },
-   {"Cubic"        , ECov::E_CUBIC,     3, _tape_cubic     },
-   {"Triangle"     , ECov::E_TRIANGLE,  1, _tape_triangle  },
-   {"Pentamodel"   , ECov::E_PENTA,     3, _tape_penta     },
-   {"Storkey"      , ECov::E_STORKEY,   1, _tape_storkey   },
-   {"Wendland1"    , ECov::E_WENDLAND1, 3, _tape_wendland1 },
-   {"Wendland2"    , ECov::E_WENDLAND2, 3, _tape_wendland2 }
-  };
+    {
+      {"Spherical", ECov::E_SPHERICAL, 3, _tape_spherical},
+      {"Cubic", ECov::E_CUBIC, 3, _tape_cubic},
+      {"Triangle", ECov::E_TRIANGLE, 1, _tape_triangle},
+      {"Pentamodel", ECov::E_PENTA, 3, _tape_penta},
+      {"Storkey", ECov::E_STORKEY, 1, _tape_storkey},
+      {"Wendland1", ECov::E_WENDLAND1, 3, _tape_wendland1},
+      {"Wendland2", ECov::E_WENDLAND2, 3, _tape_wendland2}};
   return DEF_TAPES[rank];
 }
 
@@ -105,7 +103,7 @@ double _tape_cubic(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1) cov = 1. - h2 * (7. + h * (-8.75 + h2 * (3.5 - 0.75 * h2)));
   cov = MAX(0., cov);
 
@@ -125,13 +123,9 @@ double _tape_penta(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1)
-    cov = 1.
-        - h2 * (22. / 3.
-            - h2 * (33.
-                - h * (77. / 2.
-                    - h2 * (33. / 2. - h2 * (11. / 2. - 5. / 6. * h2)))));
+    cov = 1. - h2 * (22. / 3. - h2 * (33. - h * (77. / 2. - h2 * (33. / 2. - h2 * (11. / 2. - 5. / 6. * h2)))));
 
   return (cov);
 }
@@ -143,8 +137,7 @@ double _tape_storkey(double h)
   cov = 0.;
   pi2 = 2. * GV_PI;
   if (h < 1)
-    cov = (2. * (1. - h) * (1. + cos(pi2 * h) / 2.) + 3 / pi2 * sin(pi2 * h))
-        / 3.;
+    cov = (2. * (1. - h) * (1. + cos(pi2 * h) / 2.) + 3 / pi2 * sin(pi2 * h)) / 3.;
 
   return (cov);
 }
@@ -154,7 +147,7 @@ double _tape_wendland1(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1) cov = 1 - h2 * (10 - h * (20 - h * (15 - h * 4)));
   return (cov);
 }
@@ -164,12 +157,9 @@ double _tape_wendland2(double h)
   double h2, cov;
 
   cov = 0.;
-  h2 = h * h;
+  h2  = h * h;
   if (h < 1)
-    cov = 1
-        - h2 * ((28. / 3.)
-            - h2 * (70
-                - h * ((448. / 3.) - h * (140 - h * (64 - h * (35. / 3.))))));
+    cov = 1 - h2 * ((28. / 3.) - h2 * (70 - h * ((448. / 3.) - h * (140 - h * (64 - h * (35. / 3.))))));
   return (cov);
 }
 
@@ -181,4 +171,4 @@ String Tapering::toString(const AStringFormat* /*strfmt*/) const
   sstr << "Tapering Scale        = " << _range << std::endl;
   return sstr.str();
 }
-}
+} // namespace gstlrn

--- a/src/Morpho/Morpho.cpp
+++ b/src/Morpho/Morpho.cpp
@@ -8,16 +8,14 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
-
-#include "Enum/EMorpho.hpp"
-
-#include "Matrix/MatrixSymmetric.hpp"
+#include "Morpho/Morpho.hpp"
 #include "Basic/Utilities.hpp"
 #include "Db/Db.hpp"
-#include "Morpho/Morpho.hpp"
+#include "Enum/EMorpho.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
+#include "geoslib_old_f.h"
 
-#include <math.h>
+#include <cmath>
 
 static int RADIUS[3];
 static int LARGE = 9999999;
@@ -26,11 +24,11 @@ static int LARGE = 9999999;
 #define CROSS 0
 #define BLOCK 1
 
-#define IMAGES(ix,iy,iz) ((option == BLOCK) ? imagtmp.getValue(ix,iy,iz) : imagin.getValue(ix,iy,iz))
+#define IMAGES(ix, iy, iz) ((option == BLOCK) ? imagtmp.getValue(ix, iy, iz) : imagin.getValue(ix, iy, iz))
 
-#define GRID_ADD(ix,iy,iz)  ((ix)+(NX[0]*((iy)+NX[1]*(iz))))
-#define TAB(i,j,k)          (tab[GRID_ADD(i,j,k)])
-#define COMPNUM(i,j,k)      (compnum[GRID_ADD(i,j,k)])
+#define GRID_ADD(ix, iy, iz) ((ix) + (NX[0] * ((iy) + NX[1] * (iz))))
+#define TAB(i, j, k)         (tab[GRID_ADD(i, j, k)])
+#define COMPNUM(i, j, k)     (compnum[GRID_ADD(i, j, k)])
 /*! \endcond */
 
 namespace gstlrn
@@ -42,9 +40,9 @@ namespace gstlrn
  ** \param[in]  radius Radius of the structural element
  **
  *****************************************************************************/
-void _st_morpho_image_radius_define(const VectorInt &radius)
+void _st_morpho_image_radius_define(const VectorInt& radius)
 {
-  int size = static_cast<int>(radius.size());
+  int size  = static_cast<int>(radius.size());
   RADIUS[0] = (size > 0) ? radius[0] : 0;
   RADIUS[1] = (size > 1) ? radius[1] : 0;
   RADIUS[2] = (size > 2) ? radius[2] : 0;
@@ -63,14 +61,14 @@ void _st_morpho_image_radius_define(const VectorInt &radius)
  **                   labelled from 1 to nbcomp
  **
  *****************************************************************************/
-int _st_morpho_label_size(const VectorDouble &compnum,
+int _st_morpho_label_size(const VectorDouble& compnum,
                           int nbcomp,
-                          VectorInt &sizes)
+                          VectorInt& sizes)
 {
   int total = 0;
-  for (int i = 0; i < (int) compnum.size(); i++)
+  for (int i = 0; i < (int)compnum.size(); i++)
   {
-    int val = (int) compnum[i];
+    int val = (int)compnum[i];
     if (val > 0 && val <= nbcomp)
     {
       sizes[val - 1]++;
@@ -89,13 +87,13 @@ int _st_morpho_label_size(const VectorDouble &compnum,
  ** \param[in]  nbcomp  number of connected components
  **
  *****************************************************************************/
-void _st_morpho_label_order(VectorDouble &compnum,
-                            const VectorInt &order,
+void _st_morpho_label_order(VectorDouble& compnum,
+                            const VectorInt& order,
                             int nbcomp)
 {
-  for (int i = 0; i < (int) compnum.size(); i++)
+  for (int i = 0; i < (int)compnum.size(); i++)
   {
-    int val = (int) compnum[i];
+    int val = (int)compnum[i];
     if (val <= 0) continue;
     int found = -1;
     for (int j = nbcomp - 1; j >= 0 && found < 0; j--)
@@ -110,7 +108,7 @@ void _st_morpho_label_order(VectorDouble &compnum,
  * @param imagin
  * @param imagout
  */
-void morpho_duplicate(const BImage &imagin, BImage &imagout)
+void morpho_duplicate(const BImage& imagin, BImage& imagout)
 {
   imagout = imagin;
 }
@@ -123,7 +121,7 @@ void morpho_duplicate(const BImage &imagin, BImage &imagout)
  */
 VectorDouble morpho_labelling(int option,
                               int flag_size,
-                              const BImage &imagin,
+                              const BImage& imagin,
                               double ccvoid,
                               bool verbose)
 {
@@ -131,45 +129,45 @@ VectorDouble morpho_labelling(int option,
   int i, size, nbtest, nbcomp, ix, iy, iz, icomp, ival, itest, il, jcomp[26];
   VectorInt list_array, sizes, order;
   VectorDouble compnum;
-  int id[26][3] = { { -1, 00, 00 },
-                    { 00, -1, 00 },
-                    { 00, 00, -1 },
-                    { 01, 00, 00 },
-                    { 00, 01, 00 },
-                    { 00, 00, 01 },
-                    { -1, -1, -1 },
-                    { 00, -1, -1 },
-                    { 01, -1, -1 },
-                    { -1, 00, -1 },
-                    { -1, 01, -1 },
-                    { 00, 01, -1 },
-                    { 01, 00, -1 },
-                    { 01, 01, -1 },
-                    { -1, -1, 00 },
-                    { -1, 01, 00 },
-                    { 01, -1, 00 },
-                    { 01, 01, 00 },
-                    { -1, -1, 01 },
-                    { 00, -1, 01 },
-                    { 01, -1, 01 },
-                    { -1, 00, 01 },
-                    { -1, 01, 01 },
-                    { 00, 01, 01 },
-                    { 01, 00, 01 },
-                    { 01, 01, 01 } };
-  int ndel[2] = { 6, 26 };
-  int quantum = 100;
+  int id[26][3] = {{-1, 00, 00},
+                   {00, -1, 00},
+                   {00, 00, -1},
+                   {01, 00, 00},
+                   {00, 01, 00},
+                   {00, 00, 01},
+                   {-1, -1, -1},
+                   {00, -1, -1},
+                   {01, -1, -1},
+                   {-1, 00, -1},
+                   {-1, 01, -1},
+                   {00, 01, -1},
+                   {01, 00, -1},
+                   {01, 01, -1},
+                   {-1, -1, 00},
+                   {-1, 01, 00},
+                   {01, -1, 00},
+                   {01, 01, 00},
+                   {-1, -1, 01},
+                   {00, -1, 01},
+                   {01, -1, 01},
+                   {-1, 00, 01},
+                   {-1, 01, 01},
+                   {00, 01, 01},
+                   {01, 00, 01},
+                   {01, 01, 01}};
+  int ndel[2]   = {6, 26};
+  int quantum   = 100;
 
   /* Initializations */
 
   nbtest = ndel[option];
   nbcomp = total = 0;
-  VectorInt NX = imagin.getNDimsExt(3);
+  VectorInt NX   = imagin.getNDimsExt(3);
 
   /* Attempt to allocate the initial quantum */
 
   int nxyz = imagin.getNPixels();
-  size = MIN(quantum, nxyz);
+  size     = MIN(quantum, nxyz);
   list_array.resize(size);
   compnum.resize(nxyz);
   for (i = 0; i < nxyz; i++) compnum[i] = 0.;
@@ -186,12 +184,12 @@ VectorDouble morpho_labelling(int option,
           for (itest = 0; itest < nbtest; itest++)
           {
             jcomp[itest] = LARGE;
-            jx = ix + id[itest][0];
-            jy = iy + id[itest][1];
-            jz = iz + id[itest][2];
+            jx           = ix + id[itest][0];
+            jy           = iy + id[itest][1];
+            jz           = iz + id[itest][2];
             if (imagin.isInside(jx, jy, jz))
             {
-              ival = (int) COMPNUM(jx, jy, jz);
+              ival = (int)COMPNUM(jx, jy, jz);
               if (ival > 0)
               {
                 jcomp[itest] = list_array[ival - 1];
@@ -216,14 +214,14 @@ VectorDouble morpho_labelling(int option,
               list_array.resize(size);
             }
             list_array[nbcomp - 1] = nbcomp;
-            icomp = nbcomp;
+            icomp                  = nbcomp;
           }
         }
         else
         {
           icomp = 0;
         }
-        COMPNUM(ix,iy,iz) = (double) icomp;
+        COMPNUM(ix, iy, iz) = (double)icomp;
       }
 
   /* Compressing the list */
@@ -241,11 +239,11 @@ VectorDouble morpho_labelling(int option,
     for (iy = 0; iy < imagin.getNDims(1); iy++)
       for (ix = 0; ix < imagin.getNDims(0); ix++)
       {
-        iad = (int) COMPNUM(ix, iy, iz);
+        iad = (int)COMPNUM(ix, iy, iz);
         if (iad != 0)
-          COMPNUM(ix,iy,iz) = list_array[iad - 1];
+          COMPNUM(ix, iy, iz) = list_array[iad - 1];
         else
-          COMPNUM(ix,iy,iz) = TEST;
+          COMPNUM(ix, iy, iz) = TEST;
       }
 
   /* Order the components */
@@ -264,7 +262,7 @@ VectorDouble morpho_labelling(int option,
       for (i = 0; i < nxyz; i++)
       {
         if (FFFF(compnum[i])) continue;
-        ival = (int) compnum[i];
+        ival       = (int)compnum[i];
         compnum[i] = sizes[ival - 1];
       }
 
@@ -283,9 +281,9 @@ VectorDouble morpho_labelling(int option,
     else
     {
       message("Number of connected components = %d\n", nbcomp);
-      message("Total connected volume = %d\n",total);
+      message("Total connected volume = %d\n", total);
       message("   Component     Number         Total     Cumul (percent)\n");
-      ref = sizes[order[nbcomp - 1] - 1];
+      ref   = sizes[order[nbcomp - 1] - 1];
       count = part_grain = 0;
       for (i = nbcomp - 1; i >= 0; i--)
       {
@@ -295,7 +293,7 @@ VectorDouble morpho_labelling(int option,
         {
           message("%12d  %9d  %12d      %7.3f\n", ref, count, count * ref,
                   100. * part_grain / total);
-          ref = local;
+          ref   = local;
           count = 0;
         }
 
@@ -318,11 +316,11 @@ VectorInt morpho_labelsize(int option, const BImage& imagin)
 {
   VectorInt sizes;
   VectorDouble compnum = morpho_labelling(option, 0, imagin, TEST);
-  int nbcomp = (int) compnum.size();
+  int nbcomp           = (int)compnum.size();
   if (nbcomp > 0)
   {
     sizes.resize(nbcomp, 0);
-    (void) _st_morpho_label_size(compnum, nbcomp, sizes);
+    (void)_st_morpho_label_size(compnum, nbcomp, sizes);
   }
   return sizes;
 }
@@ -331,7 +329,7 @@ VectorInt morpho_labelsize(int option, const BImage& imagin)
  * Perform the "erosion" of the input image
  */
 void morpho_erosion(int option,
-                    const VectorInt &radius,
+                    const VectorInt& radius,
                     const BImage& imagin,
                     BImage& imagout,
                     bool verbose)
@@ -356,17 +354,17 @@ void morpho_erosion(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (iz = 0; iz < imagin.getNDims(2); iz++)
     {
-      nz1 = MIN(imagin.getNDims(2) - 1, MAX(0,iz-RADIUS[2]));
-      nz2 = MIN(imagin.getNDims(2) - 1, MAX(0,iz+RADIUS[2]));
+      nz1 = MIN(imagin.getNDims(2) - 1, MAX(0, iz - RADIUS[2]));
+      nz2 = MIN(imagin.getNDims(2) - 1, MAX(0, iz + RADIUS[2]));
       for (iy = 0; iy < imagin.getNDims(1); iy++)
         for (ix = 0; ix < imagin.getNDims(0); ix++)
-          if (! IMAGES(ix, iy, iz))
+          if (!IMAGES(ix, iy, iz))
             imagout.setMaskoff(ix, iy, iz);
           else
             for (jz = nz1; jz <= nz2; jz++)
               if (!IMAGES(ix, iy, jz))
               {
-                imagout.setMaskoff(ix,  iy,  iz);
+                imagout.setMaskoff(ix, iy, iz);
                 break;
               }
     }
@@ -379,17 +377,17 @@ void morpho_erosion(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (iy = 0; iy < imagin.getNDims(1); iy++)
     {
-      ny1 = MIN(imagin.getNDims(1) - 1, MAX(0,iy-RADIUS[1]));
-      ny2 = MIN(imagin.getNDims(1) - 1, MAX(0,iy+RADIUS[1]));
+      ny1 = MIN(imagin.getNDims(1) - 1, MAX(0, iy - RADIUS[1]));
+      ny2 = MIN(imagin.getNDims(1) - 1, MAX(0, iy + RADIUS[1]));
       for (iz = 0; iz < imagin.getNDims(2); iz++)
         for (ix = 0; ix < imagin.getNDims(0); ix++)
           if (!IMAGES(ix, iy, iz))
-            imagout.setMaskoff(ix,iy,iz);
+            imagout.setMaskoff(ix, iy, iz);
           else
             for (jy = ny1; jy <= ny2; jy++)
               if (!IMAGES(ix, jy, iz))
               {
-                imagout.setMaskoff(ix,iy,iz);
+                imagout.setMaskoff(ix, iy, iz);
                 break;
               }
     }
@@ -402,17 +400,17 @@ void morpho_erosion(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (ix = 0; ix < imagin.getNDims(0); ix++)
     {
-      nx1 = MIN(imagin.getNDims(0) - 1, MAX(0,ix-RADIUS[0]));
-      nx2 = MIN(imagin.getNDims(0) - 1, MAX(0,ix+RADIUS[0]));
+      nx1 = MIN(imagin.getNDims(0) - 1, MAX(0, ix - RADIUS[0]));
+      nx2 = MIN(imagin.getNDims(0) - 1, MAX(0, ix + RADIUS[0]));
       for (iz = 0; iz < imagin.getNDims(2); iz++)
         for (iy = 0; iy < imagin.getNDims(1); iy++)
           if (!IMAGES(ix, iy, iz))
-            imagout.setMaskoff(ix,iy,iz);
+            imagout.setMaskoff(ix, iy, iz);
           else
             for (jx = nx1; jx <= nx2; jx++)
               if (!IMAGES(jx, iy, iz))
               {
-                imagout.setMaskoff(ix,iy,iz);
+                imagout.setMaskoff(ix, iy, iz);
                 break;
               }
     }
@@ -425,7 +423,7 @@ void morpho_erosion(int option,
  * Perform the "dilation" of the input image
  */
 void morpho_dilation(int option,
-                     const VectorInt &radius,
+                     const VectorInt& radius,
                      const BImage& imagin,
                      BImage& imagout,
                      bool verbose)
@@ -450,17 +448,17 @@ void morpho_dilation(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (iz = 0; iz < imagin.getNDims(2); iz++)
     {
-      nz1 = MIN(imagin.getNDims(2) - 1, MAX(0,iz-RADIUS[2]));
-      nz2 = MIN(imagin.getNDims(2) - 1, MAX(0,iz+RADIUS[2]));
+      nz1 = MIN(imagin.getNDims(2) - 1, MAX(0, iz - RADIUS[2]));
+      nz2 = MIN(imagin.getNDims(2) - 1, MAX(0, iz + RADIUS[2]));
       for (iy = 0; iy < imagin.getNDims(1); iy++)
         for (ix = 0; ix < imagin.getNDims(0); ix++)
           if (IMAGES(ix, iy, iz))
-            imagout.setOffset(ix,iy,iz);
+            imagout.setOffset(ix, iy, iz);
           else
             for (jz = nz1; jz <= nz2; jz++)
               if (IMAGES(ix, iy, jz))
               {
-                imagout.setOffset(ix,iy,iz);
+                imagout.setOffset(ix, iy, iz);
                 break;
               }
     }
@@ -473,17 +471,17 @@ void morpho_dilation(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (iy = 0; iy < imagin.getNDims(1); iy++)
     {
-      ny1 = MIN(imagin.getNDims(1) - 1, MAX(0,iy-RADIUS[1]));
-      ny2 = MIN(imagin.getNDims(1) - 1, MAX(0,iy+RADIUS[1]));
+      ny1 = MIN(imagin.getNDims(1) - 1, MAX(0, iy - RADIUS[1]));
+      ny2 = MIN(imagin.getNDims(1) - 1, MAX(0, iy + RADIUS[1]));
       for (iz = 0; iz < imagin.getNDims(2); iz++)
         for (ix = 0; ix < imagin.getNDims(0); ix++)
           if (IMAGES(ix, iy, iz))
-            imagout.setOffset(ix,iy,iz);
+            imagout.setOffset(ix, iy, iz);
           else
             for (jy = ny1; jy <= ny2; jy++)
               if (IMAGES(ix, jy, iz))
               {
-                imagout.setOffset(ix,iy,iz);
+                imagout.setOffset(ix, iy, iz);
                 break;
               }
     }
@@ -496,17 +494,17 @@ void morpho_dilation(int option,
     if (option == BLOCK) imagtmp = imagout;
     for (ix = 0; ix < imagin.getNDims(0); ix++)
     {
-      nx1 = MIN(imagin.getNDims(0) - 1, MAX(0,ix-RADIUS[0]));
-      nx2 = MIN(imagin.getNDims(0) - 1, MAX(0,ix+RADIUS[0]));
+      nx1 = MIN(imagin.getNDims(0) - 1, MAX(0, ix - RADIUS[0]));
+      nx2 = MIN(imagin.getNDims(0) - 1, MAX(0, ix + RADIUS[0]));
       for (iz = 0; iz < imagin.getNDims(2); iz++)
         for (iy = 0; iy < imagin.getNDims(1); iy++)
           if (IMAGES(ix, iy, iz))
-            imagout.setOffset(ix,iy,iz);
+            imagout.setOffset(ix, iy, iz);
           else
             for (jx = nx1; jx <= nx2; jx++)
               if (IMAGES(jx, iy, iz))
               {
-                imagout.setOffset(ix,iy,iz);
+                imagout.setOffset(ix, iy, iz);
                 break;
               }
     }
@@ -599,7 +597,7 @@ int morpho_count(const BImage& imagin)
  * Perform the "opening" of the input image (i.e. an erosion followed by a dilation)
  */
 void morpho_opening(int option,
-                    const VectorInt &radius,
+                    const VectorInt& radius,
                     const BImage& imagin,
                     BImage& imagout,
                     bool verbose)
@@ -615,7 +613,7 @@ void morpho_opening(int option,
  * Perform the "closing" of the input image (i.e. a dilation followed by an erosion)
  */
 void morpho_closing(int option,
-                    const VectorInt &radius,
+                    const VectorInt& radius,
                     const BImage& imagin,
                     BImage& imagout,
                     bool verbose)
@@ -630,29 +628,29 @@ void morpho_closing(int option,
 /**
  * Converts an input image (double) into an image (in place)
  */
-void morpho_double2imageInPlace(const VectorInt &nx,
-                                const VectorDouble &tab,
+void morpho_double2imageInPlace(const VectorInt& nx,
+                                const VectorDouble& tab,
                                 double vmin,
                                 double vmax,
-                                BImage &imagout,
+                                BImage& imagout,
                                 bool verbose)
 {
   imagout.init(nx);
-  VectorInt NX = imagout.getNDimsExt(3);
+  VectorInt NX      = imagout.getNDimsExt(3);
   unsigned char mot = 0;
-  int ind = 0;
-  int ecr = 0;
+  int ind           = 0;
+  int ecr           = 0;
   for (int iz = 0; iz < imagout.getNDims(2); iz++)
     for (int iy = 0; iy < imagout.getNDims(1); iy++)
       for (int ix = 0; ix < imagout.getNDims(0); ix++)
       {
         ind++;
-        double val = TAB(ix, iy, iz);
+        double val    = TAB(ix, iy, iz);
         double result = 1.;
         if (FFFF(val)) result = 0.;
         if (!FFFF(vmin) && val < vmin) result = 0.;
         if (!FFFF(vmax) && val >= vmax) result = 0.;
-        mot = (mot << 1) + (unsigned char) result;
+        mot = (mot << 1) + (unsigned char)result;
         if (ind == 8)
         {
           imagout.setValue(ecr, mot);
@@ -671,8 +669,8 @@ void morpho_double2imageInPlace(const VectorInt &nx,
 /**
  * Converts an input image (double) into a returned image
  */
-BImage morpho_double2image(const VectorInt &nx,
-                           const VectorDouble &tab,
+BImage morpho_double2image(const VectorInt& nx,
+                           const VectorDouble& tab,
                            double vmin,
                            double vmax,
                            bool verbose)
@@ -689,11 +687,11 @@ void morpho_image2double(const BImage& imagin,
                          int mode,
                          double grain,
                          double pore,
-                         VectorDouble &tab,
+                         VectorDouble& tab,
                          bool verbose)
 {
   VectorInt NX = imagin.getNDimsExt(3);
-  int nxyz = imagin.getNPixels();
+  int nxyz     = imagin.getNPixels();
   if (verbose)
     message("Translation: %d / %d\n", morpho_count(imagin), nxyz);
 
@@ -701,19 +699,19 @@ void morpho_image2double(const BImage& imagin,
     for (int iy = 0; iy < imagin.getNDims(1); iy++)
       for (int ix = 0; ix < imagin.getNDims(0); ix++)
       {
-        double value = imagin.getValue(ix,iy,iz) ? grain : pore;
+        double value = imagin.getValue(ix, iy, iz) ? grain : pore;
         switch (mode)
         {
           case 0:
-            TAB(ix,iy,iz) = value;
+            TAB(ix, iy, iz) = value;
             break;
 
           case 1:
-            TAB(ix,iy,iz) += value;
+            TAB(ix, iy, iz) += value;
             break;
 
           case -1:
-            TAB(ix,iy,iz) -= value;
+            TAB(ix, iy, iz) -= value;
             break;
         }
       }
@@ -723,14 +721,14 @@ void morpho_image2double(const BImage& imagin,
  * Returns the vector of distances from the grain to the edge
  */
 void morpho_distance(int option,
-                     const VectorInt &radius,
+                     const VectorInt& radius,
                      bool flagDistErode,
                      BImage& imagin,
-                     VectorDouble &dist,
+                     VectorDouble& dist,
                      bool verbose)
 {
   BImage imagout = imagin;
-  int nxyz = imagin.getNPixels();
+  int nxyz       = imagin.getNPixels();
 
   /* Copy the initial image in the distance array */
 
@@ -750,7 +748,7 @@ void morpho_distance(int option,
       if (verbose)
       {
         int count = morpho_count(imagin);
-        message("Iteration %d: Current (%d/%d)\n",iter,count,nxyz);
+        message("Iteration %d: Current (%d/%d)\n", iter, count, nxyz);
       }
     }
   }
@@ -767,7 +765,7 @@ void morpho_distance(int option,
       if (verbose)
       {
         int count = morpho_count(imagin);
-        message("Iteration %d: Current (%d/%d)\n",iter,count,nxyz);
+        message("Iteration %d: Current (%d/%d)\n", iter, count, nxyz);
       }
     }
     morpho_image2double(imagin, 1, incr, 0, dist);
@@ -798,7 +796,7 @@ VectorInt gridcell_neigh(int ndim,
 
   /* Create the grid attributes */
 
-  VectorInt    nx(ndim);
+  VectorInt nx(ndim);
   VectorDouble x0(ndim);
   VectorDouble dx(ndim);
   for (int idim = 0; idim < ndim; idim++)
@@ -869,7 +867,7 @@ VectorInt gridcell_neigh(int ndim,
 /**
  * Calculate the gradient orientations of a colored image
  */
-void db_morpho_angle2D(DbGrid *dbgrid, const VectorInt &radius, int iptr0)
+void db_morpho_angle2D(DbGrid* dbgrid, const VectorInt& radius, int iptr0)
 {
   int iad;
   double result;
@@ -894,9 +892,9 @@ void db_morpho_angle2D(DbGrid *dbgrid, const VectorInt &radius, int iptr0)
       a.fill(0.);
       b.fill(0.);
       x.fill(0.);
-      indg[0] = iix;
-      indg[1] = iiy;
-      iad = dbgrid->indiceToRank(indg);
+      indg[0]   = iix;
+      indg[1]   = iiy;
+      iad       = dbgrid->indiceToRank(indg);
       double z0 = dbgrid->getArray(iad, iptrz);
       if (FFFF(z0)) continue;
 
@@ -907,9 +905,9 @@ void db_morpho_angle2D(DbGrid *dbgrid, const VectorInt &radius, int iptr0)
           if (ix < 0 || ix >= NX[0]) continue;
           int iy = iiy + jy;
           if (iy < 0 || iy >= NX[1]) continue;
-          indg[0] = ix;
-          indg[1] = iy;
-          iad = dbgrid->indiceToRank(indg);
+          indg[0]   = ix;
+          indg[1]   = iy;
+          iad       = dbgrid->indiceToRank(indg);
           double xi = dbgrid->getCoordinate(iad, 0);
           double yi = dbgrid->getCoordinate(iad, 1);
           double zi = dbgrid->getArray(iad, iptrz);
@@ -940,14 +938,14 @@ void db_morpho_angle2D(DbGrid *dbgrid, const VectorInt &radius, int iptr0)
 /**
  * Calculate the gradient components of a colord image
  */
-void db_morpho_gradients(DbGrid *dbgrid, int iptr)
+void db_morpho_gradients(DbGrid* dbgrid, int iptr)
 {
   int j1, j2, number;
 
   /* Preliminary check */
 
   VectorInt NX = dbgrid->getNXsExt(3);
-  int ndim = dbgrid->getNDim();
+  int ndim     = dbgrid->getNDim();
   VectorInt indg(ndim);
   int iptrz = dbgrid->getColIdxByLocator(ELoc::Z);
 
@@ -963,47 +961,47 @@ void db_morpho_gradients(DbGrid *dbgrid, int iptr)
           if (ndim >= 2) indg[1] = iy;
           if (ndim >= 3) indg[2] = iz;
 
-          int nmax = dbgrid->getNX(idim);
+          int nmax    = dbgrid->getNX(idim);
           double dinc = dbgrid->getDX(idim);
 
           double v1 = 0.;
           double v2 = 0.;
-          number = 0;
+          number    = 0;
           if (idim == 0)
           {
-            j1 = (ix + 1 > nmax - 1) ? ix : ix + 1;
+            j1      = (ix + 1 > nmax - 1) ? ix : ix + 1;
             indg[0] = j1;
-            v1 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v1      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v1)) continue;
-            j2 = (ix - 1 < 0) ? ix : ix - 1;
+            j2      = (ix - 1 < 0) ? ix : ix - 1;
             indg[0] = j2;
-            v2 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v2      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v2)) continue;
             number = j1 - j2;
           }
 
           if (idim == 1)
           {
-            j1 = (iy + 1 > nmax - 1) ? iy : iy + 1;
+            j1      = (iy + 1 > nmax - 1) ? iy : iy + 1;
             indg[1] = j1;
-            v1 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v1      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v1)) continue;
-            j2 = (iy - 1 < 0) ? iy : iy - 1;
+            j2      = (iy - 1 < 0) ? iy : iy - 1;
             indg[1] = j2;
-            v2 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v2      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v2)) continue;
             number = j1 - j2;
           }
 
           if (idim == 2)
           {
-            j1 = (iz + 1 > nmax - 1) ? iz : iz + 1;
+            j1      = (iz + 1 > nmax - 1) ? iz : iz + 1;
             indg[2] = j1;
-            v1 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v1      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v1)) continue;
-            j2 = (iz - 1 < 0) ? iz : iz - 1;
+            j2      = (iz - 1 < 0) ? iz : iz - 1;
             indg[2] = j2;
-            v2 = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
+            v2      = dbgrid->getArray(dbgrid->indiceToRank(indg), iptrz);
             if (FFFF(v2)) continue;
             number = j1 - j2;
           }
@@ -1020,31 +1018,31 @@ void db_morpho_gradients(DbGrid *dbgrid, int iptr)
 /**
  * Perform a morphological operation with a DbGrid
  */
-int db_morpho_calc(DbGrid *dbgrid,
-                    int iptr0,
-                    const EMorpho &oper,
-                    double vmin,
-                    double vmax,
-                    int option,
-                    const VectorInt &radius,
-                    bool flagDistErode,
-                    bool verbose)
+int db_morpho_calc(DbGrid* dbgrid,
+                   int iptr0,
+                   const EMorpho& oper,
+                   double vmin,
+                   double vmax,
+                   int option,
+                   const VectorInt& radius,
+                   bool flagDistErode,
+                   bool verbose)
 {
-  int ntotal = dbgrid->getNSample();
+  int ntotal    = dbgrid->getNSample();
   VectorInt nxy = dbgrid->getNXs();
 
   VectorDouble tabin = dbgrid->getColumnByLocator(ELoc::Z);
-  BImage image = morpho_double2image(nxy,tabin,vmin,vmax);
+  BImage image       = morpho_double2image(nxy, tabin, vmin, vmax);
 
   if (verbose)
   {
     message("Morphological operation = %s\n", oper.getDescr().data());
-    message("Initial image = %d/%d\n",morpho_count(image),ntotal);
+    message("Initial image = %d/%d\n", morpho_count(image), ntotal);
   }
 
-  bool alreadyLoaded = false;
-  bool alreadySaved = false;
-  BImage image2 = BImage(nxy);
+  bool alreadyLoaded  = false;
+  bool alreadySaved   = false;
+  BImage image2       = BImage(nxy);
   VectorDouble tabout = VectorDouble(ntotal, TEST);
   if (oper == EMorpho::THRESH)
   {
@@ -1072,30 +1070,30 @@ int db_morpho_calc(DbGrid *dbgrid,
   }
   else if (oper == EMorpho::CC)
   {
-    tabout = morpho_labelling(0, 0, image, TEST, verbose);
+    tabout        = morpho_labelling(0, 0, image, TEST, verbose);
     alreadyLoaded = true;
   }
   else if (oper == EMorpho::CCSIZE)
   {
-    tabout = morpho_labelling(0, 1, image, TEST, verbose);
+    tabout        = morpho_labelling(0, 1, image, TEST, verbose);
     alreadyLoaded = true;
   }
   else if (oper == EMorpho::DISTANCE)
   {
-    morpho_distance(option,radius,flagDistErode,image,tabout,verbose);
+    morpho_distance(option, radius, flagDistErode, image, tabout, verbose);
     alreadyLoaded = true;
   }
   else if (oper == EMorpho::ANGLE)
   {
-    db_morpho_angle2D(dbgrid,radius,iptr0);
+    db_morpho_angle2D(dbgrid, radius, iptr0);
     alreadyLoaded = true;
-    alreadySaved = true;
+    alreadySaved  = true;
   }
   else if (oper == EMorpho::GRADIENT)
   {
     db_morpho_gradients(dbgrid, iptr0);
     alreadyLoaded = true;
-    alreadySaved = true;
+    alreadySaved  = true;
   }
   else
   {
@@ -1103,13 +1101,13 @@ int db_morpho_calc(DbGrid *dbgrid,
     return 1;
   }
 
-  if (! alreadyLoaded)
+  if (!alreadyLoaded)
   {
     if (verbose)
-      message("Resulting image = %d/%d\n",morpho_count(image2),ntotal);
+      message("Resulting image = %d/%d\n", morpho_count(image2), ntotal);
     morpho_image2double(image2, 0, 1., 0., tabout);
   }
-  if (! alreadySaved)
+  if (!alreadySaved)
   {
     dbgrid->setColumnByUID(tabout, iptr0);
   }
@@ -1143,7 +1141,7 @@ int db_morpho_calc(DbGrid *dbgrid,
  ** \remark  must start with 1
  **
  *****************************************************************************/
-Spill_Res spillPoint(DbGrid *dbgrid,
+Spill_Res spillPoint(DbGrid* dbgrid,
                      const String& name_depth,
                      const String& name_data,
                      int option,
@@ -1157,7 +1155,7 @@ Spill_Res spillPoint(DbGrid *dbgrid,
 
   double th     = 0.;
   int ind_depth = dbgrid->getUID(name_depth);
-  int ind_data = dbgrid->getUID(name_data);
+  int ind_data  = dbgrid->getUID(name_data);
   if (ind_depth < 0 || ind_data < 0)
   {
     messerr("Variables 'name_depth' and 'name_data' are compulsory");
@@ -1169,12 +1167,12 @@ Spill_Res spillPoint(DbGrid *dbgrid,
                           verbose_step, hmax, &h, &th, &ix0, &iy0);
 
   res.success = (error == 0);
-  res.h = h;
-  res.th = th;
-  res.ix0 = ix0;
-  res.iy0 = iy0;
+  res.h       = h;
+  res.th      = th;
+  res.ix0     = ix0;
+  res.iy0     = iy0;
 
   return res;
 }
 
-}
+} // namespace gstlrn

--- a/src/Neigh/ANeigh.cpp
+++ b/src/Neigh/ANeigh.cpp
@@ -10,17 +10,17 @@
 /******************************************************************************/
 #include "geoslib_old_f.h"
 
-#include "Neigh/NeighUnique.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Basic/SerializeHDF5.hpp"
-#include "Neigh/ANeigh.hpp"
-#include "Neigh/NeighMoving.hpp"
-#include "Neigh/NeighBench.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
+#include "Neigh/ANeigh.hpp"
+#include "Neigh/NeighBench.hpp"
+#include "Neigh/NeighMoving.hpp"
+#include "Neigh/NeighUnique.hpp"
 
-#include <math.h>
 #include <algorithm>
+#include <cmath>
 
 namespace gstlrn
 {
@@ -58,27 +58,26 @@ ANeigh::ANeigh(const ANeigh& r)
   , _nbghMemo(r._nbghMemo)
   , _ball(r._ball)
 {
-
 }
 
-ANeigh& ANeigh::operator=(const ANeigh &r)
+ANeigh& ANeigh::operator=(const ANeigh& r)
 {
   if (this != &r)
   {
     ASpaceObject::operator=(r);
     ASerializable::operator=(r);
-    _dbin = r._dbin;
-    _dbout = r._dbout;
-    _dbgrid = r._dbgrid;
-    _iechMemo = r._iechMemo;
-    _flagSimu = r._flagSimu;
-    _flagXvalid = r._flagXvalid;
-    _flagKFold  = r._flagKFold;
-    _useBallSearch = r._useBallSearch;
-    _ballLeafSize = r._ballLeafSize;
+    _dbin            = r._dbin;
+    _dbout           = r._dbout;
+    _dbgrid          = r._dbgrid;
+    _iechMemo        = r._iechMemo;
+    _flagSimu        = r._flagSimu;
+    _flagXvalid      = r._flagXvalid;
+    _flagKFold       = r._flagKFold;
+    _useBallSearch   = r._useBallSearch;
+    _ballLeafSize    = r._ballLeafSize;
     _flagIsUnchanged = r._flagIsUnchanged;
-    _nbghMemo = r._nbghMemo;
-    _ball = r._ball;
+    _nbghMemo        = r._nbghMemo;
+    _ball            = r._ball;
   }
   return *this;
 }
@@ -87,7 +86,7 @@ ANeigh::~ANeigh()
 {
 }
 
-int ANeigh::attach(const Db *dbin, const Db *dbout)
+int ANeigh::attach(const Db* dbin, const Db* dbout)
 {
   if (dbin == nullptr || dbout == nullptr) return 1;
   _dbin  = dbin;
@@ -147,7 +146,7 @@ void ANeigh::select(int iech_out, VectorInt& ranks)
     messageAbort("'dbin' and 'dbout' must have been attached beforehand");
     return;
   }
-  if (! _dbout->isSampleIndexValid(iech_out))
+  if (!_dbout->isSampleIndexValid(iech_out))
   {
     ranks.clear();
     return;
@@ -157,7 +156,7 @@ void ANeigh::select(int iech_out, VectorInt& ranks)
   // Then do not do anything (even in presence of colocation)
   if (_isSameTarget(iech_out))
   {
-    ranks = _nbghMemo;
+    ranks            = _nbghMemo;
     _flagIsUnchanged = true;
     return;
   }
@@ -174,12 +173,12 @@ void ANeigh::select(int iech_out, VectorInt& ranks)
   }
   else
   {
-    ranks = _nbghMemo;
+    ranks            = _nbghMemo;
     _flagIsUnchanged = true;
   }
 
   // Stop the neighborhood search if not enough point is available
-  if ((int) ranks.size() <= 0) return;
+  if ((int)ranks.size() <= 0) return;
 }
 
 /**
@@ -201,7 +200,7 @@ bool ANeigh::_isSameTarget(int iech_out)
   return flagSame;
 }
 
-void ANeigh::_checkUnchanged(int iech_out, const VectorInt &ranks)
+void ANeigh::_checkUnchanged(int iech_out, const VectorInt& ranks)
 {
   VectorInt rsorted = ranks;
   std::sort(rsorted.begin(), rsorted.end());
@@ -248,7 +247,7 @@ void ANeigh::_display(const VectorInt& ranks) const
   int ncode = _dbin->getNLoc(ELoc::C);
   int nblex = _dbin->getNLoc(ELoc::BLEX);
   int nvar  = _dbin->getNLoc(ELoc::Z);
-  nvar = 0;
+  nvar      = 0;
 
   /* Title */
 
@@ -339,7 +338,7 @@ void ANeigh::_display(const VectorInt& ranks) const
     if (nblex > 0)
     {
       for (int idim = 0; idim < ndim; idim++)
-        tab_printg(NULL, _dbin->getLocVariable(ELoc::BLEX,iech, idim));
+        tab_printg(NULL, _dbin->getLocVariable(ELoc::BLEX, iech, idim));
     }
 
     // Sector
@@ -349,7 +348,7 @@ void ANeigh::_display(const VectorInt& ranks) const
     message("\n");
     nsel++;
   }
-  }
+}
 
 /****************************************************************************/
 /*!
@@ -368,7 +367,7 @@ bool ANeigh::_discardUndefined(int iech)
 {
   if (_dbin->getNLoc(ELoc::Z) <= 0) return 0;
 
-  if (! _flagSimu)
+  if (!_flagSimu)
   {
     if (_dbin->isAllUndefined(iech)) return 0;
   }
@@ -394,25 +393,25 @@ bool ANeigh::_discardUndefined(int iech)
  *****************************************************************************/
 int ANeigh::_xvalid(int iech_in, int iech_out, double eps)
 {
-  if (! getFlagXvalid()) return 0;
-  if (! getFlagKFold())
+  if (!getFlagXvalid()) return 0;
+  if (!getFlagKFold())
   {
     if (distance_inter(_dbin, _dbout, iech_in, iech_out, NULL) < eps) return 1;
   }
   else
   {
-    if (! _dbin->hasLocVariable(ELoc::C)) return 0;
-    if (_dbin->getLocVariable(ELoc::C,iech_in,0) ==
-        _dbout->getLocVariable(ELoc::C,iech_out,0)) return 1;
+    if (!_dbin->hasLocVariable(ELoc::C)) return 0;
+    if (_dbin->getLocVariable(ELoc::C, iech_in, 0) ==
+        _dbout->getLocVariable(ELoc::C, iech_out, 0)) return 1;
   }
   return 0;
 }
 
 bool ANeigh::_isDimensionValid(int idim) const
 {
-  if (idim < 0 || idim >= (int) getNDim())
+  if (idim < 0 || idim >= (int)getNDim())
   {
-    messerr("Error in 'idim'(%d). It should lie within [0,%d[",idim,getNDim());
+    messerr("Error in 'idim'(%d). It should lie within [0,%d[", idim, getNDim());
     return false;
   }
   return true;
@@ -423,7 +422,7 @@ bool ANeigh::_deserializeAscii(std::istream& is, bool /*verbose*/)
   int ndim = 0;
 
   bool ret = true;
-  ret = ret && _recordRead<int>(is, "Space Dimension", ndim);
+  ret      = ret && _recordRead<int>(is, "Space Dimension", ndim);
   if (ret) setNDim(ndim);
   return ret;
 }
@@ -431,7 +430,7 @@ bool ANeigh::_deserializeAscii(std::istream& is, bool /*verbose*/)
 bool ANeigh::_serializeAscii(std::ostream& os, bool /*verbose*/) const
 {
   bool ret = true;
-  ret = ret && _recordWrite<int>(os, "Space Dimension", getNDim());
+  ret      = ret && _recordWrite<int>(os, "Space Dimension", getNDim());
 
   return ret;
 }
@@ -440,10 +439,11 @@ void ANeigh::setBallSearch(bool status, int leaf_size)
 {
   if (leaf_size <= 0) status = false;
   _useBallSearch = status;
-  _ballLeafSize = leaf_size;
+  _ballLeafSize  = leaf_size;
 }
 
-void ANeigh::_neighCompress(VectorInt& ranks) {
+void ANeigh::_neighCompress(VectorInt& ranks)
+{
   int necr   = 0;
   int number = (int)ranks.size();
   for (int i = 0; i < number; i++)
@@ -481,4 +481,4 @@ bool ANeigh::_serializeH5(H5::Group& grp, [[maybe_unused]] bool verbose) const
   return ret;
 }
 #endif
-}
+} // namespace gstlrn

--- a/src/OutputFormat/AOF.cpp
+++ b/src/OutputFormat/AOF.cpp
@@ -13,7 +13,7 @@
 #include "Basic/File.hpp"
 #include "Db/DbGrid.hpp"
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace gstlrn
 {
@@ -28,11 +28,11 @@ AOF::AOF(const String& filename, const Db* db)
 }
 
 AOF::AOF(const AOF& r)
-    : _filename(r._filename),
-      _db(r._db),
-      _dbgrid(r._dbgrid),
-      _cols(r._cols),
-      _file(r._file)
+  : _filename(r._filename)
+  , _db(r._db)
+  , _dbgrid(r._dbgrid)
+  , _cols(r._cols)
+  , _file(r._file)
 {
 }
 
@@ -41,10 +41,10 @@ AOF& AOF::operator=(const AOF& r)
   if (this != &r)
   {
     _filename = r._filename;
-    _db = r._db;
-    _dbgrid = r._dbgrid;
-    _cols = r._cols;
-    _file = r._file;
+    _db       = r._db;
+    _dbgrid   = r._dbgrid;
+    _cols     = r._cols;
+    _file     = r._file;
   }
   return *this;
 }
@@ -55,7 +55,7 @@ AOF::~AOF()
 
 bool AOF::isValidForGrid() const
 {
-  if (! mustBeGrid()) return true;
+  if (!mustBeGrid()) return true;
   if (_dbgrid == nullptr)
   {
     messerr("This function requires a Grid organization");
@@ -66,10 +66,10 @@ bool AOF::isValidForGrid() const
 
 bool AOF::isValidForVariable() const
 {
-  int ncol = (int) _cols.size();
+  int ncol = (int)_cols.size();
   if (mustBeOneVariable() && ncol > 1)
   {
-    messerr("This function requires a single Variable but ncol = %d",ncol);
+    messerr("This function requires a single Variable but ncol = %d", ncol);
     return false;
   }
   return true;
@@ -78,9 +78,9 @@ bool AOF::isValidForVariable() const
 bool AOF::isValidForNDim() const
 {
   int ndim = _dbgrid->getNDim();
-  if (! mustBeForNDim(ndim))
+  if (!mustBeForNDim(ndim))
   {
-    messerr("This function is not valid for the Space Dimension (%d)",ndim);
+    messerr("This function is not valid for the Space Dimension (%d)", ndim);
     return false;
   }
   return true;
@@ -93,14 +93,14 @@ bool AOF::isValidForRotation() const
   int mode = 0;
   if (_dbgrid->isGridRotated())
   {
-    mode = 1;
+    mode                = 1;
     VectorDouble angles = _dbgrid->getAngles();
     for (int idim = 1; idim < ndim; idim++)
       if (ABS(angles[idim]) > 1.e-6) mode = 2;
   }
-  if (! mustBeForRotation(mode))
+  if (!mustBeForRotation(mode))
   {
-    messerr("This function is not compatible with Grid Rotation (mode=%d)",mode);
+    messerr("This function is not compatible with Grid Rotation (mode=%d)", mode);
     return false;
   }
   return true;
@@ -144,7 +144,7 @@ void AOF::setCols(int ncol, const int* icols)
 
 void AOF::setCol(int icol)
 {
-  _cols = VectorInt(1);
+  _cols    = VectorInt(1);
   _cols[0] = icol;
 }
 
@@ -155,10 +155,10 @@ bool AOF::isAuthorized() const
     messerr("The argument 'db' must be provided");
     return false;
   }
-  if (! isValidForGrid()) return false;
-  if (! isValidForVariable()) return false;
-  if (! isValidForNDim()) return false;
-  if (! isValidForRotation()) return false;
+  if (!isValidForGrid()) return false;
+  if (!isValidForVariable()) return false;
+  if (!isValidForNDim()) return false;
+  if (!isValidForRotation()) return false;
   return true;
 }
-}
+} // namespace gstlrn

--- a/src/OutputFormat/FileLAS.cpp
+++ b/src/OutputFormat/FileLAS.cpp
@@ -13,7 +13,7 @@
 #include "Db/Db.hpp"
 #include "Basic/String.hpp"
 
-#include <string.h>
+#include <cstring>
 #include <cctype>
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/src/OutputFormat/FileVTK.cpp
+++ b/src/OutputFormat/FileVTK.cpp
@@ -28,12 +28,12 @@ FileVTK::FileVTK(const char* filename, const Db* db)
 }
 
 FileVTK::FileVTK(const FileVTK& r)
-    : AOF(r),
-      _flagBinary(r._flagBinary),
-      _factx(r._factx),
-      _facty(r._facty),
-      _factz(r._factz),
-      _factvar(r._factvar)
+  : AOF(r)
+  , _flagBinary(r._flagBinary)
+  , _factx(r._factx)
+  , _facty(r._facty)
+  , _factz(r._factz)
+  , _factvar(r._factvar)
 {
 }
 
@@ -43,10 +43,10 @@ FileVTK& FileVTK::operator=(const FileVTK& r)
   {
     AOF::operator=(r);
     _flagBinary = r._flagBinary;
-    _factx = r._factx;
-    _facty = r._facty;
-    _factz = r._factz;
-    _factvar = r._factvar;
+    _factx      = r._factx;
+    _facty      = r._facty;
+    _factz      = r._factz;
+    _factvar    = r._factvar;
   }
   return *this;
 }
@@ -63,10 +63,10 @@ int FileVTK::writeInFile()
 
   /* Preliminary checks */
 
-  int ndim = _db->getNDim();
-  int ncol = (int) _cols.size();
-  int nech = _db->getNSample();
-  int nactive = _db->getNSample(true);
+  int ndim       = _db->getNDim();
+  int ncol       = (int)_cols.size();
+  int nech       = _db->getNSample();
+  int nactive    = _db->getNSample(true);
   bool flag_grid = _db->isGrid();
 
   /* Define the reading parameters */
@@ -85,13 +85,13 @@ int FileVTK::writeInFile()
     center[icol] = 1;
   }
 
-  float** tab = (float**) mem_alloc(sizeof(float*) * ncol, 1);
+  float** tab = (float**)malloc(sizeof(float*) * ncol);
   for (int icol = 0; icol < ncol; icol++)
   {
     if (flag_grid)
-      tab[icol] = (float*) mem_alloc(sizeof(float) * nech, 1);
+      tab[icol] = (float*)malloc(sizeof(float) * nech);
     else
-      tab[icol] = (float*) mem_alloc(sizeof(float) * nactive, 1);
+      tab[icol] = (float*)malloc(sizeof(float) * nactive);
   }
 
   VectorFloat xcoor;
@@ -104,17 +104,17 @@ int FileVTK::writeInFile()
     xcoor[0] = 0.;
     if (dims[0] > 1)
       for (int i = 0; i < dims[0]; i++)
-        xcoor[i] = (float) (_factx * (_dbgrid->getX0(0) + i * _dbgrid->getDX(0)));
+        xcoor[i] = (float)(_factx * (_dbgrid->getX0(0) + i * _dbgrid->getDX(0)));
     ycoor.resize(dims[1]);
     ycoor[0] = 0.;
     if (dims[1] > 1)
       for (int i = 0; i < dims[1]; i++)
-        ycoor[i] = (float) (_facty * (_dbgrid->getX0(1) + i * _dbgrid->getDX(1)));
+        ycoor[i] = (float)(_facty * (_dbgrid->getX0(1) + i * _dbgrid->getDX(1)));
     zcoor.resize(dims[2]);
     zcoor[0] = 0.;
     if (dims[2] > 1)
       for (int i = 0; i < dims[2]; i++)
-        zcoor[i] = (float) (_factz * (_dbgrid->getX0(2) + i * _dbgrid->getDX(2)));
+        zcoor[i] = (float)(_factz * (_dbgrid->getX0(2) + i * _dbgrid->getDX(2)));
   }
   else
   {
@@ -123,19 +123,19 @@ int FileVTK::writeInFile()
 
   /* Read the coordinates (for points only) */
 
-  if (! flag_grid)
+  if (!flag_grid)
   {
     int ecr = 0;
     for (int iech = 0; iech < nech; iech++)
     {
-      if (! _db->isActive(iech)) continue;
+      if (!_db->isActive(iech)) continue;
       for (int idim = 0; idim < 3; idim++)
       {
         int fact = 1;
         if (idim == 0) fact = _factx;
         if (idim == 1) fact = _facty;
         if (idim == 2) fact = _factz;
-        points[ecr++] = (idim < ndim) ? (float) (fact * _db->getCoordinate(iech, idim)) : 0.;
+        points[ecr++] = (idim < ndim) ? (float)(fact * _db->getCoordinate(iech, idim)) : 0.;
       }
     }
   }
@@ -150,11 +150,11 @@ int FileVTK::writeInFile()
       for (int iech = 0; iech < nech; iech++)
         if (_db->isActive(iech))
         {
-          double value = (float) (_db->getArray(iech, _cols[icol]));
+          double value = (float)(_db->getArray(iech, _cols[icol]));
           if (FFFF(value))
-            tab[icol][ecr] = (float) (TEST);
+            tab[icol][ecr] = (float)(TEST);
           else
-            tab[icol][ecr] = (float) (_factvar * value);
+            tab[icol][ecr] = (float)(_factvar * value);
           ecr++;
         }
     }
@@ -168,14 +168,14 @@ int FileVTK::writeInFile()
             int iad = ix + dims[0] * (iy + dims[1] * iz);
             if (_dbgrid->isActive(iad))
             {
-              double value = (float) (_dbgrid->getValueByColIdx(iad, _cols[icol]));
+              double value = (float)(_dbgrid->getValueByColIdx(iad, _cols[icol]));
               if (FFFF(value))
-                tab[icol][ecr] = (float) (TEST);
+                tab[icol][ecr] = (float)(TEST);
               else
-                tab[icol][ecr] = (float) (_factvar * value);
+                tab[icol][ecr] = (float)(_factvar * value);
             }
             else
-              tab[icol][ecr] = (float) (TEST);
+              tab[icol][ecr] = (float)(TEST);
             ecr++;
           }
     }
@@ -188,7 +188,7 @@ int FileVTK::writeInFile()
     vc[i] = names[i].c_str();
   }
 
-    /* Write the file */
+  /* Write the file */
 
   if (flag_grid)
     write_rectilinear_mesh(getFilename().c_str(), _flagBinary, dims,
@@ -198,8 +198,9 @@ int FileVTK::writeInFile()
     write_point_mesh(getFilename().c_str(), _flagBinary, nactive, points.data(),
                      ncol, vardim.data(), vc.data(), tab);
 
-  for (int icol = 0; icol < ncol; icol++) mem_free((char*)tab[icol]);
-  mem_free((char*)tab);
+  for (int icol = 0; icol < ncol; icol++) 
+    free((char*)tab[icol]);
+  free((char*)tab);
 
   _fileClose();
   return 0;

--- a/src/OutputFormat/GridBmp.cpp
+++ b/src/OutputFormat/GridBmp.cpp
@@ -9,19 +9,19 @@
 /*                                                                            */
 /******************************************************************************/
 #include "OutputFormat/GridBmp.hpp"
-#include "OutputFormat/AOF.hpp"
+#include "Basic/AStringable.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
-#include "Basic/AStringable.hpp"
+#include "OutputFormat/AOF.hpp"
 
-#include <stdio.h>
+#include <cstdio>
 
-#define BF_TYPE 0x4D42             /* "MB" */
-#define COLOR_MASK   -1
-#define COLOR_FFFF   -2
-#define COLOR_LOWER  -3
-#define COLOR_UPPER  -4
-#define N_SAMPLE(nx,nsample) ((int) ((nx-1) / nsample) + 1)
+#define BF_TYPE               0x4D42 /* "MB" */
+#define COLOR_MASK            -1
+#define COLOR_FFFF            -2
+#define COLOR_LOWER           -3
+#define COLOR_UPPER           -4
+#define N_SAMPLE(nx, nsample) ((int)((nx - 1) / nsample) + 1)
 
 namespace gstlrn
 {
@@ -54,30 +54,30 @@ GridBmp::GridBmp(const char* filename, const Db* db)
 }
 
 GridBmp::GridBmp(const GridBmp& r)
-    : AOF(r),
-      _nsamplex(r._nsamplex),
-      _nsampley(r._nsampley),
-      _nmult(r._nmult),
-      _ncolor(r._ncolor),
-      _flag_low(r._flag_low),
-      _flag_high(r._flag_high),
-      _mask_red(r._mask_red),
-      _mask_green(r._mask_green),
-      _mask_blue(r._mask_blue),
-      _ffff_red(r._ffff_red),
-      _ffff_green(r._ffff_green),
-      _ffff_blue(r._ffff_blue),
-      _low_red(r._low_red),
-      _low_green(r._low_green),
-      _low_blue(r._low_blue),
-      _high_red(r._high_red),
-      _high_green(r._high_green),
-      _high_blue(r._high_blue),
-      _valmin(r._valmin),
-      _valmax(r._valmax),
-      _reds(r._reds),
-      _greens(r._greens),
-      _blues(r._blues)
+  : AOF(r)
+  , _nsamplex(r._nsamplex)
+  , _nsampley(r._nsampley)
+  , _nmult(r._nmult)
+  , _ncolor(r._ncolor)
+  , _flag_low(r._flag_low)
+  , _flag_high(r._flag_high)
+  , _mask_red(r._mask_red)
+  , _mask_green(r._mask_green)
+  , _mask_blue(r._mask_blue)
+  , _ffff_red(r._ffff_red)
+  , _ffff_green(r._ffff_green)
+  , _ffff_blue(r._ffff_blue)
+  , _low_red(r._low_red)
+  , _low_green(r._low_green)
+  , _low_blue(r._low_blue)
+  , _high_red(r._high_red)
+  , _high_green(r._high_green)
+  , _high_blue(r._high_blue)
+  , _valmin(r._valmin)
+  , _valmax(r._valmax)
+  , _reds(r._reds)
+  , _greens(r._greens)
+  , _blues(r._blues)
 {
 }
 
@@ -86,29 +86,29 @@ GridBmp& GridBmp::operator=(const GridBmp& r)
   if (this != &r)
   {
     AOF::operator=(r);
-    _nsamplex = r._nsamplex;
-    _nsampley = r._nsampley;
-    _nmult = r._nmult;
-    _ncolor = r._ncolor;
-    _flag_low = r._flag_low;
-    _flag_high = r._flag_high;
-    _mask_red = r._mask_red;
+    _nsamplex   = r._nsamplex;
+    _nsampley   = r._nsampley;
+    _nmult      = r._nmult;
+    _ncolor     = r._ncolor;
+    _flag_low   = r._flag_low;
+    _flag_high  = r._flag_high;
+    _mask_red   = r._mask_red;
     _mask_green = r._mask_green;
-    _mask_blue = r._mask_blue;
-    _ffff_red = r._ffff_red;
+    _mask_blue  = r._mask_blue;
+    _ffff_red   = r._ffff_red;
     _ffff_green = r._ffff_green;
-    _ffff_blue = r._ffff_blue;
-    _low_red = r._low_red;
-    _low_green = r._low_green;
-    _low_blue = r._low_blue;
-    _high_red = r._high_red;
+    _ffff_blue  = r._ffff_blue;
+    _low_red    = r._low_red;
+    _low_green  = r._low_green;
+    _low_blue   = r._low_blue;
+    _high_red   = r._high_red;
     _high_green = r._high_green;
-    _high_blue = r._high_blue;
-    _valmin = r._valmin;
-    _valmax = r._valmax;
-    _reds = r._reds;
-    _greens = r._greens;
-    _blues = r._blues;
+    _high_blue  = r._high_blue;
+    _valmin     = r._valmin;
+    _valmax     = r._valmax;
+    _reds       = r._reds;
+    _greens     = r._greens;
+    _blues      = r._blues;
   }
   return *this;
 }
@@ -119,35 +119,35 @@ GridBmp::~GridBmp()
 
 void GridBmp::setColors(const VectorInt& reds, const VectorInt& greens, const VectorInt& blues)
 {
-  _reds = reds;
+  _reds   = reds;
   _greens = greens;
-  _blues = blues;
+  _blues  = blues;
 }
 
 void GridBmp::setFFFF(int red, int green, int blue)
 {
-  _ffff_red = red;
+  _ffff_red   = red;
   _ffff_green = green;
-  _ffff_blue = blue;
+  _ffff_blue  = blue;
 }
 
 void GridBmp::setHigh(int red, int green, int blue)
 {
-  _high_red = red;
+  _high_red   = red;
   _high_green = green;
-  _high_blue = blue;
+  _high_blue  = blue;
 }
 void GridBmp::setLow(int red, int green, int blue)
 {
-  _low_red = red;
+  _low_red   = red;
   _low_green = green;
-  _low_blue = blue;
+  _low_blue  = blue;
 }
 void GridBmp::setMask(int red, int green, int blue)
 {
-  _mask_red = red;
+  _mask_red   = red;
   _mask_green = green;
-  _mask_blue = blue;
+  _mask_blue  = blue;
 }
 
 int GridBmp::writeInFile()
@@ -161,10 +161,9 @@ int GridBmp::writeInFile()
 
   /* Preliminary checks */
 
-  int ncolor = _ncolor;
-  bool flag_color_scale = (_ncolor > 0 && ! _reds.empty() && ! _greens.empty()
-      && ! _blues.empty());
-  if (! flag_color_scale) ncolor = 256;
+  int ncolor            = _ncolor;
+  bool flag_color_scale = (_ncolor > 0 && !_reds.empty() && !_greens.empty() && !_blues.empty());
+  if (!flag_color_scale) ncolor = 256;
 
   /* Initializations */
 
@@ -177,7 +176,7 @@ int GridBmp::writeInFile()
   double vmax = MINIMUM_BIG;
   for (int i = 0; i < nx * ny; i++)
   {
-    if (! _dbgrid->isActive(i)) continue;
+    if (!_dbgrid->isActive(i)) continue;
     double value = _dbgrid->getArray(i, _cols[0]);
     if (FFFF(value)) continue;
     if (value < vmin) vmin = value;
@@ -186,42 +185,42 @@ int GridBmp::writeInFile()
   double delta = (vmax - vmin);
   vmin -= delta / 100.;
   vmax += delta / 100.;
-  if (! FFFF(_valmin)) vmin = _valmin;
-  if (! FFFF(_valmax)) vmax = _valmax;
+  if (!FFFF(_valmin)) vmin = _valmin;
+  if (!FFFF(_valmax)) vmax = _valmax;
 
   /* Figure out the constants */
 
-  int infosize = 40;
+  int infosize   = 40;
   int headersize = 14;
-  int width  = _nmult * N_SAMPLE(nx, _nsamplex);
-  int height = _nmult * N_SAMPLE(ny, _nsampley);
-  int imagesize = 3 * width * height;
+  int width      = _nmult * N_SAMPLE(nx, _nsamplex);
+  int height     = _nmult * N_SAMPLE(ny, _nsampley);
+  int imagesize  = 3 * width * height;
 
   /* Write the file header, bitmap information, and bitmap pixel data... */
-  _writeOut( 0, BF_TYPE);
-  _writeOut( 1, headersize); /* Size of File Header */
-  _writeOut( 0, 0); /* Reserved */
-  _writeOut( 0, 0); /* Reserved */
-  _writeOut( 1, headersize + infosize); /* Offset */
+  _writeOut(0, BF_TYPE);
+  _writeOut(1, headersize);            /* Size of File Header */
+  _writeOut(0, 0);                     /* Reserved */
+  _writeOut(0, 0);                     /* Reserved */
+  _writeOut(1, headersize + infosize); /* Offset */
 
-  _writeOut( 1, infosize); /* Size of Information Block */
-  _writeOut( 2, width); /* Width */
-  _writeOut( 2, height); /* Height */
-  _writeOut( 0, 1); /* Number of planes */
-  _writeOut( 0, 24); /* 24-bits per pixel */
-  _writeOut( 1, 0); /* No compression */
-  _writeOut( 1, imagesize); /* Image size */
-  _writeOut( 2, 0);
-  _writeOut( 2, 0);
-  _writeOut( 1, 0);
-  _writeOut( 1, 0);
+  _writeOut(1, infosize);  /* Size of Information Block */
+  _writeOut(2, width);     /* Width */
+  _writeOut(2, height);    /* Height */
+  _writeOut(0, 1);         /* Number of planes */
+  _writeOut(0, 24);        /* 24-bits per pixel */
+  _writeOut(1, 0);         /* No compression */
+  _writeOut(1, imagesize); /* Image size */
+  _writeOut(2, 0);
+  _writeOut(2, 0);
+  _writeOut(1, 0);
+  _writeOut(1, 0);
 
   /* Writing the pixels */
 
-  indg[0] = 0;
-  indg[1] = 0;
+  indg[0]  = 0;
+  indg[1]  = 0;
   int ipad = nx * _nmult;
-  ipad = ipad - 4 * ((int) (ipad / 4));
+  ipad     = ipad - 4 * ((int)(ipad / 4));
   for (int iy = 0; iy < ny; iy++)
   {
     if (iy % _nsampley != 0) continue;
@@ -230,17 +229,17 @@ int GridBmp::writeInFile()
       for (int ix = 0; ix < nx; ix++)
       {
         if (ix % _nsamplex != 0) continue;
-        indg[0] = ix;
-        indg[1] = iy;
+        indg[0]  = ix;
+        indg[1]  = iy;
         int iech = _dbgrid->indiceToRank(indg);
         int rank = _colorRank(iech, ncolor, vmin, vmax);
         _colorInRGB(rank, flag_color_scale, &ired, &igreen, &iblue);
 
         for (int imult = 0; imult < _nmult; imult++)
         {
-          (void) fwrite(&iblue, 1, 1, _file);
-          (void) fwrite(&igreen, 1, 1, _file);
-          (void) fwrite(&ired, 1, 1, _file);
+          (void)fwrite(&iblue, 1, 1, _file);
+          (void)fwrite(&igreen, 1, 1, _file);
+          (void)fwrite(&ired, 1, 1, _file);
         }
       }
 
@@ -248,7 +247,7 @@ int GridBmp::writeInFile()
 
       int color = 0;
       for (int i = 0; i < ipad; i++)
-        (void) fwrite(&color, 1, 1, _file);
+        (void)fwrite(&color, 1, 1, _file);
     }
   }
 
@@ -284,7 +283,7 @@ void GridBmp::_writeOut(int mode, unsigned int ival)
       break;
 
     case 2: /* Signed 32-bit */
-      int jval = (int) ival;
+      int jval = (int)ival;
       putc(jval, _file);
       putc(jval >> 8, _file);
       putc(jval >> 16, _file);
@@ -312,7 +311,7 @@ void GridBmp::_writeOut(int mode, unsigned int ival)
 int GridBmp::_colorRank(int iech, int ncolor, double vmin, double vmax)
 {
   /* Check if the sample is masked off */
-  if (! _dbgrid->isActive(iech)) return COLOR_MASK;
+  if (!_dbgrid->isActive(iech)) return COLOR_MASK;
 
   /* Read the value */
   double value = _dbgrid->getArray(iech, _cols[0]);
@@ -321,7 +320,7 @@ int GridBmp::_colorRank(int iech, int ncolor, double vmin, double vmax)
   if (FFFF(value)) return COLOR_FFFF;
 
   /* Find the color */
-  int ival = (int) (ncolor * (value - vmin) / (vmax - vmin));
+  int ival = (int)(ncolor * (value - vmin) / (vmax - vmin));
 
   /* Value lower than vmin */
   if (ival < 0)
@@ -358,53 +357,53 @@ int GridBmp::_colorRank(int iech, int ncolor, double vmin, double vmax)
  *****************************************************************************/
 void GridBmp::_colorInRGB(int rank,
                           bool flag_color_scale,
-                          unsigned char *ired,
-                          unsigned char *igreen,
-                          unsigned char *iblue)
+                          unsigned char* ired,
+                          unsigned char* igreen,
+                          unsigned char* iblue)
 {
   switch (rank)
   {
     case COLOR_MASK:
-      *ired = (unsigned char) _mask_red;
-      *igreen = (unsigned char) _mask_green;
-      *iblue = (unsigned char) _mask_blue;
+      *ired   = (unsigned char)_mask_red;
+      *igreen = (unsigned char)_mask_green;
+      *iblue  = (unsigned char)_mask_blue;
       break;
 
     case COLOR_FFFF:
-      *ired = (unsigned char) _ffff_red;
-      *igreen = (unsigned char) _ffff_green;
-      *iblue = (unsigned char) _ffff_blue;
+      *ired   = (unsigned char)_ffff_red;
+      *igreen = (unsigned char)_ffff_green;
+      *iblue  = (unsigned char)_ffff_blue;
       break;
 
     case COLOR_LOWER:
-      *ired = (unsigned char) _low_red;
-      *igreen = (unsigned char) _low_green;
-      *iblue = (unsigned char) _low_blue;
+      *ired   = (unsigned char)_low_red;
+      *igreen = (unsigned char)_low_green;
+      *iblue  = (unsigned char)_low_blue;
       break;
 
     case COLOR_UPPER:
-      *ired = (unsigned char) _high_red;
-      *igreen = (unsigned char) _high_green;
-      *iblue = (unsigned char) _high_blue;
+      *ired   = (unsigned char)_high_red;
+      *igreen = (unsigned char)_high_green;
+      *iblue  = (unsigned char)_high_blue;
       break;
 
     default:
       if (flag_color_scale)
       {
-        *ired = (unsigned char) _reds[rank];
-        *igreen = (unsigned char) _greens[rank];
-        *iblue = (unsigned char) _blues[rank];
+        *ired   = (unsigned char)_reds[rank];
+        *igreen = (unsigned char)_greens[rank];
+        *iblue  = (unsigned char)_blues[rank];
       }
       else
       {
-        *ired = (unsigned char) rank;
-        *igreen = (unsigned char) rank;
-        *iblue = (unsigned char) rank;
+        *ired   = (unsigned char)rank;
+        *igreen = (unsigned char)rank;
+        *iblue  = (unsigned char)rank;
       }
   }
 }
 
-DbGrid*  GridBmp::readGridFromFile()
+DbGrid* GridBmp::readGridFromFile()
 {
   DbGrid* dbgrid = nullptr;
   int ir[256], ig[256], ib[256];
@@ -425,24 +424,24 @@ DbGrid*  GridBmp::readGridFromFile()
 
   /* Reading the file header */
 
-  (void) _compose( 2);
-  (void) _compose( 4);
-  (void) _compose( 4);
-  (void) _compose( 4);
+  (void)_compose(2);
+  (void)_compose(4);
+  (void)_compose(4);
+  (void)_compose(4);
 
   /* Reading the bitmap information header */
 
-  (void) _compose( 4);
-  nx[0] = _compose( 4);
-  nx[1] = _compose( 4);
-  (void) _compose( 2);
-  int nbits = _compose( 2);
-  int compress = _compose( 4);
-  (void) _compose( 4);
-  int ndx = _compose( 4);
-  int ndy = _compose( 4);
-  int ncol = _compose( 4);
-  (void) _compose( 4);
+  (void)_compose(4);
+  nx[0] = _compose(4);
+  nx[1] = _compose(4);
+  (void)_compose(2);
+  int nbits    = _compose(2);
+  int compress = _compose(4);
+  (void)_compose(4);
+  int ndx  = _compose(4);
+  int ndy  = _compose(4);
+  int ncol = _compose(4);
+  (void)_compose(4);
   if (ncol > 256)
   {
     messerr("Your file seems to contain more than 256 colors");
@@ -457,7 +456,7 @@ DbGrid*  GridBmp::readGridFromFile()
     ir[icol] = _readIn();
     ig[icol] = _readIn();
     ib[icol] = _readIn();
-    (void) _readIn();
+    (void)_readIn();
   }
 
   /* Final checks */
@@ -470,8 +469,8 @@ DbGrid*  GridBmp::readGridFromFile()
 
   /* Final results */
 
-  if (ndx > 0) dx[0] = 100. / (double) ndx;
-  if (ndy > 0) dx[1] = 100. / (double) ndy;
+  if (ndx > 0) dx[0] = 100. / (double)ndx;
+  if (ndy > 0) dx[1] = 100. / (double)ndy;
 
   /* Reading the image (from bottom to up) */
 
@@ -506,11 +505,11 @@ DbGrid*  GridBmp::readGridFromFile()
 
     /* Reading the padding */
 
-    for (int ix = 0; ix < npad; ix++) (void) _readIn();
+    for (int ix = 0; ix < npad; ix++) (void)_readIn();
   }
 
-   dbgrid = new DbGrid();
-   dbgrid->reset(nx,dx,x0,VectorDouble(),ELoadBy::SAMPLE,tab);
+  dbgrid = new DbGrid();
+  dbgrid->reset(nx, dx, x0, VectorDouble(), ELoadBy::SAMPLE, tab);
 
   // Close the file
 
@@ -536,7 +535,7 @@ int GridBmp::_compose(int nb)
 
   /* Initializations */
 
-  value = 0;
+  value  = 0;
   factor = 1;
 
   for (i = 0; i < nb; i++)
@@ -557,7 +556,7 @@ unsigned char GridBmp::_readIn()
 
 {
   unsigned char c;
-  c = (unsigned char) fgetc(_file);
+  c = (unsigned char)fgetc(_file);
   if (!feof(_file)) return c;
   return (c);
 }
@@ -599,16 +598,16 @@ void GridBmp::_rgb2num(int red,
                        int green,
                        int blue,
                        int a,
-                       unsigned char *c)
+                       unsigned char* c)
 {
   DECLARE_UNUSED(a);
   double value;
 
-  value = (double) (red + green + blue) / 3.;
+  value = (double)(red + green + blue) / 3.;
 
   if (value < 0.) value = 0.;
   if (value > 255.) value = 255.;
-  *c = (unsigned char) value;
+  *c = (unsigned char)value;
 }
 
-}
+} // namespace gstlrn

--- a/src/OutputFormat/GridF2G.cpp
+++ b/src/OutputFormat/GridF2G.cpp
@@ -15,7 +15,7 @@
 #include "Basic/String.hpp"
 #include "Core/io.hpp"
 
-#include <string.h>
+#include <cstring>
 
 #define F2G(ix,iy,iz,icol)  (tab[(ix) + nx[0] * ((iy) + nx[1] * ((iz) + nx[2] * (icol)))])
 

--- a/src/OutputFormat/GridIfpEn.cpp
+++ b/src/OutputFormat/GridIfpEn.cpp
@@ -16,7 +16,7 @@
 #include "Core/io.hpp"
 #include "OutputFormat/GridIfpEn.hpp"
 
-#include <string.h>
+#include <cstring>
 
 namespace gstlrn
 {

--- a/src/OutputFormat/GridZycor.cpp
+++ b/src/OutputFormat/GridZycor.cpp
@@ -8,18 +8,17 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Enum/ELoadBy.hpp"
-
 #include "OutputFormat/GridZycor.hpp"
-#include "OutputFormat/AOF.hpp"
-#include "Db/Db.hpp"
-#include "Db/DbGrid.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/String.hpp"
 #include "Core/io.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Enum/ELoadBy.hpp"
+#include "OutputFormat/AOF.hpp"
 
-#include <string.h>
-#include <stdio.h>
+#include <cstdio>
+#include <cstring>
 
 #define ZYCOR_NULL_CH "  0.1000000E+31"
 
@@ -31,7 +30,7 @@ GridZycor::GridZycor(const char* filename, const Db* db)
 }
 
 GridZycor::GridZycor(const GridZycor& r)
-    : AOF(r)
+  : AOF(r)
 {
 }
 
@@ -54,7 +53,7 @@ int GridZycor::writeInFile()
   double rbid, x0[2], xf[2], dx[2];
   double buff[5]; /* Size = nbyline */
   char card[100]; /* Size = nbyline * 20 */
-  static int nbyline = 5;
+  static int nbyline    = 5;
   static double testval = MAXIMUM_BIG;
 
   /* Open the file */
@@ -109,7 +108,7 @@ int GridZycor::writeInFile()
           }
           else
           {
-            memcpy(&card[ind], (char*) ZYCOR_NULL_CH, 15);
+            memcpy(&card[ind], (char*)ZYCOR_NULL_CH, 15);
           }
         }
         gslSPrintf(&card[15 * nbyline], "\n");
@@ -129,7 +128,7 @@ int GridZycor::writeInFile()
         }
         else
         {
-          memcpy(&card[ind], (char*) ZYCOR_NULL_CH, 15);
+          memcpy(&card[ind], (char*)ZYCOR_NULL_CH, 15);
         }
       }
       gslSPrintf(&card[15 * kk], "\n");
@@ -141,7 +140,7 @@ int GridZycor::writeInFile()
   return 0;
 }
 
-DbGrid*  GridZycor::readGridFromFile()
+DbGrid* GridZycor::readGridFromFile()
 {
   DbGrid* dbgrid = nullptr;
   char string[100];
@@ -155,73 +154,73 @@ DbGrid*  GridZycor::readGridFromFile()
 
   if (_fileReadOpen()) return dbgrid;
 
-   /* Define the delimitors */
+  /* Define the delimitors */
 
-   _file_delimitors('!', ",", '_');
+  _file_delimitors('!', ",", '_');
 
-   /* Read the lines */
+  /* Read the lines */
 
-   if (_record_read(_file, "%s", string)) return dbgrid;
-   if (string[0] != '@')
-   {
-     messerr("Missing string starting with (@). Instead: '%s'", string);
-     return dbgrid;
-   }
-   if (_record_read(_file, "%s", string)) return dbgrid;
-   if (strcmp(string, "GRID") != 0)
-   {
-     messerr("Missing string (GRID). Instead: '%s'", string);
-     return dbgrid;
-   }
-   if (_record_read(_file, "%d", &nval)) return dbgrid;
-   if (_record_read(_file, "%d", &ibid1)) return dbgrid;
-   if (_record_read(_file, "%lg", &test)) return dbgrid;
-   if (_record_read(_file, "%s", string)) return dbgrid;
-   if (_record_read(_file, "%d", &ibid2)) return dbgrid;
-   if (_record_read(_file, "%d", &ibid3)) return dbgrid;
-   if (_record_read(_file, "%d", &nx[1])) return dbgrid;
-   if (_record_read(_file, "%d", &nx[0])) return dbgrid;
-   if (_record_read(_file, "%lf", &x0[0])) return dbgrid;
-   if (_record_read(_file, "%lf", &xf[0])) return dbgrid;
-   if (_record_read(_file, "%lf", &x0[1])) return dbgrid;
-   if (_record_read(_file, "%lf", &xf[1])) return dbgrid;
-   if (_record_read(_file, "%lf", &rbid1)) return dbgrid;
-   if (_record_read(_file, "%lf", &rbid2)) return dbgrid;
-   if (_record_read(_file, "%lf", &rbid3)) return dbgrid;
+  if (_record_read(_file, "%s", string)) return dbgrid;
+  if (string[0] != '@')
+  {
+    messerr("Missing string starting with (@). Instead: '%s'", string);
+    return dbgrid;
+  }
+  if (_record_read(_file, "%s", string)) return dbgrid;
+  if (strcmp(string, "GRID") != 0)
+  {
+    messerr("Missing string (GRID). Instead: '%s'", string);
+    return dbgrid;
+  }
+  if (_record_read(_file, "%d", &nval)) return dbgrid;
+  if (_record_read(_file, "%d", &ibid1)) return dbgrid;
+  if (_record_read(_file, "%lg", &test)) return dbgrid;
+  if (_record_read(_file, "%s", string)) return dbgrid;
+  if (_record_read(_file, "%d", &ibid2)) return dbgrid;
+  if (_record_read(_file, "%d", &ibid3)) return dbgrid;
+  if (_record_read(_file, "%d", &nx[1])) return dbgrid;
+  if (_record_read(_file, "%d", &nx[0])) return dbgrid;
+  if (_record_read(_file, "%lf", &x0[0])) return dbgrid;
+  if (_record_read(_file, "%lf", &xf[0])) return dbgrid;
+  if (_record_read(_file, "%lf", &x0[1])) return dbgrid;
+  if (_record_read(_file, "%lf", &xf[1])) return dbgrid;
+  if (_record_read(_file, "%lf", &rbid1)) return dbgrid;
+  if (_record_read(_file, "%lf", &rbid2)) return dbgrid;
+  if (_record_read(_file, "%lf", &rbid3)) return dbgrid;
 
-   if (_record_read(_file, "%s", string)) return dbgrid;
-   if (strcmp(string, "@") != 0)
-   {
-     messerr("Missing string (@). Instead: %s", string);
-     return dbgrid;
-   }
+  if (_record_read(_file, "%s", string)) return dbgrid;
+  if (strcmp(string, "@") != 0)
+  {
+    messerr("Missing string (@). Instead: %s", string);
+    return dbgrid;
+  }
 
-   /* Final calculations */
+  /* Final calculations */
 
-   dx[0] = (xf[0] - x0[0]) / (nx[0] - 1);
-   dx[1] = (xf[1] - x0[1]) / (nx[1] - 1);
+  dx[0] = (xf[0] - x0[0]) / (nx[0] - 1);
+  dx[1] = (xf[1] - x0[1]) / (nx[1] - 1);
 
-   /* Reset the delimitors */
+  /* Reset the delimitors */
 
-   _file_delimitors('#', " ", ' ');
+  _file_delimitors('#', " ", ' ');
 
-   /* Core allocation */
+  /* Core allocation */
 
-   int size = nx[0] * nx[1];
-   VectorDouble tab(size);
+  int size = nx[0] * nx[1];
+  VectorDouble tab(size);
 
-   /* Read the array of real values */
+  /* Read the array of real values */
 
-   for (int ix = 0; ix < nx[0]; ix++)
-     for (int iy = 0; iy < nx[1]; iy++)
-     {
-       if (_record_read(_file, "%lf", &value)) break;
-       if (value == test) value = TEST;
-       tab[(nx[1] - iy - 1) * nx[0] + ix] = value;
-     }
+  for (int ix = 0; ix < nx[0]; ix++)
+    for (int iy = 0; iy < nx[1]; iy++)
+    {
+      if (_record_read(_file, "%lf", &value)) break;
+      if (value == test) value = TEST;
+      tab[(nx[1] - iy - 1) * nx[0] + ix] = value;
+    }
 
-   dbgrid = new DbGrid();
-   dbgrid->reset(nx,dx,x0,VectorDouble(),ELoadBy::SAMPLE,tab);
+  dbgrid = new DbGrid();
+  dbgrid->reset(nx, dx, x0, VectorDouble(), ELoadBy::SAMPLE, tab);
 
   // Close the file
 
@@ -229,4 +228,4 @@ DbGrid*  GridZycor::readGridFromFile()
 
   return dbgrid;
 }
-}
+} // namespace gstlrn

--- a/src/OutputFormat/segy.cpp
+++ b/src/OutputFormat/segy.cpp
@@ -9,16 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "OutputFormat/segy.h"
-
-#include "Basic/Utilities.hpp"
 #include "Basic/File.hpp"
+#include "Basic/Utilities.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "geoslib_old_f.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 
 namespace gstlrn
 {
@@ -66,12 +65,12 @@ struct RefStats
   double modif_scale;
 };
 
-#define MAT(i,j)            (mat[2 * (i) + (j)])
-#define SWAP_INT16(x)	(x) = ((0x00ff & ((x))>>8) | (0xff00 & ((x))<<8))
-#define SWAP_INT32(x)	(x) = ((0x000000ff & ((x))>>24) | \
-                             (0x0000ff00 & ((x))>>8) |  \
-                             (0x00ff0000 & ((x))<<8) |  \
-                             (0xff000000 & ((x))<<24))
+#define MAT(i, j)     (mat[2 * (i) + (j)])
+#define SWAP_INT16(x) (x) = ((0x00ff & ((x)) >> 8) | (0xff00 & ((x)) << 8))
+#define SWAP_INT32(x) (x) = ((0x000000ff & ((x)) >> 24) | \
+                             (0x0000ff00 & ((x)) >> 8) |  \
+                             (0x00ff0000 & ((x)) << 8) |  \
+                             (0xff000000 & ((x)) << 24))
 
 /****************************************************************************/
 /*!
@@ -105,12 +104,12 @@ static int st_to_i(int a)
 {
   unsigned short int tmp1 = (a >> 16);
   unsigned short int tmp2 = (a * 0x0000FFFF);
-  tmp2 = st_to_u(tmp2);
-  tmp1 = st_to_u(tmp1);
+  tmp2                    = st_to_u(tmp2);
+  tmp1                    = st_to_u(tmp1);
 
-  int b = (int) tmp2;
-  b = b << 16;
-  b = b | (int) tmp1;
+  int b = (int)tmp2;
+  b     = b << 16;
+  b     = b | (int)tmp1;
 
   return b;
 }
@@ -130,12 +129,10 @@ static float st_ibm2ieee(const float ibm)
   src.f = ibm;
 
   // CONVERT TO FLOAT
-  long IntMantissa = ((long) src.c[1] << 16) + ((long) src.c[2] << 8)
-                     + src.c[3];
+  long IntMantissa = ((long)src.c[1] << 16) + ((long)src.c[2] << 8) + src.c[3];
 
-  float Mantissa = float(IntMantissa) / float(0x1000000);
-  float PosResult = Mantissa
-      * (float) pow(16.0, double((src.c[0] & 0x7F) - 64));
+  float Mantissa  = float(IntMantissa) / float(0x1000000);
+  float PosResult = Mantissa * (float)pow(16.0, double((src.c[0] & 0x7F) - 64));
 
   if (src.c[0] & 0x80)
     return -PosResult;
@@ -156,9 +153,9 @@ static double st_scaling(int coor, int scale)
 {
   double value = coor;
   if (scale < 0)
-    value /= (double) ABS(scale);
+    value /= (double)ABS(scale);
   else
-    value *= (double) ABS(scale);
+    value *= (double)ABS(scale);
   return value;
 }
 
@@ -170,7 +167,7 @@ static double st_scaling(int coor, int scale)
  ** \param[in]  numTrace  Rank of the trace
  **
  *****************************************************************************/
-static void st_print_traceHead(traceHead *Theader, int numTrace)
+static void st_print_traceHead(traceHead* Theader, int numTrace)
 {
   message("\nTrace Header #%d\n", numTrace);
   message("TRACE_SEQ_GLOBAL    : %i \n", st_to_i(Theader->TRACE_SEQ_GLOBAL));
@@ -265,7 +262,7 @@ static void st_print_traceHead(traceHead *Theader, int numTrace)
  ** \param[in]  Bheader   Pointer to the Binary File header
  **
  *****************************************************************************/
-static void st_print_BFileHead(binaryFileHeader *Bheader)
+static void st_print_BFileHead(binaryFileHeader* Bheader)
 {
   message("\nBinary File Header\n");
   message("JOB_ID               :%i  \n", st_to_i(Bheader->JOB_ID));
@@ -304,38 +301,38 @@ static binaryFileHeader st_binaryFileHeader_init()
 {
   binaryFileHeader binfile;
 
-  binfile.JOB_ID = 0;
-  binfile.LINE_NUM = 0;
-  binfile.REEL_NUM = 0;
-  binfile.NUM_OF_TRACE = 0;
-  binfile.NUM_OF_AUX = 0;
-  binfile.INTERVAL_MS = 0;
-  binfile.INTERVAL_MS_ORI = 0;
-  binfile.NUM_OF_SAMPLES = 0;
-  binfile.NUM_OF_SAMPLES_ORI = 0;
-  binfile.SAMPLE_FORMAT = 0;
-  binfile.ENSEMBLE = 0;
-  binfile.TRACE_SORT = 0;
-  binfile.VERT_SUM = 0;
-  binfile.SWEEP_FREQ_START = 0;
-  binfile.SWEEP_FREQ_END = 0;
-  binfile.SWEEP_LENGTH = 0;
-  binfile.SWEEP_TYPE = 0;
-  binfile.SWEEP_NUM_CHANNEL = 0;
+  binfile.JOB_ID                = 0;
+  binfile.LINE_NUM              = 0;
+  binfile.REEL_NUM              = 0;
+  binfile.NUM_OF_TRACE          = 0;
+  binfile.NUM_OF_AUX            = 0;
+  binfile.INTERVAL_MS           = 0;
+  binfile.INTERVAL_MS_ORI       = 0;
+  binfile.NUM_OF_SAMPLES        = 0;
+  binfile.NUM_OF_SAMPLES_ORI    = 0;
+  binfile.SAMPLE_FORMAT         = 0;
+  binfile.ENSEMBLE              = 0;
+  binfile.TRACE_SORT            = 0;
+  binfile.VERT_SUM              = 0;
+  binfile.SWEEP_FREQ_START      = 0;
+  binfile.SWEEP_FREQ_END        = 0;
+  binfile.SWEEP_LENGTH          = 0;
+  binfile.SWEEP_TYPE            = 0;
+  binfile.SWEEP_NUM_CHANNEL     = 0;
   binfile.SWEEP_TAPER_LEN_START = 0;
-  binfile.SWEEP_TAPER_LEN_END = 0;
-  binfile.TAPER_TYPE = 0;
-  binfile.CORRELATED = 0;
-  binfile.BINARY_GAIN = 0;
-  binfile.AMP_RECOR = 0;
-  binfile.MEASURE_SYSTEM = 0;
-  binfile.IMPULSE_POLAR = 0;
-  binfile.POLAR_CODE = 0;
-  memset(binfile.UNNASSIGNED1,0,240);
+  binfile.SWEEP_TAPER_LEN_END   = 0;
+  binfile.TAPER_TYPE            = 0;
+  binfile.CORRELATED            = 0;
+  binfile.BINARY_GAIN           = 0;
+  binfile.AMP_RECOR             = 0;
+  binfile.MEASURE_SYSTEM        = 0;
+  binfile.IMPULSE_POLAR         = 0;
+  binfile.POLAR_CODE            = 0;
+  memset(binfile.UNNASSIGNED1, 0, 240);
   binfile.SEGY_REV_NUM = 0;
-  binfile.FIXED_LEN = 0;
+  binfile.FIXED_LEN    = 0;
   binfile.NUM_EXT_HEAD = 0;
-  memset(binfile.UNNASSIGNED2,0,94);
+  memset(binfile.UNNASSIGNED2, 0, 94);
 
   return binfile;
 }
@@ -351,10 +348,10 @@ static binaryFileHeader st_binaryFileHeader_init()
  ** \param[out] delta    Distance between two consecutive vertical samples
  **
  *****************************************************************************/
-static int st_readFileHeader(FILE *file,
+static int st_readFileHeader(FILE* file,
                              int verbOption,
-                             int *NPerTrace,
-                             double *delta)
+                             int* NPerTrace,
+                             double* delta)
 {
   unsigned char TFileHead_[3200];
   binaryFileHeader BFileHead_ = st_binaryFileHeader_init();
@@ -363,31 +360,31 @@ static int st_readFileHeader(FILE *file,
   if (fread(&BFileHead_, 1, sizeof(BFileHead_), file) == 0) return (1);
   if (verbOption >= 1) st_print_BFileHead(&BFileHead_);
   *NPerTrace = st_to_s(BFileHead_.NUM_OF_SAMPLES);
-  *delta = (double) st_to_s(BFileHead_.INTERVAL_MS) / 1000;
+  *delta     = (double)st_to_s(BFileHead_.INTERVAL_MS) / 1000;
   return (0);
 }
 
-static int st_read_trace(FILE *file,
+static int st_read_trace(FILE* file,
                          int codefmt,
                          int numtrace,
                          int nPerTrace,
                          double delta,
                          int verbOption,
-                         VectorDouble &values,
-                         VectorDouble &cotes)
+                         VectorDouble& values,
+                         VectorDouble& cotes)
 {
   short svalue;
   int minsamp, maxsamp, ivalue, imaxvalue, iminvalue;
   float fvalue, fmaxvalue, fminvalue, cote;
 
-  cote       = 0;
-  ivalue     = 0;
-  imaxvalue  = 0;
-  iminvalue  = 0;
-  fminvalue  = 0.0;
-  fmaxvalue  = 0.0;
-  minsamp    = -1;
-  maxsamp    = -1;
+  cote      = 0;
+  ivalue    = 0;
+  imaxvalue = 0;
+  iminvalue = 0;
+  fminvalue = 0.0;
+  fmaxvalue = 0.0;
+  minsamp   = -1;
+  maxsamp   = -1;
 
   if (verbOption >= 2) message("Trace %5d: ", numtrace);
   if (codefmt == 1 || codefmt == 5)
@@ -401,17 +398,17 @@ static int st_read_trace(FILE *file,
       if (fvalue > fmaxvalue)
       {
         fmaxvalue = fvalue;
-        maxsamp = i + 1;
+        maxsamp   = i + 1;
       }
       if (fvalue < fminvalue)
       {
         fminvalue = fvalue;
-        minsamp = i + 1;
+        minsamp   = i + 1;
       }
-      values[i] = (double) fvalue;
+      values[i] = (double)fvalue;
       if (ABS(values[i]) < 0.01) values[i] = TEST;
-      cotes[i] = (double) cote;
-      cote -= (float) delta;
+      cotes[i] = (double)cote;
+      cote -= (float)delta;
     }
     if (verbOption >= 2)
       message("Min(%6d) = %11.0f - Max(%6d) = %11.0f\n", minsamp, fminvalue,
@@ -430,23 +427,23 @@ static int st_read_trace(FILE *file,
       if (codefmt == 3)
       {
         if (fread(&svalue, 2, 1, file) == 0) return (1);
-        ivalue = (int) svalue;
+        ivalue = (int)svalue;
       }
 
       if (ivalue > imaxvalue)
       {
         imaxvalue = ivalue;
-        maxsamp = i + 1;
+        maxsamp   = i + 1;
       }
       if (ivalue < iminvalue)
       {
         iminvalue = ivalue;
-        minsamp = i + 1;
+        minsamp   = i + 1;
       }
-      values[i] = (double) ivalue;
+      values[i] = (double)ivalue;
       if (ABS(values[i]) < 0.01) values[i] = TEST;
-      cotes[i] = (double) cote;
-      cote -= (float) delta;
+      cotes[i] = (double)cote;
+      cote -= (float)delta;
     }
     if (verbOption >= 2)
       message("Min(%6d) = %11d - Max(%6d) = %11d\n", minsamp, iminvalue,
@@ -520,14 +517,14 @@ static int st_surface_identify(int verbOption,
   }
 
   *iaux_top = -1;
-  if (! aux_top.empty())
+  if (!aux_top.empty())
   {
     *iaux_top = surfaces->getUID(aux_top);
     if (*iaux_top < 0) return 1;
   }
 
   *iaux_bot = -1;
-  if (! aux_bot.empty())
+  if (!aux_bot.empty())
   {
     *iaux_bot = surfaces->getUID(aux_bot);
     if (*iaux_bot < 0) return 1;
@@ -559,15 +556,15 @@ static int st_surface_identify(int verbOption,
  ** \param[out] czbot     Coordinate for the Bottom along Z (or TEST)
  **
  *****************************************************************************/
-static int st_get_cuts(Db *surfaces,
+static int st_get_cuts(Db* surfaces,
                        int rank,
                        int iatt_top,
                        int iatt_bot,
                        double /*xtrace*/,
                        double /*ytrace*/,
                        double thickmin,
-                       double *cztop,
-                       double *czbot)
+                       double* cztop,
+                       double* czbot)
 {
 
   // Initializations
@@ -617,7 +614,7 @@ static int st_get_cuts(Db *surfaces,
  **
  *****************************************************************************/
 static void st_verify_refpt(RefPt refpt[3],
-                            RefStats &refstats,
+                            RefStats& refstats,
                             int nbrefpt,
                             double x0,
                             double y0,
@@ -659,12 +656,12 @@ static void st_verify_refpt(RefPt refpt[3],
  **
  *****************************************************************************/
 static void st_grid_from_3refpt(RefPt refpt[3],
-                                RefStats &refstats,
+                                RefStats& refstats,
                                 double dz,
-                                Grid &def_grid)
+                                Grid& def_grid)
 {
   double dx12, dy12, di12, dj12, dx13, dy13, di13, dj13, mat[4], a[2], di10,
-      dj10;
+    dj10;
   double dxs, dxc, dys, dyc, dx, dy, theta, det, x0, y0, cost, sint;
   int nz;
 
@@ -684,41 +681,41 @@ static void st_grid_from_3refpt(RefPt refpt[3],
 
   // Fill the matrix and vector
 
-  MAT(0,0) = +di12;
-  MAT(0,1) = -dj12;
-  MAT(1,0) = +di13;
-  MAT(1,1) = -dj13;
-  a[0] = dx12;
-  a[1] = dx13;
+  MAT(0, 0) = +di12;
+  MAT(0, 1) = -dj12;
+  MAT(1, 0) = +di13;
+  MAT(1, 1) = -dj13;
+  a[0]      = dx12;
+  a[1]      = dx13;
 
-  det = (MAT(0,0) * MAT(1, 1) - MAT(1,0) * MAT(0, 1));
+  det = (MAT(0, 0) * MAT(1, 1) - MAT(1, 0) * MAT(0, 1));
   dxc = (a[0] * MAT(1, 1) - a[1] * MAT(0, 1)) / det;
-  dys = (MAT(0,0) * a[1] - MAT(1,0) * a[0]) / det;
+  dys = (MAT(0, 0) * a[1] - MAT(1, 0) * a[0]) / det;
 
-  MAT(0,0) = +di12;
-  MAT(0,1) = +dj12;
-  MAT(1,0) = +di13;
-  MAT(1,1) = +dj13;
-  a[0] = dy12;
-  a[1] = dy13;
+  MAT(0, 0) = +di12;
+  MAT(0, 1) = +dj12;
+  MAT(1, 0) = +di13;
+  MAT(1, 1) = +dj13;
+  a[0]      = dy12;
+  a[1]      = dy13;
 
-  det = (MAT(0,0) * MAT(1, 1) - MAT(1,0) * MAT(0, 1));
+  det = (MAT(0, 0) * MAT(1, 1) - MAT(1, 0) * MAT(0, 1));
   dxs = (a[0] * MAT(1, 1) - a[1] * MAT(0, 1)) / det;
-  dyc = (MAT(0,0) * a[1] - MAT(1,0) * a[0]) / det;
+  dyc = (MAT(0, 0) * a[1] - MAT(1, 0) * a[0]) / det;
 
-  dx = sqrt(dxs * dxs + dxc * dxc);
-  dy = sqrt(dys * dys + dyc * dyc);
+  dx    = sqrt(dxs * dxs + dxc * dxc);
+  dy    = sqrt(dys * dys + dyc * dyc);
   theta = 0.5 * (atan2(dxs, dxc) + atan2(dys, dyc)) * 180. / GV_PI;
-  cost = 0.5 * (dxc / dx + dyc / dy);
-  sint = 0.5 * (dxs / dx + dys / dy);
+  cost  = 0.5 * (dxc / dx + dyc / dy);
+  sint  = 0.5 * (dxs / dx + dys / dy);
 
   // Origin of the grid
 
   di10 = refpt[0].iline - refstats.ilming;
   dj10 = refpt[0].xline - refstats.xlming;
-  x0 = refpt[0].xtrace - di10 * dx * cost + dj10 * dy * sint;
-  y0 = refpt[0].ytrace - di10 * dx * sint - dj10 * dy * cost;
-  nz = static_cast<int>((refstats.zmaxl - refstats.zminl) / dz);
+  x0   = refpt[0].xtrace - di10 * dx * cost + dj10 * dy * sint;
+  y0   = refpt[0].ytrace - di10 * dx * sint - dj10 * dy * cost;
+  nz   = static_cast<int>((refstats.zmaxl - refstats.zminl) / dz);
 
   // Fill the Grid structure
 
@@ -751,9 +748,9 @@ static void st_grid_from_3refpt(RefPt refpt[3],
  **
  *****************************************************************************/
 static void st_grid_from_2refpt(RefPt refpt[3],
-                                RefStats &refstats,
+                                RefStats& refstats,
                                 double dz,
-                                Grid &def_grid)
+                                Grid& def_grid)
 {
   double dx12, dy12, di12, dj12, di10, dj10;
   double dx, dy, theta, x0, y0, sint, cost;
@@ -761,10 +758,10 @@ static void st_grid_from_2refpt(RefPt refpt[3],
 
   // Initializations
 
-  cost = 0.;
-  sint = 0.;
-  dx = 0.;
-  dy = 0.;
+  cost  = 0.;
+  sint  = 0.;
+  dx    = 0.;
+  dy    = 0.;
   theta = 0.;
 
   // Comparing points 1 and 2
@@ -777,27 +774,27 @@ static void st_grid_from_2refpt(RefPt refpt[3],
   if (dj12 == 0)
   {
     theta = atan2(dy12, dx12) * 180. / GV_PI;
-    dx = sqrt((dx12 * dx12 + dy12 * dy12) / (di12 * di12));
-    dy = 0.;
-    cost = dx12 / (dx * di12);
-    sint = dy12 / (dx * di12);
+    dx    = sqrt((dx12 * dx12 + dy12 * dy12) / (di12 * di12));
+    dy    = 0.;
+    cost  = dx12 / (dx * di12);
+    sint  = dy12 / (dx * di12);
   }
   else if (di12 == 0)
   {
     theta = atan2(dy12, dx12) * 180. / GV_PI - 90.;
-    dy = sqrt((dx12 * dx12 + dy12 * dy12) / (dj12 * dj12));
-    dx = 0.;
-    sint = -dx12 / (dy * dj12);
-    cost = dy12 / (dy * dj12);
+    dy    = sqrt((dx12 * dx12 + dy12 * dy12) / (dj12 * dj12));
+    dx    = 0.;
+    sint  = -dx12 / (dy * dj12);
+    cost  = dy12 / (dy * dj12);
   }
 
   // Origin of the grid
 
   di10 = refpt[0].iline - refstats.ilming;
   dj10 = refpt[0].xline - refstats.xlming;
-  x0 = refpt[0].xtrace - di10 * dx * cost + dj10 * dy * sint;
-  y0 = refpt[0].ytrace - di10 * dx * sint - dj10 * dy * cost;
-  nz = static_cast<int>((refstats.zmaxl - refstats.zminl) / dz);
+  x0   = refpt[0].xtrace - di10 * dx * cost + dj10 * dy * sint;
+  y0   = refpt[0].ytrace - di10 * dx * sint - dj10 * dy * cost;
+  nz   = static_cast<int>((refstats.zmaxl - refstats.zminl) / dz);
 
   // Fill the Grid structure
 
@@ -860,9 +857,9 @@ static int st_store_refpt(int nbrefpt,
 
   // Store the new Reference point
 
-  ref0 = &refpt[nbrefpt];
-  ref0->iline = iline;
-  ref0->xline = xline;
+  ref0         = &refpt[nbrefpt];
+  ref0->iline  = iline;
+  ref0->xline  = xline;
   ref0->xtrace = xtrace;
   ref0->ytrace = ytrace;
   nbrefpt++;
@@ -876,7 +873,7 @@ static int st_store_refpt(int nbrefpt,
  ** \param[in]  def_grid  Pointer to the Grid structure
  **
  *****************************************************************************/
-static void st_print_grid(const Grid &def_grid)
+static void st_print_grid(const Grid& def_grid)
 {
   message("\n");
   message("- Resulting Grid of SEGY traces\n");
@@ -893,7 +890,7 @@ static void st_print_grid(const Grid &def_grid)
  ** \param[in,out] tab    Vector
  **
  *****************************************************************************/
-static int st_complete_squeeze_and_stretch(int ntab, VectorDouble &tab)
+static int st_complete_squeeze_and_stretch(int ntab, VectorDouble& tab)
 {
   double v1;
 
@@ -979,7 +976,7 @@ static bool st_within_layer(double z0,
       if (FFFF(cztop)) return false;
       iz1 = iz2 = static_cast<int>((nz - 1) - (cztop - cote) / delta);
       if (ABS(iz1) > nz) return false;
-      *cote_ret = cztop - delta * (nz - iz1 -1);
+      *cote_ret = cztop - delta * (nz - iz1 - 1);
       break;
 
     case 2: // Vertical averaging (iz1 & iz2 are not used)
@@ -991,17 +988,17 @@ static bool st_within_layer(double z0,
       if (FFFF(czbot)) return false;
       if (FFFF(cztop)) return false;
       if (cztop < czbot) return false;
-      double dz = (cztop - czbot) / (double) (nz - 1);
-      iz1 = static_cast<int>(floor((cote - czbot) / dz));
-      iz2 = static_cast<int>(ceil((cote - czbot + delta) / dz));
+      double dz = (cztop - czbot) / (double)(nz - 1);
+      iz1       = static_cast<int>(floor((cote - czbot) / dz));
+      iz2       = static_cast<int>(ceil((cote - czbot + delta) / dz));
       *cote_ret = czbot + dz * iz1;
       break;
   }
 
   // Calculate the vertical index
 
-  iz1 = MAX(0, MIN(iz1, nz-1));
-  iz2 = MAX(0, MIN(iz2, nz-1));
+  iz1 = MAX(0, MIN(iz1, nz - 1));
+  iz2 = MAX(0, MIN(iz2, nz - 1));
 
   // Returning arguments
 
@@ -1015,18 +1012,17 @@ static bool st_within_layer(double z0,
  ** Calculate the average
  **
  *****************************************************************************/
-static double st_get_average(int nz, const VectorDouble &writes)
+static double st_get_average(int nz, const VectorDouble& writes)
 {
   double dmean = 0.;
-  int nmean = 0;
+  int nmean    = 0;
   for (int iz = 0; iz < nz; iz++)
   {
     if (FFFF(writes[iz])) continue;
     dmean += writes[iz];
     nmean++;
   }
-  dmean = (nmean > 0) ? dmean / (double) nmean :
-                        TEST;
+  dmean = (nmean > 0) ? dmean / (double)nmean : TEST;
   return dmean;
 }
 
@@ -1043,19 +1039,19 @@ static int st_identify_trace_rank(DbGrid* surfaces,
                                   double xtrace,
                                   double ytrace)
 {
-    // Check if the surface file has been defined
+  // Check if the surface file has been defined
 
-    if (surfaces == nullptr) return -1;
+  if (surfaces == nullptr) return -1;
 
-    // The surface is valid, return the vertical bounds along trace
+  // The surface is valid, return the vertical bounds along trace
 
-    VectorDouble coor(2);
-    coor[0] = xtrace;
-    coor[1] = ytrace;
+  VectorDouble coor(2);
+  coor[0] = xtrace;
+  coor[1] = ytrace;
 
-    // Find the index of grid node
+  // Find the index of grid node
 
-    return surfaces->coordinateToRank(coor);
+  return surfaces->coordinateToRank(coor);
 }
 
 /**
@@ -1093,20 +1089,20 @@ static void st_auxiliary(Db* surfaces,
 
   if (iaux_top >= 0)
   {
-    double cote = surfaces->getArray(rank, iaux_top);
+    double cote     = surfaces->getArray(rank, iaux_top);
     refstats.auxtop = TEST;
-    (void) st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1,
-                           &iz2, &refstats.auxtop);
+    (void)st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1,
+                          &iz2, &refstats.auxtop);
   }
 
   // Project optional Auxiliary Bottom surface
 
   if (iaux_bot >= 0)
   {
-    double cote = surfaces->getArray(rank, iaux_bot);
+    double cote     = surfaces->getArray(rank, iaux_bot);
     refstats.auxbot = TEST;
-    (void) st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1,
-                           &iz2, &refstats.auxbot);
+    (void)st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1,
+                          &iz2, &refstats.auxbot);
   }
 }
 
@@ -1161,7 +1157,7 @@ static int st_load_trace(int nPerTrace,
 
     // Dispatch
 
-    if (! st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1, &iz2, &cote_ret))
+    if (!st_within_layer(z0, delta, cztop, czbot, cote, option, nz, &iz1, &iz2, &cote_ret))
       continue;
 
     // Update statistics
@@ -1204,12 +1200,12 @@ static int st_load_trace(int nPerTrace,
 static void st_print_results(int nPerTrace,
                              bool flag_surf,
                              double delta,
-                             RefStats &refstats)
+                             RefStats& refstats)
 {
   mestitle(1, "Extracting information from the SEGY file");
   if (flag_surf)
     message(
-        "(Statistics are calculated taking Surface information into account)\n");
+      "(Statistics are calculated taking Surface information into account)\n");
   message("- Number of samples per Trace    = %d \n", nPerTrace);
   message("- Interval between samples       = %lf\n", delta);
   message("- Minimum Inline number          = %d \n", refstats.ilming);
@@ -1245,19 +1241,19 @@ static void st_print_results(int nPerTrace,
  ** Get Trace characteristics
  **
  *****************************************************************************/
-void st_get_trace_params(traceHead *Theader,
-                         int *iline,
-                         int *xline,
-                         double *delta,
-                         double *xtrace,
-                         double *ytrace)
+void st_get_trace_params(traceHead* Theader,
+                         int* iline,
+                         int* xline,
+                         double* delta,
+                         double* xtrace,
+                         double* ytrace)
 {
   int scacsv = st_to_s(Theader->SCALE_COOR);
-  *delta = (double) st_to_s(Theader->SAMPLE_INTRVL) / 1000;
-  *xtrace = st_scaling(st_to_f(Theader->ENS_COOR_X), scacsv);
-  *ytrace = st_scaling(st_to_f(Theader->ENS_COOR_Y), scacsv);
-  *iline = st_to_i(Theader->INLINE);
-  *xline = st_to_i(Theader->CROSS);
+  *delta     = (double)st_to_s(Theader->SAMPLE_INTRVL) / 1000;
+  *xtrace    = st_scaling(st_to_f(Theader->ENS_COOR_X), scacsv);
+  *ytrace    = st_scaling(st_to_f(Theader->ENS_COOR_Y), scacsv);
+  *iline     = st_to_i(Theader->INLINE);
+  *xline     = st_to_i(Theader->CROSS);
 }
 
 /****************************************************************************/
@@ -1288,7 +1284,7 @@ static void st_refstats_update(int iline,
                                int xline,
                                double xtrace,
                                double ytrace,
-                               RefStats &refstats)
+                               RefStats& refstats)
 {
   if (xtrace < refstats.xming || FFFF(refstats.xming)) refstats.xming = xtrace;
   if (xtrace > refstats.xmaxg || FFFF(refstats.xmaxg)) refstats.xmaxg = xtrace;
@@ -1310,7 +1306,7 @@ static void st_refstats_update(int iline,
  ** Initialize statistics
  **
  *****************************************************************************/
-static void st_refstats_init(RefStats &refstats,
+static void st_refstats_init(RefStats& refstats,
                              double modif_high,
                              double modif_low,
                              double modif_scale)
@@ -1344,8 +1340,8 @@ static void st_refstats_init(RefStats &refstats,
   refstats.vmaxg = TEST;
   refstats.thicg = TEST;
 
-  refstats.modif_low = modif_low;
-  refstats.modif_high = modif_high;
+  refstats.modif_low   = modif_low;
+  refstats.modif_high  = modif_high;
   refstats.modif_scale = modif_scale;
 }
 
@@ -1353,93 +1349,93 @@ static traceHead st_traceHead_init()
 {
   traceHead trace;
 
-  trace.TRACE_SEQ_GLOBAL = 0;
-  trace.TRACE_SEQ_LOCAL = 0;
-  trace.ORI_RECORD_NUM = 0;
-  trace.TRACE_NUM_FIELD = 0;
-  trace.SOURCE_POINT = 0;
-  trace.ENSEMBLE_NUM = 0;
-  trace.ENS_TRACE_NUM = 0;
-  trace.TRACE_CODE = 0;
-  trace.NUM_VERT_SUM = 0;
-  trace.NUM_HORZ_SUM = 0;
-  trace.DATA_USE = 0;
-  trace.DIST_CENT_RECV = 0;
-  trace.RECV_GRP_ELEV = 0;
-  trace.SURF_ELEV_SRC = 0;
-  trace.SOURCE_DEPTH = 0;
-  trace.DATUM_ELEV_RECV = 0;
-  trace.DATUM_ELAV_SRC = 0;
-  trace.WATER_DEPTH_SRC = 0;
-  trace.WATER_DEPTH_GRP = 0;
-  trace.SCALE_DEPTH = 0;
-  trace.SCALE_COOR = 0;
-  trace.SRC_COOR_X = 0;
-  trace.SRC_COOR_Y = 0;
-  trace.GRP_COOR_X = 0;
-  trace.GRP_COOR_Y = 0;
-  trace.COOR_UNIT = 0;
-  trace.WEATHER_VEL = 0;
-  trace.SWEATHER_VEL = 0;
-  trace.UPHOLE_T_SRC = 0;
-  trace.UPHOLE_T_GRP = 0;
-  trace.SRC_STA_CORRC = 0;
-  trace.GRP_STA_CORRC = 0;
-  trace.TOTAL_STA = 0;
-  trace.LAG_TIME_A = 0;
-  trace.LAG_TIME_B = 0;
-  trace.DELAY_T = 0;
-  trace.MUTE_T_STRT = 0;
-  trace.MUTE_T_END = 0;
-  trace.NUM_OF_SAMPL = 0;
-  trace.SAMPLE_INTRVL = 0;
-  trace.GAIN_TYPE = 0;
-  trace.GAIN_CONST = 0;
-  trace.GAIN_INIT = 0;
-  trace.CORRLTD = 0;
-  trace.SWEEP_FREQ_START = 0;
-  trace.SWEEP_FREQ_END = 0;
-  trace.SWEEP_LENGTH = 0;
-  trace.SWEEP_TYPE = 0;
+  trace.TRACE_SEQ_GLOBAL      = 0;
+  trace.TRACE_SEQ_LOCAL       = 0;
+  trace.ORI_RECORD_NUM        = 0;
+  trace.TRACE_NUM_FIELD       = 0;
+  trace.SOURCE_POINT          = 0;
+  trace.ENSEMBLE_NUM          = 0;
+  trace.ENS_TRACE_NUM         = 0;
+  trace.TRACE_CODE            = 0;
+  trace.NUM_VERT_SUM          = 0;
+  trace.NUM_HORZ_SUM          = 0;
+  trace.DATA_USE              = 0;
+  trace.DIST_CENT_RECV        = 0;
+  trace.RECV_GRP_ELEV         = 0;
+  trace.SURF_ELEV_SRC         = 0;
+  trace.SOURCE_DEPTH          = 0;
+  trace.DATUM_ELEV_RECV       = 0;
+  trace.DATUM_ELAV_SRC        = 0;
+  trace.WATER_DEPTH_SRC       = 0;
+  trace.WATER_DEPTH_GRP       = 0;
+  trace.SCALE_DEPTH           = 0;
+  trace.SCALE_COOR            = 0;
+  trace.SRC_COOR_X            = 0;
+  trace.SRC_COOR_Y            = 0;
+  trace.GRP_COOR_X            = 0;
+  trace.GRP_COOR_Y            = 0;
+  trace.COOR_UNIT             = 0;
+  trace.WEATHER_VEL           = 0;
+  trace.SWEATHER_VEL          = 0;
+  trace.UPHOLE_T_SRC          = 0;
+  trace.UPHOLE_T_GRP          = 0;
+  trace.SRC_STA_CORRC         = 0;
+  trace.GRP_STA_CORRC         = 0;
+  trace.TOTAL_STA             = 0;
+  trace.LAG_TIME_A            = 0;
+  trace.LAG_TIME_B            = 0;
+  trace.DELAY_T               = 0;
+  trace.MUTE_T_STRT           = 0;
+  trace.MUTE_T_END            = 0;
+  trace.NUM_OF_SAMPL          = 0;
+  trace.SAMPLE_INTRVL         = 0;
+  trace.GAIN_TYPE             = 0;
+  trace.GAIN_CONST            = 0;
+  trace.GAIN_INIT             = 0;
+  trace.CORRLTD               = 0;
+  trace.SWEEP_FREQ_START      = 0;
+  trace.SWEEP_FREQ_END        = 0;
+  trace.SWEEP_LENGTH          = 0;
+  trace.SWEEP_TYPE            = 0;
   trace.SWEEP_TAPER_LEN_START = 0;
-  trace.SWEEP_TAPER_LEN_END = 0;
-  trace.TAPER_TYPE = 0;
-  trace.ALIAS_FREQ = 0;
-  trace.ALIAS_SLOPE = 0;
-  trace.NOTCH_FREQ = 0;
-  trace.NOTCH_SLOPE = 0;
-  trace.LOWCUT_FREQ = 0;
-  trace.HIGHCUT_FREQ = 0;
-  trace.LOWCUT_SLOPE = 0;
-  trace.HIGHCUT_SLOPE = 0;
-  trace.YEAR = 0;
-  trace.DAY = 0;
-  trace.HOUR = 0;
-  trace.MINUTE = 0;
-  trace.SECOND = 0;
-  trace.TIME_CODE = 0;
-  trace.WEIGHT_FACT = 0;
-  trace.GEOPHNE_ROLL = 0;
-  trace.GEOPHNE_TRACE = 0;
-  trace.GEOPHNE_LAST = 0;
-  trace.GAP_SIZE = 0;
-  trace.OVER_TRAVEL = 0;
-  trace.ENS_COOR_X = 0;
-  trace.ENS_COOR_Y = 0;
-  trace.INLINE = 0;
-  trace.CROSS = 0;
-  trace.SHOOTPOINT = 0;
-  trace.SHOOTPOINT_SCALE = 0;
-  trace.TRACE_UNIT = 0;
-  memset(trace.TRANSD_CONST,0,6);
+  trace.SWEEP_TAPER_LEN_END   = 0;
+  trace.TAPER_TYPE            = 0;
+  trace.ALIAS_FREQ            = 0;
+  trace.ALIAS_SLOPE           = 0;
+  trace.NOTCH_FREQ            = 0;
+  trace.NOTCH_SLOPE           = 0;
+  trace.LOWCUT_FREQ           = 0;
+  trace.HIGHCUT_FREQ          = 0;
+  trace.LOWCUT_SLOPE          = 0;
+  trace.HIGHCUT_SLOPE         = 0;
+  trace.YEAR                  = 0;
+  trace.DAY                   = 0;
+  trace.HOUR                  = 0;
+  trace.MINUTE                = 0;
+  trace.SECOND                = 0;
+  trace.TIME_CODE             = 0;
+  trace.WEIGHT_FACT           = 0;
+  trace.GEOPHNE_ROLL          = 0;
+  trace.GEOPHNE_TRACE         = 0;
+  trace.GEOPHNE_LAST          = 0;
+  trace.GAP_SIZE              = 0;
+  trace.OVER_TRAVEL           = 0;
+  trace.ENS_COOR_X            = 0;
+  trace.ENS_COOR_Y            = 0;
+  trace.INLINE                = 0;
+  trace.CROSS                 = 0;
+  trace.SHOOTPOINT            = 0;
+  trace.SHOOTPOINT_SCALE      = 0;
+  trace.TRACE_UNIT            = 0;
+  memset(trace.TRANSD_CONST, 0, 6);
   trace.TRANSD_UNIT = 0;
   trace.TRACE_IDENT = 0;
-  trace.SCALE_TIME = 0;
-  trace.SRC_ORIENT = 0;
-  memset(trace.SRC_DIRECTION,0,6);
-  memset(trace.SRC_MEASUREMT,0,6);
+  trace.SCALE_TIME  = 0;
+  trace.SRC_ORIENT  = 0;
+  memset(trace.SRC_DIRECTION, 0, 6);
+  memset(trace.SRC_MEASUREMT, 0, 6);
   trace.SRC_UNIT = 0;
-  memset(trace.UNNASSIGNED1,0,6);
+  memset(trace.UNNASSIGNED1, 0, 6);
 
   return trace;
 }
@@ -1496,8 +1492,8 @@ static traceHead st_traceHead_init()
  ** \details is meaningless. It is fixed by the user.
  **
  *****************************************************************************/
-SegYArg segy_array(const char *filesegy,
-                   DbGrid *surf2D,
+SegYArg segy_array(const char* filesegy,
+                   DbGrid* surf2D,
                    const String& top_name,
                    const String& bot_name,
                    const String& top_aux,
@@ -1525,13 +1521,13 @@ SegYArg segy_array(const char *filesegy,
 
   // Initializations
 
-  FILE* file = nullptr;
-  int nbrefpt = 0;
-  int nz = 0;
-  double delta = 0.;
-  double z0 = 0.;
-  double cztop = 0.;
-  double czbot = 0.;
+  FILE* file           = nullptr;
+  int nbrefpt          = 0;
+  int nz               = 0;
+  double delta         = 0.;
+  double z0            = 0.;
+  double cztop         = 0.;
+  double czbot         = 0.;
   traceHead traceHead_ = st_traceHead_init();
   st_refstats_init(refstats, modif_high, modif_low, modif_scale);
   segyarg.error = 1;
@@ -1539,8 +1535,8 @@ SegYArg segy_array(const char *filesegy,
   // Preliminary checks
 
   bool flag_surf = (surf2D != nullptr);
-  bool flag_top = flag_surf && (option ==  1 || option == -2);
-  bool flag_bot = flag_surf && (option == -1 || option == -2);
+  bool flag_top  = flag_surf && (option == 1 || option == -2);
+  bool flag_bot  = flag_surf && (option == -1 || option == -2);
   if (st_surface_identify(verbOption, surf2D,
                           bot_name, flag_bot, &iatt_bot,
                           top_name, flag_top, &iatt_top,
@@ -1698,10 +1694,10 @@ SegYArg segy_array(const char *filesegy,
  ** \details: by the output grid (if flag_store == 1)
  **
  *****************************************************************************/
-Grid segy_summary(const char *filesegy,
-                  DbGrid *surf2D,
-                  const String &name_top,
-                  const String &name_bot,
+Grid segy_summary(const char* filesegy,
+                  DbGrid* surf2D,
+                  const String& name_top,
+                  const String& name_bot,
                   double thickmin,
                   int option,
                   int nz_ss,
@@ -1715,21 +1711,21 @@ Grid segy_summary(const char *filesegy,
                   double modif_scale,
                   int codefmt)
 {
-  double   xtrace,ytrace;
-  int      iline,xline,nbvalues;
-  int      nPerTrace,iatt_top = 0,iatt_bot = 0,iaux_top = 0,iaux_bot = 0;
-  RefPt    refpt[3];
+  double xtrace, ytrace;
+  int iline, xline, nbvalues;
+  int nPerTrace, iatt_top = 0, iatt_bot = 0, iaux_top = 0, iaux_bot = 0;
+  RefPt refpt[3];
   RefStats refstats;
   Grid def_grid;
   VectorDouble values, cotes, writes;
 
   // Initializations
 
-  FILE* file = nullptr;
-  int nbrefpt = 0;
-  int nz = 0;
+  FILE* file   = nullptr;
+  int nbrefpt  = 0;
+  int nz       = 0;
   double delta = 0.;
-  double z0 = 0.;
+  double z0    = 0.;
   double czbot = 0.;
   double cztop = 0.;
   st_refstats_init(refstats, modif_high, modif_low, modif_scale);
@@ -1738,8 +1734,8 @@ Grid segy_summary(const char *filesegy,
   // Preliminary checks
 
   bool flag_surf = (surf2D != nullptr);
-  bool flag_top = flag_surf && (option ==  1 || option == -2);
-  bool flag_bot = flag_surf && (option == -1 || option == -2);
+  bool flag_top  = flag_surf && (option == 1 || option == -2);
+  bool flag_bot  = flag_surf && (option == -1 || option == -2);
   if (st_surface_identify(verbOption, surf2D,
                           name_bot, flag_bot, &iatt_bot,
                           name_top, flag_top, &iatt_top,
@@ -1878,11 +1874,11 @@ Grid segy_summary(const char *filesegy,
  ** \remarks - no attention is paid to the vertical mesh value.
  **
  *****************************************************************************/
-int db_segy(const char *filesegy,
-            DbGrid *grid3D,
-            DbGrid *surf2D,
-            const String &name_top,
-            const String &name_bot,
+int db_segy(const char* filesegy,
+            DbGrid* grid3D,
+            DbGrid* surf2D,
+            const String& name_top,
+            const String& name_bot,
             double thickmin,
             int option,
             int nz_ss,
@@ -1908,11 +1904,11 @@ int db_segy(const char *filesegy,
   // Initializations
 
   int nPerTrace;
-  FILE* file = nullptr;
-  int nbrefpt = 0;
-  int nz = 0;
+  FILE* file   = nullptr;
+  int nbrefpt  = 0;
+  int nz       = 0;
   double delta = 0.;
-  double z0 = 0.;
+  double z0    = 0.;
   double czbot = 0.;
   double cztop = 0.;
   int ndim     = grid3D->getNDim();
@@ -1923,8 +1919,8 @@ int db_segy(const char *filesegy,
   // Preliminary checks
 
   bool flag_surf = (surf2D != nullptr);
-  bool flag_top = flag_surf && (option == 1 || option == -2);
-  bool flag_bot = flag_surf && (option == -1 || option == -2);
+  bool flag_top  = flag_surf && (option == 1 || option == -2);
+  bool flag_bot  = flag_surf && (option == -1 || option == -2);
   if (st_surface_identify(verbOption, surf2D,
                           name_bot, flag_bot, &iatt_bot,
                           name_top, flag_top, &iatt_top,
@@ -2022,8 +2018,8 @@ int db_segy(const char *filesegy,
     if (option == 2)
     {
       double dmean = st_get_average(nz, writes);
-      indg[2] = 0;
-      rank = grid3D->indiceToRank(indg);
+      indg[2]      = 0;
+      rank         = grid3D->indiceToRank(indg);
       if (rank >= 0) grid3D->setArray(rank, iatt, dmean);
     }
     else
@@ -2031,7 +2027,7 @@ int db_segy(const char *filesegy,
       for (int iz = 0; iz < nz; iz++)
       {
         indg[2] = iz;
-        rank = grid3D->indiceToRank(indg);
+        rank    = grid3D->indiceToRank(indg);
         if (rank < 0) continue;
         grid3D->setArray(rank, iatt, writes[iz]);
       }
@@ -2053,4 +2049,4 @@ int db_segy(const char *filesegy,
   return 0;
 }
 
-}
+} // namespace gstlrn

--- a/src/OutputFormat/vtk.cpp
+++ b/src/OutputFormat/vtk.cpp
@@ -60,7 +60,7 @@ License: BSD 3-clause
 #include "Basic/String.hpp"
 #include "Basic/File.hpp"
 
-#include <string.h>
+#include <cstring>
 
 /*
  * Globals.

--- a/src/Polynomials/APolynomial.cpp
+++ b/src/Polynomials/APolynomial.cpp
@@ -10,18 +10,18 @@
 /******************************************************************************/
 #include "Polynomials/APolynomial.hpp"
 #include "Basic/VectorNumT.hpp"
-
 #include "Matrix/MatrixSparse.hpp"
-#include <string>
+
 #include <algorithm>
-#include <sstream>
+#include <cmath>
 #include <iterator>
-#include <math.h>
+#include <sstream>
+#include <string>
 
 namespace gstlrn
 {
 APolynomial::APolynomial()
-    : AStringable()
+  : AStringable()
 {
 }
 
@@ -31,23 +31,22 @@ APolynomial::APolynomial(const VectorDouble& coeffs)
   init(coeffs);
 }
 
-APolynomial::APolynomial(const APolynomial &m)
-    : AStringable(m),
-      _coeffs(m._coeffs)
+APolynomial::APolynomial(const APolynomial& m)
+  : AStringable(m)
+  , _coeffs(m._coeffs)
 {
 }
 
 APolynomial::~APolynomial()
 {
-
 }
 
-APolynomial & APolynomial::operator=(const APolynomial& p)
+APolynomial& APolynomial::operator=(const APolynomial& p)
 {
-  if (this !=& p)
+  if (this != &p)
   {
     AStringable::operator=(p);
-    _coeffs=p._coeffs;
+    _coeffs = p._coeffs;
   }
   return *this;
 }
@@ -56,7 +55,7 @@ VectorDouble APolynomial::evalOp(MatrixSparse* Op, const constvect in) const
 {
   VectorDouble result(in.size());
   vect results(result);
-  evalOp(Op,in,results);
+  evalOp(Op, in, results);
   return result;
 }
 
@@ -67,13 +66,13 @@ String APolynomial::toString(const AStringFormat* /*strfmt*/) const
   if (_coeffs.size() <= 0) return str;
 
   std::ostringstream oss;
-  str += "Polynomials of degree " + std::to_string(_coeffs.size()-1) + "\n";
+  str += "Polynomials of degree " + std::to_string(_coeffs.size() - 1) + "\n";
   if (!_coeffs.empty())
   {
     std::copy(_coeffs.begin(), _coeffs.end(),
-    std::ostream_iterator<double>(oss, " "));
+              std::ostream_iterator<double>(oss, " "));
   }
-  str +=oss.str() + "\n";
+  str += oss.str() + "\n";
   return str;
 }
 void APolynomial::init(const VectorDouble& coeffs)
@@ -85,4 +84,4 @@ void APolynomial::addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const
 {
   _addEvalOp(Op, inv, outv);
 }
-}
+} // namespace gstlrn

--- a/src/Polynomials/Chebychev.cpp
+++ b/src/Polynomials/Chebychev.cpp
@@ -8,14 +8,14 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Polynomials/Chebychev.hpp"
 #include "Basic/AException.hpp"
 #include "Basic/AFunction.hpp"
-#include "Polynomials/Chebychev.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Core/fftn.hpp"
-#include "LinearOp/AShiftOp.hpp"
 #include "Matrix/MatrixSparse.hpp"
-#include <math.h>
+
+#include <cmath>
 #include <functional>
 
 namespace gstlrn
@@ -28,7 +28,6 @@ Chebychev::Chebychev()
   , _verbose(false)
 {
   // TODO Auto-generated constructor stub
-
 }
 
 Chebychev::~Chebychev()
@@ -43,66 +42,65 @@ Chebychev* Chebychev::createFromCoeffs(const VectorDouble& coeffs)
   return cheb;
 }
 
-void Chebychev::init(int ncMax,int nDisc,double a,double b,bool verbose)
+void Chebychev::init(int ncMax, int nDisc, double a, double b, bool verbose)
 {
-  _ncMax=ncMax;
-  _nDisc=nDisc;
-  _a = a;
-  _b = b;
+  _ncMax   = ncMax;
+  _nDisc   = nDisc;
+  _a       = a;
+  _b       = b;
   _verbose = verbose;
 }
 
 int Chebychev::fit2(AFunction* f,
-                   double a ,
-                   double b ,
-                   double tol )
+                    double a,
+                    double b,
+                    double tol)
 {
-  std::function<double(double)> func = [f](double val){return f->eval(val);};
-  return fit(func,a,b,tol);
-
+  std::function<double(double)> func = [f](double val)
+  { return f->eval(val); };
+  return fit(func, a, b, tol);
 }
 
 int Chebychev::fit(const std::function<double(double)>& f, double a, double b, double tol)
 {
 
-  _coeffs.resize(_ncMax,0.);
+  _coeffs.resize(_ncMax, 0.);
 
-   /* Evaluate the coefficients of the AChebychev approximation */
+  /* Evaluate the coefficients of the AChebychev approximation */
 
-   _fillCoeffs(f,a,b);
+  _fillCoeffs(f, a, b);
 
-   /* Loop on some discretized samples of the interval */
+  /* Loop on some discretized samples of the interval */
 
-   int number = 0;
-   double incr = (b - a) / (_nDisc + 1);
-   double value = a;
-   while(value <= b)
-   {
-     int numloc = _countCoeffs(f,value,a,b);
-     number = MAX(number,numloc);
-     value  += incr;
-   }
+  int number   = 0;
+  double incr  = (b - a) / (_nDisc + 1);
+  double value = a;
+  while (value <= b)
+  {
+    int numloc = _countCoeffs(f, value, a, b);
+    number     = MAX(number, numloc);
+    value += incr;
+  }
 
+  /* Optional printout  */
 
-   /* Optional printout  */
+  if (_verbose)
+  {
+    message("AChebychev Polynomial Approximation:\n");
+    message("- Performed using %d terms\n", number);
+    message("- between %lf and %lf (Nb. discretization steps=%d)\n", a, b, _nDisc);
+    message("- with a tolerance of %lg\n", tol);
+  }
 
-   if (_verbose)
-   {
-     message("AChebychev Polynomial Approximation:\n");
-     message("- Performed using %d terms\n",number);
-     message("- between %lf and %lf (Nb. discretization steps=%d)\n",a,b,_nDisc);
-     message("- with a tolerance of %lg\n",tol);
-   }
+  /* Core Reallocation */
 
-   /* Core Reallocation */
+  _coeffs.resize(number);
 
-   _coeffs.resize(number);
+  // Optional printout
 
-   // Optional printout
-
-   if (_verbose)
-     for (int i=0; i<(int) _coeffs.size(); i++)
-       message("Chebychev coefficient[%d] = %lf\n",i+1,_coeffs[i]);
+  if (_verbose)
+    for (int i = 0; i < (int)_coeffs.size(); i++)
+      message("Chebychev coefficient[%d] = %lf\n", i + 1, _coeffs[i]);
 
   return 0;
 }
@@ -111,37 +109,36 @@ double Chebychev::eval(double x) const
 {
   double y, xc, Tx, Tm1, Tm2;
 
-   /* Calculate the approximate value until tolerance is reached */
+  /* Calculate the approximate value until tolerance is reached */
 
-   xc = 2 * (x - _a) / (_b - _a) - 1.;
-   y = _coeffs[0] + _coeffs[1] * xc;
-   Tm2 = 1.;
-   Tm1 = xc;
-   for (int i = 2; i < _ncMax; i++)
-   {
-     Tx = 2. * xc * Tm1 - Tm2;
-     y += _coeffs[i] * Tx;
-     Tm2 = Tm1;
-     Tm1 = Tx;
-   }
+  xc  = 2 * (x - _a) / (_b - _a) - 1.;
+  y   = _coeffs[0] + _coeffs[1] * xc;
+  Tm2 = 1.;
+  Tm1 = xc;
+  for (int i = 2; i < _ncMax; i++)
+  {
+    Tx = 2. * xc * Tm1 - Tm2;
+    y += _coeffs[i] * Tx;
+    Tm2 = Tm1;
+    Tm1 = Tx;
+  }
 
-   return y;
+  return y;
 }
 
-
-int Chebychev::_countCoeffs(const std::function<double(double)>& f,double x,double a,double b,double tol)const
+int Chebychev::_countCoeffs(const std::function<double(double)>& f, double x, double a, double b, double tol) const
 {
   double y, y0, y_2, xc, Tx, Tm1, Tm2;
 
   /* Get the true value  */
 
-  y0 = f(x);
-  double y0_2 = y0 * y0;
+  y0            = f(x);
+  double y0_2   = y0 * y0;
   double normy0 = y0_2 + EPSILON2;
   tol *= normy0;
   /* Calculate the approximate value until tolerance is reached */
-  xc = 2 * (x - a) / (b - a) - 1.;
-  y = _coeffs[0] + _coeffs[1] * xc;
+  xc  = 2 * (x - a) / (b - a) - 1.;
+  y   = _coeffs[0] + _coeffs[1] * xc;
   y_2 = y * y;
   if (ABS(y_2 - y0_2) < tol) return (2);
   Tm2 = 1.;
@@ -151,7 +148,7 @@ int Chebychev::_countCoeffs(const std::function<double(double)>& f,double x,doub
   {
     Tx = 2. * Tm1 * xc - Tm2;
     y += _coeffs[i] * Tx;
-    if (ABS(y * y - y0 * y0)  < tol)
+    if (ABS(y * y - y0 * y0) < tol)
       return (i + 1);
 
     Tm2 = Tm1;
@@ -161,7 +158,7 @@ int Chebychev::_countCoeffs(const std::function<double(double)>& f,double x,doub
   return (_ncMax);
 }
 
-void Chebychev::_fillCoeffs(const std::function<double(double)>& f,double a, double b)
+void Chebychev::_fillCoeffs(const std::function<double(double)>& f, double a, double b)
 {
   VectorDouble coeffs, x1, y1, x2, y2;
   int n;
@@ -170,9 +167,9 @@ void Chebychev::_fillCoeffs(const std::function<double(double)>& f,double a, dou
 
   double minsubdiv = pow(2., 20.);
   if (minsubdiv >= (_ncMax + 1.) / 2.)
-    n = static_cast<int> (minsubdiv);
+    n = static_cast<int>(minsubdiv);
   else
-    n = static_cast<int> (ceil((double) (_ncMax + 1) / 2));
+    n = static_cast<int>(ceil((double)(_ncMax + 1) / 2));
 
   /* Core allocation */
 
@@ -185,36 +182,35 @@ void Chebychev::_fillCoeffs(const std::function<double(double)>& f,double a, dou
 
   for (int i = 0; i < n; i++)
   {
-    double theta = 2. * GV_PI * ((double) i) / ((double) n);
+    double theta = 2. * GV_PI * ((double)i) / ((double)n);
     double ct    = cos(theta / 2.);
     double val1  = f(((b + a) + (b - a) * ct) / 2.);
     double val2  = f(((b + a) - (b - a) * ct) / 2.);
-    x1[i] = 0.5 * (val1 + val2);
-    y1[i] = 0.;
-    x2[i] = 0.5 * (val1 - val2) * cos(-theta / 2.);
-    y2[i] = 0.5 * (val1 - val2) * sin(-theta / 2.);
+    x1[i]        = 0.5 * (val1 + val2);
+    y1[i]        = 0.;
+    x2[i]        = 0.5 * (val1 - val2) * cos(-theta / 2.);
+    y2[i]        = 0.5 * (val1 - val2) * sin(-theta / 2.);
   }
 
   /* Perform the FFT transform */
 
-  if (fftn(1, &n, x1.data(), y1.data(),  1, 1.))
+  if (fftn(1, &n, x1.data(), y1.data(), 1, 1.))
     my_throw("Problem when calculating 1-D Fast Fourrier Transform");
   if (fftn(1, &n, x2.data(), y2.data(), -1, 1.))
     my_throw("Problem when calculating 1-D Fast Fourrier Transform");
 
   /* Store the coefficients */
 
-  double value = 2. / (double) n;
+  double value = 2. / (double)n;
   for (int i = 0; i < n; i++)
   {
     if (2 * i >= _ncMax) break;
-    _coeffs[2 * i    ] = value * x1[i];
+    _coeffs[2 * i] = value * x1[i];
     if (2 * i + 1 >= _ncMax) break;
     _coeffs[2 * i + 1] = value * x2[i];
   }
   _coeffs[0] /= 2.;
 }
-
 
 /* void Chebychev::evalOp(const ALinearOpMulti *Op,
                        const std::vector<Eigen::VectorXd> &inv,
@@ -236,29 +232,29 @@ void Chebychev::_fillCoeffs(const std::function<double(double)>& f,double a, dou
   VH::linearCombinationVVDInPlace(v1, *tm1, v2, *tm2, *tm1);
   VH::linearCombinationVVDInPlace(_coeffs[0], *tm2, _coeffs[1], *tm1, outv);
  */
-  /* Loop on the Chebychev polynomials */
-  // Op *= 2
-  /* v1 *= 2.;
-  v2 *= 2.;
+/* Loop on the Chebychev polynomials */
+// Op *= 2
+/* v1 *= 2.;
+v2 *= 2.;
 
-  for (int ib = 2; ib < (int) _coeffs.size(); ib++)
-  {
-    // t0 = (v1 Op + v2 I) tm1
-    Op->evalDirect(*tm1, *t0);
-    VH::linearCombinationVVDInPlace(v1, *t0, v2, *tm1, *t0);
+for (int ib = 2; ib < (int) _coeffs.size(); ib++)
+{
+  // t0 = (v1 Op + v2 I) tm1
+  Op->evalDirect(*tm1, *t0);
+  VH::linearCombinationVVDInPlace(v1, *t0, v2, *tm1, *t0);
 
-    // t0 = 2 * t0 - tm2
-    VH::subtractInPlace(*tm2, *t0, *t0);
+  // t0 = 2 * t0 - tm2
+  VH::subtractInPlace(*tm2, *t0, *t0);
 
-    // outv += coeff * y
-    VH::addMultiplyConstantInPlace(_coeffs[ib], *t0, outv);
+  // outv += coeff * y
+  VH::addMultiplyConstantInPlace(_coeffs[ib], *t0, outv);
 
-    // swap
-    swap = tm2;
-    tm2 = tm1;
-    tm1 = t0;
-    t0 = swap;
-  }
+  // swap
+  swap = tm2;
+  tm2 = tm1;
+  tm1 = t0;
+  t0 = swap;
+}
 } */
 
 #ifndef SWIG
@@ -266,13 +262,13 @@ void Chebychev::evalOp(MatrixSparse* S, const constvect x, vect y) const
 {
   VectorDouble tm1, tm2, px, tx;
   int nvertex;
-  MatrixSparse *T1;
+  MatrixSparse* T1;
 
-/* Initializations */
+  /* Initializations */
 
   if (!_isReady())
     my_throw("You must use 'initCoeffs' before 'operate'");
-  nvertex = S->getNCols();
+  nvertex   = S->getNCols();
   double v1 = 2. / (_b - _a);
   double v2 = -(_b + _a) / (_b - _a);
   tm1.resize(nvertex);
@@ -286,9 +282,9 @@ void Chebychev::evalOp(MatrixSparse* S, const constvect x, vect y) const
   if (T1 == nullptr) my_throw("Problem in cs_eye");
   T1->addMatInPlace(*S, v2, v1);
 
-/* Initialize the simulation */
+  /* Initialize the simulation */
 
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
   {
     tm1[i] = 0.;
     y[i]   = x[i];
@@ -296,7 +292,7 @@ void Chebychev::evalOp(MatrixSparse* S, const constvect x, vect y) const
   constvect ys(y);
   vect tm1s(tm1);
   if (T1->addVecInPlace(ys, tm1)) my_throw("Problem in addVecInPlace");
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
   {
     px[i]  = _coeffs[0] * y[i] + _coeffs[1] * tm1[i];
     tm2[i] = y[i];
@@ -304,21 +300,21 @@ void Chebychev::evalOp(MatrixSparse* S, const constvect x, vect y) const
 
   /* Loop on the AChebychev polynomials */
 
-  for (int ib=2; ib<(int) _coeffs.size(); ib++)
+  for (int ib = 2; ib < (int)_coeffs.size(); ib++)
   {
     T1->prodVecMatInPlacePtr(tm1.data(), tx.data(), false);
-    for (int i=0; i<nvertex; i++)
+    for (int i = 0; i < nvertex; i++)
     {
-      tx[i]  = 2. * tx[i] - tm2[i];
+      tx[i] = 2. * tx[i] - tm2[i];
       px[i] += _coeffs[ib] * tx[i];
       tm2[i] = tm1[i];
       tm1[i] = tx[i];
     }
   }
 
-/* Return the results */
+  /* Return the results */
 
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
     y[i] = px[i];
 
   delete T1;
@@ -329,11 +325,11 @@ void Chebychev::_addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const
   VectorDouble tm1, tm2, px, tx;
   int nvertex;
 
-/* Initializations */
+  /* Initializations */
 
   if (!_isReady())
     my_throw("You must use 'initCoeffs' before 'operate'");
-  nvertex = Op->getSize();
+  nvertex   = Op->getSize();
   double v1 = 2. / (_b - _a);
   double v2 = -(_b + _a) / (_b - _a);
   tm1.resize(nvertex);
@@ -344,20 +340,20 @@ void Chebychev::_addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const
   /* Create the T1 sparse matrix */
 
   Op->multiplyByValueAndAddDiagonal(v1, v2);
-  
-/* Initialize the simulation */
 
-  for (int i=0; i<nvertex; i++)
+  /* Initialize the simulation */
+
+  for (int i = 0; i < nvertex; i++)
   {
-    tm1[i] = 0.;
-    outv[i]   = inv[i];
+    tm1[i]  = 0.;
+    outv[i] = inv[i];
   }
   constvect ys(outv);
   vect tm1s(tm1);
   if (Op->addToDest(ys, tm1)) my_throw("Problem in addVecInPlace");
-  //Op->addToDest(ys, tm1);
+  // Op->addToDest(ys, tm1);
 
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
   {
     px[i]  = _coeffs[0] * outv[i] + _coeffs[1] * tm1[i];
     tm2[i] = outv[i];
@@ -365,25 +361,25 @@ void Chebychev::_addEvalOp(ALinearOp* Op, const constvect inv, vect outv) const
 
   /* Loop on the AChebychev polynomials */
 
-  for (int ib=2; ib<(int) _coeffs.size(); ib++)
+  for (int ib = 2; ib < (int)_coeffs.size(); ib++)
   {
     Op->addToDest(tm1, tx);
-    for (int i=0; i<nvertex; i++)
+    for (int i = 0; i < nvertex; i++)
     {
-      tx[i]  = 2. * tx[i] - tm2[i];
+      tx[i] = 2. * tx[i] - tm2[i];
       px[i] += _coeffs[ib] * tx[i];
       tm2[i] = tm1[i];
       tm1[i] = tx[i];
     }
   }
 
-/* Return the results */
+  /* Return the results */
 
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
     outv[i] = px[i];
-  
+
   Op->resetModif();
 }
 
 #endif
-}
+} // namespace gstlrn

--- a/src/Polynomials/Hermite.cpp
+++ b/src/Polynomials/Hermite.cpp
@@ -9,15 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Polynomials/Hermite.hpp"
-#include "Matrix/MatrixSquare.hpp"
-#include "Basic/Utilities.hpp"
 #include "Basic/Law.hpp"
+#include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Matrix/MatrixSquare.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
-{ 
+{
 double _convert2u(double yc, double krigest, double krigstd)
 {
   if (ABS(krigstd) < EPSILON6) return ((yc >= krigest) ? +10. : -10.);
@@ -32,16 +32,16 @@ double _convert2u(double yc, double krigest, double krigstd)
  * @param u  Lower bound of integral (-inf if set to TEST)
  * @param hnYc Vector of Hermite polynomials at cutoff
  */
-void _calculateIn(VectorDouble &In,
+void _calculateIn(VectorDouble& In,
                   double yk,
                   double sk,
                   double u,
-                  const VectorDouble &hnYc)
+                  const VectorDouble& hnYc)
 {
   double Gcomp, gusk;
   bool flag_u = !FFFF(u);
-  double r2 = 1 - sk * sk;
-  int nbpoly = static_cast<int>(In.size());
+  double r2   = 1 - sk * sk;
+  int nbpoly  = static_cast<int>(In.size());
   if (flag_u)
   {
     Gcomp = 1 - law_cdf_gaussian(u);
@@ -61,9 +61,9 @@ void _calculateIn(VectorDouble &In,
   for (int ih = 2; ih < nbpoly; ih++)
   {
     if (flag_u) cutval = gusk * hnYc[ih - 1];
-    double sqh  = sqrt((double) ih);
-    double sqh1 = sqrt((double) (ih - 1.));
-    In[ih] = -(yk * In[ih - 1] + r2 * sqh1 * In[ih - 2] + cutval) / sqh;
+    double sqh  = sqrt((double)ih);
+    double sqh1 = sqrt((double)(ih - 1.));
+    In[ih]      = -(yk * In[ih - 1] + r2 * sqh1 * In[ih - 2] + cutval) / sqh;
   }
 }
 
@@ -77,20 +77,20 @@ void _calculateIn(VectorDouble &In,
  * @param hnYc Vector of Hermite polynomials at cutoff
  * @param phi
  */
-void _calculateJJ(MatrixSquare &JJ,
-                  VectorDouble &In,
+void _calculateJJ(MatrixSquare& JJ,
+                  VectorDouble& In,
                   double yk,
                   double sk,
                   double u,
-                  const VectorDouble &hnYc,
-                  const VectorDouble &phi)
+                  const VectorDouble& hnYc,
+                  const VectorDouble& phi)
 {
   int nbpoly = static_cast<int>(phi.size());
 
   bool flag_u = !FFFF(u);
-  double s2 = sk * sk;
-  double r2 = 1 - s2;
-  double gusk = (flag_u) ? sk * law_df_gaussian(u) :  0.;
+  double s2   = sk * sk;
+  double r2   = 1 - s2;
+  double gusk = (flag_u) ? sk * law_df_gaussian(u) : 0.;
 
   _calculateIn(In, yk, sk, u, hnYc);
 
@@ -103,7 +103,7 @@ void _calculateJJ(MatrixSquare &JJ,
   for (int n = 1; n < nbpoly; n++)
   {
     if (flag_u) cutval = gusk * hnYc[n];
-    double sqn = sqrt((double) n);
+    double sqn   = sqrt((double)n);
     double value = -yk * JJ.getValue(n, 0) + s2 * sqn * JJ.getValue(n - 1, 0) - cutval;
 
     JJ.setValue(n, 1, value);
@@ -111,14 +111,13 @@ void _calculateJJ(MatrixSquare &JJ,
   }
   for (int n = 1; n < nbpoly; n++)
   {
-    double sqn  = sqrt((double) n);
-    double sqn1 = sqrt((double) (n + 1.));
+    double sqn  = sqrt((double)n);
+    double sqn1 = sqrt((double)(n + 1.));
     for (int p = n + 1; p < nbpoly; p++)
     {
       if (flag_u) cutval = gusk * hnYc[n] * hnYc[p];
-      double sqp = sqrt((double) p);
-      double value = -(yk * JJ.getValue(n, p) + sqn * r2 * JJ.getValue(n - 1, p)
-          - sqp * s2* JJ.getValue(n, p - 1) + cutval) / sqn1;
+      double sqp   = sqrt((double)p);
+      double value = -(yk * JJ.getValue(n, p) + sqn * r2 * JJ.getValue(n - 1, p) - sqp * s2 * JJ.getValue(n, p - 1) + cutval) / sqn1;
       JJ.setValue(n + 1, p, value);
       JJ.setValue(p, n + 1, value);
     }
@@ -146,9 +145,9 @@ VectorDouble hermitePolynomials(double y, double r, int nbpoly)
     {
       for (int ih = 2; ih < nbpoly; ih++)
       {
-        double sqh   = sqrt((double) ih);
-        double sqhm1 = sqrt((double) (ih - 1.));
-        poly[ih] = -(y * poly[ih - 1] + sqhm1 * poly[ih - 2]) / sqh;
+        double sqh   = sqrt((double)ih);
+        double sqhm1 = sqrt((double)(ih - 1.));
+        poly[ih]     = -(y * poly[ih - 1] + sqhm1 * poly[ih - 2]) / sqh;
       }
     }
   }
@@ -174,11 +173,11 @@ VectorDouble hermitePolynomials(double y, double r, int nbpoly)
  */
 VectorDouble hermitePolynomials(double y, double r, const VectorInt& ifacs)
 {
-  int nfact = (int) ifacs.size();
+  int nfact = (int)ifacs.size();
   VectorDouble vec(nfact);
 
-  int nbpoly = VH::maximum(ifacs);
-  VectorDouble poly = hermitePolynomials(y, r, nbpoly+1);
+  int nbpoly        = VH::maximum(ifacs);
+  VectorDouble poly = hermitePolynomials(y, r, nbpoly + 1);
 
   for (int ifac = 0; ifac < nfact; ifac++)
     vec[ifac] = poly[ifacs[ifac]];
@@ -197,7 +196,7 @@ VectorDouble hermitePolynomials(double y, double r, const VectorInt& ifacs)
  */
 VectorDouble hermiteCondExp(VectorDouble krigest,
                             VectorDouble krigstd,
-                            const VectorDouble &phi)
+                            const VectorDouble& phi)
 {
   VectorDouble condexp;
 
@@ -213,7 +212,7 @@ VectorDouble hermiteCondExp(VectorDouble krigest,
 
 double hermiteCondExpElement(double krigest,
                              double krigstd,
-                             const VectorDouble &phi)
+                             const VectorDouble& phi)
 {
   int nbpoly = static_cast<int>(phi.size());
   VectorDouble In(nbpoly);
@@ -234,7 +233,7 @@ double hermiteCondExpElement(double krigest,
  */
 VectorDouble hermiteCondStd(VectorDouble krigest,
                             VectorDouble krigstd,
-                            const VectorDouble &phi)
+                            const VectorDouble& phi)
 {
   int nech = static_cast<int>(krigest.size());
   VectorDouble condstd(nech, 0);
@@ -249,7 +248,7 @@ VectorDouble hermiteCondStd(VectorDouble krigest,
 
 double hermiteCondStdElement(double krigest,
                              double krigstd,
-                             const VectorDouble &phi)
+                             const VectorDouble& phi)
 {
   MatrixSquare JJ;
   int nbpoly = static_cast<int>(phi.size());
@@ -316,7 +315,7 @@ VectorDouble hermiteIndicatorStd(double yc,
 
 double hermiteIndicatorStdElement(double yc, double krigest, double krigstd)
 {
-  double proba = hermiteIndicatorElement(yc, krigest, krigstd);
+  double proba   = hermiteIndicatorElement(yc, krigest, krigstd);
   double probstd = sqrt(proba * (1. - proba));
   return probstd;
 }
@@ -332,9 +331,9 @@ double hermiteIndicatorStdElement(double yc, double krigest, double krigstd)
 VectorDouble hermiteMetal(double yc,
                           VectorDouble krigest,
                           VectorDouble krigstd,
-                          const VectorDouble &phi)
+                          const VectorDouble& phi)
 {
-  int nech = static_cast<int>(krigest.size());
+  int nech   = static_cast<int>(krigest.size());
   int nbpoly = static_cast<int>(phi.size());
   VectorDouble In(nbpoly);
   VectorDouble metal(nech);
@@ -356,7 +355,7 @@ VectorDouble hermiteMetal(double yc,
 double hermiteMetalElement(double yc,
                            double krigest,
                            double krigstd,
-                           const VectorDouble &phi)
+                           const VectorDouble& phi)
 {
   int nbpoly = static_cast<int>(phi.size());
   VectorDouble In(nbpoly);
@@ -375,17 +374,17 @@ double hermiteMetalElement(double yc,
 VectorDouble hermiteMetalStd(double yc,
                              VectorDouble krigest,
                              VectorDouble krigstd,
-                             const VectorDouble &phi)
+                             const VectorDouble& phi)
 {
   MatrixSquare JJ;
 
-  int nech = static_cast<int>(krigest.size());
+  int nech   = static_cast<int>(krigest.size());
   int nbpoly = static_cast<int>(phi.size());
   VectorDouble In(nbpoly);
   JJ.resetFromValue(nbpoly, nbpoly, TEST);
 
   VectorDouble metstd(nech, 0.);
-  VectorDouble hnYc = hermitePolynomials(yc, 1., nbpoly);
+  VectorDouble hnYc  = hermitePolynomials(yc, 1., nbpoly);
   VectorDouble metal = hermiteMetal(yc, krigest, krigstd, phi);
 
   for (int iech = 0; iech < nech; iech++)
@@ -406,7 +405,7 @@ VectorDouble hermiteMetalStd(double yc,
 double hermiteMetalStdElement(double yc,
                               double krigest,
                               double krigstd,
-                              const VectorDouble &phi)
+                              const VectorDouble& phi)
 {
   MatrixSquare JJ;
   int nbpoly = static_cast<int>(phi.size());
@@ -441,7 +440,7 @@ VectorDouble hermiteCoefIndicator(double yc, int nbpoly)
   VectorDouble hn = hermitePolynomials(yc, 1., nbpoly);
   VectorDouble an(nbpoly);
   double gyc = law_df_gaussian(yc);
-  an[0] = 1. - law_cdf_gaussian(yc);
+  an[0]      = 1. - law_cdf_gaussian(yc);
   for (int n = 1; n < nbpoly; n++)
     an[n] = -gyc * hn[n - 1] / sqrt(n);
 
@@ -454,7 +453,7 @@ VectorDouble hermiteCoefIndicator(double yc, int nbpoly)
  * @param phi Coefficients of Hermite polynomial
  * @return The vector of coefficients of the Metal Quantity
  */
-VectorDouble hermiteCoefMetal(double yc, const VectorDouble &phi)
+VectorDouble hermiteCoefMetal(double yc, const VectorDouble& phi)
 {
   int nbpoly = static_cast<int>(phi.size());
   VectorDouble vect(nbpoly);
@@ -475,7 +474,7 @@ MatrixSquare hermiteIncompleteIntegral(double yc, int nbpoly)
 
   TAU.resetFromValue(nbpoly, nbpoly, 0.);
   VectorDouble hn = hermitePolynomials(yc, 1., nbpoly);
-  double gy = law_df_gaussian(yc);
+  double gy       = law_df_gaussian(yc);
 
   /* Calculation of S_0n */
 
@@ -492,9 +491,7 @@ MatrixSquare hermiteIncompleteIntegral(double yc, int nbpoly)
   for (int n = 0; n < nbpoly - 1; n++)
     for (int m = 1; m < nbpoly - n; m++)
     {
-      double aa = sqrt((double) m / (double) (m + n))
-          * TAU.getValue(m - 1, n + m - 1)
-                  + gy * hn[m] * hn[m + n - 1] / sqrt((double) (m + n));
+      double aa = sqrt((double)m / (double)(m + n)) * TAU.getValue(m - 1, n + m - 1) + gy * hn[m] * hn[m + n - 1] / sqrt((double)(m + n));
       TAU.setValue(m, m + n, aa);
       TAU.setValue(m + n, m, aa);
     }
@@ -519,11 +516,11 @@ VectorDouble hermiteLognormal(double mean, double sigma, int nbpoly)
   VectorDouble hn(nbpoly);
 
   double fact = 1.;
-  hn[0] = mean;
+  hn[0]       = mean;
   for (int i = 1; i < nbpoly; i++)
   {
-    fact *= (double) i;
-    hn[i] = mean * pow(-sigma, (double) i) / sqrt(fact);
+    fact *= (double)i;
+    hn[i] = mean * pow(-sigma, (double)i) / sqrt(fact);
   }
   return hn;
 }
@@ -534,10 +531,10 @@ VectorDouble hermiteLognormal(double mean, double sigma, int nbpoly)
  * @param hn Hermite polynomial values
  * @return The result of the expansion
  */
-double hermiteSeries(const VectorDouble &an, const VectorDouble &hn)
+double hermiteSeries(const VectorDouble& an, const VectorDouble& hn)
 {
   double value = 0.;
-  for (int ih = 0; ih < (int) hn.size(); ih++)
+  for (int ih = 0; ih < (int)hn.size(); ih++)
   {
     value += an[ih] * hn[ih];
   }
@@ -557,12 +554,12 @@ VectorDouble hermiteCoefLower(double y, int nbpoly)
 
   double dg = law_df_gaussian(y);
   double dG = law_cdf_gaussian(y);
-  coeff[0] = dg + y * dG;
-  coeff[1] = dG - 1.;
+  coeff[0]  = dg + y * dG;
+  coeff[1]  = dG - 1.;
   for (int n = 2; n < nbpoly; n++)
   {
-    double sqnnm1 = sqrt((double) n * (n - 1.));
-    coeff[n] = dg * hn[n - 2] / sqnnm1;
+    double sqnnm1 = sqrt((double)n * (n - 1.));
+    coeff[n]      = dg * hn[n - 2] / sqnnm1;
   }
   return coeff;
 }
@@ -574,12 +571,12 @@ VectorDouble hermiteIndicatorLower(double y, int nbpoly)
 
   double dg = law_df_gaussian(y);
   double dG = law_cdf_gaussian(y);
-  coeff[0] = 1. - dG;
+  coeff[0]  = 1. - dG;
   for (int n = 1; n < nbpoly; n++)
   {
-    coeff[n] = -dg * hn[n - 1] / sqrt((double) n);
+    coeff[n] = -dg * hn[n - 1] / sqrt((double)n);
   }
   return coeff;
 }
 
-}
+} // namespace gstlrn

--- a/src/Polynomials/MonteCarlo.cpp
+++ b/src/Polynomials/MonteCarlo.cpp
@@ -8,11 +8,12 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Polynomials/Hermite.hpp"
 #include "Polynomials/MonteCarlo.hpp"
 #include "Basic/Law.hpp"
+#include "Polynomials/Hermite.hpp"
 
-#include <math.h>
+#include <cmath>
+
 namespace gstlrn
 {
 /**
@@ -23,29 +24,28 @@ namespace gstlrn
  * @param psi Vector of Hermite coefficients
  * @return Vector of returned values for all Hermite coefficients
  */
-double integralGaussHermite(double yc, double r, const VectorDouble &psi)
+double integralGaussHermite(double yc, double r, const VectorDouble& psi)
 {
-  int nbpoly = static_cast<int>(psi.size()) - 1;
+  int nbpoly        = static_cast<int>(psi.size()) - 1;
   VectorDouble vect = hermitePolynomials(yc, 1., nbpoly);
-  double value = hermiteSeries(vect, psi);
+  double value      = hermiteSeries(vect, psi);
   return r * r * value;
 }
-void normalizeResults(int nbsimu, double &valest)
+void normalizeResults(int nbsimu, double& valest)
 {
-  valest /= (double) nbsimu;
+  valest /= (double)nbsimu;
 }
 
-void normalizeResults(int nbsimu, double &valest, double &valstd)
+void normalizeResults(int nbsimu, double& valest, double& valstd)
 {
-  valest /= (double) nbsimu;
+  valest /= (double)nbsimu;
   valstd = valstd / nbsimu - valest * valest;
-  valstd = (valstd > 0.) ? sqrt(valstd) :
-                           0.;
+  valstd = (valstd > 0.) ? sqrt(valstd) : 0.;
 }
 
 VectorDouble MCCondExp(VectorDouble krigest,
                        VectorDouble krigstd,
-                       const VectorDouble &psi,
+                       const VectorDouble& psi,
                        int nbsimu)
 {
   VectorDouble condexp;
@@ -70,7 +70,7 @@ VectorDouble MCCondExp(VectorDouble krigest,
 
 double MCCondExpElement(double krigest,
                         double krigstd,
-                        const VectorDouble &psi,
+                        const VectorDouble& psi,
                         int nbsimu)
 {
   double valest = 0.;
@@ -86,7 +86,7 @@ double MCCondExpElement(double krigest,
 
 VectorDouble MCCondStd(VectorDouble krigest,
                        VectorDouble krigstd,
-                       const VectorDouble &psi,
+                       const VectorDouble& psi,
                        int nbsimu)
 {
   VectorDouble condstd;
@@ -113,7 +113,7 @@ VectorDouble MCCondStd(VectorDouble krigest,
 
 double MCCondStdElement(double krigest,
                         double krigstd,
-                        const VectorDouble &psi,
+                        const VectorDouble& psi,
                         int nbsimu)
 {
   double valest = 0.;
@@ -182,7 +182,7 @@ VectorDouble MCIndicatorStd(double yc,
 
   for (int iech = 0; iech < nech; iech++)
   {
-    double proba = probstd[iech];
+    double proba  = probstd[iech];
     probstd[iech] = sqrt(proba * (1. - proba));
   }
   return probstd;
@@ -193,7 +193,7 @@ double MCIndicatorStdElement(double yc,
                              double krigstd,
                              int nbsimu)
 {
-  double proba = MCIndicatorElement(yc, krigest, krigstd, nbsimu);
+  double proba   = MCIndicatorElement(yc, krigest, krigstd, nbsimu);
   double probstd = sqrt(proba * (1. - proba));
   return probstd;
 }
@@ -201,7 +201,7 @@ double MCIndicatorStdElement(double yc,
 VectorDouble MCMetal(double yc,
                      VectorDouble krigest,
                      VectorDouble krigstd,
-                     const VectorDouble &psi,
+                     const VectorDouble& psi,
                      int nbsimu)
 {
   VectorDouble metal;
@@ -229,7 +229,7 @@ VectorDouble MCMetal(double yc,
 double MCMetalElement(double yc,
                       double krigest,
                       double krigstd,
-                      const VectorDouble &psi,
+                      const VectorDouble& psi,
                       int nbsimu)
 {
   double metal = 0.;
@@ -248,7 +248,7 @@ double MCMetalElement(double yc,
 VectorDouble MCMetalStd(double yc,
                         VectorDouble krigest,
                         VectorDouble krigstd,
-                        const VectorDouble &psi,
+                        const VectorDouble& psi,
                         int nbsimu)
 {
   VectorDouble metstd;
@@ -279,7 +279,7 @@ VectorDouble MCMetalStd(double yc,
 double MCMetalStdElement(double yc,
                          double krigest,
                          double krigstd,
-                         const VectorDouble &psi,
+                         const VectorDouble& psi,
                          int nbsimu)
 {
   double metstd = 0.;
@@ -298,4 +298,4 @@ double MCMetalStdElement(double yc,
   return metstd;
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/BooleanObject.cpp
+++ b/src/Simulation/BooleanObject.cpp
@@ -17,7 +17,7 @@
 #include "Basic/VectorHelper.hpp"
 #include "Basic/Law.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {

--- a/src/Simulation/CalcSimuFFT.cpp
+++ b/src/Simulation/CalcSimuFFT.cpp
@@ -8,38 +8,38 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Db/DbGrid.hpp"
-#include "Db/Db.hpp"
-#include "Model/ModelGeneric.hpp"
-#include "Simulation/ACalcSimulation.hpp"
-#include "Simulation/SimuFFTParam.hpp"
 #include "Simulation/CalcSimuFFT.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Core/fftn.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Model/ModelGeneric.hpp"
+#include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/SimuFFTParam.hpp"
 
-#include <math.h>
+#include <cmath>
 
-#define IND(ix,iy,iz) ((iz) + _dims[2] * ((iy) + _dims[1] * (ix)))
-#define U(ix,iy,iz)   (_u[IND(ix,iy,iz)])
+#define IND(ix, iy, iz) ((iz) + _dims[2] * ((iy) + _dims[1] * (ix)))
+#define U(ix, iy, iz)   (_u[IND(ix, iy, iz)])
 
 namespace gstlrn
 {
 CalcSimuFFT::CalcSimuFFT(int nbsimu, bool verbose, int seed)
-    : ACalcSimulation(nbsimu, seed),
-      _iattOut(-1),
-      _verbose(verbose),
-      _param(),
-      _nxyz(0),
-      _nx(),
-      _shift(),
-      _dims(),
-      _dim2(),
-      _sizes_alloc(0),
-      _cmat(),
-      _rnd(),
-      _u(),
-      _v()
+  : ACalcSimulation(nbsimu, seed)
+  , _iattOut(-1)
+  , _verbose(verbose)
+  , _param()
+  , _nxyz(0)
+  , _nx()
+  , _shift()
+  , _dims()
+  , _dim2()
+  , _sizes_alloc(0)
+  , _cmat()
+  , _rnd()
+  , _u()
+  , _v()
 {
 }
 
@@ -89,10 +89,10 @@ void CalcSimuFFT::_alloc()
 {
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
 
-  _nx.resize(3,0);
-  _shift.resize(3,0);
-  _dims.resize(3,0);
-  _dim2.resize(3,0);
+  _nx.resize(3, 0);
+  _shift.resize(3, 0);
+  _dims.resize(3, 0);
+  _dim2.resize(3, 0);
   _nxyz = 1;
   for (int i = 0; i < 3; i++)
   {
@@ -166,8 +166,8 @@ int CalcSimuFFT::_getNOptimalEven(int number, int largeFactor)
   while (answer)
   {
     VectorInt factors = _getFactors(local);
-    int nfact = (int) factors.size();
-    answer = false;
+    int nfact         = (int)factors.size();
+    answer            = false;
     for (int i = 0; i < nfact; i++)
       if (factors[i] > largeFactor) answer = 1;
     if (answer) local += 2;
@@ -212,8 +212,7 @@ VectorInt CalcSimuFFT::_getFactors(int number)
       local /= j;
     }
     j += 2;
-  }
-  while (j <= local);
+  } while (j <= local);
 
   if (nfact <= 0)
     factors.push_back(1);
@@ -263,9 +262,9 @@ void CalcSimuFFT::_gridDilate()
   /* Evaluate the count of elementary grid mesh (in each direction) */
   /* for the covariance to become negligeable (<percent)*/
 
-  int ndx = 1;
-  int ndy = 1;
-  int ndz = 1;
+  int ndx     = 1;
+  int ndy     = 1;
+  int ndz     = 1;
   bool not_ok = true;
 
   while (not_ok)
@@ -375,13 +374,13 @@ void CalcSimuFFT::_gridDilate()
  **                      covariance is considered as small enough for dilation
  **
  *****************************************************************************/
-bool CalcSimuFFT::_checkCorrect(const VectorVectorDouble &xyz,
+bool CalcSimuFFT::_checkCorrect(const VectorVectorDouble& xyz,
                                 int ix,
                                 int iy,
                                 int iz,
                                 double percent)
 {
-  int ndim = _getNDim();
+  int ndim            = _getNDim();
   ModelGeneric* model = getModel();
 
   /* Calculate the reference C(0) value */
@@ -393,7 +392,7 @@ bool CalcSimuFFT::_checkCorrect(const VectorVectorDouble &xyz,
   VectorDouble d(ndim, 0.);
   for (int i = 0; i < ndim; i++)
     d[i] = ix * xyz[i][0] + iy * xyz[i][1] + iz * xyz[i][2];
-  double hh = VH::norm(d);
+  double hh    = VH::norm(d);
   double value = model->evaluateOneIncr(hh);
 
   return (value / refval <= percent / 100);
@@ -417,7 +416,7 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
   VectorInt indg(3);
   VectorInt jnd(3);
   VectorVectorDouble xyz1(3);
-  DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
+  DbGrid* dbgrid      = dynamic_cast<DbGrid*>(getDbout());
   ModelGeneric* model = getModel();
 
   /* Initializations */
@@ -431,7 +430,7 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
   double hnorm = 1.;
   for (int i = 0; i < 3; i++)
   {
-    indg[i] = 0;
+    indg[i]  = 0;
     delta[i] = del[i] = 0.;
     xyz[i] = xyz0[i] = 0.;
     xyz1[i].resize(3);
@@ -439,7 +438,7 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
       xyz1[i][j] = 0.;
   }
   dbgrid->rankToCoordinatesInPlace(dbgrid->indiceToRank(indg), xyz0);
-  xyz0.resize(3,0.);
+  xyz0.resize(3, 0.);
 
   for (int i = 0; i < 3; i++)
   {
@@ -449,7 +448,7 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
     if (i < _getNDim())
     {
       dbgrid->rankToCoordinatesInPlace(dbgrid->indiceToRank(indg), xyz1[i]);
-      xyz1[i].resize(3,0.);
+      xyz1[i].resize(3, 0.);
       for (int j = 0; j < 3; j++)
         xyz1[i][j] -= xyz0[j];
       delta[i] = dbgrid->getDX(i) * dbgrid->getNX(i);
@@ -485,14 +484,14 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
           del[0] = k1 * delta[0];
           del[1] = k2 * delta[1];
           del[2] = k3 * delta[2];
-          hnorm = VH::norm(del);
-          value = model->evaluateOneIncr(hnorm);
+          hnorm  = VH::norm(del);
+          value  = model->evaluateOneIncr(hnorm);
           scale += value;
         }
     for (int i = 0; i < 3; i++)
       del[i] = 0.;
-    hnorm = VH::norm(del);
-    value = model->evaluateOneIncr(hnorm);
+    hnorm        = VH::norm(del);
+    value        = model->evaluateOneIncr(hnorm);
     double coeff = value / scale;
 
     int ecr = 0;
@@ -517,23 +516,23 @@ void CalcSimuFFT::_prepar(bool flag_amplitude, double eps)
                 del[0] = xyz[0] + k1 * delta[0];
                 del[1] = xyz[1] + k2 * delta[1];
                 del[2] = xyz[2] + k3 * delta[2];
-                hnorm = VH::norm(del);
-                value = model->evaluateOneIncr(hnorm);
+                hnorm  = VH::norm(del);
+                value  = model->evaluateOneIncr(hnorm);
                 cplx[ecr] += coeff * value;
               }
         }
 
     /* Perform the Fast Fourier Transform */
 
-    (void) fftn(_getNDim(), _dims.data(), cplx.data(), cply.data(), -1, 1.);
+    (void)fftn(_getNDim(), _dims.data(), cplx.data(), cply.data(), -1, 1.);
 
     /* Looking for negative terms */
 
-    double total_plus = 0.;
+    double total_plus  = 0.;
     double total_moins = 0.;
     for (int i = 0; i < _sizes_alloc; i++)
     {
-      cplx[i] /= (double) _sizes_alloc;
+      cplx[i] /= (double)_sizes_alloc;
       if (cplx[i] < 0)
         total_moins -= cplx[i];
       else
@@ -892,9 +891,9 @@ void CalcSimuFFT::_setConjugate(int ix, int iy, int iz, int jx, int jy, int jz)
  ** \param[in]  iad   address for writing the simulation
  **
  *****************************************************************************/
-void CalcSimuFFT::_final(DbGrid *db, int iad)
+void CalcSimuFFT::_final(DbGrid* db, int iad)
 {
-  (void) fftn(_getNDim(), _dims.data(), _u.data(), _v.data(), 1, 1.);
+  (void)fftn(_getNDim(), _dims.data(), _u.data(), _v.data(), 1, 1.);
   int nx = MAX(_nx[0], 1);
   int ny = MAX(_nx[1], 1);
   int nz = MAX(_nx[2], 1);
@@ -973,7 +972,7 @@ double CalcSimuFFT::_support1(double sigma)
   double value = 0.;
   for (int ix = -_nx[0]; ix <= _nx[0]; ix++)
   {
-    int iix = (ix < 0) ? _dims[0] + ix : ix;
+    int iix    = (ix < 0) ? _dims[0] + ix : ix;
     double rho = _rhoSigma(sigma, iix, 0, 0);
     value += (_nx[0] - ABS(ix)) * rho;
   }
@@ -995,8 +994,8 @@ double CalcSimuFFT::_support2(double sigma)
   for (int ix = -_nx[0]; ix <= _nx[0]; ix++)
     for (int iy = -_nx[1]; iy <= _nx[1]; iy++)
     {
-      int iix = (ix < 0) ? _dims[0] + ix : ix;
-      int iiy = (iy < 0) ? _dims[1] + iy : iy;
+      int iix    = (ix < 0) ? _dims[0] + ix : ix;
+      int iiy    = (iy < 0) ? _dims[1] + iy : iy;
       double rho = _rhoSigma(sigma, iix, iiy, 0);
       value += ((_nx[0] - ABS(ix)) * (_nx[1] - ABS(iy)) * rho);
     }
@@ -1019,9 +1018,9 @@ double CalcSimuFFT::_support3(double sigma)
     for (int iy = -_nx[1]; iy <= _nx[1]; iy++)
       for (int iz = -_nx[2]; iz <= _nx[2]; iz++)
       {
-        int iix = (ix < 0) ? _dims[0] + ix : ix;
-        int iiy = (iy < 0) ? _dims[1] + iy : iy;
-        int iiz = (iz < 0) ? _dims[2] + iz : iz;
+        int iix    = (ix < 0) ? _dims[0] + ix : ix;
+        int iiy    = (iy < 0) ? _dims[1] + iy : iy;
+        int iiz    = (iz < 0) ? _dims[2] + iz : iz;
         double rho = _rhoSigma(sigma, iix, iiy, iiz);
         value += ((_nx[0] - ABS(ix)) * (_nx[1] - ABS(iy)) * (_nx[2] - ABS(iz)) * rho);
       }
@@ -1049,7 +1048,7 @@ double CalcSimuFFT::_rhoSigma(double sigma, int ix, int iy, int iz)
 
 bool CalcSimuFFT::_check()
 {
-  if (! ACalcSimulation::_check()) return false;
+  if (!ACalcSimulation::_check()) return false;
 
   if (!hasDbout()) return false;
   if (!hasModel()) return false;
@@ -1061,7 +1060,7 @@ bool CalcSimuFFT::_check()
     messerr("for this Space Dimension (%d)", ndim);
     return false;
   }
-  if (! getDbout()->isGrid())
+  if (!getDbout()->isGrid())
   {
     messerr("The argument 'dbout' should be a grid");
     return false;
@@ -1105,7 +1104,7 @@ void CalcSimuFFT::_rollback()
   _cleanVariableDb(1);
 }
 
-VectorDouble CalcSimuFFT::changeSupport(const VectorDouble &sigma)
+VectorDouble CalcSimuFFT::changeSupport(const VectorDouble& sigma)
 {
   // Allocation
 
@@ -1117,11 +1116,11 @@ VectorDouble CalcSimuFFT::changeSupport(const VectorDouble &sigma)
 
   /* Calculate the correlation matrix (possibly rescaled) */
 
-  (void) fftn(_getNDim(), _dims.data(), _cmat.data(), _rnd.data(), 1, 1.);
+  (void)fftn(_getNDim(), _dims.data(), _cmat.data(), _rnd.data(), 1, 1.);
 
   /* Loop on the different lognormal variances */
 
-  int nval = (int) sigma.size();
+  int nval = (int)sigma.size();
   VectorDouble r2val;
   if (nval > 0)
   {
@@ -1152,8 +1151,8 @@ VectorDouble CalcSimuFFT::changeSupport(const VectorDouble &sigma)
  ** \param[in]  namconv Naming Convention
  **
  *****************************************************************************/
-int simfft(DbGrid *db,
-           ModelGeneric *model,
+int simfft(DbGrid* db,
+           ModelGeneric* model,
            SimuFFTParam& param,
            int nbsimu,
            int seed,
@@ -1185,10 +1184,10 @@ int simfft(DbGrid *db,
  ** \param[in]  verbose Verbose flag
  **
  *****************************************************************************/
-VectorDouble getChangeSupport(DbGrid *db,
-                              ModelGeneric *model,
-                              const SimuFFTParam &param,
-                              const VectorDouble &sigma,
+VectorDouble getChangeSupport(DbGrid* db,
+                              ModelGeneric* model,
+                              const SimuFFTParam& param,
+                              const VectorDouble& sigma,
                               int seed,
                               bool verbose)
 {
@@ -1198,4 +1197,4 @@ VectorDouble getChangeSupport(DbGrid *db,
   simfft.setParam(param);
   return simfft.changeSupport(sigma);
 }
-}
+} // namespace gstlrn

--- a/src/Simulation/CalcSimuPartition.cpp
+++ b/src/Simulation/CalcSimuPartition.cpp
@@ -8,18 +8,18 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Simulation/CalcSimuPartition.hpp"
+#include "Basic/Law.hpp"
 #include "Calculators/CalcMigrate.hpp"
-#include "Db/DbGrid.hpp"
 #include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
 #include "Simulation/ACalcSimulation.hpp"
 #include "Simulation/CalcSimuTurningBands.hpp"
-#include "Simulation/CalcSimuPartition.hpp"
 #include "Simulation/SimuPartitionParam.hpp"
-#include "Basic/Law.hpp"
 
-#include <math.h>
+#include <cmath>
 
-#define COOR(iech,idim)    (coor[(iech) * ndim + (idim)])
+#define COOR(iech, idim) (coor[(iech) * ndim + (idim)])
 
 namespace gstlrn
 {
@@ -50,7 +50,7 @@ CalcSimuPartition::~CalcSimuPartition()
 bool CalcSimuPartition::_voronoi()
 {
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
-  int ndim = _getNDim();
+  int ndim       = _getNDim();
   VectorDouble simgrid(dbgrid->getNSample());
 
   /************************************/
@@ -63,15 +63,15 @@ bool CalcSimuPartition::_voronoi()
   for (int i = 0; i < ndim; i++)
   {
     double dil = _parparam.getDilate(i);
-    field[i] = dbgrid->getDX(i) * dbgrid->getNX(i);
-    origin[i] = dbgrid->getX0(i) - dbgrid->getDX(i) / 2. - dil * field[i] / 2.;
-    field[i] = field[i] * (1. + dil);
+    field[i]   = dbgrid->getDX(i) * dbgrid->getNX(i);
+    origin[i]  = dbgrid->getX0(i) - dbgrid->getDX(i) / 2. - dil * field[i] / 2.;
+    field[i]   = field[i] * (1. + dil);
     volume *= field[i];
   }
 
   /* Derive the number of points */
 
-  int nbpoints = (int) (volume * _parparam.getIntensity());
+  int nbpoints = (int)(volume * _parparam.getIntensity());
   if (_verbose)
     message("Boolean simulation. Intensity = %lf - Nb. seeds = %d\n",
             _parparam.getIntensity(), nbpoints);
@@ -81,7 +81,7 @@ bool CalcSimuPartition::_voronoi()
   VectorDouble coor(nbpoints * ndim, 0.);
   for (int idim = 0; idim < ndim; idim++)
     for (int ip = 0; ip < nbpoints; ip++)
-      COOR(ip,idim) = origin[idim] + field[idim] * law_uniform(0., 1.);
+      COOR(ip, idim) = origin[idim] + field[idim] * law_uniform(0., 1.);
 
   /* Create the Point Data Base */
 
@@ -97,7 +97,7 @@ bool CalcSimuPartition::_voronoi()
 
   int iattp = dbpoint->getNColumn() - 1;
   if (expandPointToGrid(dbpoint, dbgrid, iattp, -1, 0, -1, -1, -1, -1, 0,
-                           VectorDouble(), simgrid)) return 1;
+                        VectorDouble(), simgrid)) return 1;
 
   /* Save the grid in dbgrid */
 
@@ -129,7 +129,7 @@ bool CalcSimuPartition::_poisson()
   std::vector<Plane> planes;
 
   law_set_random_seed(getSeed());
-  int np = 0;
+  int np    = 0;
   int iattg = -1;
 
   /* Preliminary checks */
@@ -151,7 +151,7 @@ bool CalcSimuPartition::_poisson()
   /* Calculate the number of planes */
 
   double diagonal = dbgrid->getExtensionDiagonal();
-  np = law_poisson(diagonal * _parparam.getIntensity() * GV_PI);
+  np              = law_poisson(diagonal * _parparam.getIntensity() * GV_PI);
   if (np <= 0) return false;
 
   /* Generate the Poisson planes */
@@ -161,7 +161,7 @@ bool CalcSimuPartition::_poisson()
   /* Assigning a value to the half-space that contains the center */
 
   for (int ip = 0; ip < np; ip++)
-    planes[ip].setValue( (planes[ip].getRndval() > 0.5) ? -1 : 1);
+    planes[ip].setValue((planes[ip].getRndval() > 0.5) ? -1 : 1);
 
   /* Simulating the directing function */
 
@@ -177,10 +177,9 @@ bool CalcSimuPartition::_poisson()
     for (int ip = 0; ip < np; ip++)
     {
       double prod = 0.;
-      for (int i = 0; i < (int) cen.size(); i++)
+      for (int i = 0; i < (int)cen.size(); i++)
         prod += planes[ip].getCoor(i) * cen[i];
-      valtot += (prod + planes[ip].getIntercept() > 0) ?
-          planes[ip].getRndval() : -planes[ip].getRndval();
+      valtot += (prod + planes[ip].getIntercept() > 0) ? planes[ip].getRndval() : -planes[ip].getRndval();
     }
     dbgrid->setArray(iech, _iattOut, valtot);
   }
@@ -230,22 +229,22 @@ bool CalcSimuPartition::_poisson()
   return true;
 }
 
-double CalcSimuPartition::_stackSearch(const std::vector<Stack> &stacks,
+double CalcSimuPartition::_stackSearch(const std::vector<Stack>& stacks,
                                        double valref)
 {
-  for (int i = 0; i < (int) stacks.size(); i++)
+  for (int i = 0; i < (int)stacks.size(); i++)
   {
-    if (isEqual(stacks[i].valref,valref)) return stacks[i].valsim;
+    if (isEqual(stacks[i].valref, valref)) return stacks[i].valsim;
   }
   return TEST;
 }
 
 bool CalcSimuPartition::_check()
 {
-  if (! ACalcSimulation::_check()) return false;
+  if (!ACalcSimulation::_check()) return false;
 
-  if (! hasDbout()) return false;
-  if (! hasModel()) return false;
+  if (!hasDbout()) return false;
+  if (!hasModel()) return false;
   int ndim = _getNDim();
   if (ndim > 3)
   {
@@ -253,7 +252,7 @@ bool CalcSimuPartition::_check()
     messerr("for this Space Dimension (%d)", ndim);
     return false;
   }
-  if (! getDbout()->isGrid())
+  if (!getDbout()->isGrid())
   {
     messerr("The argument 'dbout' should be a grid");
     return false;
@@ -323,8 +322,8 @@ void CalcSimuPartition::_rollback()
  ** \param[in]  namconv     Naming Convention
  **
  *****************************************************************************/
-int tessellation_poisson(DbGrid *dbgrid,
-                         Model *model,
+int tessellation_poisson(DbGrid* dbgrid,
+                         Model* model,
                          const SimuPartitionParam& parparam,
                          int seed,
                          int verbose,
@@ -354,8 +353,8 @@ int tessellation_poisson(DbGrid *dbgrid,
  ** \param[in]  namconv     Naming Convention
  **
  *****************************************************************************/
-int tessellation_voronoi(DbGrid *dbgrid,
-                         Model *model,
+int tessellation_voronoi(DbGrid* dbgrid,
+                         Model* model,
                          const SimuPartitionParam& parparam,
                          int seed,
                          int verbose,
@@ -371,4 +370,4 @@ int tessellation_voronoi(DbGrid *dbgrid,
   return error;
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/CalcSimuSubstitution.cpp
+++ b/src/Simulation/CalcSimuSubstitution.cpp
@@ -8,27 +8,26 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Db/DbGrid.hpp"
-#include "Db/Db.hpp"
 #include "Simulation/CalcSimuSubstitution.hpp"
-#include "Simulation/SimuSubstitutionParam.hpp"
-#include "Simulation/ACalcSimulation.hpp"
 #include "Basic/Law.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/SimuSubstitutionParam.hpp"
 
-#include <math.h>
+#include <cmath>
 
-#define TRANS(i,j)     (trans[(j) + nfacies * (i)])
+#define TRANS(i, j) (trans[(j) + nfacies * (i)])
 
 namespace gstlrn
-{ 
-
+{
 
 CalcSimuSubstitution::CalcSimuSubstitution(int nbsimu, int seed, bool verbose)
-    : ACalcSimulation(nbsimu, seed),
-      _verbose(verbose),
-      _iattOut(-1),
-      _subparam(),
-      _planes()
+  : ACalcSimulation(nbsimu, seed)
+  , _verbose(verbose)
+  , _iattOut(-1)
+  , _subparam()
+  , _planes()
 {
 }
 
@@ -51,7 +50,7 @@ CalcSimuSubstitution::~CalcSimuSubstitution()
 bool CalcSimuSubstitution::_simulate()
 {
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
-  int np = 0;
+  int np         = 0;
 
   /***********************/
   /* Information process */
@@ -63,23 +62,23 @@ bool CalcSimuSubstitution::_simulate()
     /* Calculate the number of planes */
 
     double diagonal = dbgrid->getExtensionDiagonal();
-    np = law_poisson(diagonal * _subparam.getIntensity() * GV_PI);
+    np              = law_poisson(diagonal * _subparam.getIntensity() * GV_PI);
     if (np <= 0) return false;
 
     /* Generate the Poisson planes */
 
-    _planes = Plane::poissonPlanesGenerate(dbgrid,np);
+    _planes = Plane::poissonPlanesGenerate(dbgrid, np);
 
     /* Assigning a value to the half-space that contains the center */
 
     for (int ip = 0; ip < np; ip++)
     {
-      if (! _subparam.isFlagOrient())
+      if (!_subparam.isFlagOrient())
       {
         int ival = (_planes[ip].getRndval() > 0.5) ? -1 : 1;
-        _planes[ip].setValue((double) ival);
+        _planes[ip].setValue((double)ival);
       }
-      else if (! _subparam.isLocal())
+      else if (!_subparam.isLocal())
       {
         _calculValue(ip, _subparam.getFactor(), _subparam.getVector());
       }
@@ -97,7 +96,7 @@ bool CalcSimuSubstitution::_simulate()
       for (int ip = 0; ip < np; ip++)
       {
         double prod = 0.;
-        for (int i = 0; i < (int) cen.size(); i++)
+        for (int i = 0; i < (int)cen.size(); i++)
           prod += _planes[ip].getCoor(i) * cen[i];
 
         if (_subparam.isLocal())
@@ -144,8 +143,7 @@ bool CalcSimuSubstitution::_simulate()
   for (int iech = 0; iech < dbgrid->getNSample(); iech++)
   {
     if (!dbgrid->isActive(iech)) continue;
-    double value = (_subparam.isFlagDirect()) ?
-        dbgrid->getArray(iech, _iattOut) : dbgrid->getZVariable(iech, 0);
+    double value = (_subparam.isFlagDirect()) ? dbgrid->getArray(iech, _iattOut) : dbgrid->getZVariable(iech, 0);
     if (value < vmin) vmin = value;
     if (value > vmax) vmax = value;
   }
@@ -155,7 +153,7 @@ bool CalcSimuSubstitution::_simulate()
     messerr("before the Coding Process takes place");
     return false;
   }
-  np = (int) (vmax - vmin + 0.5);
+  np = (int)(vmax - vmin + 0.5);
 
   /******************/
   /* Coding process */
@@ -176,9 +174,9 @@ bool CalcSimuSubstitution::_simulate()
 
     /* Simulation of the initial state */
 
-    double u = law_uniform(0., 1.);
+    double u  = law_uniform(0., 1.);
     double w0 = 0.;
-    int ie = 0;
+    int ie    = 0;
     while (w0 < u)
       w0 += props[ie++];
     status[0] = ie - 1;
@@ -186,13 +184,13 @@ bool CalcSimuSubstitution::_simulate()
     /* Simulation of the current state */
 
     VectorDouble trans = _subparam.getTrans();
-    int nfacies = _subparam.getNfacies();
+    int nfacies        = _subparam.getNfacies();
     for (int ip = 1; ip < nstates; ip++)
     {
-      u = law_uniform(0., 1.);
+      u         = law_uniform(0., 1.);
       double p0 = 0.;
-      int je = 0;
-      ie = status[ip - 1];
+      int je    = 0;
+      ie        = status[ip - 1];
       while (p0 < u)
       {
         p0 += TRANS(ie, je);
@@ -206,9 +204,8 @@ bool CalcSimuSubstitution::_simulate()
     for (int iech = 0; iech < dbgrid->getNSample(); iech++)
     {
       if (!dbgrid->isActive(iech)) continue;
-      double value = (_subparam.isFlagDirect()) ? dbgrid->getArray(iech, _iattOut) :
-          dbgrid->getZVariable(iech, 0);
-      int ival = (int) ((value - vmin) / (vmax - vmin) * nstates);
+      double value = (_subparam.isFlagDirect()) ? dbgrid->getArray(iech, _iattOut) : dbgrid->getZVariable(iech, 0);
+      int ival     = (int)((value - vmin) / (vmax - vmin) * nstates);
       if (ival < 0) ival = 0;
       if (ival >= nstates) ival = nstates - 1;
       dbgrid->setArray(iech, _iattOut, 1 + status[ival]);
@@ -235,15 +232,15 @@ bool CalcSimuSubstitution::_simulate()
  **
  *****************************************************************************/
 void CalcSimuSubstitution::_calculValue(int ip,
-                                    double factor,
-                                    const VectorDouble& vector)
+                                        double factor,
+                                        const VectorDouble& vector)
 {
-  int ival = ((2. * _planes[ip].getRndval()) > (1. + factor)) ? -1 : 1;
+  int ival      = ((2. * _planes[ip].getRndval()) > (1. + factor)) ? -1 : 1;
   double cossin = 0.;
-  for (int i = 0; i < (int) vector.size(); i++)
+  for (int i = 0; i < (int)vector.size(); i++)
     cossin += _planes[ip].getCoor(i) * vector[i];
   if (cossin < 0) ival = -ival;
-  _planes[ip].setValue((double) ival);
+  _planes[ip].setValue((double)ival);
 }
 
 /****************************************************************************/
@@ -257,7 +254,7 @@ void CalcSimuSubstitution::_calculValue(int ip,
  ** \param[in]  eps      Tolerance
  **
  *****************************************************************************/
-VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam &subparam,
+VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam& subparam,
                                                 bool verbose,
                                                 double eps)
 {
@@ -279,13 +276,13 @@ VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam &sub
   {
     double total = 0.;
     for (int j = 0; j < nfacies; j++)
-      total += ABS(TRANS(i,j));
+      total += ABS(TRANS(i, j));
 
     if (total <= 0.)
       flag_error = 1;
     else
       for (int j = 0; j < nfacies; j++)
-        TRANS(i,j) = ABS(TRANS(i,j)) / total;
+        TRANS(i, j) = ABS(TRANS(i, j)) / total;
   }
 
   /* Wrong transition matrix: initialize it */
@@ -294,7 +291,7 @@ VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam &sub
   {
     for (int i = 0; i < nfacies; i++)
       for (int j = 0; j < nfacies; j++)
-        TRANS(i,j) = 1. / nfacies;
+        TRANS(i, j) = 1. / nfacies;
   }
 
   /* Initialize the proportion matrix */
@@ -308,14 +305,14 @@ VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam &sub
   while (diff > eps)
   {
     double w0 = 0.;
-    diff = 0.;
+    diff      = 0.;
     for (int i = 0; i < nfacies; i++)
       propold[i] = props[i];
     for (int i = 0; i < nfacies; i++)
     {
       double val = 0.;
       for (int j = 0; j < nfacies; j++)
-        val += TRANS(j,i) * propold[j];
+        val += TRANS(j, i) * propold[j];
       props[i] = val;
       w0 += val;
     }
@@ -337,9 +334,9 @@ VectorDouble CalcSimuSubstitution::_transToProp(const SimuSubstitutionParam &sub
 
 bool CalcSimuSubstitution::_check()
 {
-  if (! ACalcSimulation::_check()) return false;
+  if (!ACalcSimulation::_check()) return false;
 
-  if (! hasDbout()) return false;
+  if (!hasDbout()) return false;
   int ndim = _getNDim();
   if (ndim > 3)
   {
@@ -347,12 +344,12 @@ bool CalcSimuSubstitution::_check()
     messerr("for this Space Dimension (%d)", ndim);
     return false;
   }
-  if (! getDbout()->isGrid())
+  if (!getDbout()->isGrid())
   {
     messerr("The argument 'dbout'  should be a grid");
     return false;
   }
-  if (! _subparam.isValid(_verbose)) return false;
+  if (!_subparam.isValid(_verbose)) return false;
   return true;
 }
 
@@ -398,7 +395,7 @@ void CalcSimuSubstitution::_rollback()
  ** \param[in]  namconv     Naming convention
  **
  *****************************************************************************/
-int substitution(DbGrid *dbgrid,
+int substitution(DbGrid* dbgrid,
                  SimuSubstitutionParam& subparam,
                  int seed,
                  int verbose,
@@ -413,4 +410,4 @@ int substitution(DbGrid *dbgrid,
   int error = (simsub.run()) ? 0 : 1;
   return error;
 }
-}
+} // namespace gstlrn

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -8,29 +8,27 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
-#include "geoslib_f_private.h"
-
-#include "Simulation/ACalcSimulation.hpp"
-#include "Simulation/TurningBandOperate.hpp"
-#include "Simulation/TurningBandDirection.hpp"
 #include "Simulation/CalcSimuTurningBands.hpp"
-#include "Model/Model.hpp"
 #include "Anamorphosis/AAnam.hpp"
 #include "Anamorphosis/AnamHermite.hpp"
-#include "Covariances/CovAniso.hpp"
-#include "Geometry/GeometryHelper.hpp"
-
+#include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
 #include "Basic/OptDbg.hpp"
-#include "Basic/Law.hpp"
+#include "Covariances/CovAniso.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
+#include "Geometry/GeometryHelper.hpp"
+#include "Model/Model.hpp"
+#include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/TurningBandDirection.hpp"
+#include "Simulation/TurningBandOperate.hpp"
+#include "geoslib_f_private.h"
+#include "geoslib_old_f.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
-{ 
+{
 CalcSimuTurningBands::CalcSimuTurningBands(int nbsimu,
                                            int nbtuba,
                                            bool flag_check,
@@ -83,7 +81,7 @@ bool CalcSimuTurningBands::_resize()
     /* Allocate the structures for the seeds */
 
     int size = nvar * ncova * _nbtuba * nbsimu;
-    _seedBands.resize(size,0);
+    _seedBands.resize(size, 0);
 
     /* Allocate the structures for the directions */
 
@@ -100,12 +98,12 @@ int CalcSimuTurningBands::_getAddressBand(int ivar, int is, int ib, int isimu) c
 {
   int nvar  = _getNVar();
   int ncova = _getNCov();
-  return ivar+nvar*((is)+ncova*((ib)+_nbtuba*(isimu)));
+  return ivar + nvar * ((is) + ncova * ((ib) + _nbtuba * (isimu)));
 }
 
 void CalcSimuTurningBands::_setSeedBand(int ivar, int is, int ib, int isimu, int seed)
 {
-  int iad = _getAddressBand(ivar, is, ib, isimu);
+  int iad         = _getAddressBand(ivar, is, ib, isimu);
   _seedBands[iad] = seed;
 }
 
@@ -160,9 +158,9 @@ int CalcSimuTurningBands::_generateDirections(const Db* dbout)
 
     for (int id = 0; id < 2; id++)
     {
-      int n = 1 + ibs;
-      int p = id + 2;
-      x[id] = 0;
+      int n    = 1 + ibs;
+      int p    = id + 2;
+      x[id]    = 0;
       double d = id + 2;
       while (n > 0)
       {
@@ -215,7 +213,7 @@ int CalcSimuTurningBands::_generateDirections(const Db* dbout)
         if (cova->getFlagAniso())
         {
           VectorDouble ranges = cova->getScales();
-          double scale = 0.;
+          double scale        = 0.;
           for (int i = 0; i < 3; i++)
           {
             double val = 0.;
@@ -233,7 +231,7 @@ int CalcSimuTurningBands::_generateDirections(const Db* dbout)
             {
               double range = 0.;
               if (i < ndim) range = ranges[i];
-              if (range > 0.) val += (_getCodirAng(ibs,i) / range);
+              if (range > 0.) val += (_getCodirAng(ibs, i) / range);
             }
             scale += val * val;
             axyz[i] = val;
@@ -250,11 +248,11 @@ int CalcSimuTurningBands::_generateDirections(const Db* dbout)
         if (dbout->isGrid())
         {
           const DbGrid* dbgrid = dynamic_cast<const DbGrid*>(dbout);
-          double t00 = _codirs[ibs].projectGrid(dbgrid, 0, 0, 0);
+          double t00           = _codirs[ibs].projectGrid(dbgrid, 0, 0, 0);
           _setCodirT00(ibs, t00);
-          _setCodirDXP(ibs,_codirs[ibs].projectGrid(dbgrid, 1, 0, 0) - t00);
-          _setCodirDYP(ibs,_codirs[ibs].projectGrid(dbgrid, 0, 1, 0) - t00);
-          _setCodirDZP(ibs,_codirs[ibs].projectGrid(dbgrid, 0, 0, 1) - t00);
+          _setCodirDXP(ibs, _codirs[ibs].projectGrid(dbgrid, 1, 0, 0) - t00);
+          _setCodirDYP(ibs, _codirs[ibs].projectGrid(dbgrid, 0, 1, 0) - t00);
+          _setCodirDZP(ibs, _codirs[ibs].projectGrid(dbgrid, 0, 0, 1) - t00);
 
           if (cova->getType() == ECov::SPHERICAL || cova->getType() == ECov::CUBIC)
           {
@@ -272,7 +270,7 @@ int CalcSimuTurningBands::_generateDirections(const Db* dbout)
 
 void CalcSimuTurningBands::_dumpBands() const
 {
-  int nbands = getNDirs();
+  int nbands    = getNDirs();
   bool flagGrid = getDbout()->isGrid();
   for (int ibs = 0; ibs < nbands; ibs++)
   {
@@ -293,8 +291,8 @@ void CalcSimuTurningBands::_dumpBands() const
 void CalcSimuTurningBands::_rotateDirections(double a[3], double theta)
 {
   double dirs[3];
-  double ct = cos(theta);
-  double st = sin(theta);
+  double ct  = cos(theta);
+  double st  = sin(theta);
   int nbands = getNDirs();
 
   /* Loop on the direction coefficients */
@@ -316,7 +314,7 @@ void CalcSimuTurningBands::_rotateDirections(double a[3], double theta)
  ** \param[in]  db      Db structure
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_minmax(const Db *db)
+void CalcSimuTurningBands::_minmax(const Db* db)
 {
   double tt;
   if (db == nullptr) return;
@@ -325,9 +323,9 @@ void CalcSimuTurningBands::_minmax(const Db *db)
   if (db->isGrid())
   {
     const DbGrid* dbgrid = dynamic_cast<const DbGrid*>(db);
-    int nx = (dbgrid->getNDim() >= 1) ? dbgrid->getNX(0) : 1;
-    int ny = (dbgrid->getNDim() >= 2) ? dbgrid->getNX(1) : 1;
-    int nz = (dbgrid->getNDim() >= 3) ? dbgrid->getNX(2) : 1;
+    int nx               = (dbgrid->getNDim() >= 1) ? dbgrid->getNX(0) : 1;
+    int ny               = (dbgrid->getNDim() >= 2) ? dbgrid->getNX(1) : 1;
+    int nz               = (dbgrid->getNDim() >= 3) ? dbgrid->getNX(2) : 1;
 
     /* Case when the data obeys to a grid organization */
     /* This test is programmed for 3-D (maximum) grid  */
@@ -392,7 +390,7 @@ void CalcSimuTurningBands::_setDensity()
   if (naverage < nmini) naverage = nmini;
   if (naverage > nmaxi) naverage = nmaxi;
   double scale = _field / naverage;
-  _theta = 1. / scale;
+  _theta       = 1. / scale;
 }
 
 /****************************************************************************/
@@ -407,7 +405,7 @@ void CalcSimuTurningBands::_setDensity()
  ** \return  The modified type
  **
  *****************************************************************************/
-ECov CalcSimuTurningBands::_particularCase(const ECov &type, double param)
+ECov CalcSimuTurningBands::_particularCase(const ECov& type, double param)
 {
   static double eps = 1.e-7;
 
@@ -552,22 +550,22 @@ int CalcSimuTurningBands::_initializeSeedBands()
 void CalcSimuTurningBands::_migrationInit(int ibs,
                                           int is,
                                           double scale,
-                                          TurningBandOperate &operTB,
+                                          TurningBandOperate& operTB,
                                           double eps)
 {
   DECLARE_UNUSED(is);
   static double vexp1 = 0.1;
   static double vexp2 = 0.1967708298;
 
-  double tmin  = _getCodirTmin(ibs);
-  double tmax  = _getCodirTmax(ibs);
+  double tmin = _getCodirTmin(ibs);
+  double tmax = _getCodirTmax(ibs);
 
   /* Initializations */
 
   double delta = tmax - tmin;
   if (scale < delta * eps)
   {
-    int count = (int) ceil(delta / eps);
+    int count = (int)ceil(delta / eps);
     for (int i = 0; i < count; i++)
       operTB.pushT(law_gaussian());
   }
@@ -604,7 +602,7 @@ void CalcSimuTurningBands::_migrationInit(int ibs,
  *****************************************************************************/
 double CalcSimuTurningBands::_dilutionInit(int ibs,
                                            int is,
-                                           TurningBandOperate &operTB)
+                                           TurningBandOperate& operTB)
 {
   double scale = _getCodirScale(ibs);
   double tmin  = _getCodirTmin(ibs);
@@ -654,13 +652,13 @@ double CalcSimuTurningBands::_dilutionInit(int ibs,
  *****************************************************************************/
 double CalcSimuTurningBands::_spectralInit(int ibs,
                                            int is,
-                                           TurningBandOperate &operTB)
+                                           TurningBandOperate& operTB)
 {
   double scale = _getCodirScale(ibs);
   double param = _modelLocal->getParam(is);
   ECov type    = _modelLocal->getCovType(is);
 
-  double val = 0.;
+  double val    = 0.;
   double period = 0.;
   switch (type.toEnum())
   {
@@ -679,17 +677,17 @@ double CalcSimuTurningBands::_spectralInit(int ibs,
         val = law_gaussian();
         period += val * val;
       }
-      scale = _computeScale(param, scale);
+      scale  = _computeScale(param, scale);
       period = sqrt(2. * period) / scale;
       break;
 
     case ECov::E_SINCARD:
-      val = (law_uniform(0., 1.) >= 0.5) ? 1 : -1;
+      val    = (law_uniform(0., 1.) >= 0.5) ? 1 : -1;
       period = val / scale;
       break;
 
     case ECov::E_BESSELJ:
-      val = law_beta1(1.5, param - 0.5);
+      val    = law_beta1(1.5, param - 0.5);
       period = sqrt(val) / scale;
       break;
 
@@ -769,29 +767,29 @@ double CalcSimuTurningBands::_computeScaleKB(double param, double scale)
  *****************************************************************************/
 double CalcSimuTurningBands::_power1DInit(int ibs,
                                           int is,
-                                          TurningBandOperate &operTB)
+                                          TurningBandOperate& operTB)
 {
   double R, theta_1;
   static double log3s2, log1s2, logap1, logap1s2, logap3s2, as2, coeff, coeff3;
   static double alpha_mem = -1.;
 
   double param = _modelLocal->getParam(is);
-  if (ibs == 0 || ! isEqual(param,alpha_mem))
+  if (ibs == 0 || !isEqual(param, alpha_mem))
   {
     double scale = _getCodirScale(ibs);
-    as2 = param / 2.;
-    log3s2 = loggamma(1.5);
-    log1s2 = loggamma(0.5);
-    logap1 = loggamma(1.0 + param);
-    logap1s2 = loggamma(0.5 + as2);
-    logap3s2 = loggamma(1.5 + as2);
-    coeff = 2. * sqrt(exp(logap1) / pow(2.* GV_PI, param)) * pow(scale, as2);
-    coeff3 = sqrt(exp(log3s2 + logap1s2 - log1s2 - logap3s2));
-    alpha_mem = param;
+    as2          = param / 2.;
+    log3s2       = loggamma(1.5);
+    log1s2       = loggamma(0.5);
+    logap1       = loggamma(1.0 + param);
+    logap1s2     = loggamma(0.5 + as2);
+    logap3s2     = loggamma(1.5 + as2);
+    coeff        = 2. * sqrt(exp(logap1) / pow(2. * GV_PI, param)) * pow(scale, as2);
+    coeff3       = sqrt(exp(log3s2 + logap1s2 - log1s2 - logap3s2));
+    alpha_mem    = param;
   }
 
-  R = law_beta2(1 - as2, as2);
-  theta_1 = coeff * sqrt((R + 1.) / pow(R, as2 + 1));
+  R          = law_beta2(1 - as2, as2);
+  theta_1    = coeff * sqrt((R + 1.) / pow(R, as2 + 1));
   double phi = 2. * GV_PI * law_uniform(0., 1.);
 
   operTB.setOmega(2. * GV_PI * R);
@@ -823,29 +821,29 @@ double CalcSimuTurningBands::_power1DInit(int ibs,
  *****************************************************************************/
 double CalcSimuTurningBands::_spline1DInit(int ibs,
                                            int k,
-                                           TurningBandOperate &operTB)
+                                           TurningBandOperate& operTB)
 {
   double R;
   int twokm1;
   static double twoPI, twokp1s2, log3s2, logkp3s2, logkp1, coeff;
-  static int twok = 0;
+  static int twok  = 0;
   static int k_mem = -1;
-  double scale = _getCodirScale(ibs);
+  double scale     = _getCodirScale(ibs);
 
   if (ibs == 0 || k != k_mem)
   {
-    twok = 2 * k;
-    twokm1 = twok - 1;
+    twok     = 2 * k;
+    twokm1   = twok - 1;
     twokp1s2 = twok + 1. / 2;
-    twoPI = 2. * GV_PI;
-    log3s2 = loggamma(1.5);
+    twoPI    = 2. * GV_PI;
+    log3s2   = loggamma(1.5);
     logkp3s2 = loggamma(k + 1.5);
-    logkp1 = loggamma(k + 1.);
-    coeff = sqrt(2 * exp(logkp3s2 + logkp1 - log3s2) / pow(GV_PI, twokm1));
-    k_mem = k;
+    logkp1   = loggamma(k + 1.);
+    coeff    = sqrt(2 * exp(logkp3s2 + logkp1 - log3s2) / pow(GV_PI, twokm1));
+    k_mem    = k;
   }
 
-  R = law_beta2(1. / 2, 1. / 2);
+  R          = law_beta2(1. / 2, 1. / 2);
   double phi = twoPI * law_uniform(0., 1.);
 
   operTB.setOmega(twoPI * R * pow(scale, twok));
@@ -874,17 +872,17 @@ double CalcSimuTurningBands::_spline1DInit(int ibs,
  *****************************************************************************/
 double CalcSimuTurningBands::_irfProcessInit(int ibs,
                                              int is,
-                                             TurningBandOperate &operTB)
+                                             TurningBandOperate& operTB)
 {
   ECov type = _modelLocal->getCovType(is);
   double delta;
 
   int level = -1;
-  if (type == ECov::LINEAR)    level = 0;
+  if (type == ECov::LINEAR) level = 0;
   if (type == ECov::ORDER1_GC) level = 0;
   if (type == ECov::ORDER3_GC) level = 1;
   if (type == ECov::ORDER5_GC) level = 2;
-  int nt = operTB.getTsize();
+  int nt         = operTB.getTsize();
   VectorDouble t = operTB.getT();
 
   /* Generation of the Wiener-Levy process and its integrations */
@@ -911,7 +909,7 @@ double CalcSimuTurningBands::_irfProcessInit(int ibs,
     operTB.pushV2(val2);
   }
 
-  double scale = _getCodirScale(ibs);
+  double scale  = _getCodirScale(ibs);
   double theta1 = 1. / _theta;
   return _irfCorrec(type, theta1, scale);
 }
@@ -941,18 +939,18 @@ VectorDouble CalcSimuTurningBands::_createAIC()
   for (int icov = 0; icov < ncova; icov++)
   {
     MatrixSymmetric mat = _modelLocal->getSills(icov);
-    if (! mat.isDefinitePositive())
+    if (!mat.isDefinitePositive())
     {
       messerr("Warning: the model is not authorized");
       messerr("The coregionalization matrix for the structure %d is not definite positive",
-          icov + 1);
+              icov + 1);
       return VectorDouble();
     }
 
     // Calculate the Eigen decomposition
 
     if (mat.computeEigen()) return VectorDouble();
-    VectorDouble valpro = mat.getEigenValues();
+    VectorDouble valpro        = mat.getEigenValues();
     const MatrixSquare* vecpro = mat.getEigenVectors();
 
     /* Calculate the factor matrix */
@@ -960,8 +958,8 @@ VectorDouble CalcSimuTurningBands::_createAIC()
     for (int ivar = 0; ivar < nvar; ivar++)
       for (int jvar = 0; jvar < nvar; jvar++)
       {
-        int ijvar = ivar + nvar * jvar;
-        aic[icov*nvar*nvar + ijvar] = vecpro->getValue(ivar, jvar) * sqrt(valpro[ivar]);
+        int ijvar                       = ivar + nvar * jvar;
+        aic[icov * nvar * nvar + ijvar] = vecpro->getValue(ivar, jvar) * sqrt(valpro[ivar]);
       }
   }
   return aic;
@@ -973,8 +971,8 @@ void CalcSimuTurningBands::_spreadRegularOnGrid(int nx,
                                                 int ibs,
                                                 int is,
                                                 TurningBandOperate& operTB,
-                                                const VectorBool &activeArray,
-                                                VectorDouble &tab)
+                                                const VectorBool& activeArray,
+                                                VectorDouble& tab)
 {
   CovAniso* cova = _modelLocal->getCovAniso(is);
   double t0y, t0z, t0;
@@ -986,7 +984,7 @@ void CalcSimuTurningBands::_spreadRegularOnGrid(int nx,
   double dyp = _getCodirDYP(ibs);
   double dzp = _getCodirDZP(ibs);
 
-  t0z = t00;
+  t0z     = t00;
   int ind = 0;
   for (int iz = 0; iz < nz; iz++)
   {
@@ -1014,8 +1012,8 @@ void CalcSimuTurningBands::_spreadSpectralOnGrid(int nx,
                                                  int ibs,
                                                  int is,
                                                  TurningBandOperate& operTB,
-                                                 const VectorBool &activeArray,
-                                                 VectorDouble &tab)
+                                                 const VectorBool& activeArray,
+                                                 VectorDouble& tab)
 {
   CovAniso* cova = _modelLocal->getCovAniso(is);
   double c1, s1, c0x, s0x, c0y, s0y, c0z, s0z, cxp, sxp, cyp, syp, czp, szp;
@@ -1027,24 +1025,24 @@ void CalcSimuTurningBands::_spreadSpectralOnGrid(int nx,
   {
     c0y = c0z;
     s0y = s0z;
-    c1 = c0z * czp - s0z * szp;
-    s1 = s0z * czp + c0z * szp;
+    c1  = c0z * czp - s0z * szp;
+    s1  = s0z * czp + c0z * szp;
     c0z = c1;
     s0z = s1;
     for (int iy = 0; iy < ny; iy++)
     {
       c0x = c0y;
       s0x = s0y;
-      c1 = c0y * cyp - s0y * syp;
-      s1 = s0y * cyp + c0y * syp;
+      c1  = c0y * cyp - s0y * syp;
+      s1  = s0y * cyp + c0y * syp;
       c0y = c1;
       s0y = s1;
       for (int ix = 0; ix < nx; ix++)
       {
         if (activeArray[ind])
           tab[ind] = cova->simulateTurningBand(c0x, operTB);
-        c1 = c0x * cxp - s0x * sxp;
-        s1 = s0x * cxp + c0x * sxp;
+        c1  = c0x * cxp - s0x * sxp;
+        s1  = s0x * cxp + c0x * sxp;
         c0x = c1;
         s0x = s1;
 
@@ -1054,19 +1052,19 @@ void CalcSimuTurningBands::_spreadSpectralOnGrid(int nx,
   }
 }
 
-void CalcSimuTurningBands::_spreadRegularOnPoint(const Db *db,
+void CalcSimuTurningBands::_spreadRegularOnPoint(const Db* db,
                                                  int ibs,
                                                  int is,
-                                                 TurningBandOperate &operTB,
-                                                 const VectorBool &activeArray,
-                                                 VectorDouble &tab)
+                                                 TurningBandOperate& operTB,
+                                                 const VectorBool& activeArray,
+                                                 VectorDouble& tab)
 {
   CovAniso* cova = _modelLocal->getCovAniso(is);
   double t0;
   for (int iech = 0, nech = db->getNSample(); iech < nech; iech++)
   {
-    if (! activeArray[iech]) continue;
-    t0 = _codirs[ibs].projectPoint(db, iech);
+    if (!activeArray[iech]) continue;
+    t0        = _codirs[ibs].projectPoint(db, iech);
     tab[iech] = cova->simulateTurningBand(t0, operTB);
   }
 }
@@ -1075,15 +1073,15 @@ void CalcSimuTurningBands::_spreadSpectralOnPoint(const Db* db,
                                                   int ibs,
                                                   int is,
                                                   TurningBandOperate& operTB,
-                                                  const VectorBool &activeArray,
-                                                  VectorDouble &tab)
+                                                  const VectorBool& activeArray,
+                                                  VectorDouble& tab)
 {
   CovAniso* cova = _modelLocal->getCovAniso(is);
   double t0;
   for (int iech = 0, nech = db->getNSample(); iech < nech; iech++)
   {
     if (!activeArray[iech]) continue;
-    t0 = _codirs[ibs].projectPoint(db, iech);
+    t0        = _codirs[ibs].projectPoint(db, iech);
     tab[iech] = cova->simulateTurningBand(t0, operTB);
   }
 }
@@ -1099,8 +1097,8 @@ void CalcSimuTurningBands::_spreadSpectralOnPoint(const Db* db,
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulatePoint(Db *db,
-                                          const VectorDouble &aic,
+void CalcSimuTurningBands::_simulatePoint(Db* db,
+                                          const VectorDouble& aic,
                                           int icase,
                                           int shift)
 {
@@ -1113,7 +1111,7 @@ void CalcSimuTurningBands::_simulatePoint(Db *db,
 
   /* Core allocation */
 
-  VectorDouble tab(nech,0.);
+  VectorDouble tab(nech, 0.);
   VectorBool activeArray = db->getActiveArray();
   TurningBandOperate operTB;
 
@@ -1249,8 +1247,8 @@ void CalcSimuTurningBands::_simulatePoint(Db *db,
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateGrid(DbGrid *db,
-                                         const VectorDouble &aic,
+void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
+                                         const VectorDouble& aic,
                                          int icase,
                                          int shift)
 {
@@ -1405,14 +1403,14 @@ void CalcSimuTurningBands::_simulateGrid(DbGrid *db,
  ** \remarks At the end, the simulated gradient is stored at first point
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateGradient(Db *dbgrd,
-                                             const VectorDouble &aic,
+void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
+                                             const VectorDouble& aic,
                                              double delta)
 {
   int jsimu;
-  int icase = 0;
-  int ndim = dbgrd->getNDim();
-  int nbsimu = getNbSimu();
+  int icase              = 0;
+  int ndim               = dbgrd->getNDim();
+  int nbsimu             = getNbSimu();
   VectorBool activeArray = dbgrd->getActiveArray();
 
   for (int idim = 0; idim < ndim; idim++)
@@ -1454,10 +1452,10 @@ void CalcSimuTurningBands::_simulateGradient(Db *dbgrd,
       for (int iech = 0; iech < dbgrd->getNSample(); iech++)
       {
         if (!!activeArray[iech]) continue;
-        jsimu = isimu + idim * nbsimu + ndim * nbsimu;
+        jsimu         = isimu + idim * nbsimu + ndim * nbsimu;
         double value2 = dbgrd->getSimvar(ELoc::SIMU, iech, jsimu, 0, icase,
                                          2 * ndim * nbsimu, 1);
-        jsimu = isimu + idim * nbsimu;
+        jsimu         = isimu + idim * nbsimu;
         double value1 = dbgrd->getSimvar(ELoc::SIMU, iech, jsimu, 0, icase,
                                          2 * ndim * nbsimu, 1);
         dbgrd->setSimvar(ELoc::SIMU, iech, jsimu, 0, icase,
@@ -1481,13 +1479,13 @@ void CalcSimuTurningBands::_simulateGradient(Db *dbgrd,
  ** \remarks simulation outcome variables as for the gradients
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateTangent(Db *dbtgt,
-                                            const VectorDouble &aic,
+void CalcSimuTurningBands::_simulateTangent(Db* dbtgt,
+                                            const VectorDouble& aic,
                                             double delta)
 {
-  int icase = 0;
-  int nvar = _getNVar();
-  int nbsimu = getNbSimu();
+  int icase              = 0;
+  int nvar               = _getNVar();
+  int nbsimu             = getNbSimu();
   VectorBool activeArray = dbtgt->getActiveArray();
 
   /* Perform the simulation of the gradients at tangent points */
@@ -1499,13 +1497,12 @@ void CalcSimuTurningBands::_simulateTangent(Db *dbtgt,
   for (int isimu = 0; isimu < nbsimu; isimu++)
     for (int iech = 0; iech < dbtgt->getNSample(); iech++)
     {
-      if (! activeArray[iech]) continue;
+      if (!activeArray[iech]) continue;
 
       double value = 0.;
       for (int idim = 0; idim < dbtgt->getNDim(); idim++)
-        value += dbtgt->getLocVariable(ELoc::TGTE,iech, idim)
-            * dbtgt->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu,
-                               nvar);
+        value += dbtgt->getLocVariable(ELoc::TGTE, iech, idim) * dbtgt->getSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu,
+                                                                                  nvar);
       dbtgt->setSimvar(ELoc::SIMU, iech, isimu, 0, icase, nbsimu,
                        nvar, value);
     }
@@ -1522,7 +1519,7 @@ void CalcSimuTurningBands::_simulateTangent(Db *dbtgt,
  ** \param[in]  scale   Range of the model
  **
  *****************************************************************************/
-double CalcSimuTurningBands::_irfCorrec(const ECov &type, double theta1, double scale)
+double CalcSimuTurningBands::_irfCorrec(const ECov& type, double theta1, double scale)
 {
   switch (type.toEnum())
   {
@@ -1548,18 +1545,18 @@ double CalcSimuTurningBands::_irfCorrec(const ECov &type, double theta1, double 
 
 void CalcSimuTurningBands::_getOmegaPhi(int ibs,
                                         TurningBandOperate& operTB,
-                                        double *cxp,
-                                        double *sxp,
-                                        double *cyp,
-                                        double *syp,
-                                        double *czp,
-                                        double *szp,
-                                        double *c0z,
-                                        double *s0z)
+                                        double* cxp,
+                                        double* sxp,
+                                        double* cyp,
+                                        double* syp,
+                                        double* czp,
+                                        double* szp,
+                                        double* c0z,
+                                        double* s0z)
 {
 
-  double omega  = operTB.getOmega();
-  double phi    = operTB.getPhi();
+  double omega = operTB.getOmega();
+  double phi   = operTB.getPhi();
 
   double dxp = _getCodirDXP(ibs);
   double dyp = _getCodirDYP(ibs);
@@ -1620,7 +1617,7 @@ void CalcSimuTurningBands::_simulateNugget(Db* db,
 
         for (int iech = 0; iech < nech; iech++)
         {
-          if (! activeArray[iech]) continue;
+          if (!activeArray[iech]) continue;
           double nugget = law_gaussian();
           for (int jvar = 0; jvar < nvar; jvar++)
             db->updSimvar(ELoc::SIMU, iech, isimu, jvar, icase, nbsimu, nvar,
@@ -1655,7 +1652,7 @@ double CalcSimuTurningBands::_getAIC(const VectorDouble& aic,
  ** \param[in]  flag_dgm   1 if in the Discrete Gaussian Model
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_difference(Db *dbin,
+void CalcSimuTurningBands::_difference(Db* dbin,
                                        Model* model,
                                        int icase,
                                        bool flag_pgs,
@@ -1663,17 +1660,17 @@ void CalcSimuTurningBands::_difference(Db *dbin,
                                        bool flag_dgm)
 {
   int nbsimu = getNbSimu();
-  int nvar = _getNVar();
-  double r = 1.;
+  int nvar   = _getNVar();
+  double r   = 1.;
   if (flag_dgm)
   {
-    const AnamHermite *anamH = dynamic_cast<const AnamHermite*>(model->getAnam());
-    r = anamH->getRCoef();
+    const AnamHermite* anamH = dynamic_cast<const AnamHermite*>(model->getAnam());
+    r                        = anamH->getRCoef();
   }
 
   /* Transform the non conditional simulation into simulation error */
 
-  if (! flag_pgs)
+  if (!flag_pgs)
   {
     /********************************/
     /* Standard case (multivariate) */
@@ -1742,7 +1739,7 @@ void CalcSimuTurningBands::_difference(Db *dbin,
  ** \param[in]  icase     Rank of PGS or GRF
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_meanCorrect(Db *dbout, int icase)
+void CalcSimuTurningBands::_meanCorrect(Db* dbout, int icase)
 {
   if (_flagBayes) return;
   int nbsimu = getNbSimu();
@@ -1762,7 +1759,7 @@ void CalcSimuTurningBands::_meanCorrect(Db *dbout, int icase)
       // Loop on the samples
       for (int iech = 0; iech < nech; iech++)
       {
-        if (! activeArray[iech]) continue;
+        if (!activeArray[iech]) continue;
         dbout->updSimvar(ELoc::SIMU, iech, isimu, ivar, icase, nbsimu,
                          nvar, EOperator::ADD, getModel()->getMean(ivar));
       }
@@ -1788,26 +1785,26 @@ void CalcSimuTurningBands::_meanCorrect(Db *dbout, int icase)
  ** \remarks within a cell
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_updateData2ToTarget(Db *dbin,
-                                                Db *dbout,
+void CalcSimuTurningBands::_updateData2ToTarget(Db* dbin,
+                                                Db* dbout,
                                                 int icase,
                                                 bool flag_pgs,
                                                 bool flag_dgm)
 {
   if (dbin->getNSample() <= 0) return;
   if (flag_dgm) return;
-  int nvar = _getNVar();
-  int ndim = dbin->getNDim();
+  int nvar   = _getNVar();
+  int ndim   = dbin->getNDim();
   int nbsimu = getNbSimu();
 
   /* Calculate the field extension */
 
   double radius = dbin->getExtensionDiagonal();
-  double eps = radius * EPSILON6;
-  double eps2 = eps * eps;
+  double eps    = radius * EPSILON6;
+  double eps2   = eps * eps;
   VectorDouble coor1(ndim);
   VectorDouble coor2(ndim);
-  VectorBool activeArrayIn = dbin->getActiveArray();
+  VectorBool activeArrayIn  = dbin->getActiveArray();
   VectorBool activeArrayOut = dbout->getActiveArray();
 
   /* Dispatch according to the file type */
@@ -1851,7 +1848,7 @@ void CalcSimuTurningBands::_updateData2ToTarget(Db *dbin,
                                      1);
           if (FFFF(valdat)) continue;
           dbgrid->setSimvar(ELoc::SIMU, rank, isimu, ivar, icase, nbsimu, nvar,
-                           valdat);
+                            valdat);
         }
     }
   }
@@ -1913,11 +1910,11 @@ bool CalcSimuTurningBands::_run()
 {
   law_set_random_seed(getSeed());
   bool flag_cond = hasDbin(false);
-  int nbsimu = getNbSimu();
+  int nbsimu     = getNbSimu();
 
   // Initializations
 
-  if (! _resize()) return false;
+  if (!_resize()) return false;
   if (_generateDirections(getDbout())) return false;
   _minmax(getDbout());
   _minmax(getDbin());
@@ -2042,11 +2039,11 @@ int CalcSimuTurningBands::simulate(Db* dbin,
  ** \param[in]  delta     Value of the increment
  **
  *****************************************************************************/
-int CalcSimuTurningBands::simulatePotential(Db *dbiso,
-                                            Db *dbgrd,
-                                            Db *dbtgt,
-                                            Db *dbout,
-                                            Model *model,
+int CalcSimuTurningBands::simulatePotential(Db* dbiso,
+                                            Db* dbgrd,
+                                            Db* dbtgt,
+                                            Db* dbout,
+                                            Model* model,
                                             double delta)
 {
   setDbout(dbout);
@@ -2121,13 +2118,13 @@ int CalcSimuTurningBands::simulatePotential(Db *dbiso,
  ** \param[in]  model    Model structure
  **
  *****************************************************************************/
-bool CalcSimuTurningBands::isValidForTurningBands(const Model *model)
+bool CalcSimuTurningBands::isValidForTurningBands(const Model* model)
 {
   /* Loop on the structures */
 
   for (int is = 0; is < model->getNCov(); is++)
   {
-    if (! model->getCovAniso(is)->isValidForTurningBand()) return false;
+    if (!model->getCovAniso(is)->isValidForTurningBand()) return false;
   }
   return true;
 }
@@ -2144,12 +2141,12 @@ bool CalcSimuTurningBands::isValidForTurningBands(const Model *model)
  ** \remark Tests have only been produced for icase=0
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_checkGaussianData2Grid(Db *dbin,
-                                                   Db *dbout,
-                                                   Model *model) const
+void CalcSimuTurningBands::_checkGaussianData2Grid(Db* dbin,
+                                                   Db* dbout,
+                                                   Model* model) const
 {
   if (dbin == nullptr) return;
-  if (get_LOCATOR_NITEM(dbout,ELoc::SIMU) <= 0) return;
+  if (get_LOCATOR_NITEM(dbout, ELoc::SIMU) <= 0) return;
   int nbsimu = getNbSimu();
   if (nbsimu <= 0) return;
   DbGrid* dbgrid = dynamic_cast<DbGrid*>(dbout);
@@ -2202,13 +2199,13 @@ void CalcSimuTurningBands::_checkGaussianData2Grid(Db *dbin,
 
 bool CalcSimuTurningBands::_check()
 {
-  if (! ACalcSimulation::_check()) return false;
+  if (!ACalcSimulation::_check()) return false;
 
-  if (! hasDbout()) return false;
-  if (! hasModel()) return false;
+  if (!hasDbout()) return false;
+  if (!hasModel()) return false;
   if (hasDbin(false))
   {
-    if (! hasNeigh()) return false;
+    if (!hasNeigh()) return false;
   }
 
   int ndim = _getNDim();
@@ -2242,17 +2239,17 @@ bool CalcSimuTurningBands::_check()
 
   if (_flagDGM)
   {
-    if (! getDbout()->isGrid())
+    if (!getDbout()->isGrid())
     {
       messerr("For DGM option, the argument 'dbout'  should be a Grid");
       return false;
     }
-    if (! _modelLocal->hasAnam())
+    if (!_modelLocal->hasAnam())
     {
       messerr("For DGM option, the Model must have an Anamorphosis attached");
       return false;
     }
-    if (! _modelLocal->isChangeSupportDefined())
+    if (!_modelLocal->isChangeSupportDefined())
     {
       messerr("DGM option requires a Change of Support to be defined");
       return false;
@@ -2265,7 +2262,7 @@ bool CalcSimuTurningBands::_preprocess()
 {
   if (!ACalcSimulation::_preprocess()) return false;
 
-  int nvar = _getNVar();
+  int nvar   = _getNVar();
   int nbsimu = getNbSimu();
 
   /* Add the attributes for storing the results */
@@ -2290,7 +2287,7 @@ bool CalcSimuTurningBands::_preprocess()
   if (_flagDGM)
   {
     // Centering (only if the output file is a Grid)
-    DbGrid *dbgrid = dynamic_cast<DbGrid*>(getDbout());
+    DbGrid* dbgrid = dynamic_cast<DbGrid*>(getDbout());
     if (dbgrid != nullptr)
     {
       // Duplicating the coordinate variable names before centering
@@ -2314,7 +2311,7 @@ bool CalcSimuTurningBands::_postprocess()
 
   /* Set the error return flag */
 
-  if (! _flagAllocationAlreadyDone)
+  if (!_flagAllocationAlreadyDone)
     _renameVariable(2, VectorString(), ELoc::Z, _getNVar(), _iattOut, String(), getNbSimu());
 
   if (_flagDGM)
@@ -2352,16 +2349,16 @@ void CalcSimuTurningBands::_rollback()
  ** \remark  be defined only for conditional simulations
  **
  *****************************************************************************/
-int simtub(Db *dbin,
-           Db *dbout,
-           Model *model,
-           ANeigh *neigh,
+int simtub(Db* dbin,
+           Db* dbout,
+           Model* model,
+           ANeigh* neigh,
            int nbsimu,
            int seed,
            int nbtuba,
            bool flag_dgm,
            bool flag_check,
-           const NamingConvention &namconv)
+           const NamingConvention& namconv)
 {
   // Instantiate the Calculator
   CalcSimuTurningBands situba(nbsimu, nbtuba, flag_check, seed);
@@ -2403,10 +2400,10 @@ int simtub(Db *dbin,
  ** \remark  be defined only for conditional simulations
  **
  *****************************************************************************/
-int simbayes(Db *dbin,
-             Db *dbout,
-             Model *model,
-             ANeigh *neigh,
+int simbayes(Db* dbin,
+             Db* dbout,
+             Model* model,
+             ANeigh* neigh,
              int nbsimu,
              int seed,
              const VectorDouble& dmean,
@@ -2434,4 +2431,4 @@ int simbayes(Db *dbin,
   return error;
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuBoolean.cpp
+++ b/src/Simulation/SimuBoolean.cpp
@@ -8,26 +8,26 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Boolean/AShape.hpp"
-#include "Db/DbGrid.hpp"
-#include "Db/Db.hpp"
-#include "Simulation/ACalcSimulation.hpp"
 #include "Simulation/SimuBoolean.hpp"
-#include "Simulation/BooleanObject.hpp"
-#include "Simulation/SimuBooleanParam.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Boolean/AShape.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/BooleanObject.hpp"
+#include "Simulation/SimuBooleanParam.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
-{ 
+{
 
 SimuBoolean::SimuBoolean(int nbsimu, int seed)
-    : ACalcSimulation(nbsimu, seed),
-      AStringable(),
-      _objlist(),
-      _iptrCover(-1)
+  : ACalcSimulation(nbsimu, seed)
+  , AStringable()
+  , _objlist()
+  , _iptrCover(-1)
 {
 }
 
@@ -35,7 +35,6 @@ SimuBoolean::~SimuBoolean()
 {
   _clearAllObjects();
 }
-
 
 void SimuBoolean::_clearAllObjects()
 {
@@ -50,14 +49,14 @@ String SimuBoolean::toString(const AStringFormat* strfmt) const
 
   for (int iobj = 0; iobj < _getNObjects(); iobj++)
   {
-    sstr << "Characteristics of the Object: " << iobj+1 << std::endl;
+    sstr << "Characteristics of the Object: " << iobj + 1 << std::endl;
     sstr << _objlist[iobj]->toString(strfmt);
   }
   return sstr.str();
 }
 
-int SimuBoolean::simulate(Db *dbin,
-                          DbGrid *dbout,
+int SimuBoolean::simulate(Db* dbin,
+                          DbGrid* dbout,
                           ModelBoolean* tokens,
                           const SimuBooleanParam& boolparam,
                           int iptr_simu,
@@ -72,7 +71,7 @@ int SimuBoolean::simulate(Db *dbin,
 
   /* Count the number of conditioning pores and grains */
 
-  if (verbose) mestitle(0,"Boolean simulation");
+  if (verbose) mestitle(0, "Boolean simulation");
 
   // Clear any existing object
 
@@ -86,7 +85,7 @@ int SimuBoolean::simulate(Db *dbin,
 
   if (_generateSecondary(dbin, dbout, tokens, boolparam, verbose)) return 1;
 
-//  if (verbose) display();
+  //  if (verbose) display();
 
   // Project the objects on the output grid
 
@@ -113,7 +112,7 @@ void SimuBoolean::_projectToGrid(DbGrid* dbout,
   for (int iobj = 0; iobj < _getNObjects(); iobj++)
   {
     _objlist[iobj]->projectToGrid(dbout, iptr_simu, iptr_rank,
-                                  (int) boolparam.getFacies(), iobj + 1);
+                                  (int)boolparam.getFacies(), iobj + 1);
   }
 }
 
@@ -124,7 +123,7 @@ int SimuBoolean::_countConditioningPore(const Db* db)
   int nbpore = 0;
   for (int iech = 0; iech < db->getNSample(); iech++)
   {
-    if (! db->isActive(iech)) continue;
+    if (!db->isActive(iech)) continue;
     double data = db->getZVariable(iech, 0);
     if (FFFF(data)) continue;
     if (data) continue;
@@ -135,15 +134,15 @@ int SimuBoolean::_countConditioningPore(const Db* db)
 
 int SimuBoolean::_countConditioningGrain(const Db* db)
 {
-  if (db == nullptr) return 0 ;
+  if (db == nullptr) return 0;
 
   int nbgrain = 0;
   for (int iech = 0; iech < db->getNSample(); iech++)
   {
-    if (! db->isActive(iech)) continue;
+    if (!db->isActive(iech)) continue;
     double data = db->getZVariable(iech, 0);
     if (FFFF(data)) continue;
-    if (! data) continue;
+    if (!data) continue;
     nbgrain++;
   }
   return nbgrain;
@@ -154,8 +153,8 @@ int SimuBoolean::_getRankUncovered(const Db* db, int rank) const
   int number = 0;
   for (int iech = 0; iech < db->getNSample(); iech++)
   {
-    if (! db->isActive(iech)) continue;
-    int data = (int) db->getZVariable(iech, 0);
+    if (!db->isActive(iech)) continue;
+    int data = (int)db->getZVariable(iech, 0);
     if (data <= 0) continue;
     int cover = db->getArray(iech, _iptrCover);
     if (cover > 0) continue;
@@ -201,7 +200,7 @@ int SimuBoolean::_generatePrimary(Db* dbin,
 
   // Generate the initial objects
   int draw_more = nbgrain;
-  int iter = 0;
+  int iter      = 0;
   while (draw_more)
   {
     iter++;
@@ -216,7 +215,7 @@ int SimuBoolean::_generatePrimary(Db* dbin,
 
     /* Look for a non-covered grain */
 
-    int rank = (int) (draw_more * law_uniform(0., 1.));
+    int rank = (int)(draw_more * law_uniform(0., 1.));
     int iref = _getRankUncovered(dbin, rank);
     if (iref < 0) return 1;
     dbin->getCoordinatesInPlace(cdgrain, iref);
@@ -228,11 +227,11 @@ int SimuBoolean::_generatePrimary(Db* dbin,
 
     /* Check if the object is compatible with the constraining pores */
 
-    if (! object->isCompatiblePore(dbin)) continue;
+    if (!object->isCompatiblePore(dbin)) continue;
 
     /* Check if object is compatible with the constraining grains */
 
-    if (! object->isCompatibleGrainAdd(dbin)) continue;
+    if (!object->isCompatibleGrainAdd(dbin)) continue;
 
     /* Add the object to the list */
 
@@ -246,7 +245,7 @@ int SimuBoolean::_generatePrimary(Db* dbin,
 
   if (verbose)
   {
-    message("- Number of Initial Objects = %d\n",_getNObjects(1));
+    message("- Number of Initial Objects = %d\n", _getNObjects(1));
     message("- Number of iterations      = %d\n", iter);
   }
 
@@ -259,7 +258,7 @@ int SimuBoolean::_generateSecondary(Db* dbin,
                                     const SimuBooleanParam& boolparam,
                                     bool verbose)
 {
-  int iter = 0;
+  int iter       = 0;
   double tabtime = 0.;
   int nb_average = _getAverageCount(dbout, tokens, boolparam);
 
@@ -281,7 +280,7 @@ int SimuBoolean::_generateSecondary(Db* dbin,
     // This should be the right version
     //    tabtime += law_exponential();
 
-    double ratio = (double) nb_average / (double) (nb_average + nbObject);
+    double ratio = (double)nb_average / (double)(nb_average + nbObject);
 
     if (law_uniform(0., 1.) <= ratio)
     {
@@ -293,11 +292,11 @@ int SimuBoolean::_generateSecondary(Db* dbin,
 
       /* Check if the object is compatible with the constraining pores */
 
-      if (! object->isCompatiblePore(dbin)) continue;
+      if (!object->isCompatiblePore(dbin)) continue;
 
       /* Check if the object is compatible with the constraining grains */
 
-      if (! object->isCompatibleGrainAdd(dbin)) continue;
+      if (!object->isCompatibleGrainAdd(dbin)) continue;
 
       /* Add the object to the list */
 
@@ -326,8 +325,8 @@ int SimuBoolean::_generateSecondary(Db* dbin,
   if (verbose)
   {
     if (dbin != nullptr)
-      message("- Ending number of primary objects  = %d\n",_getNObjects(1));
-    message("- Total number of objects           = %d\n",_getNObjects());
+      message("- Ending number of primary objects  = %d\n", _getNObjects(1));
+    message("- Total number of objects           = %d\n", _getNObjects());
   }
 
   return 0;
@@ -363,14 +362,14 @@ int SimuBoolean::_deleteObject(int mode, Db* dbin)
 
   int count = _getNObjects(mode);
   if (count <= 0) return 1;
-  int rank = (int) (count * law_uniform(0., 1.));
+  int rank = (int)(count * law_uniform(0., 1.));
   int iref = _getObjectRank(mode, rank);
   if (iref < 0) return 1;
 
   /* Check if the object can be deleted */
 
   BooleanObject* object = _objlist[iref];
-  if (! object->isCompatibleGrainDelete(dbin, _iptrCover)) return 1;
+  if (!object->isCompatibleGrainDelete(dbin, _iptrCover)) return 1;
 
   /* Erase the object from the list*/
 
@@ -388,33 +387,33 @@ int SimuBoolean::_deleteObject(int mode, Db* dbin)
 }
 
 int SimuBoolean::_getAverageCount(const DbGrid* dbout,
-                                 const ModelBoolean* tokens,
-                                 const SimuBooleanParam& boolparam)
- {
-   double theta;
-   if (tokens->isFlagStat())
-   {
-     theta = tokens->getThetaCst();
-   }
-   else
-   {
-     VectorDouble vec = dbout->getColumnByLocator(ELoc::P, 0, true);
-     theta = VH::mean(vec);
-   }
+                                  const ModelBoolean* tokens,
+                                  const SimuBooleanParam& boolparam)
+{
+  double theta;
+  if (tokens->isFlagStat())
+  {
+    theta = tokens->getThetaCst();
+  }
+  else
+  {
+    VectorDouble vec = dbout->getColumnByLocator(ELoc::P, 0, true);
+    theta            = VH::mean(vec);
+  }
 
-   VectorDouble field = dbout->getExtends();
+  VectorDouble field = dbout->getExtends();
 
-   // Dilate the field (optional)
+  // Dilate the field (optional)
 
-   int ndim = dbout->getNDim();
-   double volume = 1.;
-   for (int idim = 0; idim < ndim; idim++)
-   {
-     field[idim] += 2 * boolparam.getDilate(idim);
-     volume *= field[idim];
-   }
-   return (int) (theta * volume);
- }
+  int ndim      = dbout->getNDim();
+  double volume = 1.;
+  for (int idim = 0; idim < ndim; idim++)
+  {
+    field[idim] += 2 * boolparam.getDilate(idim);
+    volume *= field[idim];
+  }
+  return (int)(theta * volume);
+}
 
 VectorDouble SimuBoolean::extractObjects() const
 {
@@ -468,7 +467,7 @@ int simbool(Db* dbin,
       messerr("Conditional Boolean simulation needs 1 variable");
       return 1;
     }
-    iptr_cover = dbin->addColumnsByConstant(1, 0.,"Cover");
+    iptr_cover = dbin->addColumnsByConstant(1, 0., "Cover");
     if (iptr_cover < 0) return 1;
   }
 
@@ -503,4 +502,4 @@ int simbool(Db* dbin,
   return 0;
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuFFTParam.cpp
+++ b/src/Simulation/SimuFFTParam.cpp
@@ -8,35 +8,35 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/AStringable.hpp"
 #include "Simulation/SimuFFTParam.hpp"
+#include "Basic/AStringable.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 SimuFFTParam::SimuFFTParam(bool flag_aliasing,
                            double percent)
-    : AStringable(),
-      _flagAliasing(flag_aliasing),
-      _percent(percent)
+  : AStringable()
+  , _flagAliasing(flag_aliasing)
+  , _percent(percent)
 {
 }
 
-SimuFFTParam::SimuFFTParam(const SimuFFTParam &r)
-    : AStringable(r),
-      _flagAliasing(r._flagAliasing),
-      _percent(r._percent)
+SimuFFTParam::SimuFFTParam(const SimuFFTParam& r)
+  : AStringable(r)
+  , _flagAliasing(r._flagAliasing)
+  , _percent(r._percent)
 {
 }
 
-SimuFFTParam& SimuFFTParam::operator=(const SimuFFTParam &r)
+SimuFFTParam& SimuFFTParam::operator=(const SimuFFTParam& r)
 {
   if (this != &r)
   {
-    AStringable::operator =(r);
+    AStringable::operator=(r);
     _flagAliasing = r._flagAliasing;
-    _percent = r._percent;
+    _percent      = r._percent;
   }
   return *this;
 }
@@ -55,4 +55,4 @@ String SimuFFTParam::toString(const AStringFormat* /*strfmt*/) const
 
   return sstr.str();
 }
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuPartitionParam.cpp
+++ b/src/Simulation/SimuPartitionParam.cpp
@@ -8,39 +8,39 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/AStringable.hpp"
 #include "Simulation/SimuPartitionParam.hpp"
+#include "Basic/AStringable.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 SimuPartitionParam::SimuPartitionParam(int nbtuba,
                                        double intensity,
                                        const VectorDouble& dilate)
-    : AStringable(),
-      _nbtuba(nbtuba),
-      _intensity(intensity),
-      _dilate(dilate)
+  : AStringable()
+  , _nbtuba(nbtuba)
+  , _intensity(intensity)
+  , _dilate(dilate)
 {
 }
 
-SimuPartitionParam::SimuPartitionParam(const SimuPartitionParam &r)
-    : AStringable(r),
-      _nbtuba(r._nbtuba),
-      _intensity(r._intensity),
-      _dilate(r._dilate)
+SimuPartitionParam::SimuPartitionParam(const SimuPartitionParam& r)
+  : AStringable(r)
+  , _nbtuba(r._nbtuba)
+  , _intensity(r._intensity)
+  , _dilate(r._dilate)
 {
 }
 
-SimuPartitionParam& SimuPartitionParam::operator=(const SimuPartitionParam &r)
+SimuPartitionParam& SimuPartitionParam::operator=(const SimuPartitionParam& r)
 {
   if (this != &r)
   {
-    AStringable::operator =(r);
-    _nbtuba = r._nbtuba;
+    AStringable::operator=(r);
+    _nbtuba    = r._nbtuba;
     _intensity = r._intensity;
-    _dilate = r._dilate;
+    _dilate    = r._dilate;
   }
   return *this;
 }
@@ -55,8 +55,8 @@ String SimuPartitionParam::toString(const AStringFormat* /*strfmt*/) const
 
   sstr << "Intensity of Poisson Law = " << _intensity << std::endl;
   sstr << "Number of Bands used for valuation simulation = " << _nbtuba << std::endl;
-  if (! _dilate.empty())
-    sstr << toVector("Dilation (used for Poisson)",_dilate);
+  if (!_dilate.empty())
+    sstr << toVector("Dilation (used for Poisson)", _dilate);
 
   return sstr.str();
 }
@@ -67,4 +67,4 @@ double SimuPartitionParam::getDilate(int idim) const
   return _dilate[idim];
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuRefineParam.cpp
+++ b/src/Simulation/SimuRefineParam.cpp
@@ -8,34 +8,34 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/AStringable.hpp"
 #include "Simulation/SimuRefineParam.hpp"
+#include "Basic/AStringable.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 SimuRefineParam::SimuRefineParam(int nmult, bool flag_SK)
-    : AStringable(),
-      _nmult(nmult),
-      _flagSK(flag_SK)
+  : AStringable()
+  , _nmult(nmult)
+  , _flagSK(flag_SK)
 {
 }
 
-SimuRefineParam::SimuRefineParam(const SimuRefineParam &r)
-    : AStringable(r),
-      _nmult(r._nmult),
-      _flagSK(r._flagSK)
+SimuRefineParam::SimuRefineParam(const SimuRefineParam& r)
+  : AStringable(r)
+  , _nmult(r._nmult)
+  , _flagSK(r._flagSK)
 {
 }
 
-SimuRefineParam& SimuRefineParam::operator=(const SimuRefineParam &r)
+SimuRefineParam& SimuRefineParam::operator=(const SimuRefineParam& r)
 {
   if (this != &r)
   {
-    AStringable::operator =(r);
-    _nmult = r._nmult;
-    _flagSK = r._flagSK ;
+    AStringable::operator=(r);
+    _nmult  = r._nmult;
+    _flagSK = r._flagSK;
   }
   return *this;
 }
@@ -57,4 +57,4 @@ String SimuRefineParam::toString(const AStringFormat* /*strfmt*/) const
   return sstr.str();
 }
 
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuSpectral.cpp
+++ b/src/Simulation/SimuSpectral.cpp
@@ -11,54 +11,54 @@
 #include "Simulation/SimuSpectral.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/VectorHelper.hpp"
-#include "Stats/Classical.hpp"
-#include "Matrix/MatrixDense.hpp"
-#include "Matrix/MatrixFactory.hpp"
-#include "Model/Model.hpp"
 #include "Covariances/CorAniso.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "Db/Db.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixFactory.hpp"
+#include "Model/Model.hpp"
+#include "Stats/Classical.hpp"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
-  SimuSpectral::  SimuSpectral(const Model* model)
-    : _ndim(0),
-      _ns(0),
-      _isPrepared(false),
-      _phi(),
-      _gamma(),
-      _omega(),
-      _spSims(),
-      _model(model)
+SimuSpectral::SimuSpectral(const Model* model)
+  : _ndim(0)
+  , _ns(0)
+  , _isPrepared(false)
+  , _phi()
+  , _gamma()
+  , _omega()
+  , _spSims()
+  , _model(model)
 {
 }
 
-  SimuSpectral::  SimuSpectral(const   SimuSpectral &r)
-    : _ndim(r._ndim),
-      _ns(r._ns),
-      _isPrepared(r._isPrepared),
-      _phi(r._phi),
-      _gamma(r._gamma),
-      _omega(r._omega),
-      _spSims(r._spSims),
-      _model(r._model)
+SimuSpectral::SimuSpectral(const SimuSpectral& r)
+  : _ndim(r._ndim)
+  , _ns(r._ns)
+  , _isPrepared(r._isPrepared)
+  , _phi(r._phi)
+  , _gamma(r._gamma)
+  , _omega(r._omega)
+  , _spSims(r._spSims)
+  , _model(r._model)
 {
 }
 
-  SimuSpectral&   SimuSpectral::operator=(const   SimuSpectral &r)
+SimuSpectral& SimuSpectral::operator=(const SimuSpectral& r)
 {
   if (this != &r)
   {
-    _ndim = r._ndim;
-    _ns = r._ns;
+    _ndim       = r._ndim;
+    _ns         = r._ns;
     _isPrepared = r._isPrepared;
-    _phi = r._phi;
-    _gamma = r._gamma;
-    _omega = r._omega;
-    _spSims = r._spSims;
-    _model = r._model;
+    _phi        = r._phi;
+    _gamma      = r._gamma;
+    _omega      = r._omega;
+    _spSims     = r._spSims;
+    _model      = r._model;
   }
   return *this;
 }
@@ -83,7 +83,7 @@ int SimuSpectral::simulate(int ns, int seed, bool verbose, int nd)
     messerr("A Model should be attached beforehand");
     return 1;
   }
-  if (! isValidForSpectral(_model)) return 1;
+  if (!isValidForSpectral(_model)) return 1;
   if (ns <= 0)
   {
     messerr("The number of simulated harmonic components should be positive");
@@ -96,17 +96,17 @@ int SimuSpectral::simulate(int ns, int seed, bool verbose, int nd)
   }
 
   _ndim = _model->getNDim();
-  _ns = ns;
+  _ns   = ns;
 
   // Cleaning any previously allocated memory
   _phi.clear();
   _gamma.clear();
-  _omega.reset(0,0);
+  _omega.reset(0, 0);
   _spSims.clear();
 
   if (seed > 0) law_set_random_seed(seed);
 
-  _phi = VectorDouble(_ns);
+  _phi       = VectorDouble(_ns);
   double pi2 = 2. * GV_PI;
   for (int is = 0; is < _ns; is++)
     _phi[is] = pi2 * law_uniform();
@@ -144,8 +144,8 @@ void SimuSpectral::_simulateOnSphere(int nd, bool verbose)
   VectorDouble spectrum = _model->getCovAniso(0)->evalSpectrumOnSphere(nd);
 
   // Simulate vector N
-  int n = 0;
-  double p = 0.;
+  int n       = 0;
+  double p    = 0.;
   VectorInt N = VectorInt(_ns, 0);
   while (p < maxU && n < _ns)
   {
@@ -165,7 +165,7 @@ void SimuSpectral::_simulateOnSphere(int nd, bool verbose)
   VectorInt Kabs = K;
   for (int is = 0; is < _ns; is++) Kabs[is] = ABS(Kabs[is]);
   VectorInt orders = VH::unique(Kabs);
-  int order_size = (int) orders.size();
+  int order_size   = (int)orders.size();
 
   // Loop on the orders
   _spSims.resize(order_size);
@@ -196,24 +196,24 @@ void SimuSpectral::_simulateOnSphere(int nd, bool verbose)
     }
 
     // Create the table of contingency
-    _spSims[kk]._k = kk;
+    _spSims[kk]._k      = kk;
     _spSims[kk]._countP = countP;
     _spSims[kk]._countM = countM;
-    _spSims[kk]._tab = contingencyTable2(Ns, Is);
+    _spSims[kk]._tab    = contingencyTable2(Ns, Is);
   }
 
   // Optional printout
   if (verbose) _printSpSims(1);
 }
 
-void SimuSpectral::_computeOnRn(Db *dbout, int iuid, bool verbose)
+void SimuSpectral::_computeOnRn(Db* dbout, int iuid, bool verbose)
 {
   int nech = dbout->getNSample(true);
 
   // Preparation
   MatrixSquare tensor = _model->getCovAniso(0)->getAniso().getTensorInverse();
-  double scale = sqrt(2. / _ns);
-  AMatrix *res = MatrixFactory::prodMatMat(&_omega, &tensor);
+  double scale        = sqrt(2. / _ns);
+  AMatrix* res        = MatrixFactory::prodMatMat(&_omega, &tensor);
 
   // Optional printout
   if (verbose)
@@ -254,13 +254,13 @@ void SimuSpectral::_computeOnRn(Db *dbout, int iuid, bool verbose)
  * @param verbose Verbose flag
  * @param namconv Naming convention (only used when 'iuid' == 0)
  */
-int SimuSpectral::compute(Db *dbout,
+int SimuSpectral::compute(Db* dbout,
                           int iuid,
                           bool verbose,
-                          const NamingConvention &namconv)
+                          const NamingConvention& namconv)
 {
-  int nech = dbout->getNSample(true);
-  int ndim = dbout->getNDim();
+  int nech             = dbout->getNSample(true);
+  int ndim             = dbout->getNDim();
   bool flagNewVariable = (iuid <= 0);
 
   if (ndim != _ndim)
@@ -274,7 +274,7 @@ int SimuSpectral::compute(Db *dbout,
     messerr("'dbout' must have a positive number of active samples");
     return 1;
   }
-  if (! _isPrepared)
+  if (!_isPrepared)
   {
     messerr("You should run 'simulate' beforehand");
     return 1;
@@ -378,8 +378,8 @@ void SimuSpectral::_printSpSims(int status)
 {
   int totalP = 0;
   int totalM = 0;
-  int ns = (int) _spSims.size();
-  mestitle(1,"List of Orders");
+  int ns     = (int)_spSims.size();
+  mestitle(1, "List of Orders");
   for (int is = 0; is < ns; is++)
   {
     _printSpSim(_spSims[is], status);
@@ -396,12 +396,12 @@ void SimuSpectral::_printSpSims(int status)
 
 void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
 {
-  int np   = dbout->getNSample(true);
+  int np = dbout->getNSample(true);
 
-  int nb = 0;
+  int nb    = 0;
   int N_max = -9999;
   VectorInt K_list;
-  for (int is = 0, size = (int) _spSims.size(); is < size; is++)
+  for (int is = 0, size = (int)_spSims.size(); is < size; is++)
   {
     nb += _spSims[is]._countP + _spSims[is]._countM;
     K_list.push_back(_spSims[is]._k);
@@ -421,7 +421,7 @@ void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
   }
 
   // Simulation
-  VectorDouble phi = dbout->getOneCoordinate(0);
+  VectorDouble phi   = dbout->getOneCoordinate(0);
   VectorDouble theta = dbout->getOneCoordinate(1);
   VectorDouble sim(np, 0.);
   VectorDouble x(np);
@@ -429,12 +429,12 @@ void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
   for (int i = 0; i < np; i++)
   {
     double cosval = cos(theta[i]);
-    x[i] = cosval;
-    w[i] = sqrt(1 - cosval * cosval);
+    x[i]          = cosval;
+    w[i]          = sqrt(1 - cosval * cosval);
   }
 
-  int K_idx = 0; // Index running in spectrum list
-  int jk = 0;    // Index running in components
+  int K_idx   = 0; // Index running in spectrum list
+  int jk      = 0; // Index running in components
   int cumComp = 0;
   VectorDouble val(np, 0.);
   VectorDouble Pmm(np, 0.);
@@ -456,8 +456,8 @@ void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
 
     if (VH::whereElement(K_list, m) >= 0)
     {
-      const spSim &spsimK = _spSims[K_idx++];
-      VectorInt N_list = _getKeys1(spsimK);
+      const spSim& spsimK = _spSims[K_idx++];
+      VectorInt N_list    = _getKeys1(spsimK);
 
       if (verbose)
         message(">>> Simulating order K = %d: component number = %d\n", m,
@@ -476,8 +476,7 @@ void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
         else
         {
           double a = sqrt((2. * n + 1.) * (2. * n - 1.) / (n - m) / (n + m));
-          double b = sqrt((2. * n + 1.) / (2. * n - 3.) * (n - 1. - m) / (n - m) * (n - 1. + m)
-              / (n + m));
+          double b = sqrt((2. * n + 1.) / (2. * n - 3.) * (n - 1. - m) / (n - m) * (n - 1. + m) / (n + m));
           for (int ip = 0; ip < np; ip++)
             Plm[ip] = a * x[ip] * P1[ip] - b * P2[ip];
           P2 = P1;
@@ -498,11 +497,11 @@ void SimuSpectral::_computeOnSphere(Db* dbout, int iuid, bool verbose)
                     cumComp, jk);
           }
 
-          for (int ii = 0, ncomp = (int) valComp.size(); ii < ncomp; ii++)
+          for (int ii = 0, ncomp = (int)valComp.size(); ii < ncomp; ii++)
           {
             if (nbrComp[ii] > 0)
             {
-              double s = valComp[ii];
+              double s   = valComp[ii];
               double fac = (s > 0) ? 1. : pow(-1., m);
 
               for (int ns = 0; ns < nbrComp[ii]; ns++)
@@ -548,7 +547,7 @@ bool SimuSpectral::isValidForSpectral(const Model* model)
   for (int is = 0; is < model->getNCov(); is++)
   {
     const CovAniso* cova = model->getCovAniso(is);
-    if (! cova->isValidForSpectral())
+    if (!cova->isValidForSpectral())
     {
       messerr("The current structure is not valid for Spectral Simulation on Rn");
       return false;
@@ -572,15 +571,15 @@ bool SimuSpectral::isValidForSpectral(const Model* model)
  *
  * @note The conditional version is not yet available
  */
-int simuSpectral(Db *dbin,
-                 Db *dbout,
-                 Model *model,
+int simuSpectral(Db* dbin,
+                 Db* dbout,
+                 Model* model,
                  int nbsimu,
                  int seed,
                  int ns,
                  int nd,
                  bool verbose,
-                 const NamingConvention &namconv)
+                 const NamingConvention& namconv)
 {
   if (dbin != nullptr)
   {
@@ -621,4 +620,4 @@ int simuSpectral(Db *dbin,
 
   return 0;
 }
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuSpherical.cpp
+++ b/src/Simulation/SimuSpherical.cpp
@@ -8,28 +8,27 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
-
-#include "Db/DbGrid.hpp"
-#include "Db/Db.hpp"
-#include "Mesh/MeshSpherical.hpp"
-#include "Model/Model.hpp"
 #include "Simulation/SimuSpherical.hpp"
-#include "Simulation/SimuSphericalParam.hpp"
-#include "Simulation/ACalcSimulation.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
 #include "Core/Keypair.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Mesh/MeshSpherical.hpp"
+#include "Model/Model.hpp"
+#include "Simulation/ACalcSimulation.hpp"
+#include "Simulation/SimuSphericalParam.hpp"
+#include "geoslib_old_f.h"
 
-#include <math.h>
+#include <cmath>
 
-#define IPTR(ix,iy)        ((iy) * nx + (ix))
-#define DISCRET(idisc)     (GV_PI * (0.5 + (idisc)) / ((double) ndisc))
+#define IPTR(ix, iy)   ((iy) * nx + (ix))
+#define DISCRET(idisc) (GV_PI * (0.5 + (idisc)) / ((double)ndisc))
 
 namespace gstlrn
 {
 SimuSpherical::SimuSpherical(int nbsimu, int seed)
-    : ACalcSimulation(nbsimu, seed)
+  : ACalcSimulation(nbsimu, seed)
 {
 }
 
@@ -37,18 +36,18 @@ SimuSpherical::~SimuSpherical()
 {
 }
 
-int SimuSpherical::simulate(DbGrid *db,
-                            Model *model,
+int SimuSpherical::simulate(DbGrid* db,
+                            Model* model,
                             const SimuSphericalParam& sphepar,
                             int iptr,
                             bool verbose)
 {
   int special = sphepar.getSpecial();
-  int degmax = sphepar.getDegmax();
-  int nx = db->getNX(0);
-  int ny = db->getNX(1);
-  int nech = db->getNSample();
-  int shunt  = (int) get_keypone("Simsph_Shunt",0);
+  int degmax  = sphepar.getDegmax();
+  int nx      = db->getNX(0);
+  int ny      = db->getNX(1);
+  int nech    = db->getNSample();
+  int shunt   = (int)get_keypone("Simsph_Shunt", 0);
   law_set_random_seed(getSeed());
 
   /* Core allocation */
@@ -57,16 +56,16 @@ int SimuSpherical::simulate(DbGrid *db,
   VectorDouble phase;
   VectorInt degree;
   VectorInt order;
-  int flag_test  = (int) get_keypone("Simsph_Test",0);
+  int flag_test = (int)get_keypone("Simsph_Test", 0);
   if (flag_test)
   {
     nbf = 1;
     phase.resize(nbf);
     degree.resize(nbf);
     order.resize(nbf);
-    phase[0]  = get_keypone("Simsph_Test_Phase",0);
-    degree[0] = (int) get_keypone("Simsph_Test_Degree",1);
-    order[0]  = (int) get_keypone("Simsph_Test_Order",0);
+    phase[0]  = get_keypone("Simsph_Test_Phase", 0);
+    degree[0] = (int)get_keypone("Simsph_Test_Degree", 1);
+    order[0]  = (int)get_keypone("Simsph_Test_Order", 0);
   }
   else
   {
@@ -86,14 +85,14 @@ int SimuSpherical::simulate(DbGrid *db,
   else
     freqs = _spectrum_any(model, sphepar);
   if (freqs.empty()) return 1;
-  set_keypair("Simsph_Spectrum_Frequencies",1,(int) freqs.size(),1,freqs.data());
+  set_keypair("Simsph_Spectrum_Frequencies", 1, (int)freqs.size(), 1, freqs.data());
 
   /* Optional printout */
 
   if (verbose)
   {
     message("Random generation seed    = %d\n", law_get_random_seed());
-    message("Number of frequencies     = %d\n", (int) freqs.size());
+    message("Number of frequencies     = %d\n", (int)freqs.size());
   }
   _spectrum_normalize(verbose, freqs);
   if (shunt == 1) return 0;
@@ -116,16 +115,16 @@ int SimuSpherical::simulate(DbGrid *db,
   if (_check_degree_order(freqs, degree, order, verbose)) return 1;
 
   // Saving option
-  set_keypair_int("Simsph_Array_Degree",1,nbf,1,degree.data());
-  set_keypair_int("Simsph_Array_Order" ,1,nbf,1,order.data());
-  set_keypair    ("Simsph_Array_Phase" ,1,nbf,1,phase.data());
+  set_keypair_int("Simsph_Array_Degree", 1, nbf, 1, degree.data());
+  set_keypair_int("Simsph_Array_Order", 1, nbf, 1, order.data());
+  set_keypair("Simsph_Array_Phase", 1, nbf, 1, phase.data());
   if (shunt == 2) return 0;
 
   /* Loop on the samples of the Data Base */
   /* We benefit in writing this as a double loop on coordinates */
   /* as some calculations can be factorized as they only concern latitude */
 
-  int ecr = 0;
+  int ecr  = 0;
   int ntot = nbf * nech;
   for (int iy = 0; iy < ny; iy++)
   {
@@ -133,16 +132,16 @@ int SimuSpherical::simulate(DbGrid *db,
     for (int ibf = 0; ibf < nbf; ibf++)
     {
       double degree_loc = degree[ibf];
-      double order_loc = order[ibf];
-      double phase_loc = phase[ibf];
-      double t1 = ut_flegendre((int) degree_loc, (int) order_loc, theta);
+      double order_loc  = order[ibf];
+      double phase_loc  = phase[ibf];
+      double t1         = ut_flegendre((int)degree_loc, (int)order_loc, theta);
       for (int ix = 0; ix < nx; ix++, ecr++)
       {
         int jech = IPTR(ix, iy);
         mes_process("Simulation on Sphere", ntot, ecr);
         if (!db->isActive(jech)) continue;
-        double phi = ut_deg2rad(db->getCoordinate(jech, 0));       // Longitude [0,360]
-        double t2 = cos(phi * order_loc + phase_loc);
+        double phi = ut_deg2rad(db->getCoordinate(jech, 0)); // Longitude [0,360]
+        double t2  = cos(phi * order_loc + phase_loc);
         db->updArray(jech, iptr, EOperator::ADD, t1 * t2);
       }
     }
@@ -150,7 +149,7 @@ int SimuSpherical::simulate(DbGrid *db,
 
   /* Final normalization */
 
-  double val = 2. / sqrt((double) nbf);
+  double val = 2. / sqrt((double)nbf);
   for (int iech = 0; iech < nech; iech++)
   {
     if (db->isActive(iech)) db->updArray(iech, iptr, EOperator::DIVIDE, val);
@@ -158,15 +157,15 @@ int SimuSpherical::simulate(DbGrid *db,
   return 0;
 }
 
-VectorDouble SimuSpherical::simulate_mesh(MeshSpherical *mesh,
-                                          Model *model,
-                                          const SimuSphericalParam &sphepar,
+VectorDouble SimuSpherical::simulate_mesh(MeshSpherical* mesh,
+                                          Model* model,
+                                          const SimuSphericalParam& sphepar,
                                           bool verbose)
 {
-  int nbf = sphepar.getNbf();
+  int nbf     = sphepar.getNbf();
   int special = sphepar.getSpecial();
-  int degmax = sphepar.getDegmax();
-  int nech = mesh->getNApices();
+  int degmax  = sphepar.getDegmax();
+  int nech    = mesh->getNApices();
   law_set_random_seed(getSeed());
 
   /* Core allocation */
@@ -192,7 +191,7 @@ VectorDouble SimuSpherical::simulate_mesh(MeshSpherical *mesh,
   if (verbose)
   {
     message("Random generation seed    = %d\n", law_get_random_seed());
-    message("Number of frequencies     = %d\n", (int) freqs.size());
+    message("Number of frequencies     = %d\n", (int)freqs.size());
   }
   _spectrum_normalize(verbose, freqs);
 
@@ -221,19 +220,19 @@ VectorDouble SimuSpherical::simulate_mesh(MeshSpherical *mesh,
     for (int ibf = 0; ibf < nbf; ibf++)
     {
       double degree_loc = degree[ibf];
-      double order_loc = order[ibf];
-      double phase_loc = phase[ibf];
-      double t1 = ut_flegendre((int) degree_loc, (int) order_loc, theta);
+      double order_loc  = order[ibf];
+      double phase_loc  = phase[ibf];
+      double t1         = ut_flegendre((int)degree_loc, (int)order_loc, theta);
 
-      double phi = ut_deg2rad(mesh->getApexCoor(iech, 0));  // Longitude [0,360]
-      double t2 = cos(phi * order_loc + phase_loc);
+      double phi = ut_deg2rad(mesh->getApexCoor(iech, 0)); // Longitude [0,360]
+      double t2  = cos(phi * order_loc + phase_loc);
       simu[iech] += t1 * t2;
     }
   }
 
   /* Final normalization */
 
-  double val = 2. / sqrt((double) nbf);
+  double val = 2. / sqrt((double)nbf);
   for (int iech = 0; iech < nech; iech++)
     simu[iech] /= val;
 
@@ -252,16 +251,16 @@ VectorDouble SimuSpherical::simulate_mesh(MeshSpherical *mesh,
 VectorDouble SimuSpherical::_spectrum_chentsov(const SimuSphericalParam& sphepar)
 {
   VectorDouble freqs;
-  int ifreq = 0;
+  int ifreq    = 0;
   double total = 0.;
 
   /* Loop on the spectrum items */
 
-  freqs.push_back(0.);            // ifreq = 0
+  freqs.push_back(0.); // ifreq = 0
   total += freqs[ifreq];
   ifreq++;
 
-  freqs.push_back(0.75);          // ifreq = 1
+  freqs.push_back(0.75); // ifreq = 1
   total += freqs[ifreq];
   ifreq++;
 
@@ -270,7 +269,7 @@ VectorDouble SimuSpherical::_spectrum_chentsov(const SimuSphericalParam& sphepar
     freqs.push_back(0.);
     ifreq++;
 
-    double ratio = ((double) (ifreq - 2.)) / ((double) (ifreq + 1.));
+    double ratio = ((double)(ifreq - 2.)) / ((double)(ifreq + 1.));
     double value = freqs[ifreq - 2] * (2. * ifreq + 1.) / (2. * ifreq - 3.);
     value *= ratio * ratio;
     freqs.push_back(value);
@@ -293,14 +292,14 @@ VectorDouble SimuSpherical::_spectrum_chentsov(const SimuSphericalParam& sphepar
  ** \param[in]  sphepar SimuSphericalParam structure
  **
  *****************************************************************************/
-VectorDouble SimuSpherical::_spectrum_exponential(Model *model,
+VectorDouble SimuSpherical::_spectrum_exponential(Model* model,
                                                   const SimuSphericalParam& sphepar)
 {
   VectorDouble freqs;
-  int ifreq = 0;
+  int ifreq    = 0;
   double total = 0.;
-  double fcs = 1. / model->getCovAniso(0)->getScaleIso();
-  double fcs2 = fcs * fcs;
+  double fcs   = 1. / model->getCovAniso(0)->getScaleIso();
+  double fcs2  = fcs * fcs;
   double expfc = exp(-fcs * GV_PI);
 
   /* Core allocation */
@@ -323,7 +322,7 @@ VectorDouble SimuSpherical::_spectrum_exponential(Model *model,
   {
     double r1 = ifreq + 1.;
     double r2 = ifreq - 2.;
-    value  = freqs[ifreq - 2] * (2. * ifreq + 1.) / (2. * ifreq - 3.);
+    value     = freqs[ifreq - 2] * (2. * ifreq + 1.) / (2. * ifreq - 3.);
     value *= (fcs2 + r2 * r2) / (fcs2 + r1 * r1);
     freqs.push_back(value);
     total += freqs[ifreq];
@@ -346,16 +345,16 @@ VectorDouble SimuSpherical::_spectrum_exponential(Model *model,
  ** \param[in]  sphepar SimuSphericalParam structure
  **
  *****************************************************************************/
-VectorDouble SimuSpherical::_spectrum_any(Model *model,
+VectorDouble SimuSpherical::_spectrum_any(Model* model,
                                           const SimuSphericalParam& sphepar)
 {
   int ndisc = sphepar.getNdisc();
-  ndisc  = (int) get_keypone("Simsph_Ndisc",ndisc);
+  ndisc     = (int)get_keypone("Simsph_Ndisc", ndisc);
   VectorDouble freqs;
   VectorDouble dd(2);
   dd[0] = dd[1] = 0.;
-  int ifreq = 0;
-  double dincr = GV_PI / ((double) sphepar.getNdisc());
+  int ifreq     = 0;
+  double dincr  = GV_PI / ((double)sphepar.getNdisc());
   VectorDouble covs(ndisc);
 
   /* Calculate the discretized covariance values */
@@ -363,8 +362,8 @@ VectorDouble SimuSpherical::_spectrum_any(Model *model,
   for (int idisc = 0; idisc < ndisc; idisc++)
   {
     double alpha = DISCRET(idisc);
-    dd[0] = 2. * sin(alpha / 2.);
-    double ca = 0.;
+    dd[0]        = 2. * sin(alpha / 2.);
+    double ca    = 0.;
     for (int icova = 0; icova < model->getNCov(); icova++)
       ca += model->evalCovFromIncr(dd, icova, ECalcMember::LHS);
     covs[idisc] = ca;
@@ -381,8 +380,8 @@ VectorDouble SimuSpherical::_spectrum_any(Model *model,
     for (int idisc = 0; idisc < ndisc; idisc++)
     {
       double alpha = DISCRET(idisc);
-      double cosa = cos(alpha);
-      double sina = sin(alpha);
+      double cosa  = cos(alpha);
+      double sina  = sin(alpha);
       an += covs[idisc] * sina * ut_legendre(ifreq, cosa);
     }
     double value = an * dincr * sqrt((2. * ifreq + 1) / 2.);
@@ -412,7 +411,7 @@ VectorDouble SimuSpherical::_spectrum_any(Model *model,
  *****************************************************************************/
 void SimuSpherical::_spectrum_normalize(int verbose, VectorDouble& freqs)
 {
-  int nfreq = (int) freqs.size();
+  int nfreq     = (int)freqs.size();
   double totpos = 0.;
   double totneg = 0.;
   for (int ifreq = 0; ifreq < nfreq; ifreq++)
@@ -449,8 +448,8 @@ void SimuSpherical::_spectrum_normalize(int verbose, VectorDouble& freqs)
  *****************************************************************************/
 int SimuSpherical::_gdiscrete(VectorDouble& freqs)
 {
-  int nfreq = (int) freqs.size();
-  double u = law_uniform(0., 1.);
+  int nfreq = (int)freqs.size();
+  double u  = law_uniform(0., 1.);
 
   double partvec = 0.;
   for (int ifreq = 0; ifreq < nfreq; ifreq++)
@@ -478,10 +477,10 @@ int SimuSpherical::_check_degree_order(const VectorDouble& freqs,
                                        VectorInt& order,
                                        int verbose)
 {
-  int nbf = (int) degree.size();
+  int nbf    = (int)degree.size();
   int degmax = 0;
-  int nfreq  = (int) freqs.size();
-  int ordmin =  nfreq;
+  int nfreq  = (int)freqs.size();
+  int ordmin = nfreq;
   int ordmax = -nfreq;
 
   for (int ibf = 0; ibf < nbf; ibf++)
@@ -510,4 +509,4 @@ bool SimuSpherical::_run()
 {
   return true;
 }
-}
+} // namespace gstlrn

--- a/src/Simulation/SimuSubstitutionParam.cpp
+++ b/src/Simulation/SimuSubstitutionParam.cpp
@@ -8,12 +8,12 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/AStringable.hpp"
 #include "Simulation/SimuSubstitutionParam.hpp"
+#include "Basic/AStringable.hpp"
 
-#include <math.h>
+#include <cmath>
 
-#define TRANS(i,j)     (_trans[(j) + _nfacies * (i)])
+#define TRANS(i, j) (_trans[(j) + _nfacies * (i)])
 
 namespace gstlrn
 {
@@ -22,57 +22,57 @@ SimuSubstitutionParam::SimuSubstitutionParam(int nfacies,
                                              bool flag_direct,
                                              bool flag_coding,
                                              bool flag_orient)
-    : AStringable(),
-      _nfacies(nfacies),
-      _nstates(0),
-      _colfac(-1),
-      _flagDirect(flag_direct),
-      _flagCoding(flag_coding),
-      _flagOrient(flag_orient),
-      _flagAuto(true),
-      _intensity(intensity),
-      _factor(0.),
-      _colang(),
-      _vector(),
-      _trans()
+  : AStringable()
+  , _nfacies(nfacies)
+  , _nstates(0)
+  , _colfac(-1)
+  , _flagDirect(flag_direct)
+  , _flagCoding(flag_coding)
+  , _flagOrient(flag_orient)
+  , _flagAuto(true)
+  , _intensity(intensity)
+  , _factor(0.)
+  , _colang()
+  , _vector()
+  , _trans()
 {
-  (void) isValid();
+  (void)isValid();
 }
 
-SimuSubstitutionParam::SimuSubstitutionParam(const SimuSubstitutionParam &r)
-    : AStringable(r),
-      _nfacies(r._nfacies),
-      _nstates(r._nstates),
-      _colfac(r._colfac),
-      _flagDirect(r._flagDirect),
-      _flagCoding(r._flagCoding),
-      _flagOrient(r._flagOrient),
-      _flagAuto(r._flagAuto),
-      _intensity(r._intensity),
-      _factor(r._factor),
-      _colang(r._colang),
-      _vector(r._vector),
-      _trans(r._trans)
+SimuSubstitutionParam::SimuSubstitutionParam(const SimuSubstitutionParam& r)
+  : AStringable(r)
+  , _nfacies(r._nfacies)
+  , _nstates(r._nstates)
+  , _colfac(r._colfac)
+  , _flagDirect(r._flagDirect)
+  , _flagCoding(r._flagCoding)
+  , _flagOrient(r._flagOrient)
+  , _flagAuto(r._flagAuto)
+  , _intensity(r._intensity)
+  , _factor(r._factor)
+  , _colang(r._colang)
+  , _vector(r._vector)
+  , _trans(r._trans)
 {
 }
 
-SimuSubstitutionParam& SimuSubstitutionParam::operator=(const SimuSubstitutionParam &r)
+SimuSubstitutionParam& SimuSubstitutionParam::operator=(const SimuSubstitutionParam& r)
 {
   if (this != &r)
   {
-    AStringable::operator =(r);
-    _nfacies = r._nfacies;
-    _nstates = r._nstates;
-    _colfac = r._colfac;
+    AStringable::operator=(r);
+    _nfacies    = r._nfacies;
+    _nstates    = r._nstates;
+    _colfac     = r._colfac;
     _flagDirect = r._flagDirect;
     _flagCoding = r._flagCoding;
     _flagOrient = r._flagOrient;
-    _flagAuto = r._flagAuto;
-    _intensity = r._intensity;
-    _factor = r._factor;
-    _colang = r._colang;
-    _vector = r._vector;
-    _trans = r._trans;
+    _flagAuto   = r._flagAuto;
+    _intensity  = r._intensity;
+    _factor     = r._factor;
+    _colang     = r._colang;
+    _vector     = r._vector;
+    _trans      = r._trans;
   }
   return *this;
 }
@@ -86,7 +86,7 @@ String SimuSubstitutionParam::toString(const AStringFormat* /*strfmt*/) const
   std::stringstream sstr;
 
   sstr << "Number of Facies = " << _nfacies << std::endl;
-  if (! _flagAuto)
+  if (!_flagAuto)
     sstr << "Number of States = " << _nstates << std::endl;
   sstr << "Intensity of Poisson Point Process = " << _intensity << std::endl;
   if (_flagDirect)
@@ -99,12 +99,11 @@ String SimuSubstitutionParam::toString(const AStringFormat* /*strfmt*/) const
     sstr << "Coding not performed: Result is the Direction information" << std::endl;
   if (_flagOrient)
     sstr << toVector("Vector orthogonal to desorientation layering", _vector);
-  sstr << "Factor for desorientation strength (0: isotropic; 1: stratified) = " <<
-      _factor << std::endl;
+  sstr << "Factor for desorientation strength (0: isotropic; 1: stratified) = " << _factor << std::endl;
   sstr << toVector("Transition probability matrix", _trans);
   if (_colfac >= 0)
     sstr << "Attribute rank for desorientation factor = " << _colfac << std::endl;
-  if (! _colang.empty())
+  if (!_colang.empty())
     sstr << toVector("Attribute ranks for Desorientation Vector", _colang);
 
   return sstr.str();
@@ -137,7 +136,7 @@ bool SimuSubstitutionParam::isValid(bool verbose)
   }
   else
   {
-    if (! _isValidTransition(verbose))
+    if (!_isValidTransition(verbose))
       _trans = VectorDouble(_nfacies * _nfacies, 1. / _nfacies);
   }
 
@@ -145,7 +144,7 @@ bool SimuSubstitutionParam::isValid(bool verbose)
 
   if (isFlagCoding())
   {
-    if (! _isIrreductibility(verbose)) return false;
+    if (!_isIrreductibility(verbose)) return false;
   }
 
   return true;
@@ -170,24 +169,24 @@ bool SimuSubstitutionParam::_isIrreductibility(bool verbose)
     double total = 0.;
     for (int j = 0; j < _nfacies; j++)
     {
-      if (TRANS(i,j) < 0. || TRANS(i,j) > 1.) return false;
+      if (TRANS(i, j) < 0. || TRANS(i, j) > 1.) return false;
       total += TRANS(i, j);
     }
     if (total <= 0.) return false;
     for (int j = 0; j < _nfacies; j++)
-      TRANS(i,j) /= total;
+      TRANS(i, j) /= total;
   }
 
   /* Check the irreductibility */
 
   VectorInt flag(_nfacies);
-  flag[0] = 0;
+  flag[0]  = 0;
   int nend = 0;
   int ndeb = 0;
   for (int i = 1; i < _nfacies; i++)
   {
     flag[i] = 0;
-    if (TRANS(i,0) > 0)
+    if (TRANS(i, 0) > 0)
     {
       flag[i] = 1;
       nend++;
@@ -199,7 +198,7 @@ bool SimuSubstitutionParam::_isIrreductibility(bool verbose)
     for (int i = 0; i < _nfacies; i++)
       if (flag[i])
         for (int j = 0; j < _nfacies; j++)
-          if (i != j && TRANS(j,i) > 0) flag[j] = 1;
+          if (i != j && TRANS(j, i) > 0) flag[j] = 1;
     ndeb = nend;
     for (int i = nend = 0; i < _nfacies; i++)
       nend += flag[i];
@@ -224,7 +223,7 @@ bool SimuSubstitutionParam::_isIrreductibility(bool verbose)
 void SimuSubstitutionParam::isValidOrientation(VectorDouble& vector,
                                                bool verbose)
 {
-  int ndim = (int) vector.size();
+  int ndim     = (int)vector.size();
   double total = 0.;
   for (int i = 0; i < ndim; i++)
     total += vector[i] * vector[i];
@@ -236,7 +235,7 @@ void SimuSubstitutionParam::isValidOrientation(VectorDouble& vector,
       messerr("It is set to the first Direction Unit vector");
     }
     vector[0] = 1.;
-    total = 1.;
+    total     = 1.;
   }
   for (int i = 0; i < ndim; i++)
     vector[i] /= sqrt(total);
@@ -275,7 +274,7 @@ void SimuSubstitutionParam::isValidFactor(double* factor, bool verbose) const
 bool SimuSubstitutionParam::isAngleLocal() const
 {
   if (_colang.empty()) return false;
-  for (int i = 0; i < (int) _colang.size(); i++)
+  for (int i = 0; i < (int)_colang.size(); i++)
     if (_colang[i] >= 0) return true;
   return false;
 }
@@ -285,9 +284,9 @@ bool SimuSubstitutionParam::isLocal() const
   return isAngleLocal() || _colfac >= 0;
 }
 
-bool SimuSubstitutionParam::_isValidTransition(bool verbose,double eps)
+bool SimuSubstitutionParam::_isValidTransition(bool verbose, double eps)
 {
-  if ((int) _trans.size() != _nfacies * _nfacies) return false;
+  if ((int)_trans.size() != _nfacies * _nfacies) return false;
 
   for (int irow = 0; irow < _nfacies; irow++)
   {
@@ -300,7 +299,7 @@ bool SimuSubstitutionParam::_isValidTransition(bool verbose,double eps)
     {
       if (verbose)
         messerr("Transition: Sum of elements of row(%d) must be 1 (%lf)",
-                irow+1,total);
+                irow + 1, total);
       return false;
     }
   }
@@ -309,8 +308,8 @@ bool SimuSubstitutionParam::_isValidTransition(bool verbose,double eps)
 
 int SimuSubstitutionParam::getColang(int idim) const
 {
-  if (idim < (int) _colang.size())
+  if (idim < (int)_colang.size())
     return _colang[idim];
   return 0.;
 }
-}
+} // namespace gstlrn

--- a/src/Skin/Skin.cpp
+++ b/src/Skin/Skin.cpp
@@ -8,70 +8,70 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Skin/ISkinFunctions.hpp"
 #include "Skin/Skin.hpp"
-#include "Db/DbGrid.hpp"
 #include "Basic/Law.hpp"
+#include "Db/DbGrid.hpp"
+#include "Skin/ISkinFunctions.hpp"
 
-#include "math.h"
+#include <cmath>
 
-#define SKIN_QUANT  1000
+#define SKIN_QUANT 1000
 
 namespace gstlrn
 {
-static int ndir[4] = { 0, 2, 4, 6 };
-static int invdir[6] = { 1, 0, 3, 2, 5, 4 };
-static int id[6][3] = { { 1, 0, 0 },
-                        { -1, 0, 0 },
-                        { 0, 1, 0 },
-                        { 0, -1, 0 },
-                        { 0, 0, 1 },
-                        { 0, 0, -1 } };
+static int ndir[4]   = {0, 2, 4, 6};
+static int invdir[6] = {1, 0, 3, 2, 5, 4};
+static int id[6][3]  = {{1, 0, 0},
+                        {-1, 0, 0},
+                        {0, 1, 0},
+                        {0, -1, 0},
+                        {0, 0, 1},
+                        {0, 0, -1}};
 
 Skin::Skin(const ISkinFunctions* skf, DbGrid* dbgrid)
-    : _skf(skf),
-      _dbgrid(dbgrid),
-      _nxyz(0),
-      _nval(0),
-      _date(0),
-      _nvalMax(0),
-      _total(0.),
-      _totalMax(0.),
-      _address(),
-      _energy()
+  : _skf(skf)
+  , _dbgrid(dbgrid)
+  , _nxyz(0)
+  , _nval(0)
+  , _date(0)
+  , _nvalMax(0)
+  , _total(0.)
+  , _totalMax(0.)
+  , _address()
+  , _energy()
 {
   if (dbgrid != nullptr)
     _nxyz = _dbgrid->getNSample();
 }
 
-Skin::Skin(const Skin &r)
-    : _skf(r._skf),
-      _dbgrid(r._dbgrid),
-      _nxyz(r._nxyz),
-      _nval(r._nval),
-      _date(r._date),
-      _nvalMax(r._nvalMax),
-      _total(r._total),
-      _totalMax(r._totalMax),
-      _address(r._address),
-      _energy(r._energy)
+Skin::Skin(const Skin& r)
+  : _skf(r._skf)
+  , _dbgrid(r._dbgrid)
+  , _nxyz(r._nxyz)
+  , _nval(r._nval)
+  , _date(r._date)
+  , _nvalMax(r._nvalMax)
+  , _total(r._total)
+  , _totalMax(r._totalMax)
+  , _address(r._address)
+  , _energy(r._energy)
 {
 }
 
-Skin& Skin::operator=(const Skin &r)
+Skin& Skin::operator=(const Skin& r)
 {
   if (this != &r)
   {
-    _skf = r._skf;
-    _dbgrid = r._dbgrid;
-    _nxyz = r._nxyz;
-    _nval = r._nval;
-    _date = r._date;
-    _nvalMax = r._nvalMax;
-    _total = r._total;
+    _skf      = r._skf;
+    _dbgrid   = r._dbgrid;
+    _nxyz     = r._nxyz;
+    _nval     = r._nval;
+    _date     = r._date;
+    _nvalMax  = r._nvalMax;
+    _total    = r._total;
     _totalMax = r._totalMax;
-    _address = r._address;
-    _energy = r._energy;
+    _address  = r._address;
+    _energy   = r._energy;
   }
   return *this;
 }
@@ -108,7 +108,7 @@ double Skin::_getWeight(int ipos, int idir)
 int Skin::_gridShift(const VectorInt& indg0, int dir)
 {
   VectorInt indg = indg0;
-  int ndim = _getNDim();
+  int ndim       = _getNDim();
 
   /* Shift the target grid node and check if it belongs to the grid */
 
@@ -160,7 +160,7 @@ void Skin::_cellDelete(int rank)
 
   _nval--;
   _address[rank] = _address[_nval];
-  _energy[rank] = _energy[_nval];
+  _energy[rank]  = _energy[_nval];
 
   /* Deallocate complementary room in the skin */
 
@@ -215,7 +215,7 @@ int Skin::_cellAdd(int ipos, double energy)
   _address.resize(_nval + 1);
   _energy.resize(_nval + 1);
   _address[rank] = ipos;
-  _energy[rank] = 0.;
+  _energy[rank]  = 0.;
   _nval++;
   if (_nval > _nvalMax) _nvalMax = _nval;
 
@@ -324,7 +324,7 @@ int Skin::remains(bool verbose)
   if (verbose)
     message("Skin iteration:%5d - Length:%4d - Energy:%lf\n",
             _date, _nval, _total);
-  return ((int) _total);
+  return ((int)_total);
 }
 
 /*****************************************************************************/
@@ -335,7 +335,7 @@ int Skin::remains(bool verbose)
  ** \param[out] ipos     Cell location
  **
  *****************************************************************************/
-void Skin::getNext(int *rank, int *ipos)
+void Skin::getNext(int* rank, int* ipos)
 {
   /* Draw a random cell */
 
@@ -351,10 +351,10 @@ void Skin::getNext(int *rank, int *ipos)
     {
       *rank = i;
       *ipos = _address[i];
-      if (! _skf->isToBeFilled(*ipos))
+      if (!_skf->isToBeFilled(*ipos))
         messageAbort(
-            "Elligible cell (%d ipos=%d) of the skin is already filled", i,
-            *ipos);
+          "Elligible cell (%d ipos=%d) of the skin is already filled", i,
+          *ipos);
       return;
     }
   }
@@ -392,8 +392,8 @@ int Skin::unstack(int rank0, int ipos0)
 
     /* Discard the neighboring cell if it cannot filled */
 
-    if (! _skf->isToBeFilled(ecr)) continue;
-    local = (int) _skf->getWeight(ipos0, dir);
+    if (!_skf->isToBeFilled(ecr)) continue;
+    local    = (int)_skf->getWeight(ipos0, dir);
     int rank = _cellAlreadyFilled(ecr);
     if (rank < 0)
     {
@@ -431,4 +431,4 @@ int Skin::_getNDim() const
     return _dbgrid->getNDim();
   return 0;
 }
-}
+} // namespace gstlrn

--- a/src/Space/SpacePoint.cpp
+++ b/src/Space/SpacePoint.cpp
@@ -9,16 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Space/SpacePoint.hpp"
-#include "Basic/AStringable.hpp"
-#include "Space/ASpace.hpp"
 #include "Basic/AException.hpp"
-#include "Basic/VectorHelper.hpp"
+#include "Basic/AStringable.hpp"
 #include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Space/ASpace.hpp"
 #include "Space/ASpaceObject.hpp"
 #include "geoslib_define.h"
 
 #include <cmath>
-#include <math.h>
 
 namespace gstlrn
 {
@@ -105,7 +104,7 @@ SpacePoint SpacePoint::spacePointOnSubspace(int ispace) const
 
   /// TODO : Memory copies
   VectorDouble vec = getSpace()->projCoord(_coord, ispace);
-  const auto sp = getSpace()->getComponent(ispace);
+  const auto sp    = getSpace()->getComponent(ispace);
   SpacePoint p(vec, _iech, sp);
   return p;
 }
@@ -116,7 +115,7 @@ void SpacePoint::setCoords(const double* coord, int size)
     std::cout << "Error: Wrong number of coordinates. Point not modified." << std::endl;
   else
     for (int idim = 0; idim < size; idim++)
-     _coord[idim] = coord[idim];
+      _coord[idim] = coord[idim];
 }
 
 bool SpacePoint::isConsistent(const ASpace* space) const
@@ -152,7 +151,7 @@ void SpacePoint::getIncrementInPlace(VectorDouble& inc, const SpacePoint& pt, in
 
 String SpacePoint::toString(const AStringFormat* /*strfmt*/) const
 {
-  return VH::toStringAsSpan(constvect(_coord.data(),getNDim()));
+  return VH::toStringAsSpan(constvect(_coord.data(), getNDim()));
 }
 
 void SpacePoint::setFFFF()
@@ -163,16 +162,16 @@ void SpacePoint::setFFFF()
 bool SpacePoint::isFFFF() const
 {
   for (int idim = 0, ndim = getNDim(); idim < ndim; idim++)
-    if (! FFFF(_coord[idim])) return false;
+    if (!FFFF(_coord[idim])) return false;
   return true;
 }
 
-double SpacePoint::getCosineToDirection(const SpacePoint &T2,
-                                        const VectorDouble &codir) const
+double SpacePoint::getCosineToDirection(const SpacePoint& T2,
+                                        const VectorDouble& codir) const
 {
   double cosdir = 0.;
-  double dn1 = 0.;
-  double dn2 = 0.;
+  double dn1    = 0.;
+  double dn2    = 0.;
   _delta.clear();
   _delta.resize(getNDim());
   getIncrementInPlace(_delta, T2);
@@ -187,12 +186,12 @@ double SpacePoint::getCosineToDirection(const SpacePoint &T2,
   return (cosdir / sqrt(prod));
 }
 
-double SpacePoint::getOrthogonalDistance(const SpacePoint &P2,
-                                         const VectorDouble &codir) const
+double SpacePoint::getOrthogonalDistance(const SpacePoint& P2,
+                                         const VectorDouble& codir) const
 {
-  double dn1 = 0.;
-  double dn2 = 0.;
-  double v = 0.;
+  double dn1   = 0.;
+  double dn2   = 0.;
+  double v     = 0.;
   double dproj = 0.;
   _delta.clear();
   _delta.resize(getNDim());
@@ -226,8 +225,8 @@ void SpacePoint::setCoordFromAngle(const VectorDouble& angles)
     {
       std::cout << "Warning: Extra angle values ignored" << std::endl;
     }
-    _coord[0] = cos( GV_PI * angles[0] / 180);
-    _coord[1] = sin( GV_PI * angles[0] / 180);
+    _coord[0] = cos(GV_PI * angles[0] / 180);
+    _coord[1] = sin(GV_PI * angles[0] / 180);
   }
   else
   {
@@ -235,4 +234,4 @@ void SpacePoint::setCoordFromAngle(const VectorDouble& angles)
   }
 }
 
-}
+} // namespace gstlrn

--- a/src/Space/SpaceRN.cpp
+++ b/src/Space/SpaceRN.cpp
@@ -9,12 +9,12 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Space/SpaceRN.hpp"
-#include "Space/ASpace.hpp"
-#include "Space/SpacePoint.hpp"
 #include "Basic/Tensor.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Space/ASpace.hpp"
+#include "Space/SpacePoint.hpp"
 
-#include <math.h>
+#include <cmath>
 #include <memory>
 
 namespace gstlrn
@@ -144,10 +144,10 @@ void SpaceRN::getDistancePointVectInPlace(const SpacePoint& p1,
   double s;
   res.resize(ranks.size());
   double* ptr = res.data();
-  auto pt1 = p1.getCoords();
-  for (const auto &i : ranks)
+  auto pt1    = p1.getCoords();
+  for (const auto& i: ranks)
   {
-    s = 0.;
+    s       = 0.;
     auto pt = p2[i].getCoords();
     for (unsigned int idim = 0; idim < _nDim; idim++)
     {
@@ -158,4 +158,4 @@ void SpaceRN::getDistancePointVectInPlace(const SpacePoint& p1,
     *ptr++ = sqrt(s);
   }
 }
-}
+} // namespace gstlrn

--- a/src/Space/SpaceTarget.cpp
+++ b/src/Space/SpaceTarget.cpp
@@ -9,15 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Space/SpaceTarget.hpp"
-#include "Space/ASpace.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Space/ASpace.hpp"
 
+#include <cmath>
 #include <iostream>
-#include <math.h>
 
 namespace gstlrn
-{ 
+{
 
 SpaceTarget::SpaceTarget(const ASpaceSharedPtr& space,
                          bool checkExtend,
@@ -52,10 +52,10 @@ SpaceTarget& SpaceTarget::operator=(const SpaceTarget& r)
     SpacePoint::operator=(r);
     _checkExtend = r._checkExtend;
     _checkCode   = r._checkCode;
-    _checkDate = r._checkDate;
-    _extend = r._extend;
-    _code = r._code;
-    _date = r._date;
+    _checkDate   = r._checkDate;
+    _extend      = r._extend;
+    _code        = r._code;
+    _date        = r._date;
   }
   return *this;
 }
@@ -64,8 +64,8 @@ SpaceTarget::~SpaceTarget()
 {
 }
 
-SpaceTarget* SpaceTarget::create(const VectorDouble &center,
-                                 const VectorDouble &extend,
+SpaceTarget* SpaceTarget::create(const VectorDouble& center,
+                                 const VectorDouble& extend,
                                  double code,
                                  double date,
                                  const ASpaceSharedPtr& space)
@@ -113,4 +113,4 @@ String SpaceTarget::toString(const AStringFormat* /*strfmt*/) const
   }
   return sstr.str();
 }
-}
+} // namespace gstlrn

--- a/src/Stats/Classical.cpp
+++ b/src/Stats/Classical.cpp
@@ -8,30 +8,30 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Stats/Classical.hpp"
+#include "Basic/AStringable.hpp"
+#include "Basic/String.hpp"
+#include "Basic/Utilities.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
-#include "Stats/Classical.hpp"
-#include "Basic/Utilities.hpp"
-#include "Basic/String.hpp"
-#include "Basic/AStringable.hpp"
 #include "Enum/EOperator.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
+#include "Enum/EStatOption.hpp"
 #include "Matrix/MatrixFactory.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
 #include "Model/Model.hpp"
+#include "Polygon/Polygons.hpp"
 #include "Space/SpaceRN.hpp"
 #include "Space/SpaceTarget.hpp"
-#include "Variogram/VarioParam.hpp"
 #include "Variogram/Vario.hpp"
-#include "Polygon/Polygons.hpp"
-#include "Enum/EStatOption.hpp"
+#include "Variogram/VarioParam.hpp"
 #include "geoslib_define.h"
-
-#include <math.h>
 #include <Matrix/Table.hpp>
-#include <string.h>
+
+#include <cmath>
+#include <cstring>
 
 namespace gstlrn
-{ 
+{
 /****************************************************************************/
 /*!
  **  Check the operator name
@@ -48,7 +48,7 @@ namespace gstlrn
  ** \remarks If an error occurred, the message is printed
  **
  *****************************************************************************/
-bool _operStatisticsCheck(const EStatOption &oper,
+bool _operStatisticsCheck(const EStatOption& oper,
                           int flag_multi,
                           int flag_indic,
                           int flag_sum,
@@ -63,9 +63,9 @@ bool _operStatisticsCheck(const EStatOption &oper,
 
   /* Monovariate check */
 
-  if (oper == EStatOption::NUM)  valid = true;
+  if (oper == EStatOption::NUM) valid = true;
   if (oper == EStatOption::MEAN) valid = true;
-  if (oper == EStatOption::VAR)  valid = true;
+  if (oper == EStatOption::VAR) valid = true;
   if (oper == EStatOption::CORR) valid = true;
   if (oper == EStatOption::STDV) valid = true;
   if (oper == EStatOption::MINI) valid = true;
@@ -84,7 +84,7 @@ bool _operStatisticsCheck(const EStatOption &oper,
   if (flag_multi)
   {
     if (oper == EStatOption::MEAN2) valid = true;
-    if (oper == EStatOption::VAR2)  valid = true;
+    if (oper == EStatOption::VAR2) valid = true;
     if (oper == EStatOption::STDV2) valid = true;
     if (flag_sum)
     {
@@ -96,16 +96,16 @@ bool _operStatisticsCheck(const EStatOption &oper,
 
   if (flag_indic)
   {
-    if (oper == EStatOption::PLUS)  valid = true;
+    if (oper == EStatOption::PLUS) valid = true;
     if (oper == EStatOption::MOINS) valid = true;
-    if (oper == EStatOption::ZERO)  valid = true;
+    if (oper == EStatOption::ZERO) valid = true;
   }
 
   /* QT variables check */
 
   if (flag_qt)
   {
-    if (oper == EStatOption::ORE)   valid = true;
+    if (oper == EStatOption::ORE) valid = true;
     if (oper == EStatOption::METAL) valid = true;
   }
 
@@ -125,13 +125,13 @@ bool _operStatisticsCheck(const EStatOption &oper,
  ** \param[out] prop       Array of proportions
  **
  *****************************************************************************/
-void _updateProportions(DbGrid *dbin,
-                        VectorInt &indg,
+void _updateProportions(DbGrid* dbin,
+                        VectorInt& indg,
                         int nfacies,
-                        VectorDouble &prop)
+                        VectorDouble& prop)
 {
   int rank = dbin->getGrid().indiceToRank(indg);
-  int ifac = (int) dbin->getZVariable(rank, 0);
+  int ifac = (int)dbin->getZVariable(rank, 0);
   if (ifac < 1 || ifac > nfacies) return;
   prop[ifac - 1] += 1.;
 }
@@ -149,7 +149,7 @@ void _updateProportions(DbGrid *dbin,
  ** \param[out] trans      Array of transitions
  **
  *****************************************************************************/
-void _updateTransition(DbGrid *dbin,
+void _updateTransition(DbGrid* dbin,
                        int pos,
                        VectorInt& indg,
                        int nfacies,
@@ -158,9 +158,9 @@ void _updateTransition(DbGrid *dbin,
 {
   int jpos = indg[pos] + orient;
   if (jpos <= 0 || jpos >= dbin->getNX(pos)) return;
-  int ifac1 = (int) dbin->getZVariable(dbin->getGrid().indiceToRank(indg), 0);
+  int ifac1 = (int)dbin->getZVariable(dbin->getGrid().indiceToRank(indg), 0);
   indg[pos] += orient;
-  int ifac2 = (int) dbin->getZVariable(dbin->getGrid().indiceToRank(indg), 0);
+  int ifac2 = (int)dbin->getZVariable(dbin->getGrid().indiceToRank(indg), 0);
   indg[pos] -= orient;
 
   if (ifac1 < 1 || ifac1 > nfacies || ifac2 < 1 || ifac2 > nfacies) return;
@@ -178,11 +178,11 @@ void _updateTransition(DbGrid *dbin,
  ** \param[in]  tab        Array of cumulative statistics
  **
  *****************************************************************************/
-void _scaleAndAffect(Db *dbout,
+void _scaleAndAffect(Db* dbout,
                      int iptr,
                      int iech,
                      int nitem,
-                     VectorDouble &tab)
+                     VectorDouble& tab)
 {
   double value;
 
@@ -254,8 +254,8 @@ void _refactor(int ncol, VectorDouble& tab)
  *****************************************************************************/
 void _copyResults(int nx,
                   int ny,
-                  const VectorDouble &tabin,
-                  VectorDouble &tabout)
+                  const VectorDouble& tabin,
+                  VectorDouble& tabout)
 {
   int ix, iy, lec;
 
@@ -279,15 +279,15 @@ void _copyResults(int nx,
 void _neighboringCell(int ndim,
                       int radius,
                       int rank0,
-                      const VectorInt &indg0,
-                      VectorInt &indg)
+                      const VectorInt& indg0,
+                      VectorInt& indg)
 {
   int nei1d, value, divid, count, reste, ratio, idim;
 
   /* Initializations */
 
   nei1d = 2 * radius + 1;
-  count = (int) pow(nei1d, (double) ndim);
+  count = (int)pow(nei1d, (double)ndim);
   value = rank0;
 
   /* Loop on the space dimensions */
@@ -297,9 +297,9 @@ void _neighboringCell(int ndim,
   {
     idim = ndim - jdim - 1;
     divid /= nei1d;
-    ratio = value / divid;
-    reste = value - ratio * divid;
-    value = reste;
+    ratio      = value / divid;
+    reste      = value - ratio * divid;
+    value      = reste;
     indg[idim] = indg0[idim] + ratio - radius;
   }
 }
@@ -315,7 +315,7 @@ void _neighboringCell(int ndim,
  ** \param[in]  proba Probability value (between 0 and 1)
  **
  *****************************************************************************/
-double _getQuantile(VectorDouble &tab, int ntab, double proba)
+double _getQuantile(VectorDouble& tab, int ntab, double proba)
 {
   int rank;
   double p1, p2, v1, v2, value;
@@ -323,14 +323,14 @@ double _getQuantile(VectorDouble &tab, int ntab, double proba)
   if (FFFF(proba)) return (TEST);
 
   VH::sortInPlace(tab, true, ntab);
-  rank = (int) (proba * (double) ntab);
-  v1 = tab[rank];
+  rank = (int)(proba * (double)ntab);
+  v1   = tab[rank];
 
   if (rank < ntab - 1)
   {
-    v2 = tab[rank + 1];
-    p1 = (double) rank / (double) ntab;
-    p2 = (double) (1 + rank) / (double) ntab;
+    v2    = tab[rank + 1];
+    p1    = (double)rank / (double)ntab;
+    p2    = (double)(1 + rank) / (double)ntab;
     value = v1 + (proba - p1) * (v2 - v1) / (p2 - p1);
   }
   else
@@ -343,10 +343,10 @@ double _getQuantile(VectorDouble &tab, int ntab, double proba)
 VectorString statOptionToName(const std::vector<EStatOption>& opers)
 {
   VectorString names;
-  for (int i = 0; i < (int) opers.size(); i++)
+  for (int i = 0; i < (int)opers.size(); i++)
   {
     const EStatOption& oper = opers[i];
-    names.push_back(String{oper.getKey()});
+    names.push_back(String {oper.getKey()});
   }
   return names;
 }
@@ -355,7 +355,7 @@ std::vector<EStatOption> KeysToStatOptions(const VectorString& opers)
 {
   std::vector<EStatOption> options;
 
-  for (int i = 0; i < (int) opers.size(); i++)
+  for (int i = 0; i < (int)opers.size(); i++)
   {
     EStatOption opt = EStatOption::fromKey(opers[i]);
     if (opt != EStatOption::UNKNOWN) options.push_back(opt);
@@ -370,9 +370,9 @@ std::vector<EStatOption> KeysToStatOptions(const VectorString& opers)
  * in this same Db in variables already created.
  * These functions should not be used in Target Language.
  */
-void dbStatisticsVariables(Db *db,
-                           const VectorString &names,
-                           const std::vector<EStatOption> &opers,
+void dbStatisticsVariables(Db* db,
+                           const VectorString& names,
+                           const std::vector<EStatOption>& opers,
                            int iptr0,
                            double proba,
                            double vmin,
@@ -382,7 +382,7 @@ void dbStatisticsVariables(Db *db,
   if (noper <= 0) return;
   if (names.empty()) return;
   VectorInt iuids = db->getUIDs(names);
-  int niuid = static_cast<int>(iuids.size());
+  int niuid       = static_cast<int>(iuids.size());
 
   /* Loop on the samples */
 
@@ -393,26 +393,26 @@ void dbStatisticsVariables(Db *db,
 
     /* Loop on the variables */
 
-    int neff = 0;
-    int nperc = 0;
-    double mean = 0.;
-    double var = 0.;
-    double stdv = 0.;
-    double sum = 0.;
+    int neff     = 0;
+    int nperc    = 0;
+    double mean  = 0.;
+    double var   = 0.;
+    double stdv  = 0.;
+    double sum   = 0.;
     double metal = 0.;
-    double mini = MAXIMUM_BIG;
-    double maxi = MINIMUM_BIG;
+    double mini  = MAXIMUM_BIG;
+    double maxi  = MINIMUM_BIG;
     for (int iuid = 0; iuid < niuid; iuid++)
     {
-      int juid = iuids[iuid];
+      int juid     = iuids[iuid];
       double value = db->getArray(iech, juid);
       if (FFFF(value)) continue;
 
       local[neff] = value;
       neff++;
       mean += value;
-      sum  += value;
-      var  += value * value;
+      sum += value;
+      var += value * value;
       if (value < mini) mini = value;
       if (value > maxi) maxi = value;
       if (!FFFF(vmin) && value < vmin) continue;
@@ -426,7 +426,7 @@ void dbStatisticsVariables(Db *db,
     if (neff > 0)
     {
       mean /= neff;
-      var = var / neff - mean * mean;
+      var  = var / neff - mean * mean;
       stdv = (var >= 0) ? sqrt(var) : 0.;
     }
 
@@ -438,7 +438,7 @@ void dbStatisticsVariables(Db *db,
       if (neff > 0)
       {
         if (opers[i] == EStatOption::NUM)
-          tab = (double) neff;
+          tab = (double)neff;
         else if (opers[i] == EStatOption::MEAN)
           tab = mean;
         else if (opers[i] == EStatOption::VAR)
@@ -456,11 +456,11 @@ void dbStatisticsVariables(Db *db,
         else if (opers[i] == EStatOption::QUANT)
           tab = _getQuantile(local, neff, proba);
         else if (opers[i] == EStatOption::Q)
-          tab = metal / (double) neff;
+          tab = metal / (double)neff;
         else if (opers[i] == EStatOption::M)
-          tab = (nperc > 0) ? metal / (double) nperc : TEST;
+          tab = (nperc > 0) ? metal / (double)nperc : TEST;
         else if (opers[i] == EStatOption::B)
-          tab = (!FFFF(vmin)) ? (metal - vmin) / (double) neff : TEST;
+          tab = (!FFFF(vmin)) ? (metal - vmin) / (double)neff : TEST;
         else
           return;
       }
@@ -480,9 +480,9 @@ void dbStatisticsVariables(Db *db,
  *
  * @return A Table containing the results
  */
-Table dbStatisticsMono(Db *db,
-                       const VectorString &names,
-                       const std::vector<EStatOption> &opers,
+Table dbStatisticsMono(Db* db,
+                       const VectorString& names,
+                       const std::vector<EStatOption>& opers,
                        bool flagIso,
                        double proba,
                        double vmin,
@@ -491,9 +491,9 @@ Table dbStatisticsMono(Db *db,
 {
   Table table;
   VectorInt iuids = db->getUIDs(names);
-  int niuid = static_cast<int>(iuids.size());
-  int noper = static_cast<int>(opers.size());
-  int nech = db->getNSample();
+  int niuid       = static_cast<int>(iuids.size());
+  int noper       = static_cast<int>(opers.size());
+  int nech        = db->getNSample();
 
   // Find the Isotopic samples (optional)
 
@@ -503,9 +503,9 @@ Table dbStatisticsMono(Db *db,
   for (int iech = 0; iech < nech; iech++)
   {
     accept[iech] = false;
-    if (! db->isActive(iech)) continue;
+    if (!db->isActive(iech)) continue;
     accept[iech] = true;
-    int nundef = 0;
+    int nundef   = 0;
     for (int iuid = 0; iuid < niuid; iuid++)
     {
       double value = db->getArray(iech, iuids[iuid]);
@@ -518,15 +518,15 @@ Table dbStatisticsMono(Db *db,
 
   for (int iuid = 0; iuid < niuid; iuid++)
   {
-    int neff = 0;
-    int nperc = 0;
-    double mean = 0.;
-    double var = 0.;
-    double stdv = 0.;
-    double sum = 0.;
-    double metal = 0.;
-    double mini = MAXIMUM_BIG;
-    double maxi = MINIMUM_BIG;
+    int neff      = 0;
+    int nperc     = 0;
+    double mean   = 0.;
+    double var    = 0.;
+    double stdv   = 0.;
+    double sum    = 0.;
+    double metal  = 0.;
+    double mini   = MAXIMUM_BIG;
+    double maxi   = MINIMUM_BIG;
     double median = TEST;
     VectorDouble valmed;
 
@@ -534,7 +534,7 @@ Table dbStatisticsMono(Db *db,
 
     for (int iech = 0; iech < nech; iech++)
     {
-      if (! accept[iech]) continue;
+      if (!accept[iech]) continue;
       double value = db->getArray(iech, iuids[iuid]);
       // Skip TEST values (this is necessary when flagIso is set to FALSE)
       if (FFFF(value)) continue;
@@ -558,14 +558,14 @@ Table dbStatisticsMono(Db *db,
     if (neff > 0)
     {
       mean /= neff;
-      var = var / neff - mean * mean;
+      var  = var / neff - mean * mean;
       stdv = (var >= 0) ? sqrt(var) : 0.;
       VH::sortInPlace(valmed);
       if (isOdd(neff))
-        median = valmed[neff/2];
+        median = valmed[neff / 2];
       else
       {
-        median = 0.5 * (valmed[neff/2] + valmed[neff/2 - 1]);
+        median = 0.5 * (valmed[neff / 2] + valmed[neff / 2 - 1]);
       }
     }
 
@@ -590,7 +590,7 @@ Table dbStatisticsMono(Db *db,
         else if (opers[i] == EStatOption::SUM)
           tab.push_back(sum);
         else if (opers[i] == EStatOption::PROP || opers[i] == EStatOption::T)
-            tab.push_back((double)nperc / (double)neff);
+          tab.push_back((double)nperc / (double)neff);
         else if (opers[i] == EStatOption::QUANT)
           tab.push_back(_getQuantile(local, neff, proba));
         else if (opers[i] == EStatOption::Q)
@@ -641,10 +641,10 @@ Table dbStatisticsMono(Db *db,
   table.setSkipDescription(true);
   table.resetFromVD(niuid, noper, tab, false);
 
-  for (int irow=0; irow<niuid; irow++)
+  for (int irow = 0; irow < niuid; irow++)
     table.setRowName(irow, db->getNameByUID(iuids[irow]));
-  for (int icol=0; icol<noper; icol++)
-    table.setColumnName(icol, String{opers[icol].getDescr()});
+  for (int icol = 0; icol < noper; icol++)
+    table.setColumnName(icol, String {opers[icol].getDescr()});
 
   return table;
 }
@@ -659,15 +659,15 @@ Table dbStatisticsMono(Db *db,
  ** \param[in]  db         Db structure
  **
  *****************************************************************************/
-VectorDouble dbStatisticsFacies(Db *db)
+VectorDouble dbStatisticsFacies(Db* db)
 {
   VectorDouble props;
 
   if (db->getNLoc(ELoc::Z) != 1)
   {
     messerr(
-        "This function requires the number of variables (%d) to be equal to 1",
-        db->getNLoc(ELoc::Z));
+      "This function requires the number of variables (%d) to be equal to 1",
+      db->getNLoc(ELoc::Z));
     return props;
   }
   int nech = db->getNSample();
@@ -680,7 +680,7 @@ VectorDouble dbStatisticsFacies(Db *db)
   for (int iech = 0; iech < nech; iech++)
   {
     if (!db->isActiveAndDefined(iech, 0)) continue;
-    int ifac = (int) db->getZVariable(iech, 0);
+    int ifac = (int)db->getZVariable(iech, 0);
     if (ifac <= 0) continue;
     props[ifac - 1] += 1.;
     neff++;
@@ -691,7 +691,7 @@ VectorDouble dbStatisticsFacies(Db *db)
   if (neff > 0)
   {
     for (int ifac = 0; ifac < nfac; ifac++)
-      props[ifac] /= (double) neff;
+      props[ifac] /= (double)neff;
   }
   return props;
 }
@@ -706,24 +706,24 @@ VectorDouble dbStatisticsFacies(Db *db)
  ** \param[in]  db         Db structure
  **
  *****************************************************************************/
-double dbStatisticsIndicator(Db *db)
+double dbStatisticsIndicator(Db* db)
 {
   if (db->getNLoc(ELoc::Z) != 1)
   {
     messerr(
-        "This function requires the number of variables (%d) to be equal to 1",
-        db->getNLoc(ELoc::Z));
+      "This function requires the number of variables (%d) to be equal to 1",
+      db->getNLoc(ELoc::Z));
     return TEST;
   }
 
   // Calculate the proportions
 
   double prop = 0.;
-  int neff = 0;
+  int neff    = 0;
   for (int iech = 0; iech < db->getNSample(); iech++)
   {
     if (!db->isActiveAndDefined(iech, 0)) continue;
-    int ifac = (int) db->getZVariable(iech, 0);
+    int ifac = (int)db->getZVariable(iech, 0);
     if (ifac == 1) prop += 1.;
     neff++;
   }
@@ -741,10 +741,10 @@ double dbStatisticsIndicator(Db *db)
  *
  * @return A Table containing the correlation matrix
  */
-Table dbStatisticsCorrel(Db *db, const VectorString &names, bool flagIso, const String& title)
+Table dbStatisticsCorrel(Db* db, const VectorString& names, bool flagIso, const String& title)
 {
   VectorInt iuids = db->getUIDs(names);
-  int niuid = static_cast<int>(iuids.size());
+  int niuid       = static_cast<int>(iuids.size());
 
   /* Core allocation */
 
@@ -819,7 +819,7 @@ Table dbStatisticsCorrel(Db *db, const VectorString &names, bool flagIso, const 
 
   // Store the results in the symmetric square matrix
   VectorString namloc = db->getNames(names);
-  int nvar = (int) namloc.size();
+  int nvar            = (int)namloc.size();
 
   Table table;
   if (title.empty())
@@ -839,7 +839,7 @@ Table dbStatisticsCorrel(Db *db, const VectorString &names, bool flagIso, const 
 /**
  * @brief Calculate the variance-covariance matrix on the isotopic data set
  * from the Z-locator variables
- * 
+ *
  * @param db Target Data Base
  */
 MatrixSymmetric dbVarianceMatrix(const Db* db)
@@ -885,7 +885,7 @@ MatrixSymmetric dbVarianceMatrix(const Db* db)
     for (int jvar = 0; jvar <= ivar; jvar++)
     {
       double value = mat.getValue(ivar, jvar);
-      value = value / numiso - mean[ivar] * mean[jvar];
+      value        = value / numiso - mean[ivar] * mean[jvar];
       mat.setValue(ivar, jvar, value);
     }
 
@@ -905,8 +905,8 @@ MatrixSymmetric dbVarianceMatrix(const Db* db)
  ** \param[in]  radius     Radius of the neighborhood
  **
  *****************************************************************************/
-int statisticsProportion(DbGrid *dbin,
-                         DbGrid *dbout,
+int statisticsProportion(DbGrid* dbin,
+                         DbGrid* dbout,
                          int pos,
                          int nfacies,
                          int radius)
@@ -1001,8 +1001,8 @@ int statisticsProportion(DbGrid *dbin,
  ** \param[in]  orient     Orientation (+1 or -1)
  **
  *****************************************************************************/
-int statisticsTransition(DbGrid *dbin,
-                         DbGrid *dbout,
+int statisticsTransition(DbGrid* dbin,
+                         DbGrid* dbout,
                          int pos,
                          int nfacies,
                          int radius,
@@ -1097,20 +1097,20 @@ int statisticsTransition(DbGrid *dbin,
  ** \param[in]  string      String array
  **
  *****************************************************************************/
-void _getRowname(const String &radix,
+void _getRowname(const String& radix,
                  int ncol,
                  int icol,
-                 const String &name,
-                 char *string)
+                 const String& name,
+                 char* string)
 {
   if (!radix.empty())
-    (void) gslSPrintf(string, "%s-%d", radix.c_str(), icol + 1);
+    (void)gslSPrintf(string, "%s-%d", radix.c_str(), icol + 1);
   else if (!name.empty())
-    (void) gslSPrintf(string, "%s", name.c_str());
+    (void)gslSPrintf(string, "%s", name.c_str());
   else if (ncol > 1)
-    (void) gslSPrintf(string, "Variable-%d", icol + 1);
+    (void)gslSPrintf(string, "Variable-%d", icol + 1);
   else
-    (void) gslSPrintf(string, "Variable");
+    (void)gslSPrintf(string, "Variable");
 }
 
 /**
@@ -1121,13 +1121,13 @@ void _getRowname(const String &radix,
  * @param flagCorrel Print the correlation matrix
  * @param radix      Radix given to the printout
  */
-void dbStatisticsPrint(const Db *db,
-                       const VectorString &names,
-                       const std::vector<EStatOption> &opers,
+void dbStatisticsPrint(const Db* db,
+                       const VectorString& names,
+                       const std::vector<EStatOption>& opers,
                        bool flagIso,
                        bool flagCorrel,
-                       const String &title,
-                       const String &radix)
+                       const String& title,
+                       const String& radix)
 {
   VectorInt iuids = db->getUIDs(names);
   if (iuids.empty()) return;
@@ -1146,20 +1146,20 @@ void dbStatisticsPrint(const Db *db,
   VectorDouble mean(ncol, 0.);
   VectorDouble mini(ncol, 0.);
   VectorDouble maxi(ncol, 0.);
-  VectorDouble var(ncol,  0.);
-  VectorDouble num(ncol,  0.);
+  VectorDouble var(ncol, 0.);
+  VectorDouble num(ncol, 0.);
   VectorDouble cov;
   if (flagCorrel) cov.resize(ncol * ncol, 0.);
 
   /* Initializations */
 
   int numiso = 0;
-  int ijcol = 0;
+  int ijcol  = 0;
   for (int icol = 0; icol < ncol; icol++)
   {
     mean[icol] = var[icol] = num[icol] = 0.;
-    mini[icol] = MAXIMUM_BIG;
-    maxi[icol] = MINIMUM_BIG;
+    mini[icol]                         = MAXIMUM_BIG;
+    maxi[icol]                         = MINIMUM_BIG;
     if (flagCorrel)
       for (int jcol = 0; jcol < ncol; jcol++, ijcol++)
         cov[ijcol] = 0.;
@@ -1229,7 +1229,7 @@ void dbStatisticsPrint(const Db *db,
   /* Printout */
   /************/
 
-  if (! title.empty()) mestitle(1, title.c_str());
+  if (!title.empty()) mestitle(1, title.c_str());
 
   /* Calculate the maximum size of the variable */
 
@@ -1237,7 +1237,7 @@ void dbStatisticsPrint(const Db *db,
   for (int icol = 0; icol < ncol; icol++)
   {
     _getRowname(radix, ncol, icol, db->getNameByUID(iuids[icol]), string);
-    taille = MAX(taille, (int ) strlen(string));
+    taille = MAX(taille, (int)strlen(string));
   }
 
   /* Print the header of the monovariate statistics */
@@ -1265,7 +1265,7 @@ void dbStatisticsPrint(const Db *db,
     tab_print_rowname(string, taille);
 
     if (_operExists(opers, EStatOption::NUM))
-      tab_printi(NULL, (int) num[icol]);
+      tab_printi(NULL, (int)num[icol]);
     if (num[icol] > 0)
     {
       if (_operExists(opers, EStatOption::MINI))
@@ -1304,7 +1304,6 @@ void dbStatisticsPrint(const Db *db,
     print_matrix("Correlation matrix", 0, 1, ncol, ncol, NULL, cov.data());
     message("\n");
   }
-
 }
 
 /**
@@ -1321,23 +1320,23 @@ MatrixSquare* sphering(const AMatrix* X)
   int nech = X->getNRows();
   int nvar = X->getNCols();
 
-  AMatrix* TX = X->transpose();
-  AMatrix* prod = MatrixFactory::prodMatMat(TX, X);
+  AMatrix* TX              = X->transpose();
+  AMatrix* prod            = MatrixFactory::prodMatMat(TX, X);
   MatrixSymmetric* prodsym = dynamic_cast<MatrixSymmetric*>(prod);
   if (prodsym == nullptr) return nullptr;
 
-  prodsym->prodScalar(1. / (double) nech);
+  prodsym->prodScalar(1. / (double)nech);
   if (prodsym->computeEigen()) return nullptr;
   VectorDouble eigen_values = prodsym->getEigenValues();
-  MatrixSquare* S = prodsym->getEigenVectors()->clone();
+  MatrixSquare* S           = prodsym->getEigenVectors()->clone();
 
   // Invert the sign of the second Eigen vector (for compatibility with R output)
-  for (int ivar = 0; ivar < nvar ; ivar++)
+  for (int ivar = 0; ivar < nvar; ivar++)
     for (int jvar = 0; jvar < nvar; jvar++)
     {
-      double signe = (jvar < nvar-1) ? 1 : -1;
+      double signe = (jvar < nvar - 1) ? 1 : -1;
       S->setValue(ivar, jvar,
-                 signe * S->getValue(ivar, jvar) / sqrt(eigen_values[jvar]));
+                  signe * S->getValue(ivar, jvar) / sqrt(eigen_values[jvar]));
     }
 
   delete TX;
@@ -1352,40 +1351,40 @@ MatrixSquare* sphering(const AMatrix* X)
  * @return Vector of results
  *
  */
-VectorDouble dbStatisticsPerCell(Db *db,
-                                 DbGrid *dbgrid,
-                                 const EStatOption &oper,
+VectorDouble dbStatisticsPerCell(Db* db,
+                                 DbGrid* dbgrid,
+                                 const EStatOption& oper,
                                  const String& name1,
                                  const String& name2,
-                                 const VectorDouble &cuts)
+                                 const VectorDouble& cuts)
 {
   VectorDouble result;
   int iuid = db->getUID(name1);
   int juid = -1;
-  if (! name2.empty()) juid = db->getUID(name2);
+  if (!name2.empty()) juid = db->getUID(name2);
   double z1 = 0.;
   double z2 = 0.;
-  int nxyz = dbgrid->getNSample();
-  int ncut = (int) cuts.size();
-  int ndim = dbgrid->getNDim();
+  int nxyz  = dbgrid->getNSample();
+  int ncut  = (int)cuts.size();
+  int ndim  = dbgrid->getNDim();
   if (juid < 0) juid = iuid;
 
-  bool flag1 = false;
-  bool flag2 = false;
+  bool flag1       = false;
+  bool flag2       = false;
   bool flag_denorm = false;
-  bool flag_q = false;
-  bool flag_t = false;
-  bool flag_s1 = false;
-  bool flag_s2 = false;
-  bool flag_v1 = false;
-  bool flag_v2 = false;
-  bool flag_v12 = false;
-  bool flag_mini = false;
-  bool flag_maxi = false;
+  bool flag_q      = false;
+  bool flag_t      = false;
+  bool flag_s1     = false;
+  bool flag_s2     = false;
+  bool flag_v1     = false;
+  bool flag_v2     = false;
+  bool flag_v12    = false;
+  bool flag_mini   = false;
+  bool flag_maxi   = false;
 
   /* Check the operator validity */
 
-  if (! _operStatisticsCheck(oper, 1, 0, 1, 0, 1)) return VectorDouble();
+  if (!_operStatisticsCheck(oper, 1, 0, 1, 0, 1)) return VectorDouble();
 
   /* Set the relevant flags */
 
@@ -1519,8 +1518,9 @@ VectorDouble dbStatisticsPerCell(Db *db,
       if (flag_v12) v12[i] = TEST;
       if (flag_mini) mini[i] = TEST;
       if (flag_maxi) maxi[i] = TEST;
-      if (flag_t || flag_q) for (int icut = 0; icut < ncut; icut++)
-        cutval[icut + i * ncut] = TEST;
+      if (flag_t || flag_q)
+        for (int icut = 0; icut < ncut; icut++)
+          cutval[icut + i * ncut] = TEST;
     }
     else
     {
@@ -1595,7 +1595,6 @@ VectorDouble dbStatisticsPerCell(Db *db,
   return result;
 }
 
-
 /**
  * \copydoc STATS_0
  *
@@ -1604,9 +1603,9 @@ VectorDouble dbStatisticsPerCell(Db *db,
  *
  * @return A Table containing the results
  */
-Table dbStatisticsMulti(Db *db,
-                        const VectorString &names,
-                        const EStatOption &oper,
+Table dbStatisticsMulti(Db* db,
+                        const VectorString& names,
+                        const EStatOption& oper,
                         bool flagMono,
                         const String& title)
 {
@@ -1615,9 +1614,9 @@ Table dbStatisticsMulti(Db *db,
   /* Initializations */
 
   VectorInt cols = db->getUIDs(names);
-  int ncol = (int) cols.size();
-  int nech = db->getNSample();
-  int ncol2 = ncol * ncol;
+  int ncol       = (int)cols.size();
+  int nech       = db->getNSample();
+  int ncol2      = ncol * ncol;
 
   /* Check that all variables are defined */
 
@@ -1633,7 +1632,7 @@ Table dbStatisticsMulti(Db *db,
 
   /* Check the validity of the operator */
 
-  if (! _operStatisticsCheck(oper, 0, 1, 0, 0, 0)) return Table();
+  if (!_operStatisticsCheck(oper, 0, 1, 0, 0, 0)) return Table();
 
   /* Core allocation */
 
@@ -1660,8 +1659,8 @@ Table dbStatisticsMulti(Db *db,
   {
     num[i] = m1[i] = m2[i] = v1[i] = v2[i] = v12[i] = 0.;
     plus[i] = moins[i] = zero[i] = 0;
-    mini[i] = MAXIMUM_BIG;
-    maxi[i] = MINIMUM_BIG;
+    mini[i]                      = MAXIMUM_BIG;
+    maxi[i]                      = MINIMUM_BIG;
   }
 
   /* Loop on the samples */
@@ -1675,7 +1674,7 @@ Table dbStatisticsMulti(Db *db,
 
     for (int icol1 = 0; icol1 < ncol; icol1++)
     {
-      int jcol1 = cols[icol1];
+      int jcol1   = cols[icol1];
       double val1 = db->getArray(iech, jcol1);
       if (FFFF(val1)) continue;
 
@@ -1683,7 +1682,7 @@ Table dbStatisticsMulti(Db *db,
 
       for (int icol2 = 0; icol2 < ncol; icol2++)
       {
-        int jcol2 = cols[icol2];
+        int jcol2   = cols[icol2];
         double val2 = db->getArray(iech, jcol2);
         if (FFFF(val2)) continue;
 
@@ -1713,23 +1712,23 @@ Table dbStatisticsMulti(Db *db,
       int iad = icol1 * ncol + icol2;
       if (num[iad] <= 0)
       {
-        m1[iad] = TEST;
-        m2[iad] = TEST;
-        v1[iad] = TEST;
-        m2[iad] = TEST;
-        v12[iad] = TEST;
-        mini[iad] = TEST;
-        maxi[iad] = TEST;
-        plus[iad] = TEST;
+        m1[iad]    = TEST;
+        m2[iad]    = TEST;
+        v1[iad]    = TEST;
+        m2[iad]    = TEST;
+        v12[iad]   = TEST;
+        mini[iad]  = TEST;
+        maxi[iad]  = TEST;
+        plus[iad]  = TEST;
         moins[iad] = TEST;
-        zero[iad] = TEST;
+        zero[iad]  = TEST;
       }
       else
       {
         m1[iad] /= num[iad];
         m2[iad] /= num[iad];
-        v1[iad] = v1[iad] / num[iad] - m1[iad] * m1[iad];
-        v2[iad] = v2[iad] / num[iad] - m2[iad] * m2[iad];
+        v1[iad]  = v1[iad] / num[iad] - m1[iad] * m1[iad];
+        v2[iad]  = v2[iad] / num[iad] - m2[iad] * m2[iad];
         v12[iad] = v12[iad] / num[iad] - m1[iad] * m2[iad];
 
         if (oper == EStatOption::STDV)
@@ -1794,9 +1793,9 @@ Table dbStatisticsMulti(Db *db,
 
   Table table;
   if (title.empty())
-    table.setTitle(String{oper.getDescr()});
+    table.setTitle(String {oper.getDescr()});
   else
-    table.setTitle(concatenateStrings(":",title,String{oper.getDescr()}));
+    table.setTitle(concatenateStrings(":", title, String {oper.getDescr()}));
   table.setSkipDescription(true);
 
   if (flagMono)
@@ -1806,11 +1805,11 @@ Table dbStatisticsMulti(Db *db,
   else
   {
     table.resetFromVD(ncol, ncol, result, false);
-    for (int icol=0; icol<ncol; icol++)
+    for (int icol = 0; icol < ncol; icol++)
       table.setColumnName(icol, db->getNameByUID(cols[icol]));
   }
-  for (int irow=0; irow<ncol; irow++)
-      table.setRowName(irow, db->getNameByUID(cols[irow]));
+  for (int irow = 0; irow < ncol; irow++)
+    table.setRowName(irow, db->getNameByUID(cols[irow]));
 
   return table;
 }
@@ -1829,24 +1828,24 @@ Table dbStatisticsMulti(Db *db,
  ** \param[in]  iptr0  Storage address (first variable)
  **
  *****************************************************************************/
-int dbStatisticsInGridTool(Db *db,
-                           DbGrid *dbgrid,
+int dbStatisticsInGridTool(Db* db,
+                           DbGrid* dbgrid,
                            const VectorString& names,
-                           const EStatOption &oper,
+                           const EStatOption& oper,
                            int radius,
                            int iptr0)
 {
-  int iptm = -1;
-  int iptn = -1;
-  int nxyz = dbgrid->getNSample();
-  int ndim = dbgrid->getNDim();
+  int iptm        = -1;
+  int iptn        = -1;
+  int nxyz        = dbgrid->getNSample();
+  int ndim        = dbgrid->getNDim();
   VectorInt iuids = db->getUIDs(names);
-  int nuid = (int) iuids.size();
-  int count = (int) pow(2. * radius + 1., (double) ndim);
+  int nuid        = (int)iuids.size();
+  int count       = (int)pow(2. * radius + 1., (double)ndim);
 
   /* Check the validity of the requested function */
 
-  if (! _operStatisticsCheck(oper, 0, 1, 0, 1, 0)) return 1;
+  if (!_operStatisticsCheck(oper, 0, 1, 0, 1, 0)) return 1;
 
   /* Create the attributes */
 
@@ -1965,7 +1964,7 @@ int dbStatisticsInGridTool(Db *db,
           dbgrid->setArray(i, iptr, TEST);
         else
         {
-          double mean = dbgrid->getArray(i, iptm) / ratio;
+          double mean  = dbgrid->getArray(i, iptm) / ratio;
           double value = dbgrid->getArray(i, iptr) / ratio - mean * mean;
           if (value < 0) value = 0.;
           if (oper == EStatOption::VAR)
@@ -2003,8 +2002,7 @@ int dbStatisticsInGridTool(Db *db,
 
   /* Delete auxiliary attributes for local calculations */
 
-  if ((oper == EStatOption::MEAN || oper == EStatOption::VAR || oper == EStatOption::STDV)
-      && iptn > 0) dbgrid->deleteColumnByUID(iptn);
+  if ((oper == EStatOption::MEAN || oper == EStatOption::VAR || oper == EStatOption::STDV) && iptn > 0) dbgrid->deleteColumnByUID(iptn);
   if ((oper == EStatOption::VAR || oper == EStatOption::STDV) && iptm > 0)
     dbgrid->deleteColumnByUID(iptm);
 
@@ -2034,8 +2032,8 @@ int dbStatisticsInGridTool(Db *db,
  ** \remarks The indices are numbered starting from 0
  **
  *****************************************************************************/
-VectorVectorInt correlationPairs(Db *db1,
-                                 Db *db2,
+VectorVectorInt correlationPairs(Db* db1,
+                                 Db* db2,
                                  const String& name1,
                                  const String& name2,
                                  bool flagFrom1,
@@ -2054,9 +2052,9 @@ VectorVectorInt correlationPairs(Db *db1,
     return indices;
   }
 
-  int nech = db1->getNSample();
-  int ndim = db1->getNDim();
-  int shift = (flagFrom1) ? 1 : 0;
+  int nech   = db1->getNSample();
+  int ndim   = db1->getNDim();
+  int shift  = (flagFrom1) ? 1 : 0;
   auto space = SpaceRN::create(ndim);
   SpaceTarget T1(space);
   SpaceTarget T2(space);
@@ -2114,10 +2112,10 @@ VectorVectorInt correlationPairs(Db *db1,
  ** \remarks The indices are numbered starting from 1
  **
  *****************************************************************************/
-VectorVectorInt hscatterPairs(Db *db,
+VectorVectorInt hscatterPairs(Db* db,
                               const String& name1,
                               const String& name2,
-                              VarioParam *varioparam,
+                              VarioParam* varioparam,
                               int ilag,
                               int idir,
                               bool verbose)
@@ -2134,16 +2132,16 @@ VectorVectorInt hscatterPairs(Db *db,
   /* Initializations */
 
   const DirParam dirparam = varioparam->getDirParam(idir);
-  int nech = db->getNSample();
-  int ndim = db->getNDim();
-  auto space = SpaceRN::create(ndim);
+  int nech                = db->getNSample();
+  int ndim                = db->getNDim();
+  auto space              = SpaceRN::create(ndim);
   SpaceTarget T1(space);
   SpaceTarget T2(space);
   indices.resize(2);
 
   // Creating a local Vario structure from VarioParam (in order to constitute the BiTargetCheck list)
 
-  Vario *vario = Vario::create(*varioparam);
+  Vario* vario = Vario::create(*varioparam);
   vario->setDb(db);
   if (vario->prepare()) return 1;
 
@@ -2193,7 +2191,7 @@ VectorVectorInt hscatterPairs(Db *db,
     if (verbose)
     {
       message("Total number of samples = %d\n", nech);
-      message("Number of pairs used for translated correlation = %d\n", (int) nb);
+      message("Number of pairs used for translated correlation = %d\n", (int)nb);
     }
   }
   return indices;
@@ -2215,15 +2213,15 @@ VectorVectorInt hscatterPairs(Db *db,
  ** \remarks same set of coordinates and same optional selection)
  **
  *****************************************************************************/
-int correlationIdentify(Db *db1,
-                        Db *db2,
+int correlationIdentify(Db* db1,
+                        Db* db2,
                         int icol1,
                         int icol2,
-                        Polygons *polygon)
+                        Polygons* polygon)
 {
   if (db1 == nullptr) return (1);
   if (db2 == nullptr) return (1);
-  int nech = db1->getNSample();
+  int nech   = db1->getNSample();
   int number = 0;
 
   /* Correlation */
@@ -2267,8 +2265,8 @@ int correlationIdentify(Db *db1,
  ** \param[in]  verbose       Verbose flag
  **
  *****************************************************************************/
-VectorVectorDouble condexp(Db *db1,
-                           Db *db2,
+VectorVectorDouble condexp(Db* db1,
+                           Db* db2,
                            int icol1,
                            int icol2,
                            double mini,
@@ -2279,7 +2277,7 @@ VectorVectorDouble condexp(Db *db1,
   VectorVectorDouble xycond(2);
   xycond[0].resize(nclass);
   xycond[1].resize(nclass);
-  VectorInt ncond(nclass,0);
+  VectorInt ncond(nclass, 0);
 
   /* Loop on the samples */
 
@@ -2333,7 +2331,7 @@ VectorVectorDouble condexp(Db *db1,
 std::map<int, int> contingencyTable(const VectorInt& values)
 {
   std::map<int, int> table;
-  for (int i = 0, size = (int) values.size(); i < size; i++)
+  for (int i = 0, size = (int)values.size(); i < size; i++)
     table[values[i]]++;
   return table;
 }
@@ -2342,14 +2340,14 @@ std::map<int, std::map<int, int>> contingencyTable2(const VectorInt& values,
                                                     const VectorInt& bins)
 {
   std::map<int, std::map<int, int>> table;
-  if ((int) values.size() != (int) bins.size())
+  if ((int)values.size() != (int)bins.size())
   {
     messerr("Arguments 'values' and 'bins' should have the same dimension");
     return table;
   }
-  for (int i = 0, size = (int) values.size(); i < size; i++)
+  for (int i = 0, size = (int)values.size(); i < size; i++)
     table[values[i]][bins[i]]++;
   return table;
 }
 
-}
+} // namespace gstlrn

--- a/src/Stats/Classical.cpp
+++ b/src/Stats/Classical.cpp
@@ -18,14 +18,13 @@
 #include "Enum/EStatOption.hpp"
 #include "Matrix/MatrixFactory.hpp"
 #include "Matrix/MatrixSymmetric.hpp"
+#include "Matrix/Table.hpp"
 #include "Model/Model.hpp"
 #include "Polygon/Polygons.hpp"
 #include "Space/SpaceRN.hpp"
 #include "Space/SpaceTarget.hpp"
 #include "Variogram/Vario.hpp"
-#include "Variogram/VarioParam.hpp"
 #include "geoslib_define.h"
-#include <Matrix/Table.hpp>
 
 #include <cmath>
 #include <cstring>

--- a/src/Stats/PCA.cpp
+++ b/src/Stats/PCA.cpp
@@ -8,85 +8,82 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "geoslib_old_f.h"
-
-#include "Basic/VectorHelper.hpp"
 #include "Stats/PCA.hpp"
-#include "Stats/PCAStringFormat.hpp"
-#include "Stats/Classical.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Db/Db.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Matrix/MatrixSquare.hpp"
+#include "Stats/Classical.hpp"
+#include "Stats/PCAStringFormat.hpp"
 #include "Variogram/Vario.hpp"
+#include "geoslib_old_f.h"
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
 PCA::PCA(int nvar)
-  : AStringable(),
-    _nVar(0),
-    _mean(),
-    _sigma(),
-    _eigval(),
-    _eigvec(),
-    _c0(),
-    _gh(),
-    _Z2F(),
-    _F2Z()
+  : AStringable()
+  , _nVar(0)
+  , _mean()
+  , _sigma()
+  , _eigval()
+  , _eigvec()
+  , _c0()
+  , _gh()
+  , _Z2F()
+  , _F2Z()
 {
   init(nvar);
 }
 
-PCA::PCA(const PCA &m)
-    : AStringable(m),
-      _nVar(m._nVar),
-      _mean(m._mean),
-      _sigma(m._sigma),
-      _eigval(m._eigval),
-      _eigvec(m._eigvec),
-      _c0(m._c0),
-      _gh(m._gh),
-      _Z2F(m._Z2F),
-      _F2Z(m._F2Z)
+PCA::PCA(const PCA& m)
+  : AStringable(m)
+  , _nVar(m._nVar)
+  , _mean(m._mean)
+  , _sigma(m._sigma)
+  , _eigval(m._eigval)
+  , _eigvec(m._eigvec)
+  , _c0(m._c0)
+  , _gh(m._gh)
+  , _Z2F(m._Z2F)
+  , _F2Z(m._F2Z)
 {
-
 }
 
-PCA& PCA::operator=(const PCA &m)
+PCA& PCA::operator=(const PCA& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
-    _nVar = m._nVar;
-    _mean = m._mean;
-    _sigma = m._sigma;
+    _nVar   = m._nVar;
+    _mean   = m._mean;
+    _sigma  = m._sigma;
     _eigval = m._eigval;
     _eigvec = m._eigvec;
-    _c0 = m._c0;
-    _gh = m._gh;
-    _Z2F = m._Z2F;
-    _F2Z = m._F2Z;
+    _c0     = m._c0;
+    _gh     = m._gh;
+    _Z2F    = m._Z2F;
+    _F2Z    = m._F2Z;
   }
   return *this;
 }
 
 PCA::~PCA()
 {
-
 }
 
 void PCA::init(int nvar)
 {
   _nVar = nvar;
-  _mean.resize  (nvar,0);
-  _sigma.resize (nvar,0);
-  _eigval.resize(nvar,0);
+  _mean.resize(nvar, 0);
+  _sigma.resize(nvar, 0);
+  _eigval.resize(nvar, 0);
   _eigvec.resize(nvar, nvar);
-  _c0.resize    (nvar, nvar);
-  _gh.resize    (nvar, nvar);
-  _Z2F.resize   (nvar, nvar);
-  _F2Z.resize   (nvar, nvar);
+  _c0.resize(nvar, nvar);
+  _gh.resize(nvar, nvar);
+  _Z2F.resize(nvar, nvar);
+  _F2Z.resize(nvar, nvar);
 }
 
 void PCA::_pcaFunctions(bool verbose)
@@ -209,7 +206,7 @@ String PCA::toString(const AStringFormat* strfmt) const
 
     sstr << toMatrix("Matrix MZ2F to transform standardized Variables Z into Factors F", _Z2F);
     sstr << "Y = (Z - m) * MZ2F)" << std::endl;
-    sstr << toMatrix("Matrix MF2Z to back-transform Factors F into standardized Variables Z",_F2Z);
+    sstr << toMatrix("Matrix MF2Z to back-transform Factors F into standardized Variables Z", _F2Z);
     sstr << "Z = m + Y * MF2Z" << std::endl;
   }
   return sstr.str();
@@ -228,7 +225,7 @@ int PCA::dbZ2F(Db* db,
   if (nvar != _nVar)
   {
     messerr("The number of Z variables (%d) does not match the number of variables in PCA (%d)",
-            nvar,_nVar);
+            nvar, _nVar);
     return 1;
   }
 
@@ -239,7 +236,7 @@ int PCA::dbZ2F(Db* db,
 
   // Optional title
 
-  if (verbose) mestitle(0,"Transform from Z to Factors");
+  if (verbose) mestitle(0, "Transform from Z to Factors");
 
   /* Rotate the factors into data in the PCA system */
 
@@ -254,7 +251,7 @@ int PCA::dbZ2F(Db* db,
     for (int ivar = 0; ivar < nvar; ivar++)
       cols[ivar] = iptr + ivar;
     VectorString names = db->getNamesByUID(cols);
-    dbStatisticsPrint(db, names, {}, true, true, "Statistics on Factors","Factor");
+    dbStatisticsPrint(db, names, {}, true, true, "Statistics on Factors", "Factor");
   }
 
   /* Set the error return code */
@@ -276,7 +273,7 @@ int PCA::dbF2Z(Db* db,
   if (nvar != _nVar)
   {
     messerr("The number of Z variables (%d) does not match the number of variables in PCA (%d)",
-            nvar,_nVar);
+            nvar, _nVar);
     return 1;
   }
 
@@ -287,7 +284,7 @@ int PCA::dbF2Z(Db* db,
 
   // Optional title
 
-  if (verbose) mestitle(0,"Transform from Factors to Z");
+  if (verbose) mestitle(0, "Transform from Factors to Z");
 
   /* Rotate the factors into data in the PCA system */
 
@@ -312,7 +309,7 @@ int PCA::dbF2Z(Db* db,
 
 VectorDouble PCA::getVarianceRatio() const
 {
-  double total = VectorHelper::cumul(_eigval);
+  double total         = VectorHelper::cumul(_eigval);
   VectorDouble eignorm = _eigval;
   VectorHelper::divideConstant(eignorm, total);
   return eignorm;
@@ -328,8 +325,8 @@ VectorDouble PCA::getVarianceRatio() const
  ** \param[in] flag_nm1    When TRUE, variance is scaled by N-1; otherwise by N
  **
  *****************************************************************************/
-void PCA::_calculateNormalization(const Db *db,
-                                  const VectorBool &isoFlag,
+void PCA::_calculateNormalization(const Db* db,
+                                  const VectorBool& isoFlag,
                                   bool verbose,
                                   bool flag_nm1)
 {
@@ -364,7 +361,7 @@ void PCA::_calculateNormalization(const Db *db,
     {
       _mean[ivar] /= niso;
       _sigma[ivar] = (_sigma[ivar] / niso - _mean[ivar] * _mean[ivar]);
-      if (flag_nm1) _sigma[ivar] *= (double) (niso / (niso-1.));
+      if (flag_nm1) _sigma[ivar] *= (double)(niso / (niso - 1.));
       _sigma[ivar] = (_sigma[ivar] > 0) ? sqrt(_sigma[ivar]) : 0.;
     }
   }
@@ -390,8 +387,8 @@ void PCA::_calculateNormalization(const Db *db,
  ** \param[in]  flag_nm1    When TRUE, variance is scaled by N-1; otherwise by N
  **
  *****************************************************************************/
-void PCA::_covariance0(const Db *db,
-                       const VectorBool &isoFlag,
+void PCA::_covariance0(const Db* db,
+                       const VectorBool& isoFlag,
                        bool verbose,
                        bool flag_nm1)
 {
@@ -400,15 +397,15 @@ void PCA::_covariance0(const Db *db,
   int niso = 0;
   VectorDouble data1(nvar);
 
-	// Initialize the matrix contents
-	_c0.fill(0);
-	
+  // Initialize the matrix contents
+  _c0.fill(0);
+
   /* Calculate the variance-covariance matrix at distance 0 */
 
   niso = 0;
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! isoFlag[iech]) continue;
+    if (!isoFlag[iech]) continue;
     _loadData(db, iech, data1);
     _center(data1, _mean, _sigma, true, false);
 
@@ -423,7 +420,7 @@ void PCA::_covariance0(const Db *db,
   for (int ivar = 0; ivar < nvar; ivar++)
     for (int jvar = 0; jvar <= ivar; jvar++)
       if (flag_nm1)
-        _c0.setValue(jvar, ivar, _c0.getValue(jvar, ivar) / (niso-1.));
+        _c0.setValue(jvar, ivar, _c0.getValue(jvar, ivar) / (niso - 1.));
       else
         _c0.setValue(jvar, ivar, _c0.getValue(jvar, ivar) / niso);
 
@@ -445,12 +442,12 @@ void PCA::_covariance0(const Db *db,
  **
  *****************************************************************************/
 void PCA::_center(VectorDouble& data,
-                  const VectorDouble &mean,
-                  const VectorDouble &sigma,
+                  const VectorDouble& mean,
+                  const VectorDouble& sigma,
                   bool flag_center,
                   bool flag_scale)
 {
-  int nvar = (int) mean.size();
+  int nvar = (int)mean.size();
   for (int ivar = 0; ivar < nvar; ivar++)
   {
     if (flag_center)
@@ -472,13 +469,13 @@ void PCA::_center(VectorDouble& data,
  **
  *****************************************************************************/
 void PCA::_uncenter(VectorDouble& data,
-                    const VectorDouble &mean,
-                    const VectorDouble &sigma,
+                    const VectorDouble& mean,
+                    const VectorDouble& sigma,
                     bool flag_center,
                     bool flag_scale)
 {
   int ivar;
-  int nvar = (int) mean.size();
+  int nvar = (int)mean.size();
 
   for (ivar = 0; ivar < nvar; ivar++)
   {
@@ -515,7 +512,7 @@ void PCA::_pcaZ2F(int iptr,
 
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! isoFlag[iech]) continue;
+    if (!isoFlag[iech]) continue;
     _loadData(db, iech, data1);
     _center(data1, mean, sigma, true, false);
     VectorDouble data2 = _Z2F.prodMatVec(data1, true);
@@ -537,10 +534,10 @@ void PCA::_pcaZ2F(int iptr,
  **
  *****************************************************************************/
 void PCA::_pcaF2Z(int iptr,
-                  Db *db,
-                  const VectorBool &isoFlag,
-                  const VectorDouble &mean,
-                  const VectorDouble &sigma)
+                  Db* db,
+                  const VectorBool& isoFlag,
+                  const VectorDouble& mean,
+                  const VectorDouble& sigma)
 {
   int nvar = db->getNLoc(ELoc::Z);
   int nech = db->getNSample();
@@ -551,7 +548,7 @@ void PCA::_pcaF2Z(int iptr,
 
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! isoFlag[iech]) continue;
+    if (!isoFlag[iech]) continue;
     _loadData(db, iech, data1);
     data2 = _F2Z.prodMatVec(data1, true);
     _uncenter(data2, mean, sigma, true, false);
@@ -561,7 +558,7 @@ void PCA::_pcaF2Z(int iptr,
   }
 }
 
-int PCA::pca_compute(const Db *db, bool verbose, bool optionPositive)
+int PCA::pca_compute(const Db* db, bool verbose, bool optionPositive)
 {
 
   /* Initializations */
@@ -581,7 +578,7 @@ int PCA::pca_compute(const Db *db, bool verbose, bool optionPositive)
 
   // Optional title
 
-  if (verbose) mestitle(0,"PCA computation");
+  if (verbose) mestitle(0, "PCA computation");
 
   /* Calculate the PCA */
 
@@ -613,7 +610,7 @@ int PCA::pca_compute(const Db *db, bool verbose, bool optionPositive)
  ** \param[in]  verbose    Verbose flag
  **
  *****************************************************************************/
-int PCA::maf_compute_interval(Db *db, double hmin, double hmax, bool verbose)
+int PCA::maf_compute_interval(Db* db, double hmin, double hmax, bool verbose)
 {
   return _mafCompute(db, VarioParam(), -1, -1, hmin, hmax, verbose);
 }
@@ -631,7 +628,7 @@ int PCA::maf_compute_interval(Db *db, double hmin, double hmax, bool verbose)
  ** \param[in]  verbose    Verbose flag
  **
  *****************************************************************************/
-int PCA::maf_compute(Db *db,
+int PCA::maf_compute(Db* db,
                      const VarioParam& varioparam,
                      int ilag0,
                      int idir0,
@@ -659,8 +656,8 @@ int PCA::maf_compute(Db *db,
  ** \remarks - or using only hmin, hmax
  **
  *****************************************************************************/
-int PCA::_mafCompute(Db *db,
-                     const VarioParam &varioparam,
+int PCA::_mafCompute(Db* db,
+                     const VarioParam& varioparam,
                      int ilag0,
                      int idir0,
                      double hmin,
@@ -684,7 +681,7 @@ int PCA::_mafCompute(Db *db,
 
   // Optional title
 
-  if (verbose) mestitle(0,"MAF computation");
+  if (verbose) mestitle(0, "MAF computation");
 
   // Calculate the normalization parameters
 
@@ -710,25 +707,25 @@ int PCA::_mafCompute(Db *db,
   return 0;
 }
 
-void PCA::_variogramh(Db *db,
-                      const VarioParam &varioparam,
+void PCA::_variogramh(Db* db,
+                      const VarioParam& varioparam,
                       int ilag0,
                       int idir0,
                       double hmin,
                       double hmax,
-                      const VectorBool &isoFlag,
+                      const VectorBool& isoFlag,
                       bool verbose)
 {
   double dist;
-  
+
   SpaceTarget T1;
   SpaceTarget T2;
   Vario* vario = nullptr;
 
   // Initializations
 
-  int nech = db->getNSample();
-  int nvar = db->getNLoc(ELoc::Z);
+  int nech   = db->getNSample();
+  int nvar   = db->getNLoc(ELoc::Z);
   int npairs = 0;
 
   // Core allocations
@@ -749,14 +746,14 @@ void PCA::_variogramh(Db *db,
 
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! isoFlag[iech]) continue;
+    if (!isoFlag[iech]) continue;
     _loadData(db, iech, data1);
 
     /* Loop on the second sample */
 
     for (int jech = 0; jech < iech; jech++)
     {
-      if (! isoFlag[jech]) continue;
+      if (!isoFlag[jech]) continue;
       _loadData(db, jech, data2);
 
       /* Should the pair be retained */
@@ -768,11 +765,11 @@ void PCA::_variogramh(Db *db,
         const DirParam& dirparam = varioparam.getDirParam(idir0);
 
         // Reject the point as soon as one BiTargetChecker is not correct
-        if (! vario->keepPair(idir0, T1, T2, &dist)) continue;
+        if (!vario->keepPair(idir0, T1, T2, &dist)) continue;
 
         double lag = dirparam.getDPas();
         double h0  = ilag0 * lag;
-        if (dist < h0 - lag/2 || dist > h0 + lag/2) continue;
+        if (dist < h0 - lag / 2 || dist > h0 + lag / 2) continue;
       }
       else
       {
@@ -826,12 +823,12 @@ void PCA::_variogramh(Db *db,
 
 VectorBool PCA::_getVectorIsotopic(const Db* db)
 {
-  int nech = db->getNSample();
+  int nech           = db->getNSample();
   VectorBool isoFlag = VectorBool(nech);
 
   for (int iech = 0; iech < nech; iech++)
   {
-    if (! db->isActive(iech))
+    if (!db->isActive(iech))
       isoFlag[iech] = false;
     else
       isoFlag[iech] = db->isIsotopic(iech);
@@ -841,7 +838,7 @@ VectorBool PCA::_getVectorIsotopic(const Db* db)
 
 void PCA::_loadData(const Db* db, int iech, VectorDouble& data)
 {
-  int nvar = (int) db->getNLoc(ELoc::Z);
+  int nvar = (int)db->getNLoc(ELoc::Z);
   for (int ivar = 0; ivar < nvar; ivar++)
     data[ivar] = db->getZVariable(iech, ivar);
 }
@@ -850,19 +847,19 @@ VectorDouble PCA::mafOfIndex() const
 {
   // Calculate the probability of each interval
   VectorDouble w = _mean;
-  int ncut = (int) _mean.size();
+  int ncut       = (int)_mean.size();
   w.push_back(1 - VH::cumul(_mean));
-  int nclass = (int) w.size();
+  int nclass = (int)w.size();
 
   // Normalize the indicator of intervals
   MatrixDense i_norm_val(nclass, ncut);
-  for (int iclass = 0 ; iclass < ncut; iclass++)
+  for (int iclass = 0; iclass < ncut; iclass++)
   {
     for (int jclass = 0; jclass < nclass; jclass++)
     {
       double value = (iclass == jclass) ? 1 : 0.;
-      value = (value - w[iclass]) / sqrt(w[iclass] * (1. - w[iclass]));
-      i_norm_val.setValue(jclass,  iclass, value);
+      value        = (value - w[iclass]) / sqrt(w[iclass] * (1. - w[iclass]));
+      i_norm_val.setValue(jclass, iclass, value);
     }
   }
 
@@ -875,4 +872,4 @@ VectorDouble PCA::mafOfIndex() const
   return maf_index;
 }
 
-}
+} // namespace gstlrn

--- a/src/Stats/Selectivity.cpp
+++ b/src/Stats/Selectivity.cpp
@@ -8,19 +8,18 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Enum/ESelectivity.hpp"
-
-#include "Basic/VectorHelper.hpp"
-#include "Basic/AStringable.hpp"
-#include "Basic/Utilities.hpp"
-#include "Db/Db.hpp"
+#include "Stats/Selectivity.hpp"
 #include "Anamorphosis/AAnam.hpp"
-#include "Anamorphosis/AnamHermite.hpp"
 #include "Anamorphosis/AnamDiscreteDD.hpp"
 #include "Anamorphosis/AnamDiscreteIR.hpp"
-#include "Stats/Selectivity.hpp"
+#include "Anamorphosis/AnamHermite.hpp"
+#include "Basic/AStringable.hpp"
+#include "Basic/Utilities.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "Enum/ESelectivity.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #define NCOLS 7
 #define Z_CUT 0
@@ -34,66 +33,66 @@
 namespace gstlrn
 {
 Selectivity::Selectivity(int ncut)
-    : AStringable(),
-      _Zcut(ncut),
-      _stats(ncut, NCOLS),
-      _zmax(TEST),
-      _proba(TEST),
-      _flagTonnageCorrect(false),
-      _numberQT(),
-      _rankQT(),
-      _flagOnlyZDefined(false)
+  : AStringable()
+  , _Zcut(ncut)
+  , _stats(ncut, NCOLS)
+  , _zmax(TEST)
+  , _proba(TEST)
+  , _flagTonnageCorrect(false)
+  , _numberQT()
+  , _rankQT()
+  , _flagOnlyZDefined(false)
 {
   VH::fill(_Zcut, TEST);
   _stats.setColumnNames(_getAllNames());
   _stats.fill(TEST);
 }
 
-Selectivity::Selectivity(const VectorDouble &zcuts,
+Selectivity::Selectivity(const VectorDouble& zcuts,
                          double zmax,
                          double proba,
                          bool flag_tonnage_correct)
-    : AStringable(),
-      _Zcut(zcuts),
-      _stats(),
-      _zmax(zmax),
-      _proba(proba),
-      _flagTonnageCorrect(flag_tonnage_correct),
-      _numberQT(),
-      _rankQT(),
-      _flagOnlyZDefined(false)
+  : AStringable()
+  , _Zcut(zcuts)
+  , _stats()
+  , _zmax(zmax)
+  , _proba(proba)
+  , _flagTonnageCorrect(flag_tonnage_correct)
+  , _numberQT()
+  , _rankQT()
+  , _flagOnlyZDefined(false)
 {
   _stats.reset(getNCuts(), NCOLS);
   _stats.setColumnNames(_getAllNames());
   _stats.fill(TEST);
 }
 
-Selectivity::Selectivity(const Selectivity &m)
-    : AStringable(m),
-      _Zcut(m._Zcut),
-      _stats(m._stats),
-      _zmax(m._zmax),
-      _proba(m._proba),
-      _flagTonnageCorrect(m._flagTonnageCorrect),
-      _numberQT(m._numberQT),
-      _rankQT(m._rankQT),
-      _flagOnlyZDefined(m._flagOnlyZDefined)
+Selectivity::Selectivity(const Selectivity& m)
+  : AStringable(m)
+  , _Zcut(m._Zcut)
+  , _stats(m._stats)
+  , _zmax(m._zmax)
+  , _proba(m._proba)
+  , _flagTonnageCorrect(m._flagTonnageCorrect)
+  , _numberQT(m._numberQT)
+  , _rankQT(m._rankQT)
+  , _flagOnlyZDefined(m._flagOnlyZDefined)
 {
 }
 
-Selectivity& Selectivity::operator=(const Selectivity &m)
+Selectivity& Selectivity::operator=(const Selectivity& m)
 {
   if (this != &m)
   {
     AStringable::operator=(m);
-    _Zcut  = m._Zcut;
-    _stats = m._stats;
-    _zmax  = m._zmax;
-    _proba = m._proba;
+    _Zcut               = m._Zcut;
+    _stats              = m._stats;
+    _zmax               = m._zmax;
+    _proba              = m._proba;
     _flagTonnageCorrect = m._flagTonnageCorrect;
-    _numberQT = m._numberQT;
-    _rankQT = m._rankQT;
-    _flagOnlyZDefined = m._flagOnlyZDefined;
+    _numberQT           = m._numberQT;
+    _rankQT             = m._rankQT;
+    _flagOnlyZDefined   = m._flagOnlyZDefined;
   }
   return *this;
 }
@@ -137,7 +136,7 @@ Selectivity* Selectivity::createByKeys(const VectorString& keys,
 {
   std::vector<ESelectivity> codes;
 
-  for (int i = 0; i < (int) keys.size(); i++)
+  for (int i = 0; i < (int)keys.size(); i++)
   {
     ESelectivity code = ESelectivity::fromKey(keys[i]);
     if (code == ESelectivity::UNKNOWN) continue;
@@ -184,8 +183,8 @@ int Selectivity::calculateFromDb(const Db* db, bool autoCuts)
   return calculateFromArray(tab, wtab, autoCuts);
 }
 
-int Selectivity::calculateFromArray(const VectorDouble &tab,
-                                    const VectorDouble &weights,
+int Selectivity::calculateFromArray(const VectorDouble& tab,
+                                    const VectorDouble& weights,
                                     bool autoCuts)
 {
   if (getNCuts() <= 0)
@@ -199,15 +198,15 @@ int Selectivity::calculateFromArray(const VectorDouble &tab,
     return 1;
   }
 
-  int nech = (int) tab.size();
+  int nech          = (int)tab.size();
   VectorDouble wtab = weights;
   if (wtab.empty())
   {
-    wtab.resize(nech,1);
+    wtab.resize(nech, 1);
   }
   else
   {
-    if (nech != (int) wtab.size())
+    if (nech != (int)wtab.size())
     {
       messerr("Arguments 'tab' and 'weights' should have same dimension");
       return 1;
@@ -231,19 +230,19 @@ int Selectivity::calculateFromArray(const VectorDouble &tab,
     double coupure = getZcut(icut);
 
     double tonnage = 0.;
-    double metal = 0.;
+    double metal   = 0.;
     for (int iech = 0; iech < nech; iech++)
     {
-      double x = tab[iech];
-      double w = wtab[iech];
+      double x     = tab[iech];
+      double w     = wtab[iech];
       double indic = (x >= coupure);
 
       tonnage += w * indic;
-      metal   += x * w * indic;
+      metal += x * w * indic;
     }
 
     tonnage /= tonref;
-    metal   /= tonref;
+    metal /= tonref;
     double benefit = metal - tonnage * coupure;
     double grade;
     if (tonnage <= 0.)
@@ -290,29 +289,29 @@ int Selectivity::calculateFromAnamorphosis(AAnam* anam)
   return 1;
 }
 
-Table Selectivity::eval(const Db *db, bool autoCuts)
+Table Selectivity::eval(const Db* db, bool autoCuts)
 {
-  (void) calculateFromDb(db, autoCuts);
+  (void)calculateFromDb(db, autoCuts);
   return getStats();
 }
-Table Selectivity::evalFromArray(const VectorDouble &tab,
-                                       const VectorDouble &weights,
-                                       bool autoCuts)
+Table Selectivity::evalFromArray(const VectorDouble& tab,
+                                 const VectorDouble& weights,
+                                 bool autoCuts)
 {
-  (void) calculateFromArray(tab, weights, autoCuts);
+  (void)calculateFromArray(tab, weights, autoCuts);
   return getStats();
 }
-Table Selectivity::evalFromAnamorphosis(AAnam *anam)
+Table Selectivity::evalFromAnamorphosis(AAnam* anam)
 {
-  (void) calculateFromAnamorphosis(anam);
+  (void)calculateFromAnamorphosis(anam);
   return getStats();
 }
 
 Table Selectivity::getStats() const
 {
   VectorString names = _getAllNames();
-  int nrow = _stats.getNRows();
-  int ncol = _stats.getNColDefined();
+  int nrow           = _stats.getNRows();
+  int ncol           = _stats.getNColDefined();
 
   // Allocate the output Table
   Table rtable(nrow, ncol, false, true);
@@ -322,7 +321,7 @@ Table Selectivity::getStats() const
   int icol_ecr = 0;
   for (int icol = 0, ncolmax = _stats.getNCols(); icol < ncolmax; icol++)
   {
-    if (! _stats.isColumnDefined(icol)) continue;
+    if (!_stats.isColumnDefined(icol)) continue;
     rtable.setColumn(icol_ecr, _stats.getColumn(icol));
     rtable.setColumnName(icol_ecr, names[icol]);
     icol_ecr++;
@@ -346,7 +345,7 @@ Selectivity* Selectivity::createInterpolation(const VectorDouble& zcuts,
   double tval, qval;
 
   int nclass = selecin.getNCuts();
-  int ncuts = (int) zcuts.size();
+  int ncuts  = (int)zcuts.size();
 
   Selectivity* selectivity = new Selectivity(ncuts);
   for (int icut = 0; icut < ncuts; icut++)
@@ -394,74 +393,74 @@ Selectivity* Selectivity::createInterpolation(const VectorDouble& zcuts,
 
 void Selectivity::setZcut(int iclass, double zcut)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, Z_CUT, zcut);
   _Zcut[iclass] = zcut;
 }
 double Selectivity::getZcut(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _Zcut[iclass];
 }
 void Selectivity::setBest(int iclass, double best)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, B_EST, best);
 }
 void Selectivity::setMest(int iclass, double mest)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, M_EST, mest);
 }
 
 void Selectivity::setQest(int iclass, double qest)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, Q_EST, qest);
 }
 void Selectivity::setQstd(int iclass, double qstd)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, Q_STD, qstd);
 }
 void Selectivity::setTest(int iclass, double test)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, T_EST, test);
 }
 void Selectivity::setTstd(int iclass, double tstd)
 {
-  if (! _isValidCut(iclass)) return;
+  if (!_isValidCut(iclass)) return;
   _stats.setValue(iclass, T_STD, tstd);
 }
 double Selectivity::getBest(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, B_EST);
 }
 double Selectivity::getMest(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, M_EST);
 }
 double Selectivity::getQest(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, Q_EST);
 }
 double Selectivity::getQstd(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, Q_STD);
 }
 double Selectivity::getTest(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, T_EST);
 }
 double Selectivity::getTstd(int iclass) const
 {
-  if (! _isValidCut(iclass)) return(TEST);
+  if (!_isValidCut(iclass)) return (TEST);
   return _stats.getValue(iclass, T_STD);
 }
 
@@ -487,8 +486,8 @@ void Selectivity::defineRecoveries(const std::vector<ESelectivity>& codes,
                                    double proba,
                                    bool verbose)
 {
-  int ncode = (int) codes.size();
-  _proba = proba;
+  int ncode = (int)codes.size();
+  _proba    = proba;
   _numberQT.reset(getNQT(), 2);
   _numberQT.fill(0);
 
@@ -666,51 +665,51 @@ String Selectivity::getVariableName(const ESelectivity& code, int icut, int mode
 
     case ESelectivity::E_Z:
       if (mode == 0)
-        return("Z-estim");
+        return ("Z-estim");
       else
-        return("Z-stdev");
+        return ("Z-stdev");
       break;
 
     case ESelectivity::E_T:
       if (mode == 0)
-        return(concatenateString("T-estim", _Zcut[icut]));
+        return (concatenateString("T-estim", _Zcut[icut]));
       else
-        return(concatenateString("T-stdev", _Zcut[icut]));
+        return (concatenateString("T-stdev", _Zcut[icut]));
       break;
 
     case ESelectivity::E_Q:
       if (mode == 0)
-        return(concatenateString("Q-estim", _Zcut[icut]));
+        return (concatenateString("Q-estim", _Zcut[icut]));
       else
-        return(concatenateString("Q-stdev", _Zcut[icut]));
+        return (concatenateString("Q-stdev", _Zcut[icut]));
       break;
 
     case ESelectivity::E_B:
       if (mode == 0)
-        return(concatenateString("B-estim", _Zcut[icut]));
+        return (concatenateString("B-estim", _Zcut[icut]));
       else
-        return(concatenateString("B-stdev", _Zcut[icut]));
+        return (concatenateString("B-stdev", _Zcut[icut]));
       break;
 
     case ESelectivity::E_M:
       if (mode == 0)
-        return(concatenateString("M-estim", _Zcut[icut]));
+        return (concatenateString("M-estim", _Zcut[icut]));
       else
-        return(concatenateString("M-stdev", _Zcut[icut]));
+        return (concatenateString("M-stdev", _Zcut[icut]));
       break;
 
     case ESelectivity::E_PROP:
       if (mode == 0)
-        return("Proba-estim");
+        return ("Proba-estim");
       else
-        return("Proba-stdev");
+        return ("Proba-stdev");
       break;
 
     case ESelectivity::E_QUANT:
       if (mode == 0)
-        return("Quant-estim");
+        return ("Quant-estim");
       else
-        return("Quant-stdev");
+        return ("Quant-stdev");
       break;
   }
 
@@ -763,7 +762,7 @@ String Selectivity::getVariableName(int rank0) const
  ** \param[in]  number       Number of cutoffs
  **
  *****************************************************************************/
-void Selectivity::_printQTvars(const char *title, int type, int number)
+void Selectivity::_printQTvars(const char* title, int type, int number)
 {
   message("- %s", title);
   if (type == 1)
@@ -786,7 +785,7 @@ bool Selectivity::_isRecoveryDefined() const
 int Selectivity::getNVar() const
 {
   int ntotal = 0;
-  if (! _isRecoveryDefined()) return ntotal;
+  if (!_isRecoveryDefined()) return ntotal;
   for (int i = 0; i < getNQT(); i++)
   {
     ntotal += _numberQT.getValue(i, 0);
@@ -798,7 +797,7 @@ int Selectivity::getNVar() const
 bool Selectivity::isUsed(const ESelectivity& code) const
 {
   if (code == ESelectivity::UNKNOWN) return false;
-  if (! _isRecoveryDefined()) return false;
+  if (!_isRecoveryDefined()) return false;
   int key = code.getValue();
   if (_numberQT.getValue(key, 0) > 0) return true;
   if (_numberQT.getValue(key, 1) > 0) return true;
@@ -808,7 +807,7 @@ bool Selectivity::isUsed(const ESelectivity& code) const
 bool Selectivity::isUsedEst(const ESelectivity& code) const
 {
   if (code == ESelectivity::UNKNOWN) return false;
-  if (! _isRecoveryDefined()) return false;
+  if (!_isRecoveryDefined()) return false;
   int key = code.getValue();
   return (_numberQT.getValue(key, 0) > 0);
 }
@@ -848,7 +847,7 @@ int Selectivity::getAddressQTEst(const ESelectivity& code, int iptr0, int rank) 
 int Selectivity::getAddressQTStd(const ESelectivity& code, int iptr0, int rank) const
 {
   if (code == ESelectivity::UNKNOWN) return -1;
-  if (! _isRecoveryDefined()) return -1;
+  if (!_isRecoveryDefined()) return -1;
   int key = code.getValue();
   if (rank < 0 || rank >= _numberQT.getValue(key, 1)) return -1;
   return (iptr0 + _rankQT.getValue(key, 1) + rank);
@@ -872,7 +871,7 @@ void Selectivity::calculateBenefitAndGrade()
     tval = getTest(iclass);
     qval = getQest(iclass);
     setBest(iclass, qval - zval * tval);
-    setMest(iclass ,(ABS(tval) < EPSILON6) ? TEST : qval / tval);
+    setMest(iclass, (ABS(tval) < EPSILON6) ? TEST : qval / tval);
   }
 }
 
@@ -887,9 +886,7 @@ void Selectivity::dumpGini() const
 
   double gini = 1.;
   for (int iclass = 0; iclass < nclass - 1; iclass++)
-    gini -= ((getTest(iclass)
-        - getTest(iclass + 1))
-             * (getQest(iclass) + getQest(iclass + 1)));
+    gini -= ((getTest(iclass) - getTest(iclass + 1)) * (getQest(iclass) + getQest(iclass + 1)));
 
   message("Gini calculated on %d classes\n", nclass);
   message("Value of the Gini index = %lf\n", gini);
@@ -902,7 +899,7 @@ void Selectivity::dumpGini() const
  *****************************************************************************/
 void Selectivity::correctTonnageOrder()
 {
-  if (! isFlagTonnageCorrect()) return;
+  if (!isFlagTonnageCorrect()) return;
   int nclass = getNCuts();
   VectorDouble ta(nclass);
   VectorDouble tb(nclass);
@@ -949,14 +946,14 @@ void Selectivity::_interpolateInterval(double zval,
                                        double ti1,
                                        double qi0,
                                        double qi1,
-                                       double *tval,
-                                       double *qval,
+                                       double* tval,
+                                       double* qval,
                                        double tol)
 {
-  double dzi = zi1 - zi0;
-  double dti = ti1 - ti0;
+  double dzi  = zi1 - zi0;
+  double dti  = ti1 - ti0;
   double zmoy = (qi1 - qi0) / (ti1 - ti0);
-  double aa0 = (zi1 - zmoy) / (zmoy - zi0);
+  double aa0  = (zi1 - zmoy) / (zmoy - zi0);
 
   if (ABS(zval - zi0) < tol)
   {
@@ -973,10 +970,8 @@ void Selectivity::_interpolateInterval(double zval,
   }
 
   double u = (zval - zi0) / dzi;
-  (*tval) = (u <= 0.) ? ti0 : ti0 + dti * pow(u, 1. / aa0);
-  (*qval) = (u <= 0.) ? qi0 :
-      qi0 + zi0 * ((*tval) - ti0)
-      + dzi * dti * pow(u, 1. + 1. / aa0) / (1. + aa0);
+  (*tval)  = (u <= 0.) ? ti0 : ti0 + dti * pow(u, 1. / aa0);
+  (*qval)  = (u <= 0.) ? qi0 : qi0 + zi0 * ((*tval) - ti0) + dzi * dti * pow(u, 1. + 1. / aa0) / (1. + aa0);
 }
 
 /****************************************************************************/
@@ -990,7 +985,7 @@ void Selectivity::_interpolateInterval(double zval,
  ** \param[in]  zstdev      St. dev.
  **
  *****************************************************************************/
-void Selectivity::storeInDb(Db *db,
+void Selectivity::storeInDb(Db* db,
                             int iech0,
                             int iptr,
                             double zestim,
@@ -1058,7 +1053,7 @@ void Selectivity::interpolateSelectivity(const Selectivity* selecin)
   double tval, qval;
 
   double z_max = getZmax();
-  int nclass = selecin->getNCuts();
+  int nclass   = selecin->getNCuts();
   int ncutmine = getNCuts();
   VectorDouble zz(nclass + 2);
   VectorDouble TT(nclass + 2);
@@ -1155,7 +1150,7 @@ void Selectivity::_defineAutomaticCutoffs(const VectorDouble& tab, double eps)
 {
   double zmin = VH::minimum(tab);
   double zmax = VH::maximum(tab) + eps;
-  int ncuts = getNCuts();
+  int ncuts   = getNCuts();
 
   if (ncuts <= 1)
   {
@@ -1163,20 +1158,20 @@ void Selectivity::_defineAutomaticCutoffs(const VectorDouble& tab, double eps)
     return;
   }
   for (int icut = 0; icut < ncuts; icut++)
-    _Zcut[icut] = zmin + (zmax - zmin) * (double) icut / ((double) (ncuts - 1));
+    _Zcut[icut] = zmin + (zmax - zmin) * (double)icut / ((double)(ncuts - 1));
 }
 
-int dbSelectivity(Db *db,
-                  const String &name,
-                  const VectorDouble &zcuts,
-                  const NamingConvention &namconv)
+int dbSelectivity(Db* db,
+                  const String& name,
+                  const VectorDouble& zcuts,
+                  const NamingConvention& namconv)
 {
   if (db == nullptr)
   {
     messerr("You need a 'Db' already defined");
     return 1;
   }
-  int ncuts = (int) zcuts.size();
+  int ncuts = (int)zcuts.size();
   if (ncuts <= 0)
   {
     messerr("argument 'zcuts' must have some cutoffs defined");
@@ -1200,7 +1195,7 @@ int dbSelectivity(Db *db,
 
   for (int iech = 0; iech < db->getNSample(); iech++)
   {
-    if (! db->isActive(iech)) continue;
+    if (!db->isActive(iech)) continue;
     double value = db->getArray(iech, iuid);
 
     for (int icut = 0; icut < ncuts; icut++)
@@ -1219,4 +1214,4 @@ int dbSelectivity(Db *db,
   return 0;
 }
 
-}
+} // namespace gstlrn

--- a/src/Variogram/DirParam.cpp
+++ b/src/Variogram/DirParam.cpp
@@ -8,17 +8,16 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include <Geometry/GeometryHelper.hpp>
-
 #include "Variogram/DirParam.hpp"
-#include "Db/Db.hpp"
-#include "Db/DbGrid.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
 #include "Space/ASpace.hpp"
+#include <Geometry/GeometryHelper.hpp>
 
-#include <math.h>
+#include <cmath>
 
 namespace gstlrn
 {
@@ -35,45 +34,45 @@ DirParam::DirParam(int nlag,
                    const VectorDouble& codir,
                    double angle2D,
                    const ASpaceSharedPtr& space)
-    : ASpaceObject(space),
-      _nLag(nlag),
-      _optionCode(opt_code),
-      _idate(idate),
-      _dLag(dlag),
-      _bench(bench),
-      _cylRad(cylrad),
-      _tolDist(toldis),
-      _tolAngle(tolang),
-      _tolCode(tolcode),
-      _breaks(breaks),
-      _codir(codir),
-      _grincr()
+  : ASpaceObject(space)
+  , _nLag(nlag)
+  , _optionCode(opt_code)
+  , _idate(idate)
+  , _dLag(dlag)
+  , _bench(bench)
+  , _cylRad(cylrad)
+  , _tolDist(toldis)
+  , _tolAngle(tolang)
+  , _tolCode(tolcode)
+  , _breaks(breaks)
+  , _codir(codir)
+  , _grincr()
 {
   _completeDefinition(angle2D);
 }
 
-DirParam::DirParam(const DbGrid *dbgrid,
+DirParam::DirParam(const DbGrid* dbgrid,
                    int nlag,
-                   const VectorInt &grincr,
+                   const VectorInt& grincr,
                    const ASpaceSharedPtr& space)
-    : ASpaceObject(space),
-      _nLag(nlag),
-      _optionCode(0),
-      _idate(0),
-      _dLag(0),
-      _bench(TEST),
-      _cylRad(TEST),
-      _tolDist(0.5),
-      _tolAngle(0.),
-      _tolCode(0),
-      _breaks(),
-      _codir(),
-      _grincr(grincr)
+  : ASpaceObject(space)
+  , _nLag(nlag)
+  , _optionCode(0)
+  , _idate(0)
+  , _dLag(0)
+  , _bench(TEST)
+  , _cylRad(TEST)
+  , _tolDist(0.5)
+  , _tolAngle(0.)
+  , _tolCode(0)
+  , _breaks()
+  , _codir()
+  , _grincr(grincr)
 {
   int ndim = getDefaultSpaceDimension();
   if (space != nullptr) ndim = space->getNDim();
 
-  _codir = dbgrid->getCodir(grincr);
+  _codir      = dbgrid->getCodir(grincr);
   double dlag = 0.;
   for (int idim = 0; idim < ndim; idim++)
     dlag += _codir[idim] * _codir[idim];
@@ -82,19 +81,19 @@ DirParam::DirParam(const DbGrid *dbgrid,
 }
 
 DirParam::DirParam(const DirParam& r)
-    : ASpaceObject(r),
-      _nLag(r._nLag),
-      _optionCode(r._optionCode),
-      _idate(r._idate),
-      _dLag(r._dLag),
-      _bench(r._bench),
-      _cylRad(r._cylRad),
-      _tolDist(r._tolDist),
-      _tolAngle(r._tolAngle),
-      _tolCode(r._tolCode),
-      _breaks(r._breaks),
-      _codir(r._codir),
-      _grincr(r._grincr)
+  : ASpaceObject(r)
+  , _nLag(r._nLag)
+  , _optionCode(r._optionCode)
+  , _idate(r._idate)
+  , _dLag(r._dLag)
+  , _bench(r._bench)
+  , _cylRad(r._cylRad)
+  , _tolDist(r._tolDist)
+  , _tolAngle(r._tolAngle)
+  , _tolCode(r._tolCode)
+  , _breaks(r._breaks)
+  , _codir(r._codir)
+  , _grincr(r._grincr)
 {
 }
 
@@ -103,18 +102,18 @@ DirParam& DirParam::operator=(const DirParam& r)
   if (this != &r)
   {
     ASpaceObject::operator=(r);
-    _nLag = r._nLag;
+    _nLag       = r._nLag;
     _optionCode = r._optionCode;
-    _idate = r._idate;
-    _dLag = r._dLag;
-    _bench = r._bench;
-    _cylRad = r._cylRad;
-    _tolDist = r._tolDist;
-    _tolAngle = r._tolAngle;
-    _tolCode = r._tolCode;
-    _breaks = r._breaks;
-    _codir = r._codir;
-    _grincr = r._grincr;
+    _idate      = r._idate;
+    _dLag       = r._dLag;
+    _bench      = r._bench;
+    _cylRad     = r._cylRad;
+    _tolDist    = r._tolDist;
+    _tolAngle   = r._tolAngle;
+    _tolCode    = r._tolCode;
+    _breaks     = r._breaks;
+    _codir      = r._codir;
+    _grincr     = r._grincr;
   }
   return *this;
 }
@@ -158,7 +157,7 @@ DirParam* DirParam::createOmniDirection(int nlag,
 
 DirParam* DirParam::createFromGrid(const DbGrid* dbgrid,
                                    int nlag,
-                                   const VectorInt &grincr,
+                                   const VectorInt& grincr,
                                    const ASpaceSharedPtr& space)
 {
   return new DirParam(dbgrid, nlag, grincr, space);
@@ -178,16 +177,16 @@ double DirParam::getCodir(int i) const
 
 void DirParam::_completeDefinition(double angle2D)
 {
-  if (! _breaks.empty())
+  if (!_breaks.empty())
   {
     if (_breaks.size() < 2) _breaks.clear();
   }
 
   int ndim = getNDim();
 
-  if (! FFFF(angle2D))
+  if (!FFFF(angle2D))
   {
-    _codir.resize(ndim,0.);
+    _codir.resize(ndim, 0.);
     _codir[0] = cos(angle2D * GV_PI / 180.);
     _codir[1] = sin(angle2D * GV_PI / 180.);
   }
@@ -229,7 +228,7 @@ void DirParam::setDPas(const DbGrid* db)
 {
   if (_grincr.empty()) return;
   double dlag = 0;
-  for (int idim = 0; idim < (int) getNDim(); idim++)
+  for (int idim = 0; idim < (int)getNDim(); idim++)
   {
     double delta = _grincr[idim] * db->getDX(idim);
     dlag += delta * delta;
@@ -240,7 +239,7 @@ void DirParam::setDPas(const DbGrid* db)
 int DirParam::getGrincr(int idim) const
 {
   if (_grincr.empty()) return 0;
-  if (! isDimensionValid(idim)) return 0;
+  if (!isDimensionValid(idim)) return 0;
   return _grincr[idim];
 }
 
@@ -272,20 +271,20 @@ String DirParam::toString(const AStringFormat* /*strfmt*/) const
   if (ndim > 1)
   {
     VectorDouble angles(ndim);
-    (void) GH::rotationGetAnglesFromCodirInPlace(_codir,angles);
+    (void)GH::rotationGetAnglesFromCodirInPlace(_codir, angles);
     if (ndim > 2)
       sstr << toVector("Direction angles (degrees)  = ", angles);
     else
       sstr << "Direction angles (degrees)  = " << toDouble(angles[0]) << std::endl;
   }
 
-  if (! FFFF(_tolAngle))
+  if (!FFFF(_tolAngle))
     sstr << "Tolerance on direction      = " << toDouble(_tolAngle)
-    << " (degrees)" << std::endl;
+         << " (degrees)" << std::endl;
 
-  if (! FFFF(_bench)  && _bench > 0.)
+  if (!FFFF(_bench) && _bench > 0.)
     sstr << "Slice bench                 = " << toDouble(_bench) << std::endl;
-  if (! FFFF(_cylRad) && _cylRad > 0.)
+  if (!FFFF(_cylRad) && _cylRad > 0.)
     sstr << "Slice radius                = " << toDouble(_cylRad) << std::endl;
 
   if (getFlagRegular())
@@ -294,7 +293,7 @@ String DirParam::toString(const AStringFormat* /*strfmt*/) const
     {
       sstr << "Calculation lag             = " << toDouble(getDPas()) << std::endl;
       sstr << "Tolerance on distance       = " << toDouble(100. * getTolDist())
-                     << " (Percent of the lag value)" << std::endl;
+           << " (Percent of the lag value)" << std::endl;
     }
   }
   else
@@ -303,11 +302,11 @@ String DirParam::toString(const AStringFormat* /*strfmt*/) const
     for (int i = 0; i < getNBreak(); i++)
     {
       sstr << " - Interval " << i + 1 << " = ["
-          << toInterval(getBreak(i), getBreak(i + 1)) << "]" << std::endl;
+           << toInterval(getBreak(i), getBreak(i + 1)) << "]" << std::endl;
     }
   }
 
-  if (! _grincr.empty())
+  if (!_grincr.empty())
   {
 
     // Case of a variogram defined on a Grid db
@@ -341,9 +340,9 @@ std::vector<DirParam> DirParam::createMultiple(int ndir,
   std::vector<DirParam> dirs;
   for (int idir = 0; idir < ndir; idir++)
   {
-    angles[0] = 180. * (double) idir / (double) ndir + angref;
-    (void) GH::rotationGetDirection2D(angles,codir);
-    double tolang = 90. / (double) ndir;
+    angles[0] = 180. * (double)idir / (double)ndir + angref;
+    (void)GH::rotationGetDirection2D(angles, codir);
+    double tolang     = 90. / (double)ndir;
     DirParam dirparam = DirParam(nlag, dlag, toldis, tolang, 0, 0, TEST, TEST, 0.,
                                  VectorDouble(), codir, TEST, space);
     dirs.push_back(dirparam);
@@ -351,7 +350,7 @@ std::vector<DirParam> DirParam::createMultiple(int ndir,
   return dirs;
 }
 
-std::vector<DirParam> DirParam::createSeveral2D(const VectorDouble &angles,
+std::vector<DirParam> DirParam::createSeveral2D(const VectorDouble& angles,
                                                 int nlag,
                                                 double dlag,
                                                 double toldis,
@@ -368,19 +367,18 @@ std::vector<DirParam> DirParam::createSeveral2D(const VectorDouble &angles,
   }
 
   VectorDouble anglesloc = VectorDouble(1);
-  VectorDouble codir  = VectorDouble(ndim);
-  int ndir = (int) angles.size();
+  VectorDouble codir     = VectorDouble(ndim);
+  int ndir               = (int)angles.size();
   if (FFFF(tolang)) tolang = 90. / ndir;
   for (int idir = 0; idir < ndir; idir++)
   {
     anglesloc[0] = angles[idir];
-    (void) GH::rotationGetDirection2D(anglesloc,codir);
+    (void)GH::rotationGetDirection2D(anglesloc, codir);
     DirParam dirparam = DirParam(nlag, dlag, toldis, tolang, 0, 0, TEST, TEST, 0.,
                                  VectorDouble(), codir, TEST, space);
     dirs.push_back(dirparam);
   }
   return dirs;
-
 }
 
 /**
@@ -404,7 +402,7 @@ std::vector<DirParam> DirParam::createMultipleInSpace(int nlag, double dlag, con
   for (int idim = 0; idim < ndim; idim++)
   {
     VH::fill(codir, 0);
-    codir[idim] = 1;
+    codir[idim]        = 1;
     DirParam* dirparam = DirParam::create(nlag, dlag, 0.5, 0., 0, 0, TEST, TEST, 0., VectorDouble(), codir, TEST, space);
     dirs.push_back(*dirparam);
     delete dirparam;
@@ -430,7 +428,7 @@ int DirParam::getLagRank(double dist) const
   int ilag = -1;
   if (getFlagRegular())
   {
-    ilag = (int) floor(distloc / getDPas() + 0.5);
+    ilag = (int)floor(distloc / getDPas() + 0.5);
     if (ABS(distloc - ilag * getDPas()) > getTolDist() * getDPas()) return (ITEST);
   }
   else
@@ -443,4 +441,4 @@ int DirParam::getLagRank(double dist) const
 
   return ilag;
 }
-}
+} // namespace gstlrn

--- a/tests/cpp/test_Francky.cpp
+++ b/tests/cpp/test_Francky.cpp
@@ -8,19 +8,17 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/OptCustom.hpp"
-#include "Basic/Law.hpp"
+#include "API/SPDE.hpp"
 #include "Basic/File.hpp"
 #include "Basic/FunctionalSpirale.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/OptCustom.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbStringFormat.hpp"
-#include "Model/Model.hpp"
 #include "Estimation/CalcKriging.hpp"
-#include "API/SPDE.hpp"
+#include "Model/Model.hpp"
 #include "Neigh/NeighUnique.hpp"
-
-#include <math.h>
 
 #define __USE_MATH_DEFINES
 #include <cmath>
@@ -32,10 +30,10 @@ using namespace gstlrn;
  ** Main Program
  **
  *****************************************************************************/
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 
 {
-  OptCustom::define("ompthreads",1);
+  OptCustom::define("ompthreads", 1);
   int seed = 10355;
   law_set_random_seed(seed);
 
@@ -43,17 +41,17 @@ int main(int argc, char *argv[])
   sfn << gslBaseName(__FILE__) << ".out";
   StdoutRedirect sr(sfn.str(), argc, argv);
 
-  DbStringFormat dbfmt(FLAG_STATS,{"Kriging*"});
+  DbStringFormat dbfmt(FLAG_STATS, {"Kriging*"});
 
   ASerializable::setPrefixName("test_Francky-");
 
   // Creating the 2-D Grid
-  auto nx = { 101, 101 };
+  auto nx      = {101, 101};
   DbGrid* grid = DbGrid::create(nx);
 
   // Creating the 2-D Data Db with a Normal Variable
   auto ndata = 100;
-  Db* dat = Db::createFromBox(ndata, {0.,0.}, {100.,100.}, 3243);
+  Db* dat    = Db::createFromBox(ndata, {0., 0.}, {100., 100.}, 3243);
 
   // Creating the Neighborhood (Unique)
   NeighUnique* neighU = NeighUnique::create();
@@ -70,8 +68,8 @@ int main(int argc, char *argv[])
   int useCholesky = 0;
   law_set_random_seed(13256);
   (void)gstlrn::simulateSPDE(nullptr, dat, model, 1, useCholesky,
-                     VectorMeshes(), nullptr, VectorMeshes(), nullptr, SPDEParam(),
-                     NamingConvention("Data", true, false));
+                             VectorMeshes(), nullptr, VectorMeshes(), nullptr, SPDEParam(),
+                             NamingConvention("Data", true, false));
   (void)dat->dumpToNF("Data.NF");
 
   // Testing Kriging (traditional method)
@@ -81,7 +79,7 @@ int main(int argc, char *argv[])
   (void)gstlrn::krigingSPDE(dat, grid, model, true, false, useCholesky);
 
   // Printout (optional)
-  (void) grid->dumpToNF("Grid.NF");
+  (void)grid->dumpToNF("Grid.NF");
   grid->display(&dbfmt);
 
   message("Test performed successfully\n");

--- a/tests/cpp/test_Gibbs.cpp
+++ b/tests/cpp/test_Gibbs.cpp
@@ -45,8 +45,8 @@ using namespace gstlrn;
 ** \param[in]  z        Array giving the simulated field
 **
 *****************************************************************************/
-static int st_save(Db    *dbgrid,
-                   const VectorInt&    colors,
+static int st_save(Db* dbgrid,
+                   const VectorInt& colors,
                    const VectorDouble& consmin,
                    const VectorDouble& consmax,
                    const VectorDouble& z)
@@ -55,26 +55,26 @@ static int st_save(Db    *dbgrid,
   int nech = dbgrid->getNSample();
 
   /* Add the terms to 'dbgrid' */
-  
-  if (! consmin.empty())
+
+  if (!consmin.empty())
   {
-    if (db_locator_attribute_add(dbgrid,ELoc::L,1,0,0.,&iptr)) return(1);
-    for (int i=0; i<nech; i++) dbgrid->setArray(i,iptr,consmin[i]);
+    if (db_locator_attribute_add(dbgrid, ELoc::L, 1, 0, 0., &iptr)) return (1);
+    for (int i = 0; i < nech; i++) dbgrid->setArray(i, iptr, consmin[i]);
   }
-  if (! consmax.empty())
+  if (!consmax.empty())
   {
-    if (db_locator_attribute_add(dbgrid,ELoc::U,1,0,0.,&iptr)) return(1);
-    for (int i=0; i<nech; i++) dbgrid->setArray(i,iptr,consmax[i]);
+    if (db_locator_attribute_add(dbgrid, ELoc::U, 1, 0, 0., &iptr)) return (1);
+    for (int i = 0; i < nech; i++) dbgrid->setArray(i, iptr, consmax[i]);
   }
-  iptr = dbgrid->addColumnsByConstant(1,0., "Color");
-  for (int i=0; i<nech; i++) dbgrid->setArray(i,iptr,colors[i]);
-  if (db_locator_attribute_add(dbgrid,ELoc::Z,1,0,0.,&iptr)) return(1);
-  for (int i=0; i<nech; i++) dbgrid->setArray(i,iptr,z[i]);
+  iptr = dbgrid->addColumnsByConstant(1, 0., "Color");
+  for (int i = 0; i < nech; i++) dbgrid->setArray(i, iptr, colors[i]);
+  if (db_locator_attribute_add(dbgrid, ELoc::Z, 1, 0, 0., &iptr)) return (1);
+  for (int i = 0; i < nech; i++) dbgrid->setArray(i, iptr, z[i]);
 
   /* Save the resulting 'dbgrid' in a neutral file */
 
-  (void) dbgrid->dumpToNF("Colored_Gibbs");
-  return(0);
+  (void)dbgrid->dumpToNF("Colored_Gibbs");
+  return (0);
 }
 
 /*****************************************************************************/
@@ -92,14 +92,14 @@ static void st_print_all(const VectorInt& colors,
                          const VectorDouble& consmin,
                          const VectorDouble& consmax,
                          const VectorDouble& sigma,
-                         const MatrixSparse *Q)
+                         const MatrixSparse* Q)
 {
-  if (! consmin.empty())
-    print_matrix ("consmin",0,0,1,10,NULL,consmin.data());
-  if (! consmax.empty())
-    print_matrix ("consmax",0,0,1,10,NULL,consmax.data());
-  print_matrix ("sigma"  ,0,0,1,10,NULL,sigma.data());
-  print_imatrix("colors" ,0,0,1,10,NULL,colors.data());
+  if (!consmin.empty())
+    print_matrix("consmin", 0, 0, 1, 10, NULL, consmin.data());
+  if (!consmax.empty())
+    print_matrix("consmax", 0, 0, 1, 10, NULL, consmax.data());
+  print_matrix("sigma", 0, 0, 1, 10, NULL, sigma.data());
+  print_imatrix("colors", 0, 0, 1, 10, NULL, colors.data());
   Q->display();
 }
 
@@ -121,22 +121,22 @@ static void st_print_all(const VectorInt& colors,
 *****************************************************************************/
 static void st_vector_compress(int nvertex,
                                int colref,
-                               const VectorDouble &z,
-                               const VectorInt &colors,
-                               VectorInt &ind,
-                               VectorDouble &zred)
+                               const VectorDouble& z,
+                               const VectorInt& colors,
+                               VectorInt& ind,
+                               VectorDouble& zred)
 {
   ind.clear();
   zred.clear();
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
   {
-    if (colors[i] != colref) 
+    if (colors[i] != colref)
       zred.push_back(z[i]);
     else
       ind.push_back(i);
   }
 }
-  
+
 /*****************************************************************************/
 /*!
 **  Draw a random value from a Gaussian distribution under the constraint
@@ -152,21 +152,21 @@ static void st_vector_compress(int nvertex,
 ** \param[in]  sigma    Standard deviation of the Gaussian distribution
 **
 *****************************************************************************/
-static double st_simcond(int    iter,
-                         int    niter,
+static double st_simcond(int iter,
+                         int niter,
                          double valmin,
                          double valmax,
                          double mean,
                          double sigma)
 {
-  double locmin,locmax,x,delta,ratio;
+  double locmin, locmax, x, delta, ratio;
 
-  ratio  = (double) (niter-iter-1) / (double) (iter+1);
-  delta  = valmax - valmin;
+  ratio = (double)(niter - iter - 1) / (double)(iter + 1);
+  delta = valmax - valmin;
   if (valmin == -10.)
     locmin = -10.;
-  else 
-  {    
+  else
+  {
     locmin = valmin - delta * ratio;
     locmin = (locmin - mean) / sigma;
   }
@@ -178,8 +178,8 @@ static double st_simcond(int    iter,
     locmax = (locmax - mean) / sigma;
   }
 
-  x = law_gaussian_between_bounds(locmin,locmax);
-  return(mean + x * sigma);
+  x = law_gaussian_between_bounds(locmin, locmax);
+  return (mean + x * sigma);
 }
 
 /*****************************************************************************/
@@ -209,40 +209,40 @@ static double st_simcond(int    iter,
 ** \remarks        (Dimension 'nvertex')
 **
 *****************************************************************************/
-static int st_gibbs(int  niter,
-                    int  ncolor,
-                    int  nvertex,
+static int st_gibbs(int niter,
+                    int ncolor,
+                    int nvertex,
                     const VectorInt& colors,
                     const VectorInt& colref,
-                    MatrixSparse **Qcols,
+                    MatrixSparse** Qcols,
                     const VectorDouble& consmin,
                     const VectorDouble& consmax,
                     const VectorDouble& sigma,
                     VectorDouble& z,
                     VectorDouble& krig)
 {
-  mestitle(1,"Entering in Gibbs algorithm with niter=%d and ncolor=%d",niter,ncolor);
+  mestitle(1, "Entering in Gibbs algorithm with niter=%d and ncolor=%d", niter, ncolor);
   VectorInt ind;
   VectorDouble zred;
 
-  for (int iter=0; iter<niter; iter++)
+  for (int iter = 0; iter < niter; iter++)
   {
-    if (iter % 1000 == 0) message("Iteration %d\n",iter);
-    for (int icol=0; icol<ncolor; icol++)
+    if (iter % 1000 == 0) message("Iteration %d\n", iter);
+    for (int icol = 0; icol < ncolor; icol++)
     {
-      st_vector_compress(nvertex,colref[icol],z,colors,ind,zred);
+      st_vector_compress(nvertex, colref[icol], z, colors, ind, zred);
       Qcols[icol]->prodVecMatInPlacePtr(zred.data(), krig.data(), false);
 
-      for (int ic=0, nc = (int) ind.size(); ic<nc; ic++)
+      for (int ic = 0, nc = (int)ind.size(); ic < nc; ic++)
       {
-        int i  = ind[ic];
-        double valmin = (! consmin.empty()) ? consmin[i] : -10.;
-        double valmax = (! consmax.empty()) ? consmax[i] : +10.;
-        z[i] = st_simcond(iter, niter, valmin, valmax, krig[ic], sigma[i]);
+        int i         = ind[ic];
+        double valmin = (!consmin.empty()) ? consmin[i] : -10.;
+        double valmax = (!consmax.empty()) ? consmax[i] : +10.;
+        z[i]          = st_simcond(iter, niter, valmin, valmax, krig[ic], sigma[i]);
       }
     }
   }
-  return(0);
+  return (0);
 }
 
 /****************************************************************************/
@@ -250,11 +250,11 @@ static int st_gibbs(int  niter,
 ** Main Program
 **
 *****************************************************************************/
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 
 {
-  bool   flag_print =  false;
-  bool   flag_save  =  true;
+  bool flag_print = false;
+  bool flag_save  = true;
 
   std::stringstream sfn;
   sfn << gslBaseName(__FILE__) << ".out";
@@ -263,117 +263,118 @@ int main(int argc, char *argv[])
   /***********************/
   /* 1 - Initializations */
   /***********************/
-  int ndim     = 2;
+  int ndim = 2;
   defineDefaultSpace(ESpaceType::RN, ndim);
   ASerializable::setPrefixName("Gibbs-");
 
   // Setup constants
 
   OptDbg::reset();
-  OptCst::define(ECst::NTCAR,10.);
-  OptCst::define(ECst::NTDEC,6.);
-  
+  OptCst::define(ECst::NTCAR, 10.);
+  OptCst::define(ECst::NTDEC, 6.);
+
   setGlobalFlagEigen(true);
 
   // 2-D grid output file
 
-  VectorInt nx = { 100, 100 };
-  VectorDouble x0 = { 0., 0. };
-  VectorDouble dx = { 1., 1. };
-  DbGrid *dbgrid = DbGrid::create(nx, dx, x0, VectorDouble(), ELoadBy::COLUMN,
-                                  VectorDouble(), VectorString(), VectorString(), 1);
-    
+  VectorInt nx    = {100, 100};
+  VectorDouble x0 = {0., 0.};
+  VectorDouble dx = {1., 1.};
+  DbGrid* dbgrid  = DbGrid::create(nx, dx, x0, VectorDouble(), ELoadBy::COLUMN,
+                                   VectorDouble(), VectorString(), VectorString(), 1);
+
   // Model for SPDE
 
-  double range_spde =   30.;
-  double param_spde =    1.;
-  double sill_spde  =    1.;
-  Model* model1 = Model::createFromParam(ECov::MATERN,range_spde,sill_spde,param_spde);
+  double range_spde = 30.;
+  double param_spde = 1.;
+  double sill_spde  = 1.;
+  Model* model1     = Model::createFromParam(ECov::MATERN, range_spde, sill_spde, param_spde);
 
   // Model for constraints
 
-  double range_cons =   50.;
-  double param_cons =    2.;
-  double sill_cons  =    1.;
-  Model* model2 = Model::createFromParam(ECov::MATERN,range_cons,sill_cons,param_cons);
+  double range_cons = 50.;
+  double param_cons = 2.;
+  double sill_cons  = 1.;
+  Model* model2     = Model::createFromParam(ECov::MATERN, range_cons, sill_cons, param_cons);
 
   // Creating the meshing for extracting Q
 
   MeshETurbo mesh(dbgrid);
-  auto P = PrecisionOpMatrix(&mesh, model1->getCovAniso(0));
+  auto P                   = PrecisionOpMatrix(&mesh, model1->getCovAniso(0));
   const MatrixSparse* Qref = P.getQ();
-  MatrixSparse* Q = new MatrixSparse(*Qref);
-  int nvertex = mesh.getNApices();
+  MatrixSparse* Q          = new MatrixSparse(*Qref);
+  int nvertex              = mesh.getNApices();
 
   // Coding the various colors
 
   VectorInt colors = Q->colorCoding();
   VectorInt colref = VH::unique(colors);
-  int ncolor = (int) colref.size();
+  int ncolor       = (int)colref.size();
 
   // Core allocation
-  
-  VectorDouble z(nvertex,0);
-  VectorDouble krig(nvertex,0);
-  VectorDouble consmin(nvertex,0);
-  VectorDouble consmax(nvertex,0);
+
+  VectorDouble z(nvertex, 0);
+  VectorDouble krig(nvertex, 0);
+  VectorDouble consmin(nvertex, 0);
+  VectorDouble consmax(nvertex, 0);
 
   // Creating the constraints
 
   int seed = 31415;
   law_set_random_seed(seed);
-  int nsimu = 2;
+  int nsimu       = 2;
   int useCholesky = 1;
   (void)gstlrn::simulateSPDE(nullptr, dbgrid, model2, nsimu, useCholesky);
 
   int rank = dbgrid->getNColumn();
-  for (int i=0; i<nvertex; i++)
+  for (int i = 0; i < nvertex; i++)
   {
-    consmin[i] = MIN(dbgrid->getArray(i,rank-1), dbgrid->getArray(i,rank-2));
-    consmax[i] = MAX(dbgrid->getArray(i,rank-1), dbgrid->getArray(i,rank-2));
-    z[i] = (consmin[i] + consmax[i]) / 2.;
+    consmin[i] = MIN(dbgrid->getArray(i, rank - 1), dbgrid->getArray(i, rank - 2));
+    consmax[i] = MAX(dbgrid->getArray(i, rank - 1), dbgrid->getArray(i, rank - 2));
+    z[i]       = (consmin[i] + consmax[i]) / 2.;
   }
-  
+
   // Creating the variance
-  
+
   VectorDouble sigma = Q->getDiagonal(0);
   VH::transformVD(sigma, -3);
 
   // Scaling the Q matrix
-  
-  (void) Q->scaleByDiag();
+
+  (void)Q->scaleByDiag();
 
   // Check the imported information
 
-  if (flag_print) st_print_all(colors,consmin,consmax,sigma,Q);
+  if (flag_print) st_print_all(colors, consmin, consmax, sigma, Q);
 
   //----------------//
   // Main Algorithm //
   //----------------//
 
-  MatrixSparse** Qcols = (MatrixSparse **) mem_alloc(sizeof(MatrixSparse *) * ncolor,1);
-  for (int icol=0; icol<ncolor; icol++)
+  MatrixSparse** Qcols = new MatrixSparse*[ncolor];
+  for (int icol = 0; icol < ncolor; icol++)
     Qcols[icol] = Q->extractSubmatrixByColor(colors, colref[icol], true, false);
 
   // Perform the Gibbs sampler
   int niter = 10;
-  (void) st_gibbs(niter, ncolor, nvertex, colors, colref, Qcols, consmin, consmax,
-                  sigma, z, krig);
+  (void)st_gibbs(niter, ncolor, nvertex, colors, colref, Qcols, consmin, consmax,
+                 sigma, z, krig);
 
   // Add the newly created field to the grid for printout
   if (flag_save)
   {
-    (void) st_save(dbgrid,colors,consmin,consmax,z);
+    (void)st_save(dbgrid, colors, consmin, consmax, z);
     DbStringFormat dbfmt(FLAG_STATS);
     dbgrid->display(&dbfmt);
   }
-  
-  for (int icol=0; icol<ncolor; icol++)
+
+  for (int icol = 0; icol < ncolor; icol++)
     delete Qcols[icol];
+  delete[] Qcols;
   delete dbgrid;
   delete model1;
   delete model2;
   delete Q;
-  
-  return(0);
+
+  return (0);
 }

--- a/tests/cpp/test_KD.cpp
+++ b/tests/cpp/test_KD.cpp
@@ -12,25 +12,25 @@
 #include "Enum/ECov.hpp"
 #include "Enum/ESpaceType.hpp"
 
-#include "Space/ASpaceObject.hpp"
-#include "Db/Db.hpp"
-#include "Db/DbStringFormat.hpp"
-#include "Model/Model.hpp"
-#include "Model/Constraints.hpp"
-#include "Basic/Law.hpp"
-#include "Basic/File.hpp"
-#include "Basic/OptDbg.hpp"
-#include "Neigh/NeighMoving.hpp"
 #include "Anamorphosis/AnamHermite.hpp"
 #include "Anamorphosis/CalcAnamTransform.hpp"
-#include "Variogram/VarioParam.hpp"
-#include "Variogram/Vario.hpp"
-#include "Estimation/CalcKriging.hpp"
-#include "Simulation/CalcSimuTurningBands.hpp"
+#include "Basic/File.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/OptDbg.hpp"
 #include "Calculators/CalcStatistics.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbStringFormat.hpp"
+#include "Estimation/CalcKriging.hpp"
 #include "Estimation/CalcKrigingFactors.hpp"
+#include "Model/Constraints.hpp"
+#include "Model/Model.hpp"
+#include "Neigh/NeighMoving.hpp"
+#include "Simulation/CalcSimuTurningBands.hpp"
+#include "Space/ASpaceObject.hpp"
+#include "Variogram/Vario.hpp"
+#include "Variogram/VarioParam.hpp"
 
-#include <math.h>
+#include <cmath>
 
 using namespace gstlrn;
 
@@ -39,7 +39,7 @@ using namespace gstlrn;
  ** Main Program
  **
  *****************************************************************************/
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
   std::stringstream sfn;
   sfn << gslBaseName(__FILE__) << ".out";
@@ -52,42 +52,42 @@ int main(int argc, char *argv[])
   DbStringFormat dbfmt(FLAG_STATS);
 
   // General parameters
-  bool verbose    = true;
+  bool verbose = true;
 
   // Generate initial grid
-  DbGrid* grid = DbGrid::create({100,100}, {0.01,0.01});
+  DbGrid* grid = DbGrid::create({100, 100}, {0.01, 0.01});
 
   // Create grid of (single) Panel
-  double dx_P = 0.250;
-  double x0_P = 0.375;
-  DbGrid* panel = DbGrid::create({1,1}, {dx_P, dx_P}, {x0_P, x0_P});
+  double dx_P   = 0.250;
+  double x0_P   = 0.375;
+  DbGrid* panel = DbGrid::create({1, 1}, {dx_P, dx_P}, {x0_P, x0_P});
   panel->display();
 
   // Discretization with blocs
-  int nx_B = 5;
-  double x0_B = x0_P + dx_P / nx_B / 2.;
-  double dx_B = dx_P / nx_B;
-  DbGrid* blocs = DbGrid::create({nx_B,nx_B}, {dx_B,dx_B}, {x0_B,x0_B});
+  int nx_B      = 5;
+  double x0_B   = x0_P + dx_P / nx_B / 2.;
+  double dx_B   = dx_P / nx_B;
+  DbGrid* blocs = DbGrid::create({nx_B, nx_B}, {dx_B, dx_B}, {x0_B, x0_B});
   blocs->display();
 
   // Simulation of the Data
   Model* model_init = Model::createFromParam(ECov::EXPONENTIAL, 0.1, 1.);
-  (void) simtub(nullptr, grid, model_init);
+  (void)simtub(nullptr, grid, model_init);
   grid->setName("Simu", "Y");
   grid->display();
 
   // Non-linear transform
-  double m_Z = 1.5;
-  double s_Z = 0.5;
+  double m_Z        = 1.5;
+  double s_Z        = 0.5;
   VectorDouble Zval = grid->getColumn("Y");
-  for (int i = 0; i < (int) Zval.size(); i++)
+  for (int i = 0; i < (int)Zval.size(); i++)
     Zval[i] = m_Z * exp(s_Z * Zval[i] - 0.5 * s_Z * s_Z);
   grid->addColumns(Zval, "Z");
   grid->display(&dbfmt);
 
   // Data extraction
-  int np = 500;
-  Db* data = Db::createSamplingDb(grid, 0., np, {"x1","x2","Y","Z"});
+  int np   = 500;
+  Db* data = Db::createSamplingDb(grid, 0., np, {"x1", "x2", "Y", "Z"});
   data->setLocator("Z", ELoc::Z, 0);
   data->display(&dbfmt);
 
@@ -98,8 +98,8 @@ int main(int argc, char *argv[])
 
   // Selectivity
   Selectivity* selectivity =
-      Selectivity::createByCodes( { ESelectivity::Q, ESelectivity::T },
-                                  { 0., 0.5 }, true, true);
+    Selectivity::createByCodes({ESelectivity::Q, ESelectivity::T},
+                               {0., 0.5}, true, true);
 
   // Global experimental selectivity
   data->display();
@@ -117,12 +117,12 @@ int main(int argc, char *argv[])
 
   // Fitting the Model on the Raw variable
   Model* model_raw = new Model(1, ndim);
-  (void) model_raw->fit(vario_raw);
+  (void)model_raw->fit(vario_raw);
   model_raw->display();
 
   // Transform Data into Gaussian variable
-  (void) anam->rawToGaussianByLocator(data);
-  data->setName("Y.Z","Gauss.Z");
+  (void)anam->rawToGaussianByLocator(data);
+  data->setName("Y.Z", "Gauss.Z");
   data->display();
 
   // Calculate the variogram of the Gaussian variable
@@ -130,15 +130,15 @@ int main(int argc, char *argv[])
   vario->display();
 
   // Fitting the Model on the Gaussian transformed variable
-  Model* model = new Model(1, ndim);
+  Model* model            = new Model(1, ndim);
   Constraints constraints = Constraints(1.);
-  (void) model->fit(vario, {ECov::EXPONENTIAL, ECov::EXPONENTIAL}, constraints);
+  (void)model->fit(vario, {ECov::EXPONENTIAL, ECov::EXPONENTIAL}, constraints);
   model->display();
 
   // Creating a Moving Neighborhood
-  int nmini = 5;
-  int nmaxi = 5;
-  double radius = 1.;
+  int nmini           = 5;
+  int nmaxi           = 5;
+  double radius       = 1.;
   NeighMoving* neighM = NeighMoving::create(false, nmaxi, radius, nmini);
   neighM->display();
 
@@ -146,14 +146,14 @@ int main(int argc, char *argv[])
 
   // Estimating the Gaussian Variable on the nodes of the Blocks
   data->display();
-  (void) kriging(data, blocs, model, neighM, 
-                 true, true, false, KrigOpt(),
-                 NamingConvention("G_PTS"));
+  (void)kriging(data, blocs, model, neighM,
+                true, true, false, KrigOpt(),
+                NamingConvention("G_PTS"));
 
   // Calculating the Conditional Expectation
-  (void) ConditionalExpectation(blocs, anam, selectivity, "G_PTS*estim",
-                                "G_PTS*stdev", false, TEST, 0,
-                                NamingConvention("PTS_Recovery",false));
+  (void)ConditionalExpectation(blocs, anam, selectivity, "G_PTS*estim",
+                               "G_PTS*stdev", false, TEST, 0,
+                               NamingConvention("PTS_Recovery", false));
   blocs->display();
 
   // ====================== Point Disjunctive Kriging =====================
@@ -166,16 +166,16 @@ int main(int argc, char *argv[])
 
   // Computing the Point factors
   int nfactor = 3;
-  (void) anam->rawToFactor(data, nfactor);
+  (void)anam->rawToFactor(data, nfactor);
   data->display();
 
   // Simple Point Kriging over the blocks
-  (void) krigingFactors(data, blocs, model, neighM,
-                        true, true, KrigOpt(), NamingConvention("DK_Pts"));
+  (void)krigingFactors(data, blocs, model, neighM,
+                       true, true, KrigOpt(), NamingConvention("DK_Pts"));
   blocs->display();
 
   // Simple Block Kriging over the blocks
-  VectorInt ndisc_B = { 5, 5 };
+  VectorInt ndisc_B = {5, 5};
   KrigOpt krigopt;
   krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_B);
   (void)krigingFactors(data, blocs, model, neighM,
@@ -183,30 +183,30 @@ int main(int argc, char *argv[])
   blocs->display();
 
   // Simple Block Kriging over the panel(s)
-  VectorInt ndisc_P = { 10, 10 };
+  VectorInt ndisc_P = {10, 10};
   krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_P);
-  (void) krigingFactors(data, panel, model, neighM, 
-                        true, true, krigopt, NamingConvention("DK_Blk"));
+  (void)krigingFactors(data, panel, model, neighM,
+                       true, true, krigopt, NamingConvention("DK_Blk"));
   panel->display();
 
   // ====================== Uniform Conditioning ==================================
 
-  OptCustom::define("ompthreads",1);
+  OptCustom::define("ompthreads", 1);
   // Perform the Point Kriging of the Raw Variable
   data->clearLocators(ELoc::Z);
-  data->setLocator("Z",ELoc::Z, 0);
+  data->setLocator("Z", ELoc::Z, 0);
   data->display();
-  (void) kriging(data, blocs, model, neighM, 
-                 true, true, false, KrigOpt(), 
-                 NamingConvention("Z_PTS"));
+  (void)kriging(data, blocs, model, neighM,
+                true, true, false, KrigOpt(),
+                NamingConvention("Z_PTS"));
   blocs->display();
 
   // Perform the Uniform Conditioning over Blocks
-  (void) UniformConditioning(blocs, anam, selectivity,
-                             "Z_PTS*estim", "Z_PTS*stdev",
-                             NamingConvention("UC",false));
+  (void)UniformConditioning(blocs, anam, selectivity,
+                            "Z_PTS*estim", "Z_PTS*stdev",
+                            NamingConvention("UC", false));
   blocs->display();
-  data->setLocator("Gauss.Z",ELoc::Z, 0);
+  data->setLocator("Gauss.Z", ELoc::Z, 0);
 
   // ====================== Block Disjunctive Kriging (DGM-1) =====================
 
@@ -226,22 +226,22 @@ int main(int argc, char *argv[])
   // Fitting the regularized model on the point Gaussian variable
   Model* model_b1_Y = new Model(1, ndim);
   constraints.setConstantSillValue(1);
-  (void) model_b1_Y->fit(vario_b1_Y, { ECov::CUBIC, ECov::EXPONENTIAL }, constraints);
+  (void)model_b1_Y->fit(vario_b1_Y, {ECov::CUBIC, ECov::EXPONENTIAL}, constraints);
 
   // Update the Model with Block Anamorphosis
   model_b1_Y->setAnam(anam_b1);
   model_b1_Y->display();
 
   // Simple Point Kriging over the blocs(s) with Model with Change of Support
-  (void) krigingFactors(data, blocs, model_b1_Y, neighM, 
-                        true, true, KrigOpt(), NamingConvention("DK_DGM1"));
+  (void)krigingFactors(data, blocs, model_b1_Y, neighM,
+                       true, true, KrigOpt(), NamingConvention("DK_DGM1"));
   blocs->display();
 
   // Simple Point Kriging over the panel(s) with Model with Change of Support
-  VectorInt ndisc_Bc = { nx_B, nx_B };
+  VectorInt ndisc_Bc = {nx_B, nx_B};
   krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_Bc);
-  (void) krigingFactors(data, panel, model_b1_Y, neighM, 
-                        true, true, krigopt, NamingConvention("DK_DGM1"));
+  (void)krigingFactors(data, panel, model_b1_Y, neighM,
+                       true, true, krigopt, NamingConvention("DK_DGM1"));
   panel->display();
 
   // ====================== Block Disjunctive Kriging (DGM-2) =====================
@@ -261,7 +261,7 @@ int main(int argc, char *argv[])
   // Fitting the regularized model on the point Gaussian variable
   Model* model_b2_Y = new Model(1, ndim);
   constraints.setConstantSillValue(r2 * r2);
-  (void) model_b2_Y->fit(vario_b2_Y, { ECov::CUBIC, ECov::EXPONENTIAL }, constraints);
+  (void)model_b2_Y->fit(vario_b2_Y, {ECov::CUBIC, ECov::EXPONENTIAL}, constraints);
 
   // Normalization of the block model to a total sill equal to 1.0
   model_b2_Y->normalize(1.0);
@@ -272,22 +272,22 @@ int main(int argc, char *argv[])
   model_b2_Y->display();
 
   // Simple Point Kriging over the blocs(s) with Model with Change of Support
-  (void) krigingFactors(data, blocs, model_b2_Y, neighM, 
-                        true, true, KrigOpt(), NamingConvention("DK_DGM2"));
+  (void)krigingFactors(data, blocs, model_b2_Y, neighM,
+                       true, true, KrigOpt(), NamingConvention("DK_DGM2"));
   blocs->display();
 
   // Simple Point Kriging over the panel(s) with Model with Change of Support
   krigopt.setOptionCalcul(EKrigOpt::BLOCK, ndisc_Bc);
-  (void) krigingFactors(data, panel, model_b2_Y, neighM, 
-                        true, true, krigopt, NamingConvention("DK_DGM2"));
+  (void)krigingFactors(data, panel, model_b2_Y, neighM,
+                       true, true, krigopt, NamingConvention("DK_DGM2"));
   panel->display();
 
   // ====================== Selectivity Function ==================================
 
   DisjunctiveKriging(blocs, anam, selectivity,
-                      blocs->getName("DK_Pts*estim"),
-                      blocs->getName("DK_Pts*stdev"),
-                      NamingConvention("QT",false));
+                     blocs->getName("DK_Pts*estim"),
+                     blocs->getName("DK_Pts*stdev"),
+                     NamingConvention("QT", false));
   blocs->display();
 
   // ====================== Free pointers ==================================

--- a/tests/cpp/test_Nostat.cpp
+++ b/tests/cpp/test_Nostat.cpp
@@ -9,17 +9,15 @@
 /*                                                                            */
 /******************************************************************************/
 #include "API/SPDE.hpp"
+#include "Basic/File.hpp"
+#include "Basic/FunctionalSpirale.hpp"
+#include "Basic/Law.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "Db/DbStringFormat.hpp"
 #include "Model/Model.hpp"
-#include "Basic/FunctionalSpirale.hpp"
-#include "Basic/File.hpp"
-#include "Basic/Law.hpp"
-#include "Basic/VectorHelper.hpp"
-
-#include <math.h>
 
 #define __USE_MATH_DEFINES
 #include <cmath>
@@ -36,7 +34,7 @@ using namespace gstlrn;
  ** - by defining a vector containing the non-stationary angle (flagDirect = false and flagByAngle = true)
  ** - by defining the vector of local tensor matrices (flagDirect = false and flagByAngle = false)
  *****************************************************************************/
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
   std::stringstream sfn;
   sfn << gslBaseName(__FILE__) << ".out";
@@ -48,7 +46,7 @@ int main(int argc, char *argv[])
   ASerializable::setPrefixName("test_nostat-");
 
   // Creating the 2-D Db
-  auto nx = { 101, 101 };
+  auto nx            = {101, 101};
   DbGrid* workingDbc = DbGrid::create(nx);
 
   // Creating the Non-stationary Model
@@ -71,7 +69,7 @@ int main(int argc, char *argv[])
     {
       VectorDouble angle = spirale.getFunctionValues(workingDbc);
       workingDbc->addColumns(angle, "Angle");
-      cova->makeAngleNoStatDb("Angle",0,workingDbc);
+      cova->makeAngleNoStatDb("Angle", 0, workingDbc);
     }
     else
     {
@@ -79,16 +77,16 @@ int main(int argc, char *argv[])
       workingDbc->addColumns(hh[0], "H1-1", ELoc::NOSTAT, 0);
       workingDbc->addColumns(hh[1], "H1-2", ELoc::NOSTAT, 1);
       workingDbc->addColumns(hh[2], "H2-2", ELoc::NOSTAT, 2);
-      cova->makeTensorNoStatDb("H1-1",0,0,workingDbc);
-      cova->makeTensorNoStatDb("H1-2",0,1,workingDbc);
-      cova->makeTensorNoStatDb("H2-2",1,1,workingDbc);
+      cova->makeTensorNoStatDb("H1-1", 0, 0, workingDbc);
+      cova->makeTensorNoStatDb("H1-2", 0, 1, workingDbc);
+      cova->makeTensorNoStatDb("H2-2", 1, 1, workingDbc);
     }
   }
 
   // Inquiry the value of the Non-stationary parameters at a given sample
   if (flagInquiry)
   {
-    int target = 1000;
+    int target        = 1000;
     VectorDouble vect = workingDbc->getSampleLocators(ELoc::NOSTAT, target);
     VH::dump("Non-stationary parameters at sample", vect);
   }
@@ -96,13 +94,13 @@ int main(int argc, char *argv[])
   int useCholesky = 0;
   law_set_random_seed(13256);
   (void)gstlrn::simulateSPDE(nullptr, workingDbc, model, 1, useCholesky,
-                     VectorMeshes(), nullptr, VectorMeshes(), nullptr, SPDEParam(),
-                     NamingConvention("Simu", true, false));
+                             VectorMeshes(), nullptr, VectorMeshes(), nullptr, SPDEParam(),
+                             NamingConvention("Simu", true, false));
 
-  DbStringFormat dbfmt(FLAG_STATS,{"Simu"});
+  DbStringFormat dbfmt(FLAG_STATS, {"Simu"});
   workingDbc->display(&dbfmt);
 
-  (void) workingDbc->dumpToNF("spirale.NF");
+  (void)workingDbc->dumpToNF("spirale.NF");
 
   message("Test performed successfully\n");
 

--- a/tests/cpp/test_Sph.cpp
+++ b/tests/cpp/test_Sph.cpp
@@ -10,71 +10,71 @@
 /******************************************************************************/
 #include "Enum/ECst.hpp"
 
-#include "Geometry/GeometryHelper.hpp"
-#include "Basic/String.hpp"
-#include "Basic/OptDbg.hpp"
-#include "Basic/OptCst.hpp"
 #include "Basic/File.hpp"
+#include "Basic/OptCst.hpp"
+#include "Basic/OptDbg.hpp"
+#include "Basic/String.hpp"
+#include "Geometry/GeometryHelper.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #define VERBOSE 0
-#define INTER 0
+#define INTER   0
 
 using namespace gstlrn;
 
 static double deg(double a)
 {
-  return(a * 180. / GV_PI);
+  return (a * 180. / GV_PI);
 }
 
 static void st_test_1(void)
 {
-  mestitle(1,"Testing the distance between two points");
-  
-  int test = 1;
+  mestitle(1, "Testing the distance between two points");
+
+  int test     = 1;
   double long1 = 10.;
   double lat1  = 4.;
   double long2 = 20.;
   double lat2  = 25.;
-  while(test)
+  while (test)
   {
     if (INTER)
     {
       message("long1 = ");
-      if (gslScanf("%lf",&long1) == EOF) return;
+      if (gslScanf("%lf", &long1) == EOF) return;
       message("lat1  = ");
-      if (gslScanf("%lf",&lat1)  == EOF) return;
+      if (gslScanf("%lf", &lat1) == EOF) return;
       message("long2 = ");
-      if (gslScanf("%lf",&long2) == EOF) return;
+      if (gslScanf("%lf", &long2) == EOF) return;
       message("lat2  = ");
-      if (gslScanf("%lf",&lat2)  == EOF) return;
+      if (gslScanf("%lf", &lat2) == EOF) return;
     }
 
-    double angle = GH::geodeticAngularDistance(long1,lat1,long2,lat2);
-    message("Angle = %lf\n",deg(angle));
+    double angle = GH::geodeticAngularDistance(long1, lat1, long2, lat2);
+    message("Angle = %lf\n", deg(angle));
 
-    if (! INTER) break;
+    if (!INTER) break;
     message("Continue (1) or Stop(0) : ");
-    if (gslScanf("%d",&test) == EOF) return;
+    if (gslScanf("%d", &test) == EOF) return;
   }
 }
 
 static void st_test_2(void)
 {
-  double a,b,c,A,B,C,perimeter,surface;
-  double ra,rb,rc;
+  double a, b, c, A, B, C, perimeter, surface;
+  double ra, rb, rc;
 
-  mestitle(1,"Testing angles of a spherical triangle");
+  mestitle(1, "Testing angles of a spherical triangle");
 
-  int test = 1;
+  int test     = 1;
   double long1 = 10.;
   double lat1  = 23.;
   double long2 = 5.;
   double lat2  = 11.;
   double long3 = 31.;
   double lat3  = 45.;
-  while(test)
+  while (test)
   {
     if (INTER)
     {
@@ -92,32 +92,32 @@ static void st_test_2(void)
       if (gslScanf("%lf", &lat3) == EOF) return;
     }
 
-    GH::geodeticAngles(long1,lat1,long2,lat2,long3,lat3,
-                       &a,&b,&c,&A,&B,&C);
+    GH::geodeticAngles(long1, lat1, long2, lat2, long3, lat3,
+                       &a, &b, &c, &A, &B, &C);
     message("a=%lf b=%lf c=%lf A=%lf B=%lf C=%lf\n",
-           deg(a),deg(b),deg(c),deg(A),deg(B),deg(C));
+            deg(a), deg(b), deg(c), deg(A), deg(B), deg(C));
     ra = (sin(a) == 0.) ? 1. : sin(A) / sin(a);
     rb = (sin(b) == 0.) ? 1. : sin(B) / sin(b);
     rc = (sin(c) == 0.) ? 1. : sin(C) / sin(c);
-    message("ratio=%lf ratiob=%lf ratioc=%lf\n",ra,rb,rc);
+    message("ratio=%lf ratiob=%lf ratioc=%lf\n", ra, rb, rc);
     perimeter = GH::geodeticTrianglePerimeter(long1, lat1, long2, lat2, long3,
                                               lat3);
-    message("Perimeter = %lf\n",deg(perimeter));
+    message("Perimeter = %lf\n", deg(perimeter));
     surface = GH::geodeticTriangleSurface(long1, lat1, long2, lat2, long3,
                                           lat3);
-    message("Surface = %lf\n",surface);
-    
-    if (! INTER) break;
+    message("Surface = %lf\n", surface);
+
+    if (!INTER) break;
     message("Continue (1) or Stop(0) : ");
-    if (gslScanf("%d",&test) == EOF) return;
+    if (gslScanf("%d", &test) == EOF) return;
   }
 }
 
 static void st_test_3(void)
 {
-  double dx,dy,s1,s2,x1,x2,y1,y2,total;
+  double dx, dy, s1, s2, x1, x2, y1, y2, total;
 
-  mestitle(1,"Covering half-sphere with spherical triangles");
+  mestitle(1, "Covering half-sphere with spherical triangles");
   int nx = 40;
   int ny = 40;
 
@@ -128,26 +128,26 @@ static void st_test_3(void)
     message("ny = ");
     if (gslScanf("%d", &ny) == EOF) return;
   }
-  dy = 90.  / (double) ny;
-  dx = 360. / (double) nx;
-  
-  total = 0.;
-  for (int iy=0; iy<ny; iy++)
-  {
-    y1 = dy * (double) (iy);
-    y2 = dy * (double) (iy+1.);
-    for (int ix=0; ix<nx; ix++)
-    {
-      x1 = dx * (double) (ix);
-      x2 = dx * (double) (ix+1.);
+  dy = 90. / (double)ny;
+  dx = 360. / (double)nx;
 
-      s1 = GH::geodeticTriangleSurface(x1,y1,x2,y1,x1,y2);
-      s2 = GH::geodeticTriangleSurface(x2,y1,x1,y2,x2,y2);
+  total = 0.;
+  for (int iy = 0; iy < ny; iy++)
+  {
+    y1 = dy * (double)(iy);
+    y2 = dy * (double)(iy + 1.);
+    for (int ix = 0; ix < nx; ix++)
+    {
+      x1 = dx * (double)(ix);
+      x2 = dx * (double)(ix + 1.);
+
+      s1 = GH::geodeticTriangleSurface(x1, y1, x2, y1, x1, y2);
+      s2 = GH::geodeticTriangleSurface(x2, y1, x1, y2, x2, y2);
       total += s1 + s2;
     }
   }
   total /= (2. * GV_PI);
-  message("Surface totale = %lf\n",total);
+  message("Surface totale = %lf\n", total);
 }
 
 /****************************************************************************/
@@ -155,7 +155,7 @@ static void st_test_3(void)
 ** Main Program
 **
 *****************************************************************************/
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
   std::stringstream sfn;
   sfn << gslBaseName(__FILE__) << ".out";
@@ -168,14 +168,14 @@ int main(int argc, char *argv[])
   /* 1.c - Setup constants */
 
   OptDbg::reset();
-  OptCst::define(ECst::NTCAR,8.);
-  OptCst::define(ECst::NTDEC,5.);
-  
+  OptCst::define(ECst::NTCAR, 8.);
+  OptCst::define(ECst::NTDEC, 5.);
+
   if (flag_1) st_test_1();
 
   if (flag_2) st_test_2();
-  
+
   if (flag_3) st_test_3();
-  
-  return(0);
+
+  return (0);
 }

--- a/tests/inter/testInter_Ask.cpp
+++ b/tests/inter/testInter_Ask.cpp
@@ -8,9 +8,8 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/String.hpp"
 #include "Basic/AStringable.hpp"
-#include <string.h>
+#include "Basic/String.hpp"
 
 /**
  * This test is meant to check the interactive questioning
@@ -27,17 +26,16 @@ int main()
   message("Testing Interactive input\n");
 
   ianswer = askInt("Enter an Integer with no Default value");
-  message("Value read = %d\n",ianswer);
+  message("Value read = %d\n", ianswer);
 
   ianswer = askInt("Enter an Integer with Default value", 14.);
-  message("Value read = %d\n",ianswer);
-  
+  message("Value read = %d\n", ianswer);
+
   ranswer = askDouble("Enter a Double with no Default value");
-  message("Value read = %lf\n",ranswer);
+  message("Value read = %lf\n", ranswer);
 
   ranswer = askDouble("Enter a Double with Default value", 14.);
-  message("Value read = %lf\n",ranswer);
-
+  message("Value read = %lf\n", ranswer);
 
   return 0;
 }


### PR DESCRIPTION
This branch concludes a long run of standard modifications performed on lot of files, including:
- suppressing some mem_alloc() and mem_free() calls (turned to more modern statement new /delete)
- replacing #include <math.h> into #include <cmath> (which is recommanded by clang-tidy)
- similar for other includes (searching for occurences of XXX.h> 