### PR TITLE
Correction for Global

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,6 @@ Checks: >-
   -readability-implicit-bool-conversion, # TODO: to be removed
 CheckOptions:
   - key: readability-function-cognitive-complexity.Threshold
-    value: 300
+    value: 500
 HeaderFilterRegex: 'include'
 UseColor: true

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.8.0
 =============
+- Correcting the output of weights for Global estimation by Kriging
 - Enclose the library in a namespace ("gstlrn")
 - Fix gstlearn_to_terra and terra_to_gstlearn (issue #566)
 - ACov* is now stored as a shared_ptr in ModelGeneric, CovList (vector) and CovBase.

--- a/include/Estimation/AModelOptimFactory.hpp
+++ b/include/Estimation/AModelOptimFactory.hpp
@@ -14,7 +14,7 @@
 #include "gstlearn_export.hpp"
 
 namespace gstlrn
-{ 
+{
 class AModelOptim;
 class ModelGeneric;
 class Db;
@@ -36,6 +36,7 @@ public:
    * @param constraints Constraints (optional)
    * @param mop ModelOptimParam containing fitting options.
    * @param nb_neighVecchia Number of Vecchia neighbors to use (for Vecchia Likelihood).
+   * @param reml Boolean parameter used for Optimization
    * @return AModelOptim*
    */
   static AModelOptim* create(ModelGeneric* model,
@@ -45,6 +46,6 @@ public:
                              Constraints* constraints,
                              const ModelOptimParam& mop,
                              int nb_neighVecchia = ITEST,
-                             bool reml = false);
+                             bool reml           = false);
 };
-}
+} // namespace gstlrn

--- a/include/Estimation/CalcGlobal.hpp
+++ b/include/Estimation/CalcGlobal.hpp
@@ -17,7 +17,6 @@
 
 #include "Calculators/ACalcInterpolator.hpp"
 
-
 namespace gstlrn
 {
 
@@ -27,14 +26,14 @@ class KrigingSystem;
 class GSTLEARN_EXPORT Global_Result
 {
 public:
-  int ntot; // Total Number of Data
-  int np;   // Number of active Data
-  int ng;   // Number of grid nodes for Domain discretization
-  double surface; // Surface of Domain
-  double zest;    // Estimate
-  double sse;     // Standard deviation of estimation
-  double cvgeo;   // Coefficient of Variation
-  double cvv;     // Variance of Domain
+  int ntot;             // Total Number of Data
+  int np;               // Number of active Data
+  int ng;               // Number of grid nodes for Domain discretization
+  double surface;       // Surface of Domain
+  double zest;          // Estimate
+  double sse;           // Standard deviation of estimation
+  double cvgeo;         // Coefficient of Variation
+  double cvv;           // Variance of Domain
   VectorDouble weights; // Weights attached to data
 
   /// Has a specific implementation in the Target language
@@ -44,10 +43,10 @@ public:
 class GSTLEARN_EXPORT CalcGlobal: public ACalcInterpolator
 {
 public:
-  CalcGlobal(int ivar0 = 0,
+  CalcGlobal(int ivar0    = 0,
              bool verbose = false);
-  CalcGlobal(const CalcGlobal &r) = delete;
-  CalcGlobal& operator=(const CalcGlobal &r) = delete;
+  CalcGlobal(const CalcGlobal& r)            = delete;
+  CalcGlobal& operator=(const CalcGlobal& r) = delete;
   virtual ~CalcGlobal();
 
   void setFlagArithmetic(bool flagArithmetic) { _flagArithmetic = flagArithmetic; }
@@ -68,21 +67,21 @@ private:
 private:
   bool _flagArithmetic;
   bool _flagKriging;
-  int    _ivar0;
-  bool   _verbose;
+  int _ivar0;
+  bool _verbose;
   Model* _modelLocal;
 
   Global_Result _gRes;
 };
 
-GSTLEARN_EXPORT Global_Result global_arithmetic(Db *dbin,
-                                                DbGrid *dbgrid,
-                                                ModelGeneric *model,
-                                                int ivar0,
-                                                bool verbose);
-GSTLEARN_EXPORT Global_Result global_kriging(Db *dbin,
-                                             Db *dbout,
-                                             ModelGeneric *model,
-                                             int ivar0,
-                                             bool verbose);
-}
+GSTLEARN_EXPORT Global_Result global_arithmetic(Db* dbin,
+                                                DbGrid* dbgrid,
+                                                ModelGeneric* model,
+                                                int ivar0    = 0,
+                                                bool verbose = false);
+GSTLEARN_EXPORT Global_Result global_kriging(Db* dbin,
+                                             Db* dbout,
+                                             ModelGeneric* model,
+                                             int ivar0    = 0,
+                                             bool verbose = false);
+} // namespace gstlrn

--- a/src/Basic/ASerializable.cpp
+++ b/src/Basic/ASerializable.cpp
@@ -10,15 +10,15 @@
 /******************************************************************************/
 #include "Basic/ASerializable.hpp"
 #include "Basic/AStringable.hpp"
+#include "Basic/File.hpp"
 #include "Basic/SerializeHDF5.hpp"
 #include "Basic/SerializeNeutralFile.hpp"
-#include "Basic/File.hpp"
 #include "Basic/String.hpp"
 #include "Enum/EFormatNF.hpp"
 
-#include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 
 namespace gstlrn
 {
@@ -52,7 +52,7 @@ void ASerializable::setDefaultFormatNF(const EFormatNF& format)
  * ASerializable::DefaultFormatNF()
  */
 bool ASerializable::dumpToNF(const String& NFFilename,
-                             const EFormatNF& format, 
+                             const EFormatNF& format,
                              bool verbose) const
 {
   bool ret = true;
@@ -74,7 +74,7 @@ bool ASerializable::dumpToNF(const String& NFFilename,
     if (SerializeNeutralFile::fileOpenWrite(*this, NFFilename, os, true))
     {
       ret = _serializeAscii(os, verbose);
-      if (! ret)
+      if (!ret)
         messerr("Problem writing in the Neutral File.");
       os.close();
     }
@@ -102,7 +102,11 @@ bool ASerializable::_fileOpenAndDeserialize(const String& filename,
   // Check that the file exists
   String filepath = ASerializable::buildFileName(1, filename, true);
   std::ifstream file(filepath);
-  if (!file.good()) return false;
+  if (!file.good())
+  {
+    messerr("The file %s does not exist", filepath.c_str());
+    return false;
+  }
 
   // Try to open it according to HDF5 format
 #ifdef HDF5
@@ -153,10 +157,10 @@ bool ASerializable::_tableWrite(std::ostream& os,
   return SerializeNeutralFile::tableWrite(os, string, ntab, tab);
 }
 
-bool ASerializable::_tableRead(std::istream &is,
-                               const String &string,
+bool ASerializable::_tableRead(std::istream& is,
+                               const String& string,
                                int ntab,
-                               double *tab)
+                               double* tab)
 {
   return SerializeNeutralFile::tableRead(is, string, ntab, tab);
 }
@@ -292,4 +296,4 @@ const String& ASerializable::getPrefixName()
 {
   return _myPrefixName;
 }
-}
+} // namespace gstlrn

--- a/src/Estimation/CalcGlobal.cpp
+++ b/src/Estimation/CalcGlobal.cpp
@@ -173,6 +173,7 @@ int CalcGlobal::_globalKriging()
   // must be corrected (C00 -> Cvv) to pass to a correct Territory variance
   // of estimation
   double c00 = Sigma00.getValue(0, 0);
+  wgt        = algebra.getLambda()->getColumn(_ivar0);
 
   /* Preliminary checks */
 
@@ -356,4 +357,4 @@ Global_Result global_kriging(Db* dbin,
   return gres;
 }
 
-}
+} // namespace gstlrn

--- a/src/LinearOp/CholeskySparse.cpp
+++ b/src/LinearOp/CholeskySparse.cpp
@@ -9,13 +9,9 @@
 /*                                                                            */
 /******************************************************************************/
 #include "LinearOp/CholeskySparse.hpp"
-#include "Basic/OptCst.hpp"
-#include "Basic/VectorHelper.hpp"
 #include "Core/SparseInv.hpp"
-#include "LinearOp/CholeskyDense.hpp"
 #include "Matrix/LinkMatrixSparse.hpp"
 #include "Matrix/MatrixSparse.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
 #include "csparse_f.h"
 #include <Eigen/src/Core/Matrix.h>
 #include <vector>
@@ -374,11 +370,10 @@ int CholeskySparse::addInvLX(const constvect vecin, vect vecout) const
 }
 
 /**
- * @brief Compute the inverse of the 'this' matrix
+ * @brief Returns the diagonal of the inverse of 'this' matrix
  *
- * @param vcur Storing the diagonal of the inverse matrix
- * @param proj Projection matrix
- * @return int
+ * @param vcur Output vector
+ * @param proj Projection sparse matrix
  *
  * @note: The method 'partial_inverse' used assumes a LTT decomposition
  * (which is not the decomposition of _factor [LDLT]). Hence a local
@@ -429,4 +424,4 @@ int CholeskySparse::_stdevEigen(VectorDouble& vcur,
   }
   return 0;
 }
-}
+} // namespace gstlrn

--- a/tests/py/output/test_Global.ref
+++ b/tests/py/output/test_Global.ref
@@ -1,0 +1,92 @@
+
+Data Base Characteristics
+=========================
+
+Data Base Summary
+-----------------
+File is organized as a set of isolated points
+Space dimension              = 2
+Number of Columns            = 4
+Total number of samples      = 10
+
+Variables
+---------
+Column = 0 - Name = rank - Locator = NA
+Column = 1 - Name = x-1 - Locator = x1
+Column = 2 - Name = x-2 - Locator = x2
+Column = 3 - Name = z - Locator = z1
+
+Data Base Grid Characteristics
+==============================
+
+Data Base Summary
+-----------------
+File is organized as a regular grid
+Space dimension              = 2
+Number of Columns            = 3
+Total number of samples      = 25
+
+Grid characteristics:
+---------------------
+Origin :      0.000     0.000
+Mesh   :      0.200     0.200
+Number :          5         5
+
+Variables
+---------
+Column = 0 - Name = rank - Locator = NA
+Column = 1 - Name = x1 - Locator = x1
+Column = 2 - Name = x2 - Locator = x2
+
+Model characteristics
+=====================
+Space dimension              = 2
+Number of variable(s)        = 1
+Number of basic structure(s) = 1
+Number of drift function(s)  = 0
+Number of drift equation(s)  = 0
+
+Covariance Part
+---------------
+Spherical
+- Sill         =      1.000
+- Range        =      0.300
+Total Sill     =      1.000
+Known Mean(s)     0.000
+
+Global estimation by arithmetic average
+---------------------------------------
+Total number of data             = 10
+Number of active data            = 10
+Sample variance                  = 1.137649
+CVsample                         = 16.682853
+CViid                            = 5.275581
+Cxx                              = 0.207223
+Cxv                              = 0.053449
+Cvv                              = 0.059393
+Estimation by arithmetic average = 0.063934
+Estimation St. dev. of the mean  = 0.399648
+CVgeo                            = 6.250923
+Surface                          = 1.000000
+Q (Estimation * Surface)         = 0.063934
+
+Printing some results from the Output structure
+Number of weights =  10
+Weights =  [0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1]
+
+Global estimation kriging
+-------------------------
+Total number of data             = 10
+Number of active data            = 10
+Number of variables              = 1
+Cvv                              = 0.059392
+Estimation by kriging            = 0.006263
+Estimation St. Dev. of the mean  = 0.205082
+CVgeo                            = 32.742863
+Surface                          = 1.000000
+Q (Estimation * Surface)         = 0.006263
+
+Printing some results from the Output structure
+Number of weights =  10
+Weights =  [0.02354868 0.03754362 0.04370817 0.04285175 0.01465401 0.04506939
+ 0.00451891 0.04878589 0.05321501 0.01313461]

--- a/tests/py/test_Global.py
+++ b/tests/py/test_Global.py
@@ -1,0 +1,34 @@
+# This test is meant to check the Global estimation 
+# either using the Arithmetic Mean algorithm or the Kriging one
+# The global estimate returns a whole structure which is partly printed here
+import gstlearn as gl
+
+# Define a 2-D Data Set in [0,1)x[0,1]
+ndata = 10
+db = gl.Db.createFillRandom(ndata)
+db.display()
+
+# Define a (coarse) grid covering the square
+nx = 5
+grid = gl.DbGrid.create([nx,nx], [1/nx, 1/nx])
+grid.display()
+
+# Define a Model
+range = 0.3
+model = gl.Model.createFromParam(gl.ECov.SPHERICAL, range)
+model.display()
+
+verbose = True
+
+# Arithmetic method: we also print
+Gres = gl.global_arithmetic(db, grid, model, 0, verbose)
+print("Printing some results from the Output structure")
+print("Number of weights = ", Gres.ntot)
+print("Weights = ", Gres.weights)
+
+# Kriging solution
+Gres = gl.global_kriging(db, grid, model, 0, verbose)
+print("Printing some results from the Output structure")
+print("Number of weights = ", Gres.ntot)
+print("Weights = ", Gres.weights)
+


### PR DESCRIPTION
In this branch:
- we continue chasing the old mem_alloc() and mem_free() statements. Work is still in progress

The branch has also served:
- to check the read/write operation for neutral files (in ASCII or HDF5 formats)
- to exhibit the weights for Global estimation: there were not printed when using the Kriged solution

An extra test has been implemented (in PY) to test that the Global estimates (using Arithmetic Mean and Kriging) are correct ... as well as the contents of the output structure (Global_Results)
