### PR TITLE
Replace mem_alloc & malloc with std::vector

### DIFF
--- a/3rd-party/gmtsph/gmtsph.hpp
+++ b/3rd-party/gmtsph/gmtsph.hpp
@@ -48,19 +48,6 @@ Website: https://gstlearn.org
 */
 #pragma once
 
-class SphTriangle
-{
-public:
-  int n_nodes; /* Number of nodes */
-  int sph_size; /* Size of arrays sph_list and sph_lptr */
-  double *sph_x; /* Array of X-coordinates for nodes */
-  double *sph_y; /* Array of Y-coordinates for nodes */
-  double *sph_z; /* Array of Z-coordinates for nodes */
-  int *sph_list; /* Set of nodal indexes */
-  int *sph_lptr; /* Set of pointers (sph_list indexes) */
-  int *sph_lend; /* Set of pointers to adjacency lists */
-};
-
 int trmesh_(int *n,
             double *x,
             double *y,

--- a/include/Core/Keypair.hpp
+++ b/include/Core/Keypair.hpp
@@ -12,8 +12,11 @@
 
 #include "gstlearn_export.hpp"
 
+#include <Basic/VectorNumT.hpp>
+
 namespace gstlrn
 {
+
 GSTLEARN_EXPORT void set_keypair(
   const char* keyword, Id origin, Id nrow, Id ncol, const double* values);
 GSTLEARN_EXPORT void app_keypair(
@@ -24,9 +27,9 @@ GSTLEARN_EXPORT void app_keypair_int(
   const char* keyword, Id origin, Id nrow, Id ncol, Id* values);
 GSTLEARN_EXPORT double get_keypone(const char* keyword, double valdef);
 GSTLEARN_EXPORT Id
-get_keypair(const char* keyword, Id* nrow, Id* ncol, double** values);
+get_keypair(const char* keyword, Id* nrow, Id* ncol, VectorDouble& values);
 GSTLEARN_EXPORT Id
-get_keypair_int(const char* keyword, Id* nrow, Id* ncol, Id** values);
+get_keypair_int(const char* keyword, Id* nrow, Id* ncol, VectorInt& values);
 GSTLEARN_EXPORT void del_keypair(const char* keyword, Id flag_exact);
 GSTLEARN_EXPORT void print_keypair(Id flag_short);
 }

--- a/include/LinearOp/CholeskySparseInv.hpp
+++ b/include/LinearOp/CholeskySparseInv.hpp
@@ -25,9 +25,9 @@ template<typename SpMat>
 class MatchPattern
 {
   using T = typename SpMat::value_type;
-  StorageIndex* m_outer;
-  StorageIndex* m_inner;
-  T* m_val;
+  std::vector<StorageIndex> m_outer;
+  std::vector<StorageIndex> m_inner;
+  std::vector<T> m_val;
   StorageIndex m_cols;
   StorageIndex m_nnz;
 
@@ -37,14 +37,14 @@ public:
     m_cols = pattern.cols();
     m_nnz  = pattern.nonZeros();
 
-    m_outer = new StorageIndex[m_cols + 1];
-    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer);
-    m_inner = new StorageIndex[m_nnz];
-    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner);
-    m_val = new T[m_nnz];
+    m_outer.resize(m_cols + 1);
+    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer.begin());
+    m_inner.resize(m_nnz);
+    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner.begin());
+    m_val.resize(m_nnz);
 
-    T* valptr = m_val;
-    for (Id j = 0; j < m_cols; ++j)
+    T* valptr = m_val.data();
+    for (int j = 0; j < m_cols; ++j)
     {
       typename SpMat::InnerIterator Acol(A, j);
       for (typename SpMat::InnerIterator pattern_col(pattern, j);
@@ -68,14 +68,14 @@ public:
   {
     m_cols  = pattern.cols();
     m_nnz   = pattern.nonZeros();
-    m_outer = new StorageIndex[m_cols + 1];
-    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer);
-    m_inner = new StorageIndex[m_nnz];
-    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner);
-    m_val = new T[m_nnz];
+    m_outer.resize(m_cols + 1);
+    std::copy(pattern.outerIndexPtr(), pattern.outerIndexPtr() + m_cols + 1, m_outer.begin());
+    m_inner.resize(m_nnz);
+    std::copy(pattern.innerIndexPtr(), pattern.innerIndexPtr() + m_nnz, m_inner.begin());
+    m_val.resize(m_nnz);
 
-    T* valptr = m_val;
-    for (Id j = 0; j < m_cols; ++j)
+    T* valptr = m_val.data();
+    for (int j = 0; j < m_cols; ++j)
     {
       for (typename SpMat::InnerIterator pattern_col(pattern, j);
            pattern_col; ++pattern_col)
@@ -85,22 +85,15 @@ public:
     }
   }
 
-  ~MatchPattern()
-  {
-    delete[] m_inner;
-    delete[] m_outer;
-    delete[] m_val;
-  }
-
   SpMat operator()()
   {
     return Eigen::Map<SpMat>(
       m_cols,
       m_cols,
       m_nnz,
-      m_outer,
-      m_inner,
-      m_val);
+      m_outer.data(),
+      m_inner.data(),
+      m_val.data());
   }
 };
 

--- a/include/Mesh/LinkSphTriangle.hpp
+++ b/include/Mesh/LinkSphTriangle.hpp
@@ -10,14 +10,28 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/VectorNumT.hpp"
 #include "geoslib_define.h"
 #include "gstlearn_export.hpp"
-
-class SphTriangle;
 
 namespace gstlrn
 {
 class Db;
+
+class SphTriangle
+{
+public:
+  int n_nodes; /* Number of nodes */
+  int sph_size; /* Size of arrays sph_list and sph_lptr */
+  VectorDouble sph_x; /* Array of X-coordinates for nodes */
+  VectorDouble sph_y; /* Array of Y-coordinates for nodes */
+  VectorDouble sph_z; /* Array of Z-coordinates for nodes */
+  std::vector<int> sph_list; /* Set of nodal indexes */
+  std::vector<int> sph_lptr; /* Set of pointers (sph_list indexes) */
+  std::vector<int> sph_lend; /* Set of pointers to adjacency lists */
+};
+
+
 
 GSTLEARN_EXPORT void meshes_2D_sph_init(SphTriangle* t);
 GSTLEARN_EXPORT void meshes_2D_sph_free(SphTriangle* t, Id mode);

--- a/include/OutputFormat/vtk.h
+++ b/include/OutputFormat/vtk.h
@@ -39,7 +39,11 @@
 /* ************************************************************************* //
 //                              visit_writer.h                               //
 // ************************************************************************* */
- 
+
+#pragma once
+
+#include <Basic/VectorNumT.hpp>
+
 /*
 // This file contains function prototypes for writing out point meshes,
 // unstructured meshes, rectilinear meshes, regular meshes, and
@@ -102,7 +106,7 @@ void write_point_mesh(const char* filename,
                       Id nvars,
                       Id* vardim,
                       const char* const* varnames,
-                      float** vars);
+                      VectorVectorFloat& vars);
 
 /* ****************************************************************************
 //  Function: write_unstructured_mesh
@@ -191,7 +195,7 @@ void write_unstructured_mesh(const char* filename,
                              Id* vardim,
                              Id* centering,
                              const char* const* varnames,
-                             float** vars);
+                             VectorVectorFloat& vars);
 
 /* ****************************************************************************
 //  Function: write_regular_mesh
@@ -232,7 +236,7 @@ void write_regular_mesh(const char* filename,
                         Id* vardim,
                         Id* centering,
                         const char* const* varnames,
-                        float** vars);
+                        VectorVectorFloat& vars);
 
 /* ****************************************************************************
 //  Function: write_rectilinear_mesh
@@ -282,7 +286,7 @@ void write_rectilinear_mesh(const char* filename,
                             Id* vardim,
                             Id* centering,
                             const char* const* varnames,
-                            float** vars);
+                            VectorVectorFloat& vars);
 
 /* ****************************************************************************
 //  Function: write_curvilinear_mesh
@@ -324,5 +328,6 @@ void write_curvilinear_mesh(const char* filename,
                             Id* vardim,
                             Id* centering,
                             const char* const* varnames,
-                            float** vars);
-}
+                            VectorVectorFloat& vars);
+
+} // namespace gstlrn

--- a/include/Variogram/Vario.hpp
+++ b/include/Variogram/Vario.hpp
@@ -33,8 +33,8 @@ typedef struct
   VectorInt tab_jech;
   VectorInt tab_ipas;
   VectorInt tab_sort;
-  char* tab_aux_iech;
-  char* tab_aux_jech;
+  std::vector<char> tab_aux_iech;
+  std::vector<char> tab_aux_jech;
   VectorDouble tab_dist;
 } Vario_Order;
 

--- a/include/geoslib_d.h
+++ b/include/geoslib_d.h
@@ -26,11 +26,11 @@ public:
   EKrigOpt calcul;    /* Type of calculation (EKrigOpt) */
   Id ndim;           /* Space dimension */
   Id ntot;           /* Number of discretization points */
-  Id* ndisc;         /* Array of discretization counts */
-  double* disc1;      /* Discretization coordinates */
-  double* disc2;      /* Discretization randomized coordinates */
+  VectorInt ndisc;    /* Array of discretization counts */
+  VectorDouble disc1; /* Discretization coordinates */
+  VectorDouble disc2; /* Discretization randomized coordinates */
   Id flag_data_disc; /* Discretization flag */
-  double* dsize;
+  VectorDouble dsize;
 };
 
 class Model;

--- a/include/geoslib_old_f.h
+++ b/include/geoslib_old_f.h
@@ -72,10 +72,10 @@ GSTLEARN_EXPORT Id foxleg_f(Id ndat,
 /* Prototyping the functions in util.c */
 /***************************************/
 
-GSTLEARN_EXPORT Id* ut_split_into_two(Id ncolor,
-                                       Id flag_half,
-                                       Id verbose,
-                                       Id* nposs);
+GSTLEARN_EXPORT VectorInt ut_split_into_two(Id ncolor,
+                                            Id flag_half,
+                                            Id verbose,
+                                            Id* nposs);
 GSTLEARN_EXPORT void projec_query(Id* actif);
 GSTLEARN_EXPORT void projec_print(void);
 GSTLEARN_EXPORT void projec_toggle(Id mode);

--- a/src/Basic/Utilities.cpp
+++ b/src/Basic/Utilities.cpp
@@ -181,19 +181,20 @@ void ut_sort_double(Id safe, Id nech, Id* ind, double* value)
   static Id LISTE_L[LSTACK];
   static Id LISTE_R[LSTACK];
   Id i, j, p, l, r, pstack, inddev, inddeu;
-  double *tab, tablev, tableu;
+  std::vector<double> tab;
+  double tablev, tableu;
 
   /* Initialization */
 
   inddev = 0;
   if (safe)
   {
-    tab = (double*)mem_alloc(sizeof(double) * nech, 1);
+    tab.resize(nech);
     for (i = 0; i < nech; i++)
       tab[i] = value[i];
   }
   else
-    tab = value;
+    tab = {value, value + nech};
 
   /* Segmentation */
 
@@ -404,8 +405,6 @@ void ut_sort_double(Id safe, Id nech, Id* ind, double* value)
       if (ind) ind[i] = inddev;
     }
   }
-
-  if (safe) mem_free((char*)tab);
 }
 
 /****************************************************************************/

--- a/src/Core/util.cpp
+++ b/src/Core/util.cpp
@@ -902,23 +902,20 @@ void print_last_message(void)
  ** \remarks The elements of each row are set to 0 or 1 (subset rank)
  **
  *****************************************************************************/
-Id* ut_split_into_two(Id ncolor, Id flag_half, Id verbose, Id* nposs)
+VectorInt ut_split_into_two(Id ncolor, Id flag_half, Id verbose, Id* nposs)
 {
   Id p, nmax, ncomb, np, lec;
-  Id* mattab;
+  VectorInt mattab;
 
   /* Initializations */
 
   p      = (flag_half) ? static_cast<Id>(floor((double)ncolor / 2.)) : ncolor - 1;
   nmax   = static_cast<Id>(pow(2, ncolor));
-  mattab = nullptr;
   np     = 0;
 
   /* Core allocation */
 
-  mattab = (Id*)mem_alloc(sizeof(Id) * ncolor * nmax, 1);
-  for (Id i = 0; i < ncolor * nmax; i++)
-    mattab[i] = 0;
+  mattab.resize(ncolor * nmax);
 
   for (Id nsub = 1; nsub <= p; nsub++)
   {
@@ -934,7 +931,7 @@ Id* ut_split_into_two(Id ncolor, Id flag_half, Id verbose, Id* nposs)
 
   /* Resize */
 
-  mattab = (Id*)mem_realloc((char*)mattab, sizeof(Id) * ncolor * np, 1);
+  mattab.resize(ncolor * np);
   *nposs = np;
 
   /* Verbose option */

--- a/src/Core/util.cpp
+++ b/src/Core/util.cpp
@@ -35,7 +35,7 @@ typedef struct
   Id origin;
   Id nrow;
   Id ncol;
-  double* values;
+  VectorDouble values;
 } Keypair;
 
 typedef struct
@@ -55,11 +55,11 @@ typedef struct
 
 static Projec_Environ PROJEC = {0};
 static Id KEYPAIR_NTAB      = 0;
-static Keypair* KEYPAIR_TABS = NULL;
+static std::vector<Keypair> KEYPAIR_TABS;
 static Id DISTANCE_NDIM     = 0;
-static double* DISTANCE_TAB1 = NULL;
-static double* DISTANCE_TAB2 = NULL;
-static char** LAST_MESSAGE   = NULL;
+static VectorDouble DISTANCE_TAB1;
+static VectorDouble DISTANCE_TAB2;
+static std::vector<std::vector<char>> LAST_MESSAGE;
 static Id NB_LAST_MESSAGE   = 0;
 
 /****************************************************************************/
@@ -199,8 +199,7 @@ static Keypair* st_get_keypair_address(const char* keyword)
   {
     found = KEYPAIR_NTAB;
     KEYPAIR_NTAB++;
-    auto* placeholder = realloc((char*)KEYPAIR_TABS, sizeof(Keypair) * KEYPAIR_NTAB);
-    KEYPAIR_TABS      = (Keypair*)placeholder;
+    KEYPAIR_TABS.resize(KEYPAIR_NTAB);
   }
 
   /* Store the attribute (compressing the name and suppressing blanks) */
@@ -217,7 +216,7 @@ static Keypair* st_get_keypair_address(const char* keyword)
     keypair->origin = 0;
     keypair->nrow   = 0;
     keypair->ncol   = 0;
-    keypair->values = NULL;
+    keypair->values.clear();
   }
 
   return (keypair);
@@ -248,12 +247,11 @@ static void st_keypair_attributes(Keypair* keypair,
   {
     // Free the array if attributes are different
 
-    if (keypair->values != NULL)
+    if (!keypair->values.empty())
     {
       if (keypair->ncol != ncol)
       {
-        free((char*)keypair->values);
-        keypair->values = nullptr;
+        keypair->values.clear();
       }
     }
 
@@ -292,39 +290,11 @@ static void st_keypair_attributes(Keypair* keypair,
  *****************************************************************************/
 static void st_keypair_allocate(Keypair* keypair, Id nrow, Id ncol)
 {
-  Id old_size, new_size;
 
-  new_size = nrow * ncol;
-  old_size = keypair->nrow * keypair->ncol;
-
-  // If dimensions are unchanged, do nothing
-
-  if (new_size == old_size && keypair->values != NULL) return;
-
-  // Dimensions are different
-
-  if (old_size == 0)
-  {
-
-    // The old dimensions are null, allocate the contents
-
-    keypair->values = (double*)malloc(sizeof(double) * new_size);
-  }
-  else
-  {
-
-    // The old_dimensions are non zero, reallocate the contents
-
-    auto* placeholder = realloc((char*)keypair->values, sizeof(double) * new_size);
-    keypair->values   = (double*)placeholder;
-  }
-
-  // Ultimate check that allocaiton has been performed correctly
-
-  if (keypair->values == NULL) messageAbort("Keyword allocation failed");
+  const auto new_size = nrow * ncol;
+  keypair->values.resize(new_size);
 
   // Set the number of rows
-
   keypair->nrow = nrow;
 }
 
@@ -368,9 +338,6 @@ static void st_keypair_copy(Keypair* keypair, Id type, Id start, void* values)
  ** \param[in]  ncol           Number of columns
  ** \param[in]  values         Array of values (Dimension: nrow * ncol)
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
 void set_keypair(const char* keyword,
                  Id origin,
@@ -409,8 +376,6 @@ void set_keypair(const char* keyword,
  **
  ** \remarks Appending extends the number of rows but keeps the number of
  ** \remarks columns and the origin unchanged... otherwise fatal error is issued
- ** \remarks All keypair related function use realloc (rather than mem_realloc)
- ** \remarks not to show up in the memory leak calculations
  **
  *****************************************************************************/
 void app_keypair(const char* keyword,
@@ -459,9 +424,6 @@ void app_keypair(const char* keyword,
  ** \param[in]  ncol           Number of columns
  ** \param[in]  values         Array of values (Dimension: nrow * ncol)
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
 void set_keypair_int(const char* keyword,
                      Id origin,
@@ -500,8 +462,6 @@ void set_keypair_int(const char* keyword,
  **
  ** \remarks Appending extends the number of rows but keeps the number of
  ** \remarks columns and the origin unchanged ... otherwise fatal error is issued
- ** \remarks All keypair related function use realloc (rather than mem_realloc)
- ** \remarks not to show up in the memory leak calculations
  **
  *****************************************************************************/
 void app_keypair_int(const char* keyword,
@@ -546,9 +506,6 @@ void app_keypair_int(const char* keyword,
  **
  ** \param[in]  indice    Index of the Keyword to be deleted
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
 static void del_keypone(Id indice)
 {
@@ -561,8 +518,7 @@ static void del_keypone(Id indice)
   /* Delete the current keypair */
 
   keypair = &KEYPAIR_TABS[indice];
-  free((char*)keypair->values);
-  keypair->values = nullptr;
+  keypair->values.clear();
 
   /* Shift all subsequent keypairs */
 
@@ -570,8 +526,7 @@ static void del_keypone(Id indice)
     KEYPAIR_TABS[i - 1] = KEYPAIR_TABS[i];
 
   KEYPAIR_NTAB--;
-  auto* placeholder = realloc((char*)KEYPAIR_TABS, sizeof(Keypair) * KEYPAIR_NTAB);
-  KEYPAIR_TABS      = (Keypair*)placeholder;
+  KEYPAIR_TABS.resize(KEYPAIR_NTAB);
 }
 
 /****************************************************************************/
@@ -580,9 +535,6 @@ static void del_keypone(Id indice)
  **
  ** \param[in]  keyword    Keyword to be deleted
  ** \param[in]  flag_exact 1 if Exact keyword matching is required
- **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
  **
  *****************************************************************************/
 void del_keypair(const char* keyword, Id flag_exact)
@@ -650,7 +602,7 @@ void del_keypair(const char* keyword, Id flag_exact)
 double get_keypone(const char* keyword, double valdef)
 {
   Id found;
-  double *rtab, retval;
+  double retval;
   Keypair* keypair;
 
   /* Check if the keyword has been defined */
@@ -660,7 +612,7 @@ double get_keypone(const char* keyword, double valdef)
   if (found >= 0)
   {
     keypair = &KEYPAIR_TABS[found];
-    rtab    = (double*)keypair->values;
+    const auto &rtab    = keypair->values;
     if (keypair->nrow * keypair->ncol == 1) retval = rtab[0];
   }
 
@@ -684,14 +636,10 @@ double get_keypone(const char* keyword, double valdef)
  **
  ** \remark  The returned array must be freed by the calling function
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
-Id get_keypair(const char* keyword, Id* nrow, Id* ncol, double** values)
+Id get_keypair(const char* keyword, Id* nrow, Id* ncol, VectorDouble& values)
 {
   Id found, size;
-  double* valloc;
   Keypair* keypair;
 
   /* Check if the keyword has been defined */
@@ -706,10 +654,9 @@ Id get_keypair(const char* keyword, Id* nrow, Id* ncol, double** values)
   *ncol   = keypair->ncol;
   size    = (*nrow) * (*ncol);
 
-  valloc = (double*)malloc(sizeof(double) * size);
+  values.resize(size);
   for (Id i = 0; i < size; i++)
-    valloc[i] = keypair->values[i];
-  *values = valloc;
+    values[i] = keypair->values[i];
 
   return (0);
 }
@@ -728,13 +675,10 @@ Id get_keypair(const char* keyword, Id* nrow, Id* ncol, double** values)
  **
  ** \remark  The returned array must be freed by the calling function
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
-Id get_keypair_int(const char* keyword, Id* nrow, Id* ncol, Id** values)
+Id get_keypair_int(const char* keyword, Id* nrow, Id* ncol, VectorInt& values)
 {
-  Id *valloc, found, size;
+  Id found, size;
   Keypair* keypair;
 
   /* Check if the keyword has been defined */
@@ -749,10 +693,9 @@ Id get_keypair_int(const char* keyword, Id* nrow, Id* ncol, Id** values)
   *ncol   = keypair->ncol;
   size    = (*nrow) * (*ncol);
 
-  valloc = (Id*)malloc(sizeof(Id) * size);
+  values.resize(size);
   for (Id i = 0; i < size; i++)
-    valloc[i] = (Id)keypair->values[i];
-  *values = valloc;
+    values[i] = (Id)keypair->values[i];
 
   return (0);
 }
@@ -787,7 +730,7 @@ void print_keypair(Id flag_short)
       }
       else
         print_matrix(keypair->keyword, 0, 0, keypair->ncol, keypair->nrow, NULL,
-                     keypair->values);
+                     keypair->values.data());
     }
 }
 
@@ -848,22 +791,17 @@ double ut_distance(Id ndim, const double* tab1, const double* tab2)
  ** \param[out] tab1   Array for coordinates of first sample
  ** \param[out] tab2   Array for coordinates of second sample
  **
- ** \remarks This function uses realloc (rather than mem_realloc)
- ** \remarks not to show up in the memory leak calculations
- **
  *****************************************************************************/
 void ut_distance_allocated(Id ndim, double** tab1, double** tab2)
 {
   if (DISTANCE_NDIM < ndim)
   {
-    auto* dtab    = realloc((char*)DISTANCE_TAB1, sizeof(double) * ndim);
-    DISTANCE_TAB1 = (double*)dtab;
-    auto* dtab2   = realloc((char*)DISTANCE_TAB2, sizeof(double) * ndim);
-    DISTANCE_TAB2 = (double*)dtab2;
+    DISTANCE_TAB1.resize(ndim);
+    DISTANCE_TAB2.resize(ndim);
     DISTANCE_NDIM = ndim;
   }
-  *tab1 = DISTANCE_TAB1;
-  *tab2 = DISTANCE_TAB2;
+  *tab1 = DISTANCE_TAB1.data();
+  *tab2 = DISTANCE_TAB2.data();
 }
 
 /****************************************************************************/
@@ -876,8 +814,6 @@ void ut_distance_allocated(Id ndim, double** tab1, double** tab2)
  **                           -1 to concatenate the string to the last message
  ** \param[in]  string         Current string
  **
- ** \remarks All keypair related function use malloc
- ** \remarks not to show up in the memory leak calculations
  **
  *****************************************************************************/
 void set_last_message(Id mode, const char* string)
@@ -891,12 +827,7 @@ void set_last_message(Id mode, const char* string)
   {
     case 0:
       if (NB_LAST_MESSAGE <= 0) return;
-      for (Id i = 0; i < NB_LAST_MESSAGE; i++)
-      {
-        free((char*)LAST_MESSAGE[i]);
-        LAST_MESSAGE[i] = nullptr;
-      }
-      free((char*)LAST_MESSAGE);
+      LAST_MESSAGE.clear();
       NB_LAST_MESSAGE = 0;
       break;
 
@@ -905,13 +836,13 @@ void set_last_message(Id mode, const char* string)
       if (size <= 0) return;
 
       if (NB_LAST_MESSAGE <= 0)
-        LAST_MESSAGE = (char**)malloc(sizeof(char*) * 1);
+        LAST_MESSAGE.resize(1);
       else
       {
-        auto* placeholder = realloc((char*)LAST_MESSAGE, sizeof(char*) * (NB_LAST_MESSAGE + 1));
-        LAST_MESSAGE      = (char**)placeholder;
+        LAST_MESSAGE.resize(NB_LAST_MESSAGE + 1);
       }
-      LAST_MESSAGE[NB_LAST_MESSAGE] = address = (char*)malloc(size + 1);
+      LAST_MESSAGE[NB_LAST_MESSAGE].resize(size + 1);
+      address = LAST_MESSAGE[NB_LAST_MESSAGE].data();
       (void)gslStrcpy(address, string);
       address[size] = '\0';
       NB_LAST_MESSAGE++;
@@ -927,9 +858,9 @@ void set_last_message(Id mode, const char* string)
         return;
       }
 
-      sizaux                            = static_cast<Id>(strlen(LAST_MESSAGE[NB_LAST_MESSAGE - 1]));
-      LAST_MESSAGE[NB_LAST_MESSAGE - 1] = address = (char*)realloc(
-        (char*)LAST_MESSAGE[NB_LAST_MESSAGE - 1], size + sizaux + 2);
+      sizaux                            = static_cast<Id>(strlen(LAST_MESSAGE[NB_LAST_MESSAGE - 1].data()));
+      LAST_MESSAGE[NB_LAST_MESSAGE - 1].resize(size + sizaux + 2);
+      address = LAST_MESSAGE[NB_LAST_MESSAGE - 1].data();
       address[sizaux] = ' ';
       (void)gslStrcpy(&address[sizaux + 1], string);
       address[size + sizaux + 1] = '\0';
@@ -949,7 +880,7 @@ void print_last_message(void)
   mestitle(0, "Last Message");
   for (Id i = 0; i < NB_LAST_MESSAGE; i++)
   {
-    message(">>> %s\n", LAST_MESSAGE[i]);
+    message(">>> %s\n", LAST_MESSAGE[i].data());
   }
   message("\n");
 }

--- a/src/Core/variopgs.cpp
+++ b/src/Core/variopgs.cpp
@@ -11,7 +11,6 @@
 #include "Basic/AException.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
-#include "Basic/Memory.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Basic/Utilities.hpp"
 #include "Core/CTables.hpp"
@@ -354,7 +353,7 @@ static void st_rules_print(const char* title,
 static void st_relem_subdivide(Relem* relem0, Id half, Id noper)
 {
   Split* split;
-  Id *divs, ndiv, number, ncur, previous_oper, verbose;
+  Id ndiv, number, ncur, previous_oper, verbose;
 
   verbose = 0;
   ncur    = static_cast<Id>(relem0->facies.size());
@@ -363,9 +362,9 @@ static void st_relem_subdivide(Relem* relem0, Id half, Id noper)
   previous_oper = 1;
   if (relem0->old_split != NULL) previous_oper = relem0->old_split->oper;
 
-  divs   = ut_split_into_two(ncur, half, verbose, &ndiv);
+  auto divs   = ut_split_into_two(ncur, half, verbose, &ndiv);
   number = ndiv * noper;
-  mem_free((char*)divs);
+  divs.clear();
 
   relem0->splits.resize(number);
 
@@ -386,7 +385,7 @@ static void st_relem_subdivide(Relem* relem0, Id half, Id noper)
         st_relem_subdivide(split->relems[i], 0, NGRF);
       }
     }
-    mem_free((char*)divs);
+    divs.clear();
   }
 
   relem0->splits.resize(number);
@@ -1780,17 +1779,15 @@ Vario_Order* vario_order_manage(Id mode,
       vorder_loc->tab_dist.resize(0);
       vorder_loc->size_aux     = size_aux;
       vorder_loc->flag_dist    = flag_dist;
-      vorder_loc->tab_aux_iech = nullptr;
-      vorder_loc->tab_aux_jech = nullptr;
+      vorder_loc->tab_aux_iech.clear();
+      vorder_loc->tab_aux_jech.clear();
       break;
 
     case 0:
       vorder_loc = vorder;
       if (vorder == nullptr) return (vorder_loc);
-      vorder_loc->tab_aux_iech = (char*)mem_free(
-        (char*)vorder_loc->tab_aux_iech);
-      vorder_loc->tab_aux_jech = (char*)mem_free(
-        (char*)vorder_loc->tab_aux_jech);
+      vorder_loc->tab_aux_iech.clear();
+      vorder_loc->tab_aux_jech.clear();
       break;
 
     case -1:
@@ -1798,10 +1795,8 @@ Vario_Order* vario_order_manage(Id mode,
       if (vorder == nullptr) return (vorder_loc);
       if (vorder_loc != nullptr)
       {
-        vorder_loc->tab_aux_iech = (char*)mem_free(
-          (char*)vorder_loc->tab_aux_iech);
-        vorder_loc->tab_aux_jech = (char*)mem_free(
-          (char*)vorder_loc->tab_aux_jech);
+        vorder_loc->tab_aux_iech.clear();
+        vorder_loc->tab_aux_jech.clear();
         delete vorder_loc;
         vorder_loc = nullptr;
       }
@@ -1851,12 +1846,8 @@ Id vario_order_add(Vario_Order* vorder,
     vorder->tab_sort.resize(vorder->nalloc);
     if (vorder->size_aux > 0)
     {
-      vorder->tab_aux_iech = (char*)mem_realloc(
-        (char*)vorder->tab_aux_iech, vorder->nalloc * vorder->size_aux, 0);
-      if (vorder->tab_aux_iech == nullptr) return (1);
-      vorder->tab_aux_jech = (char*)mem_realloc(
-        (char*)vorder->tab_aux_jech, vorder->nalloc * vorder->size_aux, 0);
-      if (vorder->tab_aux_jech == nullptr) return (1);
+      vorder->tab_aux_iech.resize(vorder->nalloc * vorder->size_aux);
+      vorder->tab_aux_jech.resize(vorder->nalloc * vorder->size_aux);
     }
     if (vorder->flag_dist)
       vorder->tab_dist.resize(vorder->nalloc);
@@ -1961,12 +1952,8 @@ Vario_Order* vario_order_final(Vario_Order* vorder, Id* npair)
 
     if (vorder->size_aux > 0)
     {
-      vorder->tab_aux_iech = (char*)mem_realloc(
-        (char*)vorder->tab_aux_iech, vorder->npair * vorder->size_aux, 0);
-      if (vorder->tab_aux_iech == nullptr) error = 1;
-      vorder->tab_aux_jech = (char*)mem_realloc(
-        (char*)vorder->tab_aux_jech, vorder->npair * vorder->size_aux, 0);
-      if (vorder->tab_aux_iech == nullptr) error = 1;
+      vorder->tab_aux_iech.resize(vorder->npair * vorder->size_aux);
+      vorder->tab_aux_jech.resize(vorder->npair * vorder->size_aux);
     }
   }
   vorder->nalloc = vorder->npair;

--- a/src/Mesh/LinkSphTriangle.cpp
+++ b/src/Mesh/LinkSphTriangle.cpp
@@ -12,7 +12,7 @@
 
 #include "Basic/Law.hpp"
 #include "Basic/MathFunc.hpp"
-#include "Basic/Memory.hpp"
+#include "Basic/VectorNumT.hpp"
 #include "Core/Keypair.hpp"
 #include "Db/Db.hpp"
 #include "Geometry/GeometryHelper.hpp"
@@ -40,12 +40,12 @@ void meshes_2D_sph_init(SphTriangle* t)
 {
   t->n_nodes  = 0;
   t->sph_size = 0;
-  t->sph_x    = nullptr;
-  t->sph_y    = nullptr;
-  t->sph_z    = nullptr;
-  t->sph_list = nullptr;
-  t->sph_lptr = nullptr;
-  t->sph_lend = nullptr;
+  t->sph_x.clear();
+  t->sph_y.clear();
+  t->sph_z.clear();
+  t->sph_list.clear();
+  t->sph_lptr.clear();
+  t->sph_lend.clear();
 }
 
 /*****************************************************************************/
@@ -62,14 +62,14 @@ void meshes_2D_sph_free(SphTriangle* t, Id mode)
   if (t == (SphTriangle*)NULL) return;
   if (mode == 0)
   {
-    t->sph_x   = (double*)mem_free((char*)t->sph_x);
-    t->sph_y   = (double*)mem_free((char*)t->sph_y);
-    t->sph_z   = (double*)mem_free((char*)t->sph_z);
+    t->sph_x.clear();
+    t->sph_y.clear();
+    t->sph_z.clear();
     t->n_nodes = 0;
   }
-  t->sph_list = (int*)mem_free((char*)t->sph_list);
-  t->sph_lptr = (int*)mem_free((char*)t->sph_lptr);
-  t->sph_lend = (int*)mem_free((char*)t->sph_lend);
+  t->sph_list.clear();
+  t->sph_lptr.clear();
+  t->sph_lend.clear();
   t->sph_size = 0;
 }
 
@@ -110,17 +110,11 @@ Id meshes_2D_sph_from_db(Db* db, SphTriangle* t)
 
   /* Core allocation */
 
-  nold     = t->n_nodes;
-  ecr      = nold;
-  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
-                                  sizeof(double) * (nold + neff), 0);
-  if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
-                                  sizeof(double) * (nold + neff), 0);
-  if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
-                                  sizeof(double) * (nold + neff), 0);
-  if (t->sph_z == nullptr) goto label_end;
+  nold = t->n_nodes;
+  ecr  = nold;
+  t->sph_x.resize(nold + neff);
+  t->sph_y.resize(nold + neff);
+  t->sph_z.resize(nold + neff);
 
   /* Load the points */
 
@@ -140,7 +134,6 @@ Id meshes_2D_sph_from_db(Db* db, SphTriangle* t)
 
   error = 0;
 
-label_end:
   if (error) meshes_2D_sph_free(t, 0);
   return (error);
 }
@@ -168,17 +161,11 @@ Id meshes_2D_sph_from_points(Id nech, double* x, double* y, SphTriangle* t)
 
   /* List of points */
 
-  nold     = t->n_nodes;
-  ecr      = nold;
-  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
-                                  sizeof(double) * (nold + nech), 0);
-  if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
-                                  sizeof(double) * (nold + nech), 0);
-  if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
-                                  sizeof(double) * (nold + nech), 0);
-  if (t->sph_z == nullptr) goto label_end;
+  nold = t->n_nodes;
+  ecr  = nold;
+  t->sph_x.resize(nold + nech);
+  t->sph_y.resize(nold + nech);
+  t->sph_z.resize(nold + nech);
 
   /* Load the information */
 
@@ -196,7 +183,6 @@ Id meshes_2D_sph_from_points(Id nech, double* x, double* y, SphTriangle* t)
 
   error = 0;
 
-label_end:
   if (error) meshes_2D_sph_free(t, 0);
   return (error);
 }
@@ -264,15 +250,9 @@ Id meshes_2D_sph_from_auxiliary(const String& triswitch, SphTriangle* t)
 
   /* Reallocate to maximum size */
 
-  t->sph_x = (double*)mem_realloc((char*)t->sph_x,
-                                  sizeof(double) * (nold + npoint), 0);
-  if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*)mem_realloc((char*)t->sph_y,
-                                  sizeof(double) * (nold + npoint), 0);
-  if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*)mem_realloc((char*)t->sph_z,
-                                  sizeof(double) * (nold + npoint), 0);
-  if (t->sph_z == nullptr) goto label_end;
+  t->sph_x.resize(nold + npoint);
+  t->sph_y.resize(nold + npoint);
+  t->sph_z.resize(nold + npoint);
 
   /* Check that random points are not too close from hard nodes */
 
@@ -309,13 +289,10 @@ Id meshes_2D_sph_from_auxiliary(const String& triswitch, SphTriangle* t)
 
   /* Final resize */
 
-  nech     = ecr;
-  t->sph_x = (double*)mem_realloc((char*)t->sph_x, sizeof(double) * nech, 0);
-  if (t->sph_x == nullptr) goto label_end;
-  t->sph_y = (double*)mem_realloc((char*)t->sph_y, sizeof(double) * nech, 0);
-  if (t->sph_y == nullptr) goto label_end;
-  t->sph_z = (double*)mem_realloc((char*)t->sph_z, sizeof(double) * nech, 0);
-  if (t->sph_z == nullptr) goto label_end;
+  nech = ecr;
+  t->sph_x.resize(nech);
+  t->sph_y.resize(nech);
+  t->sph_z.resize(nech);
   t->n_nodes = static_cast<int>(nech);
 
   /* Set the error return code */
@@ -341,7 +318,7 @@ void meshes_2D_sph_print(SphTriangle* t, Id brief)
 
   message("- Number of nodes   = %d\n", t->n_nodes);
 
-  if (!brief && t->n_nodes > 0 && t->sph_x != nullptr && t->sph_y != nullptr && t->sph_z != nullptr)
+  if (!brief && t->n_nodes > 0 && !t->sph_x.empty() && !t->sph_y.empty() && !t->sph_z.empty())
   {
     message("\nCoordinates in Cartesian (R=1); then in Longitude - Latitude\n");
     for (Id i = 0; i < t->n_nodes; i++)
@@ -367,44 +344,31 @@ void meshes_2D_sph_print(SphTriangle* t, Id brief)
  *****************************************************************************/
 Id meshes_2D_sph_create(Id verbose, SphTriangle* t)
 {
-  int *loc_near, *loc_next, *loc_lnew, error, skip_rnd, seed_memo;
-  double *loc_dist, memo[3][3], ampli, value, cste;
+  std::vector<int> loc_near, loc_next, loc_lnew;
+  VectorDouble loc_dist;
+  int error, skip_rnd, seed_memo;
+  double memo[3][3], ampli, value, cste;
 
   /* Initializations */
 
   error    = 1;
   skip_rnd = (int)get_keypone("Skip_Random", 0);
-  loc_near = loc_next = loc_lnew = nullptr;
-  loc_dist                       = nullptr;
   if (t == (SphTriangle*)NULL || t->n_nodes < 3) return (1);
 
   /* Re-allocate the arrays within the SphTriangle structure */
 
   meshes_2D_sph_free(t, 1);
   t->sph_size = 6 * t->n_nodes - 12;
-  t->sph_list = (int*)mem_alloc(sizeof(Id) * t->sph_size, 0);
-  if (t->sph_list == nullptr) goto label_end;
-  for (Id i = 0; i < t->sph_size; i++)
-    t->sph_list[i] = ITEST;
-  t->sph_lptr = (int*)mem_alloc(sizeof(int) * t->sph_size, 0);
-  if (t->sph_lptr == nullptr) goto label_end;
-  for (int i = 0; i < t->sph_size; i++)
-    t->sph_lptr[i] = ITEST;
-  t->sph_lend = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
-  if (t->sph_lend == nullptr) goto label_end;
-  for (int i = 0; i < t->n_nodes; i++)
-    t->sph_lend[i] = ITEST;
+  t->sph_list.resize(t->sph_size, ITEST);
+  t->sph_lptr.resize(t->sph_size, ITEST);
+  t->sph_lend.resize(t->sph_size, ITEST);
 
   /* Allocate local arrays */
 
-  loc_lnew = (int*)mem_alloc(sizeof(int) * t->sph_size, 0);
-  if (loc_lnew == nullptr) goto label_end;
-  loc_near = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
-  if (loc_near == nullptr) goto label_end;
-  loc_next = (int*)mem_alloc(sizeof(int) * t->n_nodes, 0);
-  if (loc_next == nullptr) goto label_end;
-  loc_dist = (double*)mem_alloc(sizeof(double) * t->n_nodes, 0);
-  if (loc_dist == nullptr) goto label_end;
+  loc_lnew.resize(t->sph_size);
+  loc_near.resize(t->n_nodes);
+  loc_next.resize(t->n_nodes);
+  loc_dist.resize(t->n_nodes);
 
   /* Avoid having three first points colinear */
 
@@ -428,9 +392,10 @@ Id meshes_2D_sph_create(Id verbose, SphTriangle* t)
     law_set_random_seed(seed_memo);
   }
 
-  (void)trmesh_(&t->n_nodes, t->sph_x, t->sph_y, t->sph_z, t->sph_list,
-                t->sph_lptr, t->sph_lend, loc_lnew, loc_near, loc_next,
-                loc_dist, &error);
+  (void)trmesh_(&t->n_nodes, t->sph_x.data(), t->sph_y.data(), t->sph_z.data(), t->sph_list.data(),
+                t->sph_lptr.data(), t->sph_lend.data(),
+                loc_lnew.data(), loc_near.data(), loc_next.data(),
+                loc_dist.data(), &error);
 
   /* Restore the initial coordinates */
 
@@ -470,10 +435,6 @@ Id meshes_2D_sph_create(Id verbose, SphTriangle* t)
   meshes_2D_sph_free(t, 1);
 
 label_end:
-  mem_free((char*)loc_near);
-  mem_free((char*)loc_next);
-  mem_free((char*)loc_lnew);
-  mem_free((char*)loc_dist);
   return (error);
 }
 

--- a/src/Mesh/MeshSphericalExt.cpp
+++ b/src/Mesh/MeshSphericalExt.cpp
@@ -129,7 +129,7 @@ void MeshSphericalExt::_meshesSphLoadVertices(SphTriangle* t)
   lec      = 0;
   int nrow = 6;
   std::vector<int> ltri(2 * nrow * t->n_nodes, 0);
-  (void)trlist_(&t->n_nodes, t->sph_list, t->sph_lptr, t->sph_lend, &nrow,
+  (void)trlist_(&t->n_nodes, t->sph_list.data(), t->sph_lptr.data(), t->sph_lend.data(), &nrow,
                 &nt, ltri.data(), &error);
   if (error) return;
 

--- a/src/OutputFormat/FileVTK.cpp
+++ b/src/OutputFormat/FileVTK.cpp
@@ -85,13 +85,13 @@ Id FileVTK::writeInFile()
     center[icol] = 1;
   }
 
-  float** tab = (float**)malloc(sizeof(float*) * ncol);
+  VectorVectorFloat tab(ncol);
   for (Id icol = 0; icol < ncol; icol++)
   {
     if (flag_grid)
-      tab[icol] = (float*)malloc(sizeof(float) * nech);
+      tab[icol].resize(nech);
     else
-      tab[icol] = (float*)malloc(sizeof(float) * nactive);
+      tab[icol].resize(nactive);
   }
 
   VectorFloat xcoor;
@@ -197,10 +197,6 @@ Id FileVTK::writeInFile()
   else
     write_point_mesh(getFilename().c_str(), _flagBinary, nactive, points.data(),
                      ncol, vardim.data(), vc.data(), tab);
-
-  for (Id icol = 0; icol < ncol; icol++) 
-    free((char*)tab[icol]);
-  free((char*)tab);
 
   _fileClose();
   return 0;

--- a/src/OutputFormat/vtk.cpp
+++ b/src/OutputFormat/vtk.cpp
@@ -162,7 +162,7 @@ static void force_big_endian(unsigned char *bytes)
   if (!doneTest)
   {
     Id tmp1 = 1;
-    unsigned char *tmp2 = (unsigned char *) &tmp1;
+    auto *tmp2 = (unsigned char *) &tmp1;
     if (*tmp2 != 0)
       shouldSwap = 1;
     doneTest = 1;
@@ -343,7 +343,7 @@ void write_variables(Id nvars,
                      const Id* vardim,
                      const Id* centering,
                      const char* const* varname,
-                     float** vars,
+                     VectorVectorFloat& vars,
                      Id npts,
                      Id ncells)
 {
@@ -659,7 +659,7 @@ void write_point_mesh(const char* filename,
                       Id nvars,
                       Id* vardim,
                       const char* const* varnames,
-                      float** vars)
+                      VectorVectorFloat& vars)
 {
   Id   i;
   char  str[128];
@@ -790,7 +790,7 @@ void write_unstructured_mesh(const char* filename,
                              Id* vardim,
                              Id* centering,
                              const char* const* varnames,
-                             float** vars)
+                             VectorVectorFloat& vars)
 {
   Id   i, j;
   char  str[128];
@@ -888,7 +888,7 @@ void write_rectilinear_mesh(const char* filename,
                             Id* vardim,
                             Id* centering,
                             const char* const* varnames,
-                            float** vars)
+                            VectorVectorFloat& vars)
 {
   Id   i;
   char  str[128];
@@ -965,7 +965,7 @@ void write_regular_mesh(const char* filename,
                         Id* vardim,
                         Id* centering,
                         const char* const* varnames,
-                        float** vars)
+                        VectorVectorFloat& vars)
 {
   Id  i;
  
@@ -1030,7 +1030,7 @@ void write_curvilinear_mesh(const char* filename,
                             Id* vardim,
                             Id* centering,
                             const char* const* varnames,
-                            float** vars)
+                            VectorVectorFloat& vars)
 {
   Id   i;
   char  str[128];

--- a/tests/data/testvar.cpp
+++ b/tests/data/testvar.cpp
@@ -30,7 +30,7 @@ using namespace gstlrn;
 
 int main(int argc, char* argv[])
 {
-  char* filename = new char[BUFFER_LENGTH];
+  std::vector<char> filename(BUFFER_LENGTH);
   DbGrid* dbout;
   Vario* vario;
   Model* model;
@@ -71,29 +71,29 @@ int main(int argc, char* argv[])
 
   /* Define the environment */
 
-  ascii_filename("Environ", 0, 0, filename);
-  ascii_environ_read(filename, verbose);
+  ascii_filename("Environ", 0, 0, filename.data());
+  ascii_environ_read(filename.data(), verbose);
 
   /* Define the options */
 
-  ascii_filename("Option", 0, 0, filename);
-  ascii_option_defined(filename, 0, "Norm_sill", 0, &flag_norm_sill);
-  ascii_option_defined(filename, 0, "Goulard_used", 0, &flag_goulard_used);
+  ascii_filename("Option", 0, 0, filename.data());
+  ascii_option_defined(filename.data(), 0, "Norm_sill", 0, &flag_norm_sill);
+  ascii_option_defined(filename.data(), 0, "Goulard_used", 0, &flag_goulard_used);
 
   /* Define the output grid file */
 
-  ascii_filename("Grid", 0, 0, filename);
-  dbout = DbGrid::createFromNF(filename, verbose);
+  ascii_filename("Grid", 0, 0, filename.data());
+  dbout = DbGrid::createFromNF(filename.data(), verbose);
 
   /* Look for simulations */
 
-  ascii_filename("Simu", 0, 0, filename);
-  ascii_simu_read(filename, verbose, &nbsimu, &nbtuba, &seed);
+  ascii_filename("Simu", 0, 0, filename.data());
+  ascii_simu_read(filename.data(), verbose, &nbsimu, &nbtuba, &seed);
 
   /* Define the model */
 
-  ascii_filename("Model", 0, 0, filename);
-  model = Model::createFromNF(filename, verbose);
+  ascii_filename("Model", 0, 0, filename.data());
+  model = Model::createFromNF(filename.data(), verbose);
   if (model == (Model*)NULL) goto label_end;
 
   // Define and store the Space
@@ -113,13 +113,13 @@ int main(int argc, char* argv[])
 
   /* Define the variogram */
 
-  ascii_filename("Vario", 0, 0, filename);
-  vario = Vario::createFromNF(filename, verbose);
+  ascii_filename("Vario", 0, 0, filename.data());
+  vario = Vario::createFromNF(filename.data(), verbose);
   if (vario == (Vario*)NULL) goto label_end;
   if (dbout != (Db*)NULL)
   {
     vario->compute(dbout, ECalcVario::VARIOGRAM);
-    ascii_filename("Vario", 0, 1, filename);
+    ascii_filename("Vario", 0, 1, filename.data());
   }
   vario->display();
   if (!vario->dumpToNF("Vario.dat", EFormatNF::DEFAULT, verbose))
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
   if (model_auto_fit(vario, model, verbose, mauto, constraints, options))
     messageAbort("model_auto_fit");
   model->display();
-  ascii_filename("Model", 0, 1, filename);
+  ascii_filename("Model", 0, 1, filename.data());
   if (!model->dumpToNF("Model.out", EFormatNF::DEFAULT, verbose))
     messageAbort("ascii_model_write");
 
@@ -151,6 +151,5 @@ label_end:
   delete model;
   delete dbout;
   delete vario;
-  delete[] filename;
   return (0);
 }


### PR DESCRIPTION
This PR replaces a few `mem_alloc`s & `malloc`s with `VectorInt`, `VectorDouble` or `std::vector` when applicable.

There is still a few `mem_alloc` left, in particular in `krige.cpp` and `spde.cpp`. Those ones seems harder to tackle.

Pierre