### PR TITLE
Fixes for gstlearnext

### DIFF
--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -26,6 +26,7 @@ public:
   static VectorVectorInt    initVVInt(Id nval1, Id nval2, Id value = 0);
 
   static VectorInt          initVInt(const Id* values, Id number);
+  static VectorInt          initVInt(const I32* values, Id number);
   static VectorDouble       initVDouble(const double* values, Id number);
   static VectorVectorDouble initVVDouble(const double* value, Id n1, Id n2);
 

--- a/include/Mesh/Delaunay.hpp
+++ b/include/Mesh/Delaunay.hpp
@@ -39,7 +39,7 @@ GSTLEARN_EXPORT AMesh* meshes_turbo_3D_grid_build(DbGrid* dbgrid);
 GSTLEARN_EXPORT void mesh_stats(Id ndim,
                                 Id ncorner,
                                 Id nmesh,
-                                const Id* meshes,
+                                const I32* meshes,
                                 const double* points);
                                 
 }

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -55,6 +55,14 @@ VectorInt VectorHelper::initVInt(const Id* values, Id number)
   return vec;
 }
 
+VectorInt VectorHelper::initVInt(const I32* values, Id number)
+{
+  if (values == nullptr) return VectorInt();
+  VectorInt vec(number);
+  for (Id i = 0; i < number; i++) vec[i] = values[i];
+  return vec;
+}
+
 VectorDouble VectorHelper::initVDouble(const double* values, Id number)
 {
   if (values == nullptr) return VectorDouble();

--- a/src/Mesh/Delaunay.cpp
+++ b/src/Mesh/Delaunay.cpp
@@ -715,7 +715,7 @@ Id meshes_2D_write(const char* file_name,
  ** \param[in]  points    Array of 'ndim' coordinates for mesh vertex
  **
  *****************************************************************************/
-void mesh_stats(Id ndim, Id ncorner, Id nmesh, const Id* meshes, const double* points)
+void mesh_stats(Id ndim, Id ncorner, Id nmesh, const I32* meshes, const double* points)
 {
   VectorDouble mini(ndim, 0.);
   VectorDouble maxi(ndim, 0.);


### PR DESCRIPTION
This PR amends recent integer changes to make them more compatible with `gstlearnext`.
There still are a few `int` -> `Id` conversions to do in `gstlearnext` to have it build again though but they are contained in only 2 files: `src/MeshExt/LinkTriangle.cpp` and `src/MeshExt/LinkTetrahedron.cpp`
Pierre