### PR TITLE
Fix 3D ipynb render for demos and courses generation

### DIFF
--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -50,13 +50,14 @@ jobs:
         python-version: ${{env.PYTHON_VERSION}}
         activate-environment: true
 
+    # Downgrade notebook and plotly (for 3D render) using nbconvert generation
     - name: Install Python dependencies
       run: |
         uv pip install numpy
         uv pip install jupyter
         uv pip install notebook==6.1.6
         uv pip install matplotlib
-        uv pip install plotly
+        uv pip install plotly==6.0.1
         uv pip install pandas
         uv pip install scipy
         uv pip install dash

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -60,13 +60,14 @@ jobs:
         python-version: ${{env.PYTHON_VERSION}}
         activate-environment: true
 
+    # Downgrade notebook and plotly (for 3D render) using nbconvert generation
     - name: Install Python dependencies
       run: |
         uv pip install numpy
         uv pip install jupyter
         uv pip install notebook==6.1.6
         uv pip install matplotlib
-        uv pip install plotly
+        uv pip install plotly==6.0.1
         uv pip install pandas
         uv pip install scipy
         uv pip install dash

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -66,7 +66,7 @@ jobs:
         uv pip install jupyter
         uv pip install notebook==6.1.6
         uv pip install matplotlib
-        uv pip install plotly
+        uv pip install plotly==6.0.1
         uv pip install pandas
         uv pip install scipy
         uv pip install dash

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -60,6 +60,7 @@ jobs:
         python-version: ${{env.PYTHON_VERSION}}
         activate-environment: true
 
+    # Downgrade notebook and plotly (for 3D render) using nbconvert generation
     - name: Install Python dependencies
       run: |
         uv pip install numpy


### PR DESCRIPTION
3D render for plotly doesn't work anymore since plotly 6.1.0 while using nbconvert for HTLM generation.
plotly has been downgraded to 6.0.1in the GH workflows called by publish_doc