### PR TITLE
Fix comment in 03_Graphics.ipynb

### DIFF
--- a/doc/courses/python/03_Graphics.ipynb
+++ b/doc/courses/python/03_Graphics.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The module gstlearn.plot contains various plot functions for gstlearn objets: DbGrid, Db, Vario, Model, Polygons... These functions are also accessible as methods of each class. For example for a grid, we could use equivalently gp.grid(mygrid,...) or mygrid.plot(...), or for more specific functions: gp.point(mygrid,...) or mygrid.plot_point(...)"
+    "The module gstlearn.plot contains various plot functions for gstlearn objets: DbGrid, Db, Vario, Model, Polygons... These functions are also accessible as methods of each class. For example for a grid, we could use equivalently gp.raster(mygrid,...) or mygrid.plot(...). A grid could also be plotted as points using gp.symbol(mygrid,...)."
    ]
   },
   {
@@ -951,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The comment of 03_Graphics.ipynb was obsolete (still referred to gp.grid function that has been replaced by gp.raster a long time ago)