### PR TITLE
GitHub Actions: Uniformize uv use in workflows

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -62,14 +62,14 @@ jobs:
         brew install boost
         brew install eigen
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ matrix.python.py }}
+        activate-environment: true
 
     - name: Install Python dependencies
       run: |
-        uv venv
         uv pip install numpy
 
     - name: Build & install NLopt static libraries
@@ -80,7 +80,7 @@ jobs:
 
     - name : Configure build directory
       run : |
-        uv run cmake \
+        cmake \
           -B${{ env.BUILD_DIR }} \
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
@@ -140,25 +140,25 @@ jobs:
       with:
         name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ matrix.python.py }}
+        activate-environment: true
 
     - name: Install macOS dependencies
       run: brew install llvm
 
     - name: Install Python package
       run: |
-        uv venv
         uv pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
-        uv run python tests/py/test_Arguments.py
-        uv run python tests/py/test_Assessors.py
-        uv run python tests/py/test_Matrix.py
+        python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
 
   publish:
     needs: test

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -76,12 +76,14 @@ jobs:
       run: |
         echo "/opt/python/${{ matrix.python }}/bin" >> $GITHUB_PATH
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
 
     - name: Install Python dependencies
       run: |
-        uv venv
         uv pip install numpy
 
     - name: Build & install NLopt static libraries
@@ -92,7 +94,7 @@ jobs:
 
     - name : Configure build directory
       run : |
-        uv run cmake \
+        cmake \
           -B${{ env.BUILD_DIR }} \
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
@@ -150,20 +152,22 @@ jobs:
       run: |
         echo "/opt/python/${{ matrix.python }}/bin" >> $GITHUB_PATH
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{env.PYTHON_VERSION}}
+        activate-environment: true
 
     - name: Install Python package
       run: |
-        uv venv
         uv pip install "./$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
-        uv run python tests/py/test_Arguments.py
-        uv run python tests/py/test_Assessors.py
-        uv run python tests/py/test_Matrix.py
+        python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
 
   publish:
     needs: test

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -148,22 +148,22 @@ jobs:
       with:
         name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ matrix.python.py }}
+        activate-environment: true
 
     - name: Install Python package
       run: |
-        uv venv
         uv pip install "$(ls *.whl)[conv]"
 
     - name: Test installed Python package
       run: |
-        uv run python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
-        uv run python tests/py/test_Arguments.py
-        uv run python tests/py/test_Assessors.py
-        uv run python tests/py/test_Matrix.py
+        python -c 'import gstlearn as gl; gl.acknowledge_gstlearn()'
+        python tests/py/test_Arguments.py
+        python tests/py/test_Assessors.py
+        python tests/py/test_Matrix.py
 
   publish:
     needs: test


### PR DESCRIPTION
This PR uniformizes the use of `uv` between the `publish` and the `nonreg` workflows.
Only the `publish` workflows have been modified.

Corresponding `publish` run: https://github.com/pierre-guillou/gstlearn/actions/runs/17371086615

Pierre