### PR TITLE
GitHub Actions: Fix Windows artifacts

### DIFF
--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -73,6 +73,7 @@ jobs:
       run: |
         cmake `
           -B${{ env.BUILD_DIR }} `
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON `
           -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DBUILD_TESTING=ON `
           -DBUILD_PYTHON=ON

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -91,32 +91,24 @@ jobs:
 
     - name: Compress output logs and neutral files
       if: success() || failure()
-      shell: powershell
+      shell: bash
       run: |
         cd ${{env.BUILD_DIR}}/tests
-        Get-ChildItem -Recurse -Filter '*.out' | Select-Object -ExpandProperty Fullname | Resolve-Path -Relative > logs.txt
-        foreach ($filename in Get-Content .\logs.txt)
-        {
-            Compress-Archive -Update $filename .\msvc-logs.zip
-        }
-        cd ${{ env.GSTLEARN_OUTPUT_DIR }}
-        Get-ChildItem -Recurse -Filter '*.*' | Select-Object -ExpandProperty Fullname | Resolve-Path -Relative > neutral.txt
-        foreach ($filename in Get-Content .\neutral.txt)
-        {
-            Compress-Archive -Update $filename .\msvc-neutral.zip
-        }
-        Move-Item -Path msvc-neutral.zip -Destination ${{github.workspace}}
+        find . -type f -name "*.out" -print0 | tar -czvf msvc-logs.tar.gz --null -T -
+        cd $GITHUB_WORKSPACE/build/gstlearn_dir
+        find . -type f -name "*.*" -print0 | tar -czvf msvc-neutral.tar.gz --null -T -
+        mv msvc-neutral.tar.gz $GITHUB_WORKSPACE/
 
     - name: Publish output logs as artefact
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: msvc-nonreg-logs
-        path: ${{env.BUILD_DIR}}/tests/msvc-logs.zip
+        path: ${{env.BUILD_DIR}}/tests/msvc-logs.tar.gz
 
     - name: Publish output neutral files as artefact
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: msvc-neutral-files
-        path: ${{github.workspace}}/msvc-neutral.zip
+        path: ${{github.workspace}}/msvc-neutral.tar.gz

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -79,32 +79,24 @@ jobs:
 
     - name: Compress output logs and neutral files
       if: success() || failure()
-      shell: powershell
+      shell: bash
       run: |
         cd ${{env.BUILD_DIR}}/tests
-        Get-ChildItem -Recurse -Filter '*.out' | Select-Object -ExpandProperty Fullname | Resolve-Path -Relative > logs.txt
-        foreach ($filename in Get-Content .\logs.txt)
-        {
-            Compress-Archive -Update $filename .\rtools-logs.zip
-        }
-        cd ${{ env.GSTLEARN_OUTPUT_DIR }}
-        Get-ChildItem -Recurse -Filter '*.*' | Select-Object -ExpandProperty Fullname | Resolve-Path -Relative > neutral.txt
-        foreach ($filename in Get-Content .\neutral.txt)
-        {
-            Compress-Archive -Update $filename .\rtools-neutral.zip
-        }
-        Move-Item -Path rtools-neutral.zip -Destination ${{github.workspace}}
+        find . -type f -name "*.out" -print0 | tar -czvf rtools-logs.tar.gz --null -T -
+        cd $GITHUB_WORKSPACE/build/gstlearn_dir
+        find . -type f -name "*.*" -print0 | tar -czvf rtools-neutral.tar.gz --null -T -
+        mv rtools-neutral.tar.gz $GITHUB_WORKSPACE/
 
     - name: Publish output logs as artefact
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: rtools-nonreg-logs
-        path: ${{env.BUILD_DIR}}/tests/rtools-logs.zip
+        path: ${{env.BUILD_DIR}}/tests/rtools-logs.tar.gz
 
     - name: Publish output neutral files as artefact
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: rtools-neutral-files
-        path: ${{github.workspace}}/rtools-neutral.zip
+        path: ${{github.workspace}}/rtools-neutral.tar.gz

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         cmake `
           -B${{ env.BUILD_DIR }} `
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON `
           -DBUILD_TESTING=ON `
           -DBUILD_R=ON `
           -DBUILD_PYTHON=OFF `

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -853,7 +853,6 @@ namespace gstlrn {
       {
         if (!argp) {
           %argument_nullref("$type", $symname, $argnum);
-          $1 = nullptr;
         }
         else
           $1 = %reinterpret_cast(argp, $ltype);
@@ -892,7 +891,6 @@ namespace gstlrn {
       {
         if (!argp) {
           %argument_nullref("$type", $symname, $argnum);
-          $1 = nullptr;
         }
         else
           $1 = %reinterpret_cast(argp, $ltype);


### PR DESCRIPTION
This PR fixes the gathering of the Windows workflows artifacts by switching from Powershell to bash.

Also, since there is no warnings left, the compilation of gstlearn in the nonreg rtools workflow is now done with `-Werror` enabled (there are still "unreachable code" warnings when building the Python wrapper in nonreg msvc).

Pierre