### PR TITLE
GitHub Actions: Test Doxygen comments

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -110,13 +110,12 @@ jobs:
   # Code lint job #
   # ------------- #
   lint-code:
-    if: false                   # disabled for now
     runs-on: ubuntu-latest
     strategy:
       matrix:
         config:
-          - {tidy: true, sa: false, dox: false}
-          - {tidy: false, sa: true, dox: false}
+          # - {tidy: true, sa: false, dox: false}
+          # - {tidy: false, sa: true, dox: false}
           - {tidy: false, sa: false, dox: true}
 
     steps:

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -47,6 +47,8 @@ set(DOXYGEN_PREDEFINED "GSTLEARN_EXPORT="
                        "VectorVectorFloat" "VectorT<VectorFloat>"
                        "protected=private")
 
+set(DOXYGEN_MARKDOWN_ID_STYLE GITHUB)
+
 # Ajoutez ces lignes pour mieux gérer les surcharges
 set(DOXYGEN_HIDE_SCOPE_NAMES NO)
 set(DOXYGEN_QUALIFY_CLASSES YES)

--- a/include/Model/ModelOptimParam.hpp
+++ b/include/Model/ModelOptimParam.hpp
@@ -85,10 +85,10 @@ class GSTLEARN_EXPORT ModelOptimParam: public AStringable
    * @param wmode       type of weighting function (0, 1, 2 or 3, see above)
    * @note The default value for wmode is 2
    */
-  Id    getWmode() const { return _wmode; }
   void   setWmode(Id wmode) { _wmode = wmode; }
-  Id    getMaxiter() const { return _maxiter; }
+  Id    getWmode() const { return _wmode; }
   void   setMaxiter(Id maxiter) { _maxiter = maxiter; }
+  Id    getMaxiter() const { return _maxiter; }
   double getTolred() const { return _tolred; }
   void   setTolred(double tolred) { _tolred = tolred; }
 


### PR DESCRIPTION
This PR enables the `check-code` workflow job that makes sure that Doxygen passes without warnings on gstlearn's code.

A few warnings have been fixed:
- a doc-comment in ModelOptimParam.hpp on the wrong method,
- Markdown heading links not recognised by Doxgen in the main README.

Pierre