### PR TITLE
Fix links to doxygen in 01_course for R users

### DIFF
--- a/doc/courses/r/01_gstlearn_start.Rmd
+++ b/doc/courses/r/01_gstlearn_start.Rmd
@@ -103,11 +103,11 @@ For people who were using [RGeostats](http://rgeostats.free.fr), here is the des
 
 * The objects manipulated through *gstlearn* R package (Database, Variograms, Polygons, etc...) are now **external pointers**.
 
-* If you need to duplicate your objects, a simple assignment (e.g. `db2 = db1`) is not possible. You must use the `clone` method by doing this: `db2 = db1$clone()`. All classes that inherits from `ICloneable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classICloneable.html)).
+* If you need to duplicate your objects, a simple assignment (e.g. `db2 = db1`) is not possible. You must use the `clone` method by doing this: `db2 = db1$clone()`. All classes that inherits from `ICloneable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classgstlrn_1_1ICloneable.html).
 
 * The *gstlearn* objects memory content is not stored in the R workspace anymore. This means that saving the R workspace (`.RData`) is dangerous because it stores only memory pointers that won't be valid when loading the workspace in a future R session.
 
-* People who want to recover the objects content for a future R session, have to save them to 'Neutral Files' using `dumpToNF` method before quitting R. All classes that inherits from `ASerializable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classASerializable.html)). The following R code explains how to create a 'Neutral File' and load it later:
+* People who want to recover the objects content for a future R session, have to save them to 'Neutral Files' using `dumpToNF` method before quitting R. All classes that inherits from `ASerializable` have this capability ([see here](https://soft.mines-paristech.fr/gstlearn/doxygen-latest/classgstlrn_1_1ASerializable.html)). The following R code explains how to create a 'Neutral File' and load it later:
 
 ```{r , eval=FALSE}
 # Create a Neutral File storing db content


### PR DESCRIPTION
The links to the doxygen documentation (ICloneable and ASerializable) has been fixed in the 01_gstlearn_start.Rmd course.