### PR TITLE
Improvement graphic representation in py

### DIFF
--- a/doc/courses/python/03_Graphics.ipynb
+++ b/doc/courses/python/03_Graphics.ipynb
@@ -951,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/python/modules/plot.py
+++ b/python/modules/plot.py
@@ -908,6 +908,8 @@ def _ax_literal(ax, db, name=None,
     if len(tabx) <= 0: 
         return
     
+    name = _getDefaultVariableName(db, name)
+
     labval = _getVariable(db, name, posX, posY, None, useSel, False)
     valid = ~np.isnan(labval)
 
@@ -917,7 +919,7 @@ def _ax_literal(ax, db, name=None,
         if not np.isnan(txt):
             ax.annotate(round(txt,2), (tabx[i], taby[i]), fontsize=fontsize)
   
-    name = _getDefaultVariableName(db, name)
+
     
     if len(ax.get_title()) <= 0:
         ax.decoration(title = db.getName(name)[0])
@@ -1204,6 +1206,8 @@ def _ax_isoline(ax, dbgrid, name=None, useSel = True,
     
     **kwargs : arguments passed to matplotlib.pyplot.contour
     '''    
+    name = _getDefaultVariableName(dbgrid, name)
+    
     x0, y0, X, Y, Xrot, Yrot, data, tr = _getGridVariable(dbgrid, name, useSel, posX=posX, posY=posY, corner=corner, shading="nearest")
     ax.set_xlim(np.nanmin(Xrot), np.nanmax(Xrot))
     ax.set_ylim(np.nanmin(Yrot), np.nanmax(Yrot))
@@ -1214,8 +1218,6 @@ def _ax_isoline(ax, dbgrid, name=None, useSel = True,
         levels = np.linspace(np.nanmin(data), np.nanmax(data), nlevel)
 
     res = ax.contour(Xrot, Yrot, data, levels, **kwargs)
-    
-    name = _getDefaultVariableName(dbgrid, name)
         
     if len(ax.get_title()) <= 0:
         ax.decoration(title = dbgrid.getName(name)[0])


### PR DESCRIPTION
When using plot.py or plot.R, several functions are available for various representation modes; raster, isoline (for grids), symbols (for points).
Some of them require a single variable to be represented, usually specified by an argument called 'name'.
If this 'name' is not provided, a generic trick provides a variable name by default, i.e.:
- the first Z-variable (if some Z-variables are defined)
- the last variable added to the Db file
This automation was not active fin the case of isoline representation. It has been corrected.

We also checked that this contour representation allows the user either to specify the list of levels to be represented or their number (then levels are calculated automatically between the minimum and the maximum of the variable).We checked that this property is available in py (using arguments called 'nlevels') or in R (using the argument 'bins').
