### PR TITLE
Correct lower and upper in gibbs

### DIFF
--- a/doc/courses/python/02_Db.ipynb
+++ b/doc/courses/python/02_Db.ipynb
@@ -686,7 +686,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/03_Graphics.ipynb
+++ b/doc/courses/python/03_Graphics.ipynb
@@ -937,7 +937,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },
@@ -951,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/courses/python/04_Variography.ipynb
+++ b/doc/courses/python/04_Variography.ipynb
@@ -48,12 +48,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
+      "application/javascript": "\nIPython.OutputArea.prototype._should_scroll = function(lines) {\n    return false;\n}\n",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -855,9 +850,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (gstlearn)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
-   "name": ".venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -869,7 +864,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/doc/courses/python/05_Kriging.ipynb
+++ b/doc/courses/python/05_Kriging.ipynb
@@ -981,7 +981,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/06a_Multivariate.ipynb
+++ b/doc/courses/python/06a_Multivariate.ipynb
@@ -1750,7 +1750,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/06b_FKA.ipynb
+++ b/doc/courses/python/06b_FKA.ipynb
@@ -434,7 +434,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/07a_Simulations.ipynb
+++ b/doc/courses/python/07a_Simulations.ipynb
@@ -625,7 +625,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/07b_Condexp.ipynb
+++ b/doc/courses/python/07b_Condexp.ipynb
@@ -401,7 +401,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/08_SimuPGS.ipynb
+++ b/doc/courses/python/08_SimuPGS.ipynb
@@ -386,7 +386,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/courses/python/09_SPDE.ipynb
+++ b/doc/courses/python/09_SPDE.ipynb
@@ -311,7 +311,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "project_gstlearn (3.10.5)",
    "language": "python",
    "name": "python3"
   },

--- a/include/Gibbs/AGibbs.hpp
+++ b/include/Gibbs/AGibbs.hpp
@@ -16,10 +16,10 @@
 #include "Basic/AStringable.hpp"
 
 namespace gstlrn
-{ 
+{
 class Db;
 
-class GSTLEARN_EXPORT AGibbs : public AStringable
+class GSTLEARN_EXPORT AGibbs: public AStringable
 {
 public:
   AGibbs();
@@ -32,17 +32,17 @@ public:
          Id seed,
          Id flag_order,
          bool flag_decay);
-  AGibbs(const AGibbs &r);
-  AGibbs& operator=(const AGibbs &r);
+  AGibbs(const AGibbs& r);
+  AGibbs& operator=(const AGibbs& r);
   virtual ~AGibbs();
 
   /// Interface for AStringable
   String toString(const AStringFormat* strfmt = nullptr) const override;
 
   /// Interface for AGibbs
-  virtual Id calculInitialize(VectorVectorDouble &y, Id isimu, Id ipgs) = 0;
+  virtual Id calculInitialize(VectorVectorDouble& y, Id isimu, Id ipgs)  = 0;
   virtual void update(VectorVectorDouble& y, Id isimu, Id ipgs, Id iter) = 0;
-  virtual Id covmatAlloc(bool verbose, bool verboseTimer = false) = 0;
+  virtual Id covmatAlloc(bool verbose, bool verboseTimer = false)        = 0;
   virtual double getSimulate(VectorVectorDouble& y,
                              double yk,
                              double sk,
@@ -50,22 +50,22 @@ public:
                              Id ipgs,
                              Id ivar,
                              Id iact,
-                             Id iter) = 0;
-  virtual Id checkGibbs(const VectorVectorDouble& y, Id isimu, Id ipgs) = 0;
-  virtual void cleanup() { }
+                             Id iter)                                    = 0;
+  virtual Id checkGibbs(const VectorVectorDouble& y, Id isimu, Id ipgs)  = 0;
+  virtual void cleanup() {}
 
   void init(Id npgs,
             Id nvar,
             Id nburn,
             Id niter,
-            Id seed = 3241,
-            Id flag_order = 0,
-            bool flag_decay= true);
-  Id run(VectorVectorDouble &y,
-          Id ipgs0 = 0,
-          Id isimu0 = 0,
-          bool verboseTimer = false,
-          bool flagCheck = false);
+            Id seed         = 3241,
+            Id flag_order   = 0,
+            bool flag_decay = true);
+  Id run(VectorVectorDouble& y,
+         Id ipgs0          = 0,
+         Id isimu0         = 0,
+         bool verboseTimer = false,
+         bool flagCheck    = false);
 
   Id getNvar() const { return _nvar; }
   void setNvar(Id nvar) { _nvar = nvar; }
@@ -88,16 +88,16 @@ public:
   Id getRank(Id ipgs, Id ivar) const;
 
 protected:
-  Id  _getDimension() const;
-  Id  _getSampleRankNumber() const;
+  Id _getDimension() const;
+  Id _getSampleRankNumber() const;
   void _statsInit();
   bool _isConstraintTight(Id icase, Id iact, double* value) const;
-  void _updateStats(const VectorVectorDouble &y,
+  void _updateStats(const VectorVectorDouble& y,
                     Id ipgs,
                     Id jter,
                     double amort = 0.9);
-  void _getBoundsDecay(Id iter, double *vmin, double *vmax) const;
-  Id  _boundsCheck(Id ipgs, Id ivar, Id iact, double *vmin, double *vmax) const;
+  void _getBoundsDecay(Id iter, double* vmin, double* vmax) const;
+  Id _boundsCheck(Id ipgs, Id ivar, Id iact, double* vmin, double* vmax) const;
   void _printInequalities(Id iact,
                           Id ivar,
                           double simval,
@@ -114,7 +114,7 @@ protected:
 
 private:
   VectorInt _calculateSampleRanks() const;
-  Id  _getRelativeRank(Id iech);
+  Id _getRelativeRank(Id iech);
 
 private:
   Id _npgs;
@@ -126,12 +126,12 @@ private:
   //  -1 if the descending order must be honored
   //   0 if no order relationship must be honored
   bool _flagDecay;
-  Id  _optionStats; // 0: no storage; 1: printout; 2: Neutral File
+  Id _optionStats; // 0: no storage; 1: printout; 2: Neutral File
 
   VectorInt _ranks; // Internal array use to store indices of active samples
   // Pointer to the reference Db (only stored for efficiency)
-  Db*   _db;
+  Db* _db;
   // Optional Table used to store performance statistics (see _optionStats)
   Table _stats;
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsFactory.hpp
+++ b/include/Gibbs/GibbsFactory.hpp
@@ -25,12 +25,12 @@ public:
   GibbsFactory();
   virtual ~GibbsFactory();
 
-  static AGibbs *createGibbs(Db* db,
+  static AGibbs* createGibbs(Db* db,
                              Model* model,
                              bool flagMoving);
-  static AGibbs *createGibbs(Db* db,
-                             const std::vector<Model *>& models,
+  static AGibbs* createGibbs(Db* db,
+                             const std::vector<Model*>& models,
                              double rho,
                              bool flag_propagation);
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsMMulti.hpp
+++ b/include/Gibbs/GibbsMMulti.hpp
@@ -15,7 +15,6 @@
 #include "Gibbs/GibbsMulti.hpp"
 #include "LinearOp/CholeskySparse.hpp"
 
-
 namespace gstlrn
 {
 class Db;
@@ -27,45 +26,45 @@ class GSTLEARN_EXPORT GibbsMMulti: public GibbsMulti
 public:
   GibbsMMulti();
   GibbsMMulti(Db* db, Model* model);
-  GibbsMMulti(const GibbsMMulti &r);
-  GibbsMMulti& operator=(const GibbsMMulti &r);
+  GibbsMMulti(const GibbsMMulti& r);
+  GibbsMMulti& operator=(const GibbsMMulti& r);
   virtual ~GibbsMMulti();
 
-  void update(VectorVectorDouble &y, Id isimu, Id ipgs, Id iter) override;
+  void update(VectorVectorDouble& y, Id isimu, Id ipgs, Id iter) override;
   Id covmatAlloc(bool verbose, bool verboseTimer = false) override;
 
   void setEps(double eps) { _eps = eps; }
   void cleanup() override;
 
-  void setFlagStoreInternal(bool flagStoreInternal) ;
+  void setFlagStoreInternal(bool flagStoreInternal);
 
 private:
-  Id  _getNVar() const;
-  Id  _getSize() const;
+  Id _getNVar() const;
+  Id _getSize() const;
   void _storeWeights(Id icol);
   void _storeWeightsMS(Id icol, NF_Triplet& NF_T);
   void _getWeights(Id icol) const;
   void _calculateWeights(Id icol,
-                         VectorDouble &b,
+                         VectorDouble& b,
                          double tol = EPSILON3) const;
-  Id  _storeAllWeights(bool verbose = false);
-  Id  _getSizeOfWeights(const VectorDouble& weights) const;
-  double _getEstimate(Id ipgs, Id icol, const VectorVectorDouble &y) const;
+  Id _storeAllWeights(bool verbose = false);
+  Id _getSizeOfWeights(const VectorDouble& weights) const;
+  double _getEstimate(Id ipgs, Id icol, const VectorVectorDouble& y) const;
   void _allocate();
   double _getVariance(Id icol) const;
   Id _getColumn(Id iact, Id ivar) const;
-  void _splitCol(Id icol, Id *iact, Id *ivar) const;
+  void _splitCol(Id icol, Id* iact, Id* ivar) const;
   void _updateStatWeights(Id* nzero);
 
 private:
-  std::shared_ptr<MatrixSparse>   _Cmat;
+  std::shared_ptr<MatrixSparse> _Cmat;
   CholeskySparse* _CmatChol;
-  double          _eps;
-  bool            _flagStoreInternal;
+  double _eps;
+  bool _flagStoreInternal;
 
   VectorVectorDouble _areas;
-  MatrixSparse*      _matWgt;
+  MatrixSparse* _matWgt;
 
   mutable VectorDouble _weights;
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsMulti.hpp
+++ b/include/Gibbs/GibbsMulti.hpp
@@ -10,8 +10,8 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
 #include "Gibbs/AGibbs.hpp"
+#include "gstlearn_export.hpp"
 
 namespace gstlrn
 {
@@ -23,12 +23,12 @@ class GSTLEARN_EXPORT GibbsMulti: public AGibbs
 public:
   GibbsMulti();
   GibbsMulti(Db* db, Model* model);
-  GibbsMulti(const GibbsMulti &r);
-  GibbsMulti& operator=(const GibbsMulti &r);
+  GibbsMulti(const GibbsMulti& r);
+  GibbsMulti& operator=(const GibbsMulti& r);
   virtual ~GibbsMulti();
 
   /// Interface for AGibbs
-  Id calculInitialize(VectorVectorDouble &y, Id isimu, Id ipgs) override;
+  Id calculInitialize(VectorVectorDouble& y, Id isimu, Id ipgs) override;
   double getSimulate(VectorVectorDouble& y,
                      double yk,
                      double sk,
@@ -44,4 +44,4 @@ public:
 private:
   Model* _model;
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsMultiMono.hpp
+++ b/include/Gibbs/GibbsMultiMono.hpp
@@ -10,21 +10,21 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
 #include "Gibbs/AGibbs.hpp"
+#include "gstlearn_export.hpp"
 
 namespace gstlrn
 {
 class Db;
 class Model;
 
-class GSTLEARN_EXPORT GibbsMultiMono : public AGibbs
+class GSTLEARN_EXPORT GibbsMultiMono: public AGibbs
 {
 public:
   GibbsMultiMono();
   GibbsMultiMono(Db* db, const std::vector<Model*>& models, double rho);
-  GibbsMultiMono(const GibbsMultiMono &r);
-  GibbsMultiMono& operator=(const GibbsMultiMono &r);
+  GibbsMultiMono(const GibbsMultiMono& r);
+  GibbsMultiMono& operator=(const GibbsMultiMono& r);
   virtual ~GibbsMultiMono();
 
   Model* getModels(Id ivar) const { return _models[ivar]; } // TODO: protect by const asap
@@ -32,7 +32,7 @@ public:
   Id getNVar() const { return static_cast<Id>(_models.size()); }
 
   /// Interface for AGibbs
-  Id calculInitialize(VectorVectorDouble &y, Id isimu, Id ipgs) override;
+  Id calculInitialize(VectorVectorDouble& y, Id isimu, Id ipgs) override;
   double getSimulate(VectorVectorDouble& y,
                      double yk,
                      double sk,
@@ -44,7 +44,7 @@ public:
   Id checkGibbs(const VectorVectorDouble& y, Id isimu, Id ipgs) override;
 
 private:
-  std::vector<Model *> _models;
+  std::vector<Model*> _models;
   double _rho;
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsUMulti.hpp
+++ b/include/Gibbs/GibbsUMulti.hpp
@@ -19,24 +19,24 @@ namespace gstlrn
 class Db;
 class Model;
 
-class GSTLEARN_EXPORT GibbsUMulti : public GibbsMulti
+class GSTLEARN_EXPORT GibbsUMulti: public GibbsMulti
 {
 public:
   GibbsUMulti();
   GibbsUMulti(Db* db, Model* model);
-  GibbsUMulti(const GibbsUMulti &r);
-  GibbsUMulti& operator=(const GibbsUMulti &r);
+  GibbsUMulti(const GibbsUMulti& r);
+  GibbsUMulti& operator=(const GibbsUMulti& r);
   virtual ~GibbsUMulti();
 
-  void update(VectorVectorDouble &y, Id isimu, Id ipgs, Id iter) override;
+  void update(VectorVectorDouble& y, Id isimu, Id ipgs, Id iter) override;
   Id covmatAlloc(bool verbose, bool verboseTimer = false) override;
 
 private:
-  Id    _getSize() const;
+  Id _getSize() const;
   double _getVariance(Id iecr) const;
   double _getEstimate(Id ipgs, Id iecr, VectorVectorDouble& y);
 
 private:
   VectorDouble _covmat;
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsUMultiMono.hpp
+++ b/include/Gibbs/GibbsUMultiMono.hpp
@@ -12,8 +12,8 @@
 
 #include "gstlearn_export.hpp"
 
-#include "GibbsMultiMono.hpp"
 #include "Gibbs/AGibbs.hpp"
+#include "GibbsMultiMono.hpp"
 
 namespace gstlrn
 {
@@ -26,16 +26,16 @@ class Model;
  * - Multivariate case: Multiple Monovariate systems
  * (even if the model is provided as multivariate)
  */
-class GSTLEARN_EXPORT GibbsUMultiMono : public GibbsMultiMono
+class GSTLEARN_EXPORT GibbsUMultiMono: public GibbsMultiMono
 {
 public:
   GibbsUMultiMono();
-  GibbsUMultiMono(Db* db, const std::vector<Model *>& models, double rho);
-  GibbsUMultiMono(const GibbsUMultiMono &r);
-  GibbsUMultiMono& operator=(const GibbsUMultiMono &r);
+  GibbsUMultiMono(Db* db, const std::vector<Model*>& models, double rho);
+  GibbsUMultiMono(const GibbsUMultiMono& r);
+  GibbsUMultiMono& operator=(const GibbsUMultiMono& r);
   virtual ~GibbsUMultiMono();
 
-  void update(VectorVectorDouble &y, Id isimu, Id ipgs, Id iter) override;
+  void update(VectorVectorDouble& y, Id isimu, Id ipgs, Id iter) override;
   Id covmatAlloc(bool verbose, bool verboseTimer = false) override;
 
 private:
@@ -45,4 +45,4 @@ private:
 private:
   VectorVectorDouble _covmat; // One matrix per variable
 };
-}
+} // namespace gstlrn

--- a/include/Gibbs/GibbsUPropMono.hpp
+++ b/include/Gibbs/GibbsUPropMono.hpp
@@ -26,16 +26,16 @@ class Model;
  * - Propagation algorithm (no need to establish and invert Covariance matrix)
  * - No bound provided
  */
-class GSTLEARN_EXPORT GibbsUPropMono : public GibbsMultiMono
+class GSTLEARN_EXPORT GibbsUPropMono: public GibbsMultiMono
 {
 public:
   GibbsUPropMono();
-  GibbsUPropMono(Db* db, const std::vector<Model *>& models, double rho);
-  GibbsUPropMono(const GibbsUPropMono &r);
-  GibbsUPropMono& operator=(const GibbsUPropMono &r);
+  GibbsUPropMono(Db* db, const std::vector<Model*>& models, double rho);
+  GibbsUPropMono(const GibbsUPropMono& r);
+  GibbsUPropMono& operator=(const GibbsUPropMono& r);
   virtual ~GibbsUPropMono();
 
-  void update(VectorVectorDouble &y, Id isimu, Id ipgs, Id iter) override;
+  void update(VectorVectorDouble& y, Id isimu, Id ipgs, Id iter) override;
   Id covmatAlloc(bool verbose, bool verboseTimer = false) override;
 
   double getEps() const { return _eps; }
@@ -47,4 +47,4 @@ private:
   double _rval;
   double _eps;
 };
-}
+} // namespace gstlrn

--- a/src/Core/simtub.cpp
+++ b/src/Core/simtub.cpp
@@ -556,7 +556,7 @@ static void st_check_facies_data2grid(Db* dbin,
     for (isimu = 0; isimu < nbsimu; isimu++)
     {
       facres = static_cast<Id>(dbgrid->getSimvar(ELoc::FACIES, jech, isimu, 0, ipgs,
-                                     nbsimu, 1));
+                                                 nbsimu, 1));
       if (flag_show)
       {
         if (facdat == facres)
@@ -1505,20 +1505,40 @@ Id gibbs_sampler(Db* dbin,
                  const NamingConvention& namconv)
 {
   DECLARE_UNUSED(flag_sym_neigh);
-  Id error, iptr, npgs, nvar, iptr_ce, iptr_cstd;
-  PropDef* propdef;
+  Id iptr;
 
   /* Initializations */
 
-  error   = 1;
-  npgs    = 1;
-  nvar    = 0;
-  iptr_ce = iptr_cstd = -1;
-  propdef             = nullptr;
+  Id error         = 1;
+  Id npgs          = 1;
+  Id nvar          = 0;
+  Id iptr_ce       = -1;
+  Id iptr_cstd     = -1;
+  PropDef* propdef = nullptr;
+  AGibbs* gibbs    = nullptr;
+  std::vector<Model*> modvec;
+  VectorVectorDouble y;
 
   /**********************/
   /* Preliminary checks */
   /**********************/
+
+  /* Model */
+
+  if (model == nullptr)
+  {
+    messerr("No Model is provided");
+    return 1;
+  }
+  nvar = model->getNVar();
+  if (!flag_propagation)
+  {
+    if (model->stabilize(percent, true)) return 1;
+  }
+  if (flag_norm)
+  {
+    if (model->standardize(true)) return 1;
+  }
 
   /* Db */
 
@@ -1527,77 +1547,102 @@ Id gibbs_sampler(Db* dbin,
     if (dbin->getNInterval() > 0)
     {
       messerr("The propagation algorithm is incompatible with bounds");
-      goto label_end;
+      return 1;
     }
   }
+  else
+  {
+    if (dbin->getNLoc(ELoc::L) != nvar)
+    {
+      messerr("There must be as many Lower bound variables (%d)",
+              dbin->getNInterval());
+      messerr("as there are variables defined in the Model (%d)", nvar);
+      return 1;
+    }
+    if (dbin->getNLoc(ELoc::U) != nvar)
+    {
+      messerr("There must be as many Upper bound variables (%d)",
+              dbin->getNInterval());
+      messerr("as there are variables defined in the Model (%d)", nvar);
+      return 1;
+    }
 
-  /* Model */
+    // Check the consistency of the bounds
+    // If Z-locator is defined, check the consistency with the bounds
+    Id nvarDb = dbin->getNLoc(ELoc::Z);
+    if (nvarDb > 0)
+    {
+      if (nvarDb != nvar)
+      {
+        messerr("Some Z-variables are defined");
+        messerr("Their count (%d) must match the number of variables defined in the Model (%d)",
+                nvarDb, nvar);
+        return 1;
+      }
 
-  if (model == nullptr)
-  {
-    messerr("No Model is provided");
-    goto label_end;
-  }
-  nvar = model->getNVar();
-  if (!flag_propagation)
-  {
-    if (model->stabilize(percent, true)) goto label_end;
-  }
-  if (flag_norm)
-  {
-    if (model->standardize(true)) goto label_end;
+      // Convert the Z-values into bounds
+      for (Id iech = 0; iech < dbin->getNSample(); iech++)
+      {
+        if (!dbin->isActive(iech)) continue;
+        for (Id ivar = 0; ivar < nvar; ivar++)
+        {
+          double value = dbin->getLocVariable(ELoc::Z, iech, ivar);
+          if (FFFF(value)) continue;
+
+          dbin->setLocVariable(ELoc::L, iech, ivar, value);
+          dbin->setLocVariable(ELoc::U, iech, ivar, value);
+        }
+      }
+
+      // Cancel the Z-locator for the rest of the Gibbs function
+      dbin->clearLocators(ELoc::Z);
+    }
   }
 
   /*******************/
   /* Core allocation */
   /*******************/
 
-  propdef = proportion_manage(1, 0, 1, 1, 0, nvar, 0, dbin, NULL,
-                              VectorDouble(), propdef);
+  propdef = proportion_manage(1, 0, 1, 1, 0, nvar, 0, dbin, NULL, VectorDouble(), propdef);
   if (propdef == nullptr) goto label_end;
 
   /**********************/
   /* Add the attributes */
   /**********************/
 
-  if (db_locator_attribute_add(dbin, ELoc::GAUSFAC, nbsimu * nvar, 0, 0.,
-                               &iptr)) goto label_end;
+  if (db_locator_attribute_add(dbin, ELoc::GAUSFAC, nbsimu * nvar, 0, 0., &iptr)) goto label_end;
 
   /*****************/
   /* Gibbs sampler */
   /*****************/
 
+  if (!flag_multi_mono)
   {
-    AGibbs* gibbs;
-    if (!flag_multi_mono)
-    {
-      gibbs = GibbsFactory::createGibbs(dbin, model, flag_moving);
-    }
-    else
-    {
-      std::vector<Model*> modvec;
-      modvec.push_back(model);
-      gibbs = GibbsFactory::createGibbs(dbin, modvec, 0., flag_propagation);
-    }
-    if (gibbs == nullptr) goto label_end;
-    gibbs->setOptionStats(gibbs_optstats);
-    gibbs->init(npgs, nvar, gibbs_nburn, gibbs_niter, seed);
-
-    // Allocate the Gaussian vector
-
-    VectorVectorDouble y = gibbs->allocY();
-
-    /* Allocate the covariance matrix inverted */
-
-    if (gibbs->covmatAlloc(verbose)) goto label_end;
-
-    // Invoke the Gibbs calculator
-
-    for (Id isimu = 0; isimu < nbsimu; isimu++)
-      if (gibbs->run(y, 0, isimu)) goto label_end;
-
-    delete gibbs;
+    gibbs = GibbsFactory::createGibbs(dbin, model, flag_moving);
   }
+  else
+  {
+    modvec.push_back(model);
+    gibbs = GibbsFactory::createGibbs(dbin, modvec, 0., flag_propagation);
+  }
+  if (gibbs == nullptr) goto label_end;
+  gibbs->setOptionStats(gibbs_optstats);
+  gibbs->init(npgs, nvar, gibbs_nburn, gibbs_niter, seed);
+
+  // Allocate the Gaussian vector
+
+  y = gibbs->allocY();
+
+  /* Allocate the covariance matrix inverted */
+
+  if (gibbs->covmatAlloc(verbose)) goto label_end;
+
+  // Invoke the Gibbs calculator
+
+  for (Id isimu = 0; isimu < nbsimu; isimu++)
+    if (gibbs->run(y, 0, isimu)) goto label_end;
+
+  delete gibbs;
 
   /* Convert the simulations */
 
@@ -1624,8 +1669,7 @@ Id gibbs_sampler(Db* dbin,
   /* Set the error return flag */
 
   error = 0;
-  namconv.setNamesAndLocators(dbin, VectorString(), ELoc::UNKNOWN, nvar, dbin, iptr, String(),
-                              nbsimu);
+  namconv.setNamesAndLocators(dbin, VectorString(), ELoc::UNKNOWN, nvar, dbin, iptr, String(), nbsimu);
 
 label_end:
   proportion_manage(-1, 0, 1, 1, 0, nvar, 0, dbin, NULL, VectorDouble(), propdef);

--- a/src/Gibbs/GibbsUMulti.cpp
+++ b/src/Gibbs/GibbsUMulti.cpp
@@ -69,9 +69,9 @@ Id GibbsUMulti::covmatAlloc(bool verbose, bool /*verboseTimer*/)
   if (verbose) mestitle(1, "Gibbs using Unique Neighborhood");
   Db* db       = getDb();
   Model* model = getModel();
-  Id nvar     = model->getNVar();
+  Id nvar      = model->getNVar();
   auto nact    = _getSampleRankNumber();
-  Id neq      = nvar * nact;
+  Id neq       = nvar * nact;
 
   // Establish Covariance Matrix
 
@@ -181,4 +181,4 @@ void GibbsUMulti::update(VectorVectorDouble& y,
 
   _updateStats(y, ipgs, iter);
 }
-}
+} // namespace gstlrn


### PR DESCRIPTION
When running gibbs_sampler facility while defining simultaneously Lower bound (Loc::L), Upper bound (Loc::U) and exact value (Loc::Z), a severe conflict may rise as the array dimensioning was defined by the number of active and defined samples for the Z-locator variable. This remains true in the multivariate case.
Moreover, the algorithm was not clear to decide if the sample was hard or soft when the three variables were defined.
Now things are much simpler...

As a prior step and if the three variables are defined (for a given sample and for any variable):
- the value of the Z-locator variable is copied into the corresponding L-locator and U-locator samples (regardless of there previous contents)
- the Z-locator is cancelled, so that the rest of the algorithm is performed only using Lower and Upper bound (which must still be consistent)
