### PR TITLE
Enhancement for Db

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ This file contains the logs between consecutive releases
 
 Release 1.10.0
 ==============
+- For generating a VectorDouble containing the sequence of values, please now use VH::sequenceVD() 
+- Db() offers the possibility to overload operators.
+- Db::createReduce() and Db::resetReduce() have a new mode for keeping only isotopic samples
 - Extend the ability to generate drift functions for any space and IRF order (setDriftIRF)
 - Correct the Global estimation by Kriging (estimation and variance of estimation error)
 - Make the results of Global estimation displayable

--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -10,9 +10,9 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
-#include "geoslib_define.h"
 #include "Basic/VectorNumT.hpp"
+#include "geoslib_define.h"
+#include "gstlearn_export.hpp"
 #include <vector>
 
 namespace gstlrn
@@ -20,23 +20,23 @@ namespace gstlrn
 class GSTLEARN_EXPORT VectorHelper
 {
 public:
-  static VectorInt          initVInt(Id nval, Id value = 0.);
-  static VectorDouble       initVDouble(Id nval, double value = 0.);
+  static VectorInt initVInt(Id nval, Id value = 0.);
+  static VectorDouble initVDouble(Id nval, double value = 0.);
   static VectorVectorDouble initVVDouble(Id nval1, Id nval2, double value = 0.);
-  static VectorVectorInt    initVVInt(Id nval1, Id nval2, Id value = 0);
+  static VectorVectorInt initVVInt(Id nval1, Id nval2, Id value = 0);
 
-  static VectorInt          initVInt(const Id* values, Id number);
-  static VectorInt          initVInt(const I32* values, Id number);
-  static VectorDouble       initVDouble(const double* values, Id number);
+  static VectorInt initVInt(const Id* values, Id number);
+  static VectorInt initVInt(const I32* values, Id number);
+  static VectorDouble initVDouble(const double* values, Id number);
   static VectorVectorDouble initVVDouble(const double* value, Id n1, Id n2);
 
   static VectorString initVString(Id ntab, char** names);
-  
+
   static void dump(const String& title, const VectorVectorInt& vect, bool skipLine = true);
   static void dump(const String& title, const VectorVectorDouble& vect, bool skipLine = true);
   static void dump(const String& title, const VectorDouble& vect, bool skipLine = true);
-  static void dump(const String& title, const VectorString &vect, bool skipLine = true);
-  static void dump(const String& title, const VectorInt &vect, bool skipLine = true);
+  static void dump(const String& title, const VectorString& vect, bool skipLine = true);
+  static void dump(const String& title, const VectorInt& vect, bool skipLine = true);
   static String toStringAsSpan(constvect vec);
   static String toStringAsVD(const VectorDouble& vec); // TODO rename
   static String toStringAsVVD(const VectorVectorDouble& vec);
@@ -44,23 +44,23 @@ public:
   static String toStringAsVS(const VectorString& vec);
   static String toStringAsVI(const VectorInt& vec);
 
-  #ifndef SWIG
+#ifndef SWIG
   static void dumpStats(const String& title, constvect vect, Id nmax = -1);
   static void dumpRange(const String& title, constvect vect, Id nmax = -1);
 #endif
   static void dumpStats(const String& title, const VectorDouble& vectin, Id nmax = -1);
-  static void dumpRange(const String &title, const VectorDouble& vectin, Id nmax = -1);
-  static void dumpRange(const String &title, const VectorInt &vect);
-  static void dumpNNZ(const String &title, const VectorDouble &vect, Id nclass = 10);
+  static void dumpRange(const String& title, const VectorDouble& vectin, Id nmax = -1);
+  static void dumpRange(const String& title, const VectorInt& vect);
+  static void dumpNNZ(const String& title, const VectorDouble& vect, Id nclass = 10);
 
-  static Id maximum(const VectorInt &vec, bool flagAbs = false);
-  static Id minimum(const VectorInt &vec, bool flagAbs = false);
-  static double maximum(const VectorDouble &vec, bool flagAbs = false, const VectorDouble& aux = VectorDouble(), Id mode=0);
-  static double minimum(const VectorDouble &vec, bool flagAbs = false, const VectorDouble& aux = VectorDouble(), Id mode=0);
-  static double maximum(const VectorVectorDouble &vec, bool flagAbs = false);
-  static double maximum(const std::vector<std::vector<double>> &vec, bool flagAbs = false);
+  static Id maximum(const VectorInt& vec, bool flagAbs = false);
+  static Id minimum(const VectorInt& vec, bool flagAbs = false);
+  static double maximum(const VectorDouble& vec, bool flagAbs = false, const VectorDouble& aux = VectorDouble(), Id mode = 0);
+  static double minimum(const VectorDouble& vec, bool flagAbs = false, const VectorDouble& aux = VectorDouble(), Id mode = 0);
+  static double maximum(const VectorVectorDouble& vec, bool flagAbs = false);
+  static double maximum(const std::vector<std::vector<double>>& vec, bool flagAbs = false);
 
-  static double minimum(const VectorVectorDouble &vec, bool flagAbs = false);
+  static double minimum(const VectorVectorDouble& vec, bool flagAbs = false);
   static Id product(const VectorInt& vec);
   static double product(const VectorDouble& vec);
   static Id countUndefined(const VectorDouble& vec);
@@ -68,28 +68,28 @@ public:
   static bool hasUndefined(const VectorDouble& vec);
   static double extensionDiagonal(const VectorDouble& mini, const VectorDouble& maxi);
 
-  static Id    count(const VectorVectorInt& vec);
-  static Id    cumul(const VectorInt& vec);
-  static Id    cumul(const VectorVectorInt& vec);
-  static double cumul(const VectorDouble &vec);
-  static double cumulLog(const VectorDouble &vec);
+  static Id count(const VectorVectorInt& vec);
+  static Id cumul(const VectorInt& vec);
+  static Id cumul(const VectorVectorInt& vec);
+  static double cumul(const VectorDouble& vec);
+  static double cumulLog(const VectorDouble& vec);
   static VectorInt cumulIncrement(const VectorVectorInt& vec);
   static double mean(const VectorDouble& vec);
-  static double variance(const VectorDouble &vec, bool scaleByN = false);
-  static double stdv(const VectorDouble &vec, bool scaleByN = false);
-  static double norm(const VectorDouble &vec);
-  static double normL1(const VectorDouble &vec);
-  static double norminf(const VectorDouble &vec);
+  static double variance(const VectorDouble& vec, bool scaleByN = false);
+  static double stdv(const VectorDouble& vec, bool scaleByN = false);
+  static double norm(const VectorDouble& vec);
+  static double normL1(const VectorDouble& vec);
+  static double norminf(const VectorDouble& vec);
   static double median(const VectorDouble& vec);
   static double normDistance(const VectorDouble& veca, const VectorDouble& vecb);
-  static double correlation(const VectorDouble &veca, const VectorDouble &vecb);
+  static double correlation(const VectorDouble& veca, const VectorDouble& vecb);
   static VectorDouble quantiles(const VectorDouble& vec, const VectorDouble& probas);
 
   static bool isConstant(const VectorDouble& vect, double refval = TEST);
   static bool isConstant(const VectorInt& vect, Id refval = ITEST);
-  static bool isEqual(const VectorDouble &v1,
-                     const VectorDouble &v2,
-                     double eps = EPSILON10);
+  static bool isEqual(const VectorDouble& v1,
+                      const VectorDouble& v2,
+                      double eps = EPSILON10);
   static bool isEqual(const VectorInt& v1, const VectorInt& v2);
   static bool isEqualExtended(const VectorDouble& v1,
                               const VectorDouble& v2,
@@ -100,15 +100,15 @@ public:
 
   static void sequenceInPlace(Id n, VectorInt& vec);
   static VectorInt sequence(Id number, Id ideb = 0, Id step = 1);
-  static VectorDouble sequence(double valFrom,
-                               double valTo,
-                               double valStep = 1.,
-                               double ratio   = 1.);
+  static VectorDouble sequenceVD(double valFrom,
+                                 double valTo,
+                                 double valStep = 1.,
+                                 double ratio   = 1.);
   static void fill(VectorDouble& vec, double v, Id size = 0);
   static void fill(VectorInt& vec, Id v, Id size = 0);
-  static void fill(VectorVectorDouble &vec, double value);
+  static void fill(VectorVectorDouble& vec, double value);
   static void fillUndef(VectorDouble& vec, double repl);
-  
+
 #ifndef SWIG
   static void addMultiplyConstantInPlace(double val1,
                                          const constvect in,
@@ -124,10 +124,10 @@ public:
   static void addInPlace(constvect in, vect dest);
 
 #endif
-  static VectorDouble add(const VectorDouble &veca, const VectorDouble &vecb);
+  static VectorDouble add(const VectorDouble& veca, const VectorDouble& vecb);
   static void addInPlace(VectorDouble& dest, const VectorDouble& src);
   static void addInPlace(VectorInt& dest, const VectorInt& src);
-  static void addInPlace(std::vector<double>& dest, const std::vector<double> &src);
+  static void addInPlace(std::vector<double>& dest, const std::vector<double>& src);
   static void addInPlace(const VectorDouble& veca,
                          const VectorDouble& vecb,
                          VectorDouble& res,
@@ -136,9 +136,9 @@ public:
                          const VectorInt& vecb,
                          VectorInt& res,
                          Id size = 0);
-  static void addInPlace(const double *veca,
-                         const double *vecb,
-                         double *res,
+  static void addInPlace(const double* veca,
+                         const double* vecb,
+                         double* res,
                          Id size);
   static void addInPlace(const VectorVectorDouble& in1,
                          const VectorVectorDouble& in2,
@@ -146,16 +146,16 @@ public:
   static void addInPlace(const std::vector<std::vector<double>>& in1,
                          const std::vector<std::vector<double>>& in2,
                          std::vector<std::vector<double>>& outv);
-  
-  static void addSquareInPlace(VectorDouble &dest, const VectorDouble &src);
+
+  static void addSquareInPlace(VectorDouble& dest, const VectorDouble& src);
   static VectorDouble subtract(const VectorDouble& veca, const VectorDouble& vecb);
-  static VectorDouble subtract(constvect veca,constvect vecb);
-  static VectorInt    subtract(const VectorInt& veca, const VectorInt& vecb);
-  static void   subtractInPlace(const constvect in1,
-                                const constvect in2,
-                                vect  outv);
-  static void subtractInPlace(VectorDouble &dest, const VectorDouble &src);
-  static void subtractInPlace(VectorInt &dest, const VectorInt &src);
+  static VectorDouble subtract(constvect veca, constvect vecb);
+  static VectorInt subtract(const VectorInt& veca, const VectorInt& vecb);
+  static void subtractInPlace(const constvect in1,
+                              const constvect in2,
+                              vect outv);
+  static void subtractInPlace(VectorDouble& dest, const VectorDouble& src);
+  static void subtractInPlace(VectorInt& dest, const VectorInt& src);
   static void subtractInPlace(const VectorVectorDouble& in1,
                               const VectorVectorDouble& in2,
                               VectorVectorDouble& outv);
@@ -179,30 +179,30 @@ public:
 
   static void multiplyConstant(VectorDouble& vec, double v);
   static void multiplyConstantInPlace(const VectorDouble& vec, double v, VectorDouble& vecout);
-  static void multiplyConstantSelfInPlace(VectorDouble &vec, double v);
+  static void multiplyConstantSelfInPlace(VectorDouble& vec, double v);
   static void addMultiplyConstantInPlace(double val1,
-                                         const VectorDouble &in1,
-                                         VectorDouble &outv,
+                                         const VectorDouble& in1,
+                                         VectorDouble& outv,
                                          Id iad);
   static void addMultiplyConstantInPlace(double val1,
-                                         const VectorVectorDouble &in1,
-                                         VectorVectorDouble &outv);
+                                         const VectorVectorDouble& in1,
+                                         VectorVectorDouble& outv);
   static void divideConstant(VectorDouble& vec, double v);
   static void copy(const VectorDouble& vecin, VectorDouble& vecout, Id size = -1);
-  static void copy(const VectorInt &vecin, VectorInt &vecout, Id size = -1);
-  static void copy(const VectorVectorDouble &inv, VectorVectorDouble &outv);
-  static void copy(const std::vector<std::vector<double>> &inv, std::vector<std::vector<double>> &outv);
+  static void copy(const VectorInt& vecin, VectorInt& vecout, Id size = -1);
+  static void copy(const VectorVectorDouble& inv, VectorVectorDouble& outv);
+  static void copy(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv);
 
   static void addConstant(VectorDouble& vec, double v);
   static void addConstant(VectorInt& vec, Id v);
-  static void mean1AndMean2ToStdev(const VectorDouble &mean1,
-                                   const VectorDouble &mean2,
-                                   VectorDouble &std,
+  static void mean1AndMean2ToStdev(const VectorDouble& mean1,
+                                   const VectorDouble& mean2,
+                                   VectorDouble& std,
                                    Id number);
 
-  static void normalize(VectorDouble& vec, Id norm=2);
-  static void normalize(double *tab, Id ntab);
-  static void normalizeFromGaussianDistribution(VectorDouble &vec,
+  static void normalize(VectorDouble& vec, Id norm = 2);
+  static void normalize(double* tab, Id ntab);
+  static void normalizeFromGaussianDistribution(VectorDouble& vec,
                                                 double mini = 0.,
                                                 double maxi = 1.);
   static VectorDouble normalScore(const VectorDouble& data,
@@ -218,74 +218,74 @@ public:
   static void inverse(VectorDouble& res, const constvect vec);
 #endif // !SWIG
 
-  static double innerProduct(const VectorDouble &veca, const VectorDouble &vecb, Id size = -1);
+  static double innerProduct(const VectorDouble& veca, const VectorDouble& vecb, Id size = -1);
   static double innerProduct(const double* veca, const double* vecb, Id size);
-  static double innerProduct(const VectorVectorDouble &x,
-                             const VectorVectorDouble &y);
-  static double innerProduct(const std::vector<double> &veca, const std::vector<double> &vecb, Id size = -1);
+  static double innerProduct(const VectorVectorDouble& x,
+                             const VectorVectorDouble& y);
+  static double innerProduct(const std::vector<double>& veca, const std::vector<double>& vecb, Id size = -1);
 
-  static VectorDouble crossProduct3D(const VectorDouble &veca, const VectorDouble &vecb);
-  static void crossProduct3DInPlace(const double *a, const double *b, double *v);
+  static VectorDouble crossProduct3D(const VectorDouble& veca, const VectorDouble& vecb);
+  static void crossProduct3DInPlace(const double* a, const double* b, double* v);
 
-  static VectorDouble cumsum(const VectorDouble &vecin, bool flagAddZero, bool revert=false);
-  static void cumulateInPlace(VectorDouble &vec);
-  static void cumulate(VectorDouble &veca, const VectorDouble &vecb, double coeff = 1., double addval = 0.);
+  static VectorDouble cumsum(const VectorDouble& vecin, bool flagAddZero, bool revert = false);
+  static void cumulateInPlace(VectorDouble& vec);
+  static void cumulate(VectorDouble& veca, const VectorDouble& vecb, double coeff = 1., double addval = 0.);
   static void getMostSignificant(const VectorDouble& vec, double tol = EPSILON6, Id nmax = -1);
 
-  static VectorDouble simulateUniform(Id n = 1,
+  static VectorDouble simulateUniform(Id n        = 1,
                                       double mini = 0.,
                                       double maxi = 1.);
-  static VectorDouble simulateBernoulli(Id n = 1,
+  static VectorDouble simulateBernoulli(Id n         = 1,
                                         double proba = 0.5,
-                                        double vone = 1.,
+                                        double vone  = 1.,
                                         double velse = 0.);
-  static VectorDouble simulateGaussian(Id n = 1,
-                                       double mean = 0.,
+  static VectorDouble simulateGaussian(Id n         = 1,
+                                       double mean  = 0.,
                                        double sigma = 1.);
-  static void simulateGaussianInPlace(VectorDouble &vec,
-                                      double mean = 0.,
+  static void simulateGaussianInPlace(VectorDouble& vec,
+                                      double mean  = 0.,
                                       double sigma = 1.);
   static VectorInt sampleRanks(Id ntotal,
                                double proportion = 0.,
-                               Id number = 0,
-                               Id seed = 242141,
-                               Id optSort = 0);
-  static void normalizeCodir(Id ndim, VectorDouble &codir);
+                               Id number         = 0,
+                               Id seed           = 242141,
+                               Id optSort        = 0);
+  static void normalizeCodir(Id ndim, VectorDouble& codir);
 
-  static bool         isInList(const VectorInt& vec, Id item);
-  static VectorInt    sort(const VectorInt& vecin, bool ascending = true, Id size = -1);
+  static bool isInList(const VectorInt& vec, Id item);
+  static VectorInt sort(const VectorInt& vecin, bool ascending = true, Id size = -1);
   static VectorDouble sort(const VectorDouble& vecin, bool ascending = true, Id size = -1);
-  static void         sortInPlace(VectorInt& vecin, bool ascending = true, Id size = -1);
-  static void         sortInPlace(VectorDouble& vecin, bool ascending = true, Id size = -1);
-  static bool         isSorted(const VectorDouble& vec, bool ascending = true);
+  static void sortInPlace(VectorInt& vecin, bool ascending = true, Id size = -1);
+  static void sortInPlace(VectorDouble& vecin, bool ascending = true, Id size = -1);
+  static bool isSorted(const VectorDouble& vec, bool ascending = true);
   static VectorDouble unique(const VectorDouble& vecin, Id size = -1);
-  static VectorInt    unique(const VectorInt& vecin, Id size = -1);
-  static VectorInt    orderRanks(const VectorInt& vecin, bool ascending = true, Id size = -1);
-  static VectorInt    orderRanks(const VectorDouble& vecin, bool ascending = true, Id size = -1);
-  static VectorInt    sortRanks(const VectorDouble& vecin, bool ascending = true, Id size = -1);
-  static VectorInt    reorder(const VectorInt& vecin, const VectorInt& order, Id size = -1);
+  static VectorInt unique(const VectorInt& vecin, Id size = -1);
+  static VectorInt orderRanks(const VectorInt& vecin, bool ascending = true, Id size = -1);
+  static VectorInt orderRanks(const VectorDouble& vecin, bool ascending = true, Id size = -1);
+  static VectorInt sortRanks(const VectorDouble& vecin, bool ascending = true, Id size = -1);
+  static VectorInt reorder(const VectorInt& vecin, const VectorInt& order, Id size = -1);
   static VectorDouble reorder(const VectorDouble& vecin, const VectorInt& order, Id size = -1);
   static VectorDouble revert(const VectorDouble& vecin);
-  static VectorInt    revert(const VectorInt& vecin);
+  static VectorInt revert(const VectorInt& vecin);
   static VectorDouble sample(const VectorDouble& vecin, const VectorInt& indKeep);
-  
+
   static void arrangeInPlace(Id safe,
                              VectorInt& ranks,
                              VectorDouble& values,
                              bool ascending = true,
-                             Id size       = -1);
+                             Id size        = -1);
   static void arrangeInPlace(Id safe,
-                             VectorInt &ranks,
-                             VectorInt &values,
+                             VectorInt& ranks,
+                             VectorInt& values,
                              bool ascending = true,
-                             Id size = -1);
-  static VectorInt filter(const VectorInt &vecin,
-                          Id vmin = ITEST,
-                          Id vmax = ITEST,
+                             Id size        = -1);
+  static VectorInt filter(const VectorInt& vecin,
+                          Id vmin        = ITEST,
+                          Id vmax        = ITEST,
                           bool ascending = true);
   static VectorInt complement(const VectorInt& vec, const VectorInt& sel);
 
-  static std::pair<double,double> rangeVals(const VectorDouble& vec);
+  static std::pair<double, double> rangeVals(const VectorDouble& vec);
   static void unflattenInPlace(const std::vector<double>& vd, std::vector<std::vector<double>>& vvd);
   static void flattenInPlace(const std::vector<std::vector<double>>& vvd, std::vector<double>& vd);
   static VectorDouble flatten(const VectorVectorDouble& vvd);
@@ -294,22 +294,22 @@ public:
   static std::vector<std::vector<double>> unflatten(const std::vector<double>& vd, const VectorInt& sizes);
   static void flattenInPlace(const VectorVectorDouble& vvd, VectorDouble& vd);
   static void linearCombinationInPlace(double val1,
-                                       const VectorDouble &vd1,
+                                       const VectorDouble& vd1,
                                        double val2,
-                                       const VectorDouble &vd2,
-                                       VectorDouble &outv);
+                                       const VectorDouble& vd2,
+                                       VectorDouble& outv);
   static void linearCombinationVVDInPlace(double val1,
-                                          const VectorVectorDouble &vvd1,
+                                          const VectorVectorDouble& vvd1,
                                           double val2,
-                                          const VectorVectorDouble &vvd2,
-                                          VectorVectorDouble &outv);
-  static double innerProduct(const std::vector<std::vector<double>> &x,
-                             const std::vector<std::vector<double>> &y);
+                                          const VectorVectorDouble& vvd2,
+                                          VectorVectorDouble& outv);
+  static double innerProduct(const std::vector<std::vector<double>>& x,
+                             const std::vector<std::vector<double>>& y);
   static void linearCombinationVVDInPlace(double val1,
-                                          const std::vector<std::vector<double>> &vvd1,
+                                          const std::vector<std::vector<double>>& vvd1,
                                           double val2,
-                                          const std::vector<std::vector<double>> &vvd2,
-                                          std::vector<std::vector<double>> &outv);
+                                          const std::vector<std::vector<double>>& vvd2,
+                                          std::vector<std::vector<double>>& outv);
 
   static VectorDouble suppressTest(const VectorDouble& vecin);
   static void extractInPlace(const VectorDouble& vecin, VectorDouble& vecout, Id start);
@@ -317,14 +317,14 @@ public:
 
   static void transformVD(VectorDouble& tab, Id oper_choice = 1);
 
-  static void squeezeAndStretchInPlaceForward(const VectorDouble &vecin,
-                                              VectorDouble &vecout,
+  static void squeezeAndStretchInPlaceForward(const VectorDouble& vecin,
+                                              VectorDouble& vecout,
                                               double origin,
                                               double mesh,
                                               double top,
                                               double bot);
-  static void squeezeAndStretchInPlaceBackward(const VectorDouble &vecin,
-                                               VectorDouble &vecout,
+  static void squeezeAndStretchInPlaceBackward(const VectorDouble& vecin,
+                                               VectorDouble& vecout,
                                                double origin,
                                                double mesh,
                                                double top,
@@ -336,17 +336,19 @@ public:
   static double norm(const std::vector<double>& vec);
   static bool isIsotropic(const VectorVectorInt& sampleRanks);
 
-  static VectorDouble reduceOne(const VectorDouble &vecin, Id index);
-  static VectorDouble reduce(const VectorDouble &vecin, const VectorInt& vindex);
-  static VectorDouble compress(const VectorDouble &vecin, const VectorInt& vindex);
+  static VectorDouble reduceOne(const VectorDouble& vecin, Id index);
+  static VectorDouble reduce(const VectorDouble& vecin, const VectorInt& vindex);
+  static VectorDouble compress(const VectorDouble& vecin, const VectorInt& vindex);
   static void truncateDecimalsInPlace(VectorDouble& vec, Id ndec);
   static void truncateDigitsInPlace(VectorDouble& vec, Id ndec);
-  static void simulateGaussianInPlace(std::vector<double> &vec,
-                                           double mean = 0.,
-                                           double sigma = 1.);
+  static void simulateGaussianInPlace(std::vector<double>& vec,
+                                      double mean  = 0.,
+                                      double sigma = 1.);
 };
 
-//typedef VectorHelper VH;
-class VH: public VectorHelper {};
+// typedef VectorHelper VH;
+class VH: public VectorHelper
+{
+};
 
-}
+} // namespace gstlrn

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -151,6 +151,7 @@ public:
   Id resetReduce(const Db* dbin,
                  const VectorString& names = VectorString(),
                  const VectorInt& ranks    = VectorInt(),
+                 bool flagIsotopic         = false,
                  bool verbose              = false);
   Id resetFromGridRandomized(const DbGrid* dbin,
                              double randperc        = 0.,
@@ -209,6 +210,7 @@ public:
   static Db* createReduce(const Db* dbin,
                           const VectorString& names = VectorString(),
                           const VectorInt& ranks    = VectorInt(),
+                          bool flagIsotopic         = false,
                           bool verbose              = false);
   static Db* createFillRandom(Id ndat,
                               Id ndim                         = 2,
@@ -924,6 +926,23 @@ public:
                        bool skipTitle            = false) const;
 
   void dumpGeometry(Id iech, Id jech) const;
+
+  // Operator overload
+  double& operator()(Id iech, const String& name)
+  {
+    auto iuid = getUID(name);
+    auto icol = getColIdxByUID(iuid);
+    auto iad  = _getAddress(iech, icol);
+    return _array[iad];
+  }
+
+  const double& operator()(Id iech, const String& name) const
+  {
+    auto iuid = getUID(name);
+    auto icol = getColIdxByUID(iuid);
+    auto iad  = _getAddress(iech, icol);
+    return _array[iad];
+  }
 
 protected:
   bool _deserializeAscii(std::istream& is, bool verbose = false) override;

--- a/src/Anamorphosis/PPMT.cpp
+++ b/src/Anamorphosis/PPMT.cpp
@@ -412,7 +412,7 @@ Id PPMT::fitFromMatrix(AMatrix* Y, Id niter, bool verbose)
   _generateAllDirections();
 
   Id np                = Y->getNRows();
-  VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
+  VectorDouble sequence = VH::sequenceVD(1., np, 1., 1. + np);
   VectorDouble N0       = VH::qnormVec(sequence);
 
   // Optional Pre-processing
@@ -506,7 +506,7 @@ Id PPMT::rawToGaussian(Db* db,
   if (niter <= 0) niter = getNiter();
   niter = MIN(niter, getNiter());
 
-  VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
+  VectorDouble sequence = VH::sequenceVD(1., np, 1., 1. + np);
   VectorDouble N0       = VH::qnormVec(sequence);
 
   // Pre-processing
@@ -560,7 +560,7 @@ Id PPMT::gaussianToRaw(Db* db,
   if (niter <= 0) niter = getNiter();
   niter = MIN(niter, getNiter());
 
-  VectorDouble sequence = VH::sequence(1., np, 1., 1. + np);
+  VectorDouble sequence = VH::sequenceVD(1., np, 1., 1. + np);
   VectorDouble N0       = VH::qnormVec(sequence);
 
   // Loop on the iterations (reverse order)

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -1031,10 +1031,10 @@ VectorInt VectorHelper::sequence(Id number, Id ideb, Id step)
  * @param ratio   The whole sequence can be ultimately scaled by 'ratio'
  * @return
  */
-VectorDouble VectorHelper::sequence(double valFrom,
-                                    double valTo,
-                                    double valStep,
-                                    double ratio)
+VectorDouble VectorHelper::sequenceVD(double valFrom,
+                                      double valTo,
+                                      double valStep,
+                                      double ratio)
 {
   VectorDouble vec;
 

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -4766,7 +4766,7 @@ void Db::_addRank(Id nech)
             "Nothing is done");
     return;
   }
-  VectorDouble ranks = VH::sequence(1., static_cast<double>(nech));
+  VectorDouble ranks = VH::sequenceVD(1., static_cast<double>(nech));
   addColumns(ranks, "rank");
 }
 
@@ -5359,13 +5359,30 @@ void Db::_loadValues(const Db* db,
   }
 }
 
+/**
+ * @brief Copy in 'this' the contents of 'dbin' while:
+ * - reducing the list of variables
+ * - reducing the count of samples
+ * - restricting to the isotopic sub dataset
+ *
+ * @param dbin Input Db
+ * @param names List of saved variable names
+ * @param ranks List of saved samples
+ * @param flagIsotopic When True, restrict copy to isotropic samples
+ * @param verbose Verbose flag
+ * @return Id
+ */
 Id Db::resetReduce(const Db* dbin,
                    const VectorString& names,
                    const VectorInt& ranks,
+                   bool flagIsotopic,
                    bool verbose)
 {
-  // Creating the vector of selected samples
+  // Creating the vector of variables
+  VectorString namloc = names;
+  if (namloc.empty()) namloc = dbin->getAllNames();
 
+  // Creating the vector of selected samples
   VectorInt ranksel = ranks;
   if (ranksel.empty())
   {
@@ -5374,19 +5391,32 @@ Id Db::resetReduce(const Db* dbin,
     else
       ranksel = VH::sequence(dbin->getNSample());
   }
-  _nech         = static_cast<Id>(ranksel.size());
+
+  // Restrict to the isotopic sub dataset (optional)
+
+  if (flagIsotopic)
+  {
+    VectorInt rankInit = ranksel;
+    ranksel.clear();
+    for (Id jech = 0, ninter = static_cast<Id>(rankInit.size()); jech < ninter; jech++)
+    {
+      Id iech   = rankInit[jech];
+      bool keep = true;
+      for (Id ivar = 0, nvar = static_cast<Id>(namloc.size()); ivar < nvar && keep; ivar++)
+      {
+        if (FFFF(dbin->getValue(namloc[ivar], iech))) keep = false;
+      }
+      if (keep) ranksel.push_back(iech);
+    }
+  }
+  _nech = static_cast<Id>(ranksel.size());
+
   bool flagMask = _nech != dbin->getNSample();
   if (verbose)
     message("From %d samples, the extraction concerns %d samples\n",
             dbin->getNSample(), _nech);
 
-  // Creating the vector of variables
-
-  VectorString namloc = names;
-  if (namloc.empty()) namloc = dbin->getAllNames();
-
   // Create the (empty) architecture
-
   _ncol = static_cast<Id>(namloc.size());
   resetDims(_ncol, _nech);
 
@@ -5405,8 +5435,7 @@ Id Db::resetReduce(const Db* dbin,
 
   if (getNLoc(ELoc::X) <= 0)
   {
-    // Extract vector of coordinates from input 'Db' (converted into a
-    // 'DbGrid')
+    // Extract vector of coordinates from input 'Db' (converted into 'DbGrid')
     const auto* dbgrid = dynamic_cast<const DbGrid*>(dbin);
     if (dbgrid != nullptr)
     {
@@ -5430,7 +5459,6 @@ Id Db::resetReduce(const Db* dbin,
       }
     }
   }
-
   return 0;
 }
 
@@ -5724,10 +5752,11 @@ Db* Db::createSamplingDb(const Db* dbin,
 Db* Db::createReduce(const Db* dbin,
                      const VectorString& names,
                      const VectorInt& ranks,
+                     bool flagIsotopic,
                      bool verbose)
 {
   Db* db = new Db;
-  if (db->resetReduce(dbin, names, ranks, verbose) != 0)
+  if (db->resetReduce(dbin, names, ranks, flagIsotopic, verbose) != 0)
   {
     db = dbin->clone();
   }

--- a/tests/cpp/test_Matrix.cpp
+++ b/tests/cpp/test_Matrix.cpp
@@ -366,13 +366,13 @@ int main(int argc, char* argv[])
 
   Id icol0 = 1;
   message("Setting Column (%d) to a vector (sequence from 1 to %d)\n", icol0, nrow);
-  VectorDouble myCol = VH::sequence(1., static_cast<double>(nrow));
+  VectorDouble myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSG.setColumn(icol0, myCol);
   MSG.display();
 
   Id irow0 = 2;
   message("Setting Row (%d) to a vector (sequence from 1 to %d)\n", irow0, ncol);
-  VectorDouble myRow = VH::sequence(1., static_cast<double>(ncol));
+  VectorDouble myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSG.setRow(irow0, myRow);
   MSG.display();
 
@@ -403,22 +403,22 @@ int main(int argc, char* argv[])
   MSG.display();
 
   message("Multiplying current matrix column-wise by a vector (sequence)\n");
-  myCol = VH::sequence(1., static_cast<double>(nrow));
+  myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSG.multiplyColumn(myCol);
   MSG.display();
 
   message("Dividing current matrix column-wise by a vector (sequence)\n");
-  myCol = VH::sequence(1., static_cast<double>(nrow));
+  myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSG.divideColumn(myCol);
   MSG.display();
 
   message("Multiplying current matrix row-wise by a vector (sequence)\n");
-  myRow = VH::sequence(1., static_cast<double>(ncol));
+  myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSG.multiplyRow(myRow);
   MSG.display();
 
   message("Dividing current matrix row-wise by a vector (sequence)\n");
-  myRow = VH::sequence(1., static_cast<double>(ncol));
+  myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSG.divideRow(myRow);
   MSG.display();
 
@@ -426,22 +426,22 @@ int main(int argc, char* argv[])
   VectorDouble myColRes;
 
   message("Multiplying sequence vector by matrix\n");
-  myCol    = VH::sequence(1., static_cast<double>(nrow));
+  myCol    = VH::sequenceVD(1., static_cast<double>(nrow));
   myRowRes = MSG.prodVecMat(myCol, false);
   VH::dump("Resulting Vector", myRowRes);
 
   message("Multiplying matrix (transposed) by sequence vector\n");
-  myCol    = VH::sequence(1., static_cast<double>(nrow));
+  myCol    = VH::sequenceVD(1., static_cast<double>(nrow));
   myRowRes = MSG.prodMatVec(myCol, true);
   VH::dump("Resulting Vector", myRowRes);
 
   message("Multiplying matrix by sequence vector\n");
-  myRow    = VH::sequence(1., static_cast<double>(ncol));
+  myRow    = VH::sequenceVD(1., static_cast<double>(ncol));
   myColRes = MSG.prodMatVec(myRow, false);
   VH::dump("Resulting Vector", myColRes);
 
   message("Multiplying sequence vector by matrix (transposed)\n");
-  myRow    = VH::sequence(1., static_cast<double>(ncol));
+  myRow    = VH::sequenceVD(1., static_cast<double>(ncol));
   myColRes = MSG.prodVecMat(myRow, true);
   VH::dump("Resulting Vector", myColRes);
 
@@ -451,7 +451,7 @@ int main(int argc, char* argv[])
   MSG.display();
 
   message("Clearing matrix and Setting Diagonal to a vector (sequence from 1 to %d)\n", ncol);
-  VectorDouble myDiag = VH::sequence(1., static_cast<double>(ncol));
+  VectorDouble myDiag = VH::sequenceVD(1., static_cast<double>(ncol));
   MSG.setDiagonal(myDiag);
   MSG.display();
 
@@ -465,12 +465,12 @@ int main(int argc, char* argv[])
   MSP->display();
 
   message("Setting terms of Column (%d) to a vector (sequence from 1 to %d)\n", icol0, nrow);
-  myCol = VH::sequence(1., static_cast<double>(nrow));
+  myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSP->setColumn(icol0, myCol);
   MSP->display();
 
   message("Setting terms of Row (%d) to a vector (sequence from 1 to %d)\n", irow0, ncol);
-  myRow = VH::sequence(1., static_cast<double>(ncol));
+  myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSP->setRow(irow0, myRow);
   MSP->display();
 
@@ -496,42 +496,42 @@ int main(int argc, char* argv[])
   MSP->display();
 
   message("Multiplying current matrix column-wise by a vector (sequence)\n");
-  myCol = VH::sequence(1., static_cast<double>(nrow));
+  myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSP->multiplyColumn(myCol);
   MSP->display();
 
   message("Dividing current matrix column-wise by a vector (sequence)\n");
-  myCol = VH::sequence(1., static_cast<double>(nrow));
+  myCol = VH::sequenceVD(1., static_cast<double>(nrow));
   MSP->divideColumn(myCol);
   MSP->display();
 
   message("Multiplying current matrix row-wise by a vector (sequence)\n");
-  myRow = VH::sequence(1., static_cast<double>(ncol));
+  myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSP->multiplyRow(myRow);
   MSP->display();
 
   message("Dividing current matrix row-wise by a vector (sequence)\n");
-  myRow = VH::sequence(1., static_cast<double>(ncol));
+  myRow = VH::sequenceVD(1., static_cast<double>(ncol));
   MSP->divideRow(myRow);
   MSP->display();
 
   message("Multiplying sequence vector by matrix\n");
-  myCol    = VH::sequence(1., static_cast<double>(nrow));
+  myCol    = VH::sequenceVD(1., static_cast<double>(nrow));
   myRowRes = MSP->prodVecMat(myCol, false);
   VH::dump("Resulting Vector", myRowRes);
 
   message("Multiplying matrix (transposed) by sequence vector\n");
-  myCol    = VH::sequence(1., static_cast<double>(nrow));
+  myCol    = VH::sequenceVD(1., static_cast<double>(nrow));
   myRowRes = MSP->prodMatVec(myCol, true);
   VH::dump("Resulting Vector", myRowRes);
 
   message("Multiplying matrix by sequence vector\n");
-  myRow    = VH::sequence(1., static_cast<double>(ncol));
+  myRow    = VH::sequenceVD(1., static_cast<double>(ncol));
   myColRes = MSP->prodMatVec(myRow, false);
   VH::dump("Resulting Vector", myColRes);
 
   message("Multiplying sequence vector by matrix (transposed)\n");
-  myRow    = VH::sequence(1., static_cast<double>(ncol));
+  myRow    = VH::sequenceVD(1., static_cast<double>(ncol));
   myColRes = MSP->prodVecMat(myRow, true);
   VH::dump("Resulting Vector", myColRes);
 
@@ -541,7 +541,7 @@ int main(int argc, char* argv[])
   MSP->display();
 
   message("Clearing matrix and Setting Diagonal to a vector (sequence from 1 to %d)\n", ncol);
-  myDiag = VH::sequence(1., static_cast<double>(ncol));
+  myDiag = VH::sequenceVD(1., static_cast<double>(ncol));
   MSP->setDiagonal(myDiag);
   MSP->display();
 

--- a/tests/cpp/test_Model.cpp
+++ b/tests/cpp/test_Model.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
   result.display();
 
   // Sample the Model at regular steps
-  VectorDouble hh = VH::sequence(0., 3., 3. / 50.);
+  VectorDouble hh = VH::sequenceVD(0., 3., 3. / 50.);
   CovCalcMode mode(ECalcMember::LHS);
   mode.setAsVario(true);
   VH::dump("\nModel sampled", modellmc.sample(hh, VectorDouble(), 0, 0, &mode));
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
   defineDefaultSpace(ESpaceType::SN, 2);
   Id ns             = 20;
   Id nincr          = 30;
-  VectorDouble incr = VH::sequence(0., GV_PI + EPSILON10, GV_PI / (nincr - 1.));
+  VectorDouble incr = VH::sequenceVD(0., GV_PI + EPSILON10, GV_PI / (nincr - 1.));
   double mu         = 1.0;
   double kappa      = 2.0;
 

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -9,11 +9,10 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Basic/OptCst.hpp"
+#include "Basic/VectorHelper.hpp"
 #include "Basic/VectorT.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbStringFormat.hpp"
-#include "Estimation/Vecchia.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
 #include "Model/Model.hpp"
 #include "geoslib_define.h"
 
@@ -31,122 +30,46 @@ int main(int argc, char* argv[])
   OptCst::define(ECst::NTCOL, -1);
   OptCst::define(ECst::NTROW, -1);
 
-  auto* model1 = Model::createFromParam(ECov::EXPONENTIAL);
-  model1->setDriftIRF(0);
-  MatrixSymmetric* sills = MatrixSymmetric::createRandomDefinitePositive(2);
-  auto* model2           = Model::createFromParam(ECov::EXPONENTIAL, 1, 0., 1., VectorDouble(), *sills);
-  model2->setDriftIRF(0);
+  Id nvar    = 3;
+  Id ndim    = 2;
+  Id ndat    = 15;
+  auto dbfmt = DbStringFormat(FLAG_ARRAY, VectorString(), VectorInt(), false);
+  VectorDouble hetero(nvar, 0.1);
+  auto* db           = Db::createFillRandom(ndat, ndim, nvar, 0, 0, 0., 0.1, hetero);
+  VectorString names = {"z-1", "z-3"};
+  VectorInt ranks    = VH::sequence(5., 3, 1);
+  Db* dbaux;
 
-  Id nbVecchia = 8;
-  double like;
-  bool verbose = false;
-  int mode     = 0;
+  // Complete file
+  mestitle(1, "Initial data set");
+  db->display(&dbfmt);
 
-  Id nvar  = 1;
-  Id dim   = 2;
-  Id ndat  = 6;
-  Id indNa = 3;
-  VectorDouble sel(ndat, 1.);
-  sel[indNa] = 0.;
-  auto dbfmt = DbStringFormat(FLAG_VARS | FLAG_ARRAY, VectorString(), VectorInt(), false);
+  message("\n---> Reducing by:\n");
+  message(" - selecting some variables (z-1 and z-3)\n");
+  message(" - suppressing masked samples\n");
+  dbaux = Db::createReduce(db, names);
+  dbaux->display(&dbfmt);
+  delete dbaux;
 
-  // Constructing a Monovariate Db
-  nvar       = 1;
-  Db* dbref1 = Db::createFillRandom(ndat, dim, nvar, 0, 0, 0);
-  dbref1->setValue("z", indNa, TEST);
-  dbref1->addSelection(sel, "sel");
+  message("\n---> Reducing by:\n");
+  message(" - selecting some variables (z-1 and z-3)\n");
+  message(" - selecting some sample ranks (5 samples starting from rank 3)\n");
+  dbaux = Db::createReduce(db, names, ranks);
+  dbaux->display(&dbfmt);
+  delete dbaux;
 
-  // Constructing a bivariate Db
-  nvar       = 2;
-  Db* dbref2 = Db::createFillRandom(ndat, dim, nvar, 0, 0, 0);
-  dbref2->setValue("z-1", indNa, TEST);
-  dbref2->setValue("z-2", indNa, TEST);
-  dbref2->addSelection(sel, "sel");
+  message("\n---> Reducing by:\n");
+  message(" - selecting some variables (z-1 and z-3)\n");
+  message(" - selecting only samples where all variables are defined\n");
+  dbaux = Db::createReduce(db, names, VectorInt(), true);
+  dbaux->display(&dbfmt);
+  delete dbaux;
 
-  if (mode == 0 || mode == 10 || mode == 11)
-  {
-    message("\n>>>>> Db1 when removing the bad sample\n");
-    Db* db = dbref1->clone();
-    db->deleteSample(indNa);
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model1, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 10 || mode == 12)
-  {
-    message("\n>>>>> Db1 with Selection\n");
-    Db* db = dbref1->clone();
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model1, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 10 || mode == 13)
-  {
-    message("\n>>>>> Db1 with TEST values\n");
-    Db* db = dbref1->clone();
-    db->clearSelection();
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model1, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 10 || mode == 14)
-  {
-    message("\n>>>>> Db1 with TEST values using traditional LogLikelihood\n");
-    Db* db = dbref1->clone();
-    db->clearSelection();
-    if (verbose) db->display(&dbfmt);
-    like = -model1->computeLogLikelihood(db, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 20 || mode == 21)
-  {
-    message("\n>>>>> Db2 when removing the bad sample\n");
-    Db* db = dbref2->clone();
-    db->deleteSample(indNa);
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model2, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 20 || mode == 22)
-  {
-    message("\n>>>>> Db2 with Selection\n");
-    Db* db = dbref2->clone();
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model2, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 20 || mode == 23)
-  {
-    message("\n>>>>> Db2 with TEST values\n");
-    Db* db = dbref2->clone();
-    db->clearSelection();
-    if (verbose) db->display(&dbfmt);
-    like = logLikelihoodVecchia(db, model2, nbVecchia, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
-
-  if (mode == 0 || mode == 20 || mode == 24)
-  {
-    message("\n>>>>> Db2 with TEST values using traditional LogLikelihood\n");
-    Db* db = dbref2->clone();
-    db->clearSelection();
-    if (verbose) db->display(&dbfmt);
-    like = -model2->computeLogLikelihood(db, verbose);
-    message("Likelihood = %lf\n", like);
-    delete db;
-  }
+  // Checking operators
+  db->display(&dbfmt);
+  double value = (*db)(3, "z-1");
+  message("Valeur initiale = %f\n", value);
+  (*db)(3, "z-1") = 12.;
+  db->display(&dbfmt);
   return 0;
 }


### PR DESCRIPTION
The functions createReduce() and resetReduce() have been improved.
They allow creating a copy of the contents of an input Db by:
- keeping a limited set of variables
- keeping a limited set of samples (or only the active samples when a selection is present)

It now allows keeping the subset of samples for which all variables are defined (isotopic).

The operator have been overloaded for Db to allow following syntax:
- read the value of the variable called "varname" for sample "14": db(14, "varname")
- assign a new value (say 12) to this sample / variable: db(14, "varname") = 12