### PR TITLE
Switch Id to long long

### DIFF
--- a/include/Basic/SerializeHDF5.hpp
+++ b/include/Basic/SerializeHDF5.hpp
@@ -38,9 +38,9 @@ namespace SerializeHDF5
   {
     return H5::PredType::NATIVE_DOUBLE;
   }
-  inline H5::DataType getHDF5Type([[maybe_unused]] const long a)
+  inline H5::DataType getHDF5Type([[maybe_unused]] const Id a)
   {
-    return H5::PredType::NATIVE_LONG;
+    return H5::PredType::NATIVE_LLONG;
   }
   inline H5::DataType getHDF5Type([[maybe_unused]] const bool a)
   {

--- a/include/Basic/VectorNumT.hpp
+++ b/include/Basic/VectorNumT.hpp
@@ -50,7 +50,7 @@ public:
     : Parent(vec)
   {
   }
-  inline VectorNumT(size_type count, const T& value = T())
+  inline VectorNumT(size_type count, const T& value = {})
     : Parent(count, value)
   {
   }

--- a/include/Basic/VectorT.hpp
+++ b/include/Basic/VectorT.hpp
@@ -44,7 +44,7 @@ public:
 public:
   inline VectorT()                                                    : _v() { }
   inline VectorT(const Vector& vec)                                   : _v(vec) { }
-  inline VectorT(size_type count, const T& value = T())               : _v(count, value) { }
+  inline VectorT(size_type count, const T& value = {})                : _v(count, value) { }
   template< class InputIt >
   inline VectorT(InputIt first, InputIt last)                         : _v() { _v.assign(first, last); }
   inline VectorT(const VectorT& other) = default;

--- a/include/geoslib_define.h
+++ b/include/geoslib_define.h
@@ -28,7 +28,7 @@ typedef unsigned char UChar;
 
 /// Main type for gstlearn 64-bits integers, to be used in priority
 /// when an integer is needed.
-using Id = long;
+using Id = long long;
 
 /// Secondary integer type. To be used instead of "int". No "int"
 /// should be voluntarily introduced in gstlearn.

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -105,18 +105,15 @@
     // Test argument
     if (obj == NULL) return SWIG_TypeError;
 
-    long long v = 0; // Biggest integer type whatever the platform
-    int myres = SWIG_AsVal_long_SS_long(obj, &v);
+    int myres = SWIG_AsVal_long_SS_long(obj, &value);
     //std::cout << "convertToCpp(int): v=" << v << std::endl;
     if (SWIG_IsOK(myres) || myres == SWIG_OverflowError)
     {
-      if (myres == SWIG_OverflowError || v == NPY_INT_NA) // NaN, Inf or out of bound value becomes NA
+      if (myres == SWIG_OverflowError || value == NPY_INT_NA) // NaN, Inf or out of bound value becomes NA
       {
-        myres = SWIG_OK;
         value = getNA<Id>();
       }
-      else
-        myres = SWIG_AsVal_long(obj, &value);
+      myres = SWIG_OK;
     }
     return myres;
   }
@@ -489,7 +486,7 @@ namespace gstlrn
   template <> NPY_TYPES numpyType<bool>()    { return NPY_BOOL; }
   
   template<typename Type> struct TypeHelper;
-  template <> struct TypeHelper<Id>    { static bool hasFixedSize() { return true; } };
+  template <> struct TypeHelper<Id>     { static bool hasFixedSize() { return true; } };
   template <> struct TypeHelper<double> { static bool hasFixedSize() { return true; } };
   template <> struct TypeHelper<String> { static bool hasFixedSize() { return false; } };
   template <> struct TypeHelper<float>  { static bool hasFixedSize() { return true; } };
@@ -900,7 +897,7 @@ namespace gstlrn {
 %extend VectorT<String> {
   std::string __repr__() {  return $self->toString(); }
 }
-%extend VectorNumT<long> {
+%extend VectorNumT<long long> {
   std::string __repr__() {  return $self->toString(); }
 }
 %extend VectorNumT<double> {
@@ -912,7 +909,7 @@ namespace gstlrn {
 %extend VectorNumT<UChar> {
   std::string __repr__() {  return $self->toString(); }
 }
-%extend VectorT<VectorNumT<long> > {
+%extend VectorT<VectorNumT<long long> > {
   std::string __repr__() {  return $self->toString(); }
 }
 %extend VectorT<VectorNumT<double> >{

--- a/r/rgstlearn.i
+++ b/r/rgstlearn.i
@@ -46,7 +46,7 @@ namespace gstlrn {
     int myres = SWIG_TypeError;
     if (Rf_length(obj) > 0) // Prevent NULL value from becoming NA
     {
-      myres = SWIG_AsVal_long(obj, &value);
+      myres = SWIG_AsVal_long_SS_long(obj, &value);
       //std::cout << "convertToCpp(int): value=" << value << std::endl;
       if (SWIG_IsOK(myres) && value == R_NaInt) // NA, NaN, Inf or out of bounds value becomes NA
         value = getNA<Id>();
@@ -680,15 +680,15 @@ setMethod(f = "show", signature = "_p_gstlrn__AStringable",                     
 setMethod(f = "show", signature = "_p_gstlrn__VectorTT_double_t",               definition = function(object){ VectorTDouble_display(object) })
 setMethod(f = "show", signature = "_p_gstlrn__VectorNumTT_double_t",            definition = function(object){ VectorTDouble_display(object) })
 
-setMethod(f = "show", signature = "_p_gstlrn__VectorTT_long_t",                  definition = function(object){ VectorTInt_display(object) })
-setMethod(f = "show", signature = "_p_gstlrn__VectorNumTT_long_t",               definition = function(object){ VectorTInt_display(object) })
+setMethod(f = "show", signature = "_p_gstlrn__VectorTT_long_long_t",            definition = function(object){ VectorTInt_display(object) })
+setMethod(f = "show", signature = "_p_gstlrn__VectorNumTT_long_long_t",         definition = function(object){ VectorTInt_display(object) })
 
 setMethod(f = "show", signature = "_p_gstlrn__VectorTT_float_t",                definition = function(object){ VectorTFloat_display(object) })
 setMethod(f = "show", signature = "_p_gstlrn__VectorNumTT_float_t",             definition = function(object){ VectorTFloat_display(object) })
 
-setMethod(f = "show", signature = "_p_gstlrn__VectorTT_gstlrn__String_t",               definition = function(object){ VectorString_display(object) })
+setMethod(f = "show", signature = "_p_gstlrn__VectorTT_gstlrn__String_t",       definition = function(object){ VectorString_display(object) })
 
-setMethod(f = "show", signature = "_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_t_t",    definition = function(object){ VectorVectorInt_display(object) })
+setMethod(f = "show", signature = "_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_long_t_t", definition = function(object){ VectorVectorInt_display(object) })
 
 setMethod(f = "show", signature = "_p_gstlrn__VectorTT_gstlrn__VectorNumTT_double_t_t", definition = function(object){ VectorVectorDouble_display(object) })
 
@@ -791,8 +791,8 @@ function(x, i, value)
   x
 }
 
-setMethod('[',    '_p_gstlrn__VectorTT_long_t',                         getVitem)
-setMethod('[<-',  '_p_gstlrn__VectorTT_long_t',                         setVitem)
+setMethod('[',    '_p_gstlrn__VectorTT_long_long_t',                    getVitem)
+setMethod('[<-',  '_p_gstlrn__VectorTT_long_long_t',                    setVitem)
 setMethod('[',    '_p_gstlrn__VectorTT_double_t',                       getVitem)
 setMethod('[<-',  '_p_gstlrn__VectorTT_double_t',                       setVitem)
 setMethod('[',    '_p_gstlrn__VectorTT_gstlrn__String_t',               getVitem) # TODO : Different from swigex and don't know why (_p_VectorTT_std__string_t)
@@ -801,16 +801,16 @@ setMethod('[',    '_p_gstlrn__VectorTT_float_t',                        getVitem
 setMethod('[<-',  '_p_gstlrn__VectorTT_float_t',                        setVitem)
 setMethod('[',    '_p_gstlrn__VectorTT_gstlrn__UChar_t',                getVitem)
 setMethod('[<-',  '_p_gstlrn__VectorTT_gstlrn__UChar_t',                setVitem)
-setMethod('[',    '_p_gstlrn__VectorNumTT_long_t',                      getVitem)
-setMethod('[<-',  '_p_gstlrn__VectorNumTT_long_t',                      setVitem)
+setMethod('[',    '_p_gstlrn__VectorNumTT_long_long_t',                 getVitem)
+setMethod('[<-',  '_p_gstlrn__VectorNumTT_long_long_t',                 setVitem)
 setMethod('[',    '_p_gstlrn__VectorNumTT_double_t',                    getVitem)
 setMethod('[<-',  '_p_gstlrn__VectorNumTT_double_t',                    setVitem)
 setMethod('[',    '_p_gstlrn__VectorNumTT_float_t',                     getVitem)
 setMethod('[<-',  '_p_gstlrn__VectorNumTT_float_t',                     setVitem)
 setMethod('[',    '_p_gstlrn__VectorNumTT_gstlrn__UChar_t',             getVitem)
 setMethod('[<-',  '_p_gstlrn__VectorNumTT_gstlrn__UChar_t',             setVitem)
-setMethod('[[',   '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_t_t',   getVitem)
-setMethod('[[<-', '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_t_t',   setVitem)
+setMethod('[[',   '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_long_t_t', getVitem)
+setMethod('[[<-', '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_long_long_t_t', setVitem)
 setMethod('[[',   '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_double_t_t', getVitem)
 setMethod('[[<-', '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_double_t_t', setVitem)
 setMethod('[[',   '_p_gstlrn__VectorTT_gstlrn__VectorNumTT_float_t_t',  getVitem)

--- a/src/Basic/MathFunc.cpp
+++ b/src/Basic/MathFunc.cpp
@@ -2614,6 +2614,7 @@ MatrixDense ut_legendreMatNorm(Id n, const VectorDouble& v)
 MatrixDense ut_legendreAssociatedMat(Id l, const VectorDouble& v, bool flagNorm)
 {
   Id nrow = static_cast<Id>(v.size());
+  if(nrow <= 0) return {};
   Id ncol = l + 1;
   MatrixDense res(nrow, ncol);
 

--- a/src/Core/convert.cpp
+++ b/src/Core/convert.cpp
@@ -273,7 +273,7 @@ void csv_print_double(double value)
   else
   {
     if (CSV_ENCODE.flagInteger)
-      (void)fprintf(CSV_ENCODE.file, "%ld", static_cast<Id>(value));
+      (void)fprintf(CSV_ENCODE.file, "%lld", static_cast<Id>(value));
     else
       (void)fprintf(CSV_ENCODE.file, "%lf", value);
   }

--- a/src/Core/io.cpp
+++ b/src/Core/io.cpp
@@ -444,7 +444,7 @@ void _file_write(FILE* file, const char* format, va_list ap)
     if (ret_i == TEST)
       fprintf(file, "%5.1lf", ASCII_TEST);
     else
-      fprintf(file, "%ld", ret_i);
+      fprintf(file, "%lld", ret_i);
     if (OptDbg::query(EDbg::INTERFACE)) message("Encoded Integer = %i\n", ret_i);
   }
   else if (!strcmp(format, "%f"))

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -2535,7 +2535,7 @@ static void st_vario_dump(FILE* file,
   Id ix, iy, iz, num;
   double cov;
 
-  fprintf(file, "*%3ld %3ld\n", ix0, iy0);
+  fprintf(file, "*%3lld %3lld\n", ix0, iy0);
 
   for (ix = -cov_nn[0]; ix <= cov_nn[0]; ix++)
     for (iy = -cov_nn[1]; iy <= cov_nn[1]; iy++)
@@ -2543,7 +2543,7 @@ static void st_vario_dump(FILE* file,
       {
         num = (num_tot == nullptr) ? 0 : NUM_TOT(ix, iy, iz);
         cov = COV_TOT(ix, iy, iz);
-        fprintf(file, "%3ld %3ld %3ld %3ld %lf\n", ix, iy, iz, num, cov);
+        fprintf(file, "%3lld %3lld %3lld %3lld %lf\n", ix, iy, iz, num, cov);
       }
 }
 

--- a/src/OutputFormat/GridArcGis.cpp
+++ b/src/OutputFormat/GridArcGis.cpp
@@ -59,8 +59,8 @@ Id GridArcGis::writeInFile()
 
   /* Write a comment */
 
-  fprintf(_file, "NCOLS %ld\n", _dbgrid->getNX(0));
-  fprintf(_file, "NROWS %ld\n", _dbgrid->getNX(1));
+  fprintf(_file, "NCOLS %lld\n", _dbgrid->getNX(0));
+  fprintf(_file, "NROWS %lld\n", _dbgrid->getNX(1));
   fprintf(_file, "XLLCORNER %lf\n", _dbgrid->getX0(0));
   fprintf(_file, "YLLCORNER %lf\n", _dbgrid->getX0(1));
   fprintf(_file, "CELLSIZE %lf\n", _dbgrid->getDX(0));

--- a/src/OutputFormat/GridIfpEn.cpp
+++ b/src/OutputFormat/GridIfpEn.cpp
@@ -274,7 +274,7 @@ Id GridIfpEn::_readLine(Id mode,
 
   if (mode == 1)
   {
-    if (gslSScanf(&line[start], "%ld", valint) != 1) return (1);
+    if (gslSScanf(&line[start], "%lld", valint) != 1) return (1);
   }
   else if (mode == 2)
   {

--- a/src/OutputFormat/GridIrap.cpp
+++ b/src/OutputFormat/GridIrap.cpp
@@ -66,7 +66,7 @@ Id GridIrap::writeInFile()
   double ymax = ymin + dy * (ny - 1);
 
   /* Write the header */
-  fprintf(_file, "%ld %ld %lf %lf\n", nx, ny, dx, dy);
+  fprintf(_file, "%lld %lld %lf %lf\n", nx, ny, dx, dy);
   fprintf(_file, "%lf %lf %lf %lf\n", xmin, xmax, ymin, ymax);
 
   Id necr = 0;

--- a/src/OutputFormat/GridZycor.cpp
+++ b/src/OutputFormat/GridZycor.cpp
@@ -69,7 +69,7 @@ Id GridZycor::writeInFile()
 
   /* Title line */
 
-  fprintf(_file, "@GRID ZYCOR FILE    ,   GRID,  %ld\n", nbyline);
+  fprintf(_file, "@GRID ZYCOR FILE    ,   GRID,  %lld\n", nbyline);
   fprintf(_file, "     15, %13lg,    ,    0,     1\n", testval);
 
   /* Grid description */
@@ -83,7 +83,7 @@ Id GridZycor::writeInFile()
   }
 
   rbid = 0.;
-  fprintf(_file, "%6ld, %6ld, %13lf, %13lf, %13lf, %13lf\n", nx[1], nx[0], x0[0],
+  fprintf(_file, "%6lld, %6lld, %13lf, %13lf, %13lf, %13lf\n", nx[1], nx[0], x0[0],
           xf[0], x0[1], xf[1]);
   fprintf(_file, " %15lf, %15lf, %15lf\n", rbid, rbid, rbid);
   fprintf(_file, "@\n");

--- a/swig/swig_exp.i
+++ b/swig/swig_exp.i
@@ -12,16 +12,16 @@
 // Export VectorXXX classes
 %include Basic/VectorT.hpp
 %include Basic/VectorNumT.hpp
-%template(VectorTInt)         gstlrn::VectorT< long >;
+%template(VectorTInt)         gstlrn::VectorT< long long >;
 %template(VectorTDouble)      gstlrn::VectorT< double >;
 %template(VectorTFloat)       gstlrn::VectorT< float >;
 %template(VectorBool)         gstlrn::VectorT< UChar >; // See VectorT.hpp
 %template(VectorString)       gstlrn::VectorT< String >;
-%template(VectorInt)          gstlrn::VectorNumT< long >;
+%template(VectorInt)          gstlrn::VectorNumT< long long >;
 %template(VectorDouble)       gstlrn::VectorNumT< double >;
 %template(VectorFloat)        gstlrn::VectorNumT< float >;
 %template(VectorUChar)        gstlrn::VectorNumT< UChar >;
-%template(VectorVectorInt)    gstlrn::VectorT< VectorNumT< long > >;
+%template(VectorVectorInt)    gstlrn::VectorT< VectorNumT< long long > >;
 %template(VectorVectorDouble) gstlrn::VectorT< VectorNumT< double > >;
 %template(VectorVectorFloat)  gstlrn::VectorT< VectorNumT< float > >;
 //}

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -398,6 +398,7 @@
 %include std_string.i
 %template(DoNotUseVectorIntStd)     std::vector< int >;
 %template(DoNotUseVectorLongStd)    std::vector< long >;
+%template(DoNotUseVectorLLongStd)   std::vector< long long >;
 %template(DoNotUseVectorSizeT)      std::vector< size_t >; // Keep size_t here otherwise asptr fails!
 %template(DoNotUseVectorDoubleStd)  std::vector< double >;
 %template(DoNotUseVectorStringStd)  std::vector< std::string >; // Keep std::string here otherwise asptr fails!
@@ -406,6 +407,7 @@
 %template(DoNotUseVectorBoolStd)    std::vector< bool >;
 %template(DoNotUseVVectorIntStd)    std::vector< std::vector< int > >;
 %template(DoNotUseVVectorLongStd)   std::vector< std::vector< long > >;
+%template(DoNotUseVVectorLLongStd)  std::vector< std::vector< long long > >;
 %template(DoNotUseVVectorDoubleStd) std::vector< std::vector< double > >;
 %template(DoNotUseVVectorFloatStd)  std::vector< std::vector< float > >; 
 


### PR DESCRIPTION
This PR modifies the default integer type, `Id`, from `long` to `long long`. `long` is 32-bits on Windows while `long long` is 64-bits everywhere.

A simple change, yet a lot of hard-to-track issues, in particular in the SWIG wrapper. This explains why, at the end, `long long` has been used instead of `int64_t`.

Fixes #700.

Pierre