### PR TITLE
Improve db  create from polygon

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.10.0
 ==============
+- Improvement in DbGrid::createFromPolygon (better management of default value + ability to define the selection in the newly create Grid File)
+- Correct the Polygon extension calculation
 - New functions in Db: getRanksAbsoluteToRelativeVec() and getRanksRelativeToAbsolute()
 - For generating a VectorDouble containing the sequence of values, please now use VH::sequenceVD() 
 - Db() offers the possibility to overload operators (robustified against illegal argument).

--- a/doc/demo/python/Tuto_Polygons.ipynb
+++ b/doc/demo/python/Tuto_Polygons.ipynb
@@ -194,13 +194,47 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8ab2da8b",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "gp.plot(grid, alpha=0.3)\n",
     "gp.polygon(newpoly)\n",
     "gp.polygon(poly, edgecolor='red')\n",
     "gp.decoration(title=\"(Simplified) Polygon in its dilated selection\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dae7412e-ec99-4147-925f-6d22e3f32f7e",
+   "metadata": {},
+   "source": [
+    "New interface allowing to create a Grid directly from a polygon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90e57cb1-7a7e-4fad-b7e5-71c83bc90d7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid2 = gl.DbGrid.createFromPolygon(newpoly, dx=[1000,1000])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "284c3b98-24d5-4d82-b1fd-e70fb068c070",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "gp.plot(grid2, alpha=0.3)\n",
+    "gp.polygon(newpoly, edgecolor='red')\n",
+    "gp.decoration(title=\"Polygon and the newly created Grid\")"
    ]
   }
  ],

--- a/include/Db/DbGrid.hpp
+++ b/include/Db/DbGrid.hpp
@@ -101,10 +101,10 @@ public:
                                   const VectorDouble& x0     = VectorDouble(),
                                   const VectorDouble& margin = VectorDouble());
   static DbGrid* createFromPolygon(Polygons* polygon,
-                                   const VectorInt& nodes    = VectorInt(),
-                                   const VectorDouble& dcell = VectorDouble(),
-                                   bool flagAddSelection     = true,
-                                   bool flagAddSampleRank    = true);
+                                   const VectorInt& nx    = VectorInt(),
+                                   const VectorDouble& dx = VectorDouble(),
+                                   bool flagAddSelection  = true,
+                                   bool flagAddSampleRank = true);
   static DbGrid* createCoarse(DbGrid* dbin,
                               const VectorInt& nmult,
                               bool flagCell          = true,
@@ -179,10 +179,10 @@ public:
                      const VectorDouble& x0     = VectorDouble(),
                      const VectorDouble& margin = VectorDouble());
   Id resetFromPolygon(Polygons* polygon,
-                      const VectorInt& nodes    = VectorInt(),
-                      const VectorDouble& dcell = VectorDouble(),
-                      bool flagAddSelection     = true,
-                      bool flagAddSampleRank    = true);
+                      const VectorInt& nx    = VectorInt(),
+                      const VectorDouble& dx = VectorDouble(),
+                      bool flagAddSelection  = true,
+                      bool flagAddSampleRank = true);
 
   DbGrid* coarsify(const VectorInt& nmult);
   DbGrid* refine(const VectorInt& nmult);

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -163,7 +163,7 @@ Id DbGrid::reset(const VectorInt& nx,
  * @param x0       Vector of the expected origin of the grid (in coordinate)
  * @param margin   Vector of the expected margins of the grid (in distance)
  *
- * @remarks Arguments 'nodes' and 'dcell' are disjunctive. If both defined, 'dcell' prevails
+ * @remarks Arguments 'nx' and 'dx' are disjunctive. If both defined, 'nx' prevails
  */
 Id DbGrid::resetCoveringDb(const Db* db,
                            const VectorInt& nx,
@@ -230,8 +230,8 @@ Id DbGrid::resetCoveringDb(const Db* db,
 }
 
 Id DbGrid::resetFromPolygon(Polygons* polygon,
-                            const VectorInt& nodes,
-                            const VectorDouble& dcell,
+                            const VectorInt& nx,
+                            const VectorDouble& dx,
                             bool flagAddSelection,
                             bool flagAddSampleRank)
 {
@@ -252,23 +252,23 @@ Id DbGrid::resetFromPolygon(Polygons* polygon,
     double x0  = (idim == 0) ? xmin : ymin;
     double ext = (idim == 0) ? xmax - xmin : ymax - ymin;
 
-    Id nx     = 10;
-    double dx = ext / static_cast<double>(nx);
-    if (ndim == static_cast<Id>(nodes.size()))
+    Id nxloc     = 10;
+    double dxloc = ext / static_cast<double>(nxloc);
+    if (ndim == static_cast<Id>(nx.size()))
     {
-      nx = nodes[idim];
-      dx = ext / static_cast<double>(nx);
+      nxloc = nx[idim];
+      dxloc = ext / static_cast<double>(nxloc);
     }
-    if (ndim == static_cast<Id>(dcell.size()))
+    if (ndim == static_cast<Id>(dx.size()))
     {
-      dx = dcell[idim];
-      nx = static_cast<Id>(ext / dx);
+      dxloc = dx[idim];
+      nxloc = static_cast<Id>(ext / dxloc);
     }
 
-    nx_tab.push_back(nx);
+    nx_tab.push_back(nxloc);
     x0_tab.push_back(x0);
-    dx_tab.push_back(dx);
-    nech *= nx;
+    dx_tab.push_back(dxloc);
+    nech *= nxloc;
   }
   Id ncol = (flagAddSampleRank) ? ndim + 1 : ndim;
 
@@ -335,26 +335,26 @@ DbGrid* DbGrid::createCoveringDb(const Db* db,
  * Creating a regular unrotated grid Db which covers the input Polygon
  *
  * @param polygon    Pointer to the input Polygon
- * @param nodes      Vector of the expected number of nodes
- * @param dcell      Vector of the expected dimensions for the grid cells
+ * @param nx         Vector of the expected number of nodes
+ * @param dx         Vector of the expected dimensions for the grid cells
  * @param flagAddSelection true if a selection variable must be created
  * @param flagAddSampleRank true if the sample rank must be generated
  *
  * @remarks The aim of this procedure is to create a regular (unrotated) grid
  *          which covers the extension of the input Polygon
- * @remarks If 'nodes' is not defined, it is set to 10 by default along each space dimension
- * @remarks If 'nodes' is defined, 'dcell' is derived
- * @remarks If 'dcell' is defined, 'nodes' is derived
- * @remarks If both 'nodes' and 'dcell' are defined, 'dcell' prevails over 'nodes'
+ * @remarks If 'nx' is not defined, it is set to 10 by default along each space dimension
+ * @remarks If 'nx' is defined, 'dx' is derived
+ * @remarks If 'dx' is defined, 'nx' is derived
+ * @remarks If both 'nx' and 'dx' are defined, 'dx' prevails over 'nx'
  */
 DbGrid* DbGrid::createFromPolygon(Polygons* polygon,
-                                  const VectorInt& nodes,
-                                  const VectorDouble& dcell,
+                                  const VectorInt& nx,
+                                  const VectorDouble& dx,
                                   bool flagAddSelection,
                                   bool flagAddSampleRank)
 {
   auto* dbgrid = new DbGrid;
-  if (dbgrid->resetFromPolygon(polygon, nodes, dcell, flagAddSelection, flagAddSampleRank))
+  if (dbgrid->resetFromPolygon(polygon, nx, dx, flagAddSelection, flagAddSampleRank))
   {
     messerr("Error when creating DbGrid from Polygon");
     delete dbgrid;

--- a/src/Polygon/Polygons.cpp
+++ b/src/Polygon/Polygons.cpp
@@ -251,6 +251,10 @@ void Polygons::getExtension(double* xmin,
                             double* ymax) const
 {
   double xmin_loc, xmax_loc, ymin_loc, ymax_loc;
+  *xmin = 1.e30;
+  *ymin = 1.e30;
+  *xmax = -1.e30;
+  *ymax = -1.e30;
 
   for (Id ipol = 0; ipol < getNPolyElem(); ipol++)
   {

--- a/tests/ipynb/output/Tuto_Polygons.asciidoc
+++ b/tests/ipynb/output/Tuto_Polygons.asciidoc
@@ -64,3 +64,9 @@ Number of active grid nodes = 1593571
 ----
 #NO_DIFF#XXX
 ----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----


### PR DESCRIPTION
This branch corresponds to a suggestion from N. Bez to improve DbGrid::createFromPolygon:
- allow the arguments 'nodes' and 'dcell' to remain undefined by the user. The rule is the following (as explained in the documentation of the function):
- If 'nodes' is undefined, it is defaulted to 10 for each space dimension
- If 'nodes' is defined, 'dcell' is derived so that the non-rotated grid covers the whole polygon extension
- if 'dcell' is defined, 'nodes' is derives so that the non-rotated grid covers the whole polygon extension
- If both are defined, 'dcell' prevails

The argument 'nodes' has been renamed into 'nx' and 'dcell' into 'dx'.

An additional argument 'addSelection' allows adding the selection of the grid nodes belonging to the polygon in the newly created grid.

An extra bug has been fixed in the calculation of the Polygon extension.
