### PR TITLE
Add Space when using Db::getSamplesFromNbghAsSP

### DIFF
--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -513,8 +513,8 @@ private:
   virtual void _load(const SpacePoint& p, bool option) const;
   virtual void _attachNoStatDb(const Db* db);
 
-  void _optimizationPreProcessForTarget(const Db* db2,
-                                        const VectorInt& nbgh2 = VectorInt()) const;
+  void _optimizationPreProcessForTarget(const Db* db,
+                                        const VectorInt& nbgh = VectorInt()) const;
 
   void _loopOnData(MatrixDense& mat,
                    const SpacePoint& p2,

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -496,6 +496,7 @@ public:
                       const ASpaceSharedPtr& space,
                       bool useSel = false) const;
   void getSamplesFromNbghAsSP(std::vector<SpacePoint>& pvec,
+                              const ASpaceSharedPtr& space,
                               const VectorInt& nbgh) const;
 
   bool hasLocator(const ELoc& locatorType) const;

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -149,15 +149,15 @@ void ACov::optimizationPreProcessForData(const Db* db1) const
   _optimPreProcessedData = true;
 }
 
-void ACov::_optimizationPreProcessForTarget(const Db* db2, const VectorInt& nbgh2) const
+void ACov::_optimizationPreProcessForTarget(const Db* db, const VectorInt& nbgh) const
 {
   std::vector<SpacePoint> ps;
 
-  // Add projected samples from db2 (optional)
-  if (nbgh2.empty())
-    db2->getSamplesAsSP(ps, getSpace(), true);
+  // Add projected samples from db (optional)
+  if (nbgh.empty())
+    db->getSamplesAsSP(ps, getSpace(), true);
   else
-    db2->getSamplesFromNbghAsSP(ps, nbgh2);
+    db->getSamplesFromNbghAsSP(ps, getSpace(), nbgh);
   _optimizationPreProcess(2, ps);
 }
 
@@ -250,15 +250,13 @@ void ACov::_setNoStatDbIfNecessary(const Db* db)
     attachNoStatDb(db);
 }
 
-void ACov::_attachNoStatDb(const Db* db)
-{
-  DECLARE_UNUSED(db)
-}
+void ACov::_attachNoStatDb(const Db* db) {
+  DECLARE_UNUSED(db)}
 
 VectorDouble ACov::informCoords(const VectorVectorDouble& coords,
-                                                      const EConsElem& econs,
-                                                      Id iv1,
-                                                      Id iv2) const
+                                const EConsElem& econs,
+                                Id iv1,
+                                Id iv2) const
 {
   VectorDouble result(coords[0].size(), getValue(econs, iv1, iv2));
   _tabNoStat->informCoords(coords, econs, iv1, iv2, result);
@@ -2523,12 +2521,12 @@ void ACov::setContext(const CovContext& ctxt)
   _setContext(ctxt);
 }
 
-bool ACov::isValidForSpectral() const 
+bool ACov::isValidForSpectral() const
 {
   return false;
 }
 
-MatrixDense ACov::simulateSpectralOmega(Id ns) const 
+MatrixDense ACov::simulateSpectralOmega(Id ns) const
 {
   DECLARE_UNUSED(ns);
   message("ACov::simulateSpectralOmega: Not implemented");

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -809,10 +809,23 @@ void Db::getSamplesAsSP(std::vector<SpacePoint>& pvec,
 }
 
 void Db::getSamplesFromNbghAsSP(std::vector<SpacePoint>& pvec,
+                                const std::shared_ptr<const ASpace>& space,
                                 const VectorInt& nbgh) const
 {
   Id nbsize = static_cast<Id>(nbgh.size());
-  pvec.resize(nbsize);
+
+  // If pvec already exist, check the space dimension (only on the first element)
+  if (pvec.empty() || pvec.front().getSpace().get() != space.get())
+  {
+    pvec.clear();
+    SpacePoint p(space);
+    pvec.assign(nbsize, p);
+  }
+  else
+  {
+    pvec.resize(nbsize);
+  }
+
   for (Id irel = 0; irel < nbsize; irel++)
     getSampleAsSPInPlace(pvec[irel], nbgh[irel]);
 }
@@ -853,7 +866,10 @@ double Db::getCoordinate(Id iech, Id idim, bool flag_rotate) const
 void Db::getCoordinatesInPlace(VectorDouble& coor, Id iech, bool flag_rotate) const
 {
   DECLARE_UNUSED(flag_rotate);
-  for (Id idim = 0, ndim = getNDim(); idim < ndim; idim++)
+  // Adding a light protection
+  Id nsize = static_cast<Id>(coor.size());
+  Id ndim  = MIN(nsize, getNDim());
+  for (Id idim = 0; idim < ndim; idim++)
   {
     auto icol  = getColIdxByLocator(ELoc::X, idim);
     coor[idim] = _array[_getAddress(iech, icol)];

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -8,6 +8,10 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "Neigh/NeighMoving.hpp"
+#include "Space/SpaceRN.hpp"
 #include "geoslib_define.h"
 
 using namespace gstlrn;
@@ -17,5 +21,48 @@ int main(int argc, char* argv[])
   DECLARE_UNUSED(argc);
   DECLARE_UNUSED(argv);
 
+  // Define the two Dbs in different space dimensions
+  Id ndat   = 100;
+  Id ndim2  = 2;
+  Id ndim3  = 3;
+  auto* db2 = Db::createFillRandom(ndat, ndim2, 1);
+  auto* db3 = Db::createFillRandom(ndat, ndim3, 1);
+
+  // Define the Moving neighborhood
+  Id nmaxi      = 10;
+  double radius = 0.5;
+  auto* neigh   = NeighMoving::create(false, nmaxi, radius);
+
+  // Attach the neighborhood to the first Db (Space Dimension 2)
+  neigh->attach(db2, db2);
+  neigh->display();
+
+  VectorInt nbgh;
+  std::vector<SpacePoint> pvec;
+
+  // Perform a neighborhood selection on Db2
+  Id itarget2 = 4;
+  neigh->select(itarget2, nbgh);
+  VH::dump("For Target Point", nbgh);
+  auto space2 = SpaceRN::create(ndim2);
+  db2->getSamplesFromNbghAsSP(pvec, space2, nbgh);
+  for (Id i = 0; i < nmaxi; i++)
+    pvec[i].display();
+
+  // Attach the neighborhood to the second Db (Space Dimension 3)
+  neigh->attach(db3, db3);
+  neigh->display();
+
+  // Perform a neighborhood selection on Db3
+  Id itarget3 = 34;
+  neigh->select(itarget3, nbgh);
+  VH::dump("For Target Point", nbgh);
+  auto space3 = SpaceRN::create(ndim3);
+  db3->getSamplesFromNbghAsSP(pvec, space3, nbgh);
+  for (Id i = 0; i < nmaxi; i++)
+    pvec[i].display();
+
+  delete db2;
+  delete db3;
   return 0;
 }


### PR DESCRIPTION
This branch corrects the bug mentionned by R. MOYEN concerning the methodconst std::shared_ptr<const ASpace>& space,
This method should mimic the one called Db::getSampleAsSP() which loads all the samples of a Db as a vector of SpacePoints.
The latter had an additional argument: const std::shared_ptr<const ASpace>& space,
which allows dimensioning each  element of the returned vector to a SpacePoint with the correct number of coordinates (defined by Space).
The same argument has been added to the function const std::shared_ptr<const ASpace>& space.

Moreover, one could be surprised that these methods need a Space definition, although they are defined in a Db which knows how many X Locator have been defined. This is meant for a future application where the space dimension could be different from the number of X locator defined in the Db: as an example, the space (passed as argument) could come from a composite model and be smaller thatn the total number of coordinates defined in the Db.
Nevertheless a slight protection has been added to load each spacepoint with a number of coordinates which MUST be equal to the minimum between the space dimension (defined in space) and the dimension of the coordinate vector (defined in the space point).

