### PR TITLE
Fix bug with ShiftOpStencil when the mesh is not defined on every point of the grid

### DIFF
--- a/doc/demo/python/Tuto_ShiftOpStencil.ipynb
+++ b/doc/demo/python/Tuto_ShiftOpStencil.ipynb
@@ -1,0 +1,609 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shift Operator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial aims to show how to handle the Shift Operator as used in SPDE algorithms.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gstlearn as gl\n",
+    "import gstlearn.plot as gp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We demonstrate the use of the Shift Operator while performing a Kriging operation using SPDE. The output data base is a regular 2-D grid (with square unit mesh of 1 unit) while the Input data base is reduced to a single point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using a toy example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncell = 7\n",
+    "center = int(ncell / 2)\n",
+    "db_out_small = gl.DbGrid.create([ ncell, ncell ])\n",
+    "db_out_small.display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_in_small = gl.Db.createFromOnePoint([ center, center])\n",
+    "db_in_small.addColumns([1], \"z\", gl.ELoc.Z)\n",
+    "db_in_small.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Constructing a Model composed of a single Matern Covariance, with range = 1 and param=0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 1\n",
+    "param = 0.5\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "model.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to create a Mesh (using the Turbo algorithm based on the output grid). Then we should create an array of meshes whose dimension must match the number of covariances in the Model (that we will keep equal to 1 in this tutorial)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_small = gl.MeshETurbo.createFromGrid(db_out_small)\n",
+    "mesh_small.display()\n",
+    "meshes_small = gl.VectorMeshes([ mesh_small ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let us concentrate on the Shift Operator. It may be performed:\n",
+    "- using the Standard algorithm\n",
+    "- or using the Stencil algorithm (all similar tiles)\n",
+    "\n",
+    "This information is provided in the **SPDEParam** field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = gl.SPDEParam()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We perform a first Kriging operation not using the Stencil lagorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(False)\n",
+    "err = gl.krigingSPDE(db_in_small, db_out_small, model, True, False, False,\n",
+    "               meshes_small, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-No-Stencil\"))\n",
+    "result = gl.MatrixDense(ncell, ncell)\n",
+    "result.setValues(db_out_small.getColumn(\"K-No-Stencil.z.estim\"), False)\n",
+    "result.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We perform a similar Kriging operation, but using the Stencil option this time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "err = gl.krigingSPDE(db_in_small, db_out_small, model, True, False, False,\n",
+    "               meshes_small, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-With-Stencil\"))\n",
+    "result = gl.MatrixDense(ncell, ncell)\n",
+    "result.setValues(db_out_small.getColumn(\"K-With-Stencil.z.estim\"), False)\n",
+    "result.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The estimation results are not very similar:\n",
+    "- this is essentially linked to the fact that the Stencil version required that a grid node can only be treated if the stencil (centered on the target node) is completely included within the grid. This implies that the border of the grid cannot be processed and is set to 0\n",
+    "- the non-peripheral nodes are more similar but their count is small in this examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using a reasonable grid size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The calls for using a much larger grid as it is done in the subsequent paragraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncell = 51\n",
+    "center = int(ncell / 2)\n",
+    "db_out = gl.DbGrid.create([ ncell, ncell ])\n",
+    "\n",
+    "db_in = gl.Db.createFromOnePoint([ center, center])\n",
+    "db_in.addColumns([1], \"z\", gl.ELoc.Z)\n",
+    "\n",
+    "mesh = gl.MeshETurbo.createFromGrid(db_out)\n",
+    "meshes = gl.VectorMeshes([ mesh ])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(False)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-No-Stencil\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-With-Stencil\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1,2, figsize=(11,5))\n",
+    "ax[0].raster(db_out, name=\"K-No-Stencil.z.estim\", flagLegend=True)\n",
+    "ax[1].raster(db_out, name=\"K-With-Stencil.z.estim\", flagLegend=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clearly, with this choice of parameters, the results of the options are very close."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking the impact of the range"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use the Stencil option (quicker calculations) to visualize the impact of the range of the model. We recall that the grid dimension is 50 x 50."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "param = 0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 1\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Range-1\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 5\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Range-5\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 10\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Range-10\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 25\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Range-25\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(2,2, figsize=(11,11))\n",
+    "ax[0,0].raster(db_out, name=\"K-Range-1.z.estim\", flagLegend=True)\n",
+    "ax[0,1].raster(db_out, name=\"K-Range-5.z.estim\", flagLegend=True)\n",
+    "ax[1,0].raster(db_out, name=\"K-Range-10.z.estim\", flagLegend=True)\n",
+    "ax[1,1].raster(db_out, name=\"K-Range-25.z.estim\", flagLegend=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking the impact of the regularity parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Still using the Stencil option (quicker calculations), we check the impact of the regularity term (**param**). The range is left constant equal to 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "range = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = 0.5\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Param-0.5\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = 2\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Param-2\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1,2, figsize=(11,5))\n",
+    "ax[0].raster(db_out, name=\"K-Param-0.5.z.estim\", flagLegend=True)\n",
+    "ax[1].raster(db_out, name=\"K-Param-2.z.estim\", flagLegend=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clearly the impact of the regularity parameter is not obvious on an estimation case: it would be much more visible in a simulation case."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use of a Selection on the output grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us consider that the output grid is partially masked off (using a selection for example) and compare the behavior of Kriging when use the Stencil option or not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first return to the small grid to visualize the impact of the selection on the values estimated at the nodes of the grid. We now create a selection in the upper left corner (smallet indices for X and Y)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncell = 7\n",
+    "db_out_small = gl.DbGrid.create([ ncell, ncell ])\n",
+    "\n",
+    "iuid = db_out_small.addColumnsByConstant(1, 1., \"sel\", gl.ELoc.SEL)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([0,0]), 0)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([0,1]), 0)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([1,0]), 0)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([2,0]), 0)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([1,1]), 0)\n",
+    "db_out_small.setValue(\"sel\", db_out_small.indiceToRank([0,2]), 0)\n",
+    "\n",
+    "result = gl.MatrixDense(ncell, ncell)\n",
+    "result.setValues(db_out_small.getColumn(\"sel\"), False)\n",
+    "result.display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 1\n",
+    "param = 0.5\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(False)\n",
+    "err = gl.krigingSPDE(db_in_small, db_out_small, model, True, False, False,\n",
+    "               meshes_small, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-No-Stencil\"))\n",
+    "result = gl.MatrixDense(ncell, ncell)\n",
+    "result.setValues(db_out_small.getColumn(\"K-No-Stencil.z.estim\"), False)\n",
+    "result.display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "err = gl.krigingSPDE(db_in_small, db_out_small, model, True, False, False,\n",
+    "               meshes_small, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-With-Stencil\"))\n",
+    "result = gl.MatrixDense(ncell, ncell)\n",
+    "result.setValues(db_out_small.getColumn(\"K-With-Stencil.z.estim\"), False)\n",
+    "result.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once more, we can check the quality of the Stencil option:\n",
+    "- it produces a result very close to the Standard option (although in a much faster way)\n",
+    "- the guard zone is maintained: e.g. the masked area and the edge of the field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the large grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We return to more decent grid size in order to visualize the impact of the selection. We add a selection based on a single cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iuid = db_out.addColumnsByConstant(1, 1., \"sel\", gl.ELoc.SEL)\n",
+    "db_out.setValue(\"sel\", db_out.indiceToRank([20,15]), 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We return to a long range model (range = 10)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range = 10\n",
+    "param = 0.5\n",
+    "model = gl.Model.createFromParam(gl.ECov.MATERN, range, 1., param)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(False)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Sel-No-Stencil\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params.setUseStencil(True)\n",
+    "err = gl.krigingSPDE(db_in, db_out, model, True, False, False,\n",
+    "               meshes, None, None, None, None, None, params, False, namconv = gl.NamingConvention(\"K-Sel-With-Stencil\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1,2, figsize=(11,5))\n",
+    "ax[0].raster(db_out, name=\"K-Sel-No-Stencil.z.estim\", flagLegend=True)\n",
+    "ax[1].raster(db_out, name=\"K-Sel-With-Stencil.z.estim\", flagLegend=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, in order to demonstrate that the Stencil Option does not impair the quality of the result, we display a scatter plot between the two results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.correlation(db_out,\"K-Sel-No-Stencil.z.estim\",\"K-Sel-With-Stencil.z.estim\", bins=100, cmin=1)\n",
+    "ax.decoration(title=\"Scatter Plot between the two options\")\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -120,15 +120,17 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
       total = 0.;
 
       // Check if the target point is not on the edge and not masked
-      if (_isInside[ic] && indirect.getAToR(ic) >= 0)
+      if (_isInside[ic])
       {
-        grid.rankToIndice(ic, center);
+        Id rank = indirect.getRToA(ic);
+        grid.rankToIndice(rank, center);
         for (Id iw = 0; iw < nw; iw++)
         {
           local = center;
           VH::addInPlace(local, _relativeShifts[iw]);
           Id ie = grid.indiceToRank(local);
-          if (indirect.getAToR(ie) >= 0) total += (*currentWeights)[iw] * inv[ie];
+          rank = indirect.getAToR(ie);
+          if (rank >= 0) total += (*currentWeights)[iw] * inv[rank];
         }
       }
       outv[ic] = total;
@@ -274,9 +276,11 @@ Id ShiftOpStencil::_buildInternal(const MeshETurbo* mesh,
   Id size = _mesh->getNApices();
   _isInside.fill(true, size);
 
+  const Indirection& indirect = _mesh->getGridIndirect();
   for (Id i = 0; i < size; i++)
   {
-    grid.rankToIndice(i, center);
+    Id rank = indirect.isDefined() ? indirect.getRToA(i) : i;
+    grid.rankToIndice(rank, center);
     bool flagInside = true;
     for (Id idim = 0; idim < ndim && flagInside; idim++)
     {

--- a/tests/ipynb/output/Tuto_ShiftOpStencil.asciidoc
+++ b/tests/ipynb/output/Tuto_ShiftOpStencil.asciidoc
@@ -1,0 +1,198 @@
+#NO_DIFF#XXX
+----
+
+Data Base Grid Characteristics
+==============================
+
+Data Base Summary
+-----------------
+File is organized as a regular grid
+Space dimension              = 2
+Number of Columns            = 3
+Total number of samples      = 49
+
+Grid characteristics:
+---------------------
+Origin :      0.000     0.000
+Mesh   :      1.000     1.000
+Number :          7         7
+
+Variables
+---------
+Column = 0 - Name = rank - Locator = NA
+Column = 1 - Name = x1 - Locator = x1
+Column = 2 - Name = x2 - Locator = x2
+----
+
+
+#NO_DIFF#XXX
+----
+
+Data Base Characteristics
+=========================
+
+Data Base Summary
+-----------------
+File is organized as a set of isolated points
+Space dimension              = 2
+Number of Columns            = 4
+Total number of samples      = 1
+
+Variables
+---------
+Column = 0 - Name = rank - Locator = NA
+Column = 1 - Name = x-1 - Locator = x1
+Column = 2 - Name = x-2 - Locator = x2
+Column = 3 - Name = z - Locator = z1
+----
+
+
+#NO_DIFF#XXX
+----
+
+Model characteristics
+=====================
+Space dimension              = 2
+Number of variable(s)        = 1
+Number of basic structure(s) = 1
+Number of drift function(s)  = 0
+Number of drift equation(s)  = 0
+
+Covariance Part
+---------------
+Matern (Third Parameter = 0.5)
+- Sill         =      1.000
+- Range        =      1.000
+- Theo. Range  =      0.408
+Total Sill     =      1.000
+Known Mean(s)     0.000
+----
+
+
+#NO_DIFF#XXX
+----
+
+Turbo Meshing
+=============
+
+Grid characteristics:
+---------------------
+Origin :      0.000     0.000
+Mesh   :      1.000     1.000
+Number :          7         7
+Euclidean Geometry
+Space Dimension           = 2
+Number of Apices per Mesh = 3
+Number of Meshes          = 72
+Number of Apices          = 49
+
+Bounding Box Extension
+----------------------
+Dim #1 - Min:0 - Max:6
+Dim #2 - Min:0 - Max:6
+----
+
+
+#NO_DIFF#XXX
+----
+- Number of rows    = 7
+- Number of columns = 7
+               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
+     [  0,]     0.001     0.002     0.005     0.010     0.005     0.002     0.001
+     [  1,]     0.002     0.004     0.014     0.035     0.014     0.004     0.002
+     [  2,]     0.005     0.014     0.064     0.208     0.064     0.014     0.005
+     [  3,]     0.010     0.035     0.208     0.977     0.208     0.035     0.010
+     [  4,]     0.005     0.014     0.064     0.208     0.064     0.014     0.005
+     [  5,]     0.002     0.004     0.014     0.035     0.014     0.004     0.002
+     [  6,]     0.001     0.002     0.005     0.010     0.005     0.002     0.001
+----
+
+
+#NO_DIFF#XXX
+----
+- Number of rows    = 7
+- Number of columns = 7
+               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
+     [  0,]     0.000     0.000     0.000     0.000     0.000     0.000     0.000
+     [  1,]     0.000     0.003     0.013     0.033     0.013     0.003     0.000
+     [  2,]     0.000     0.013     0.064     0.208     0.064     0.013     0.000
+     [  3,]     0.000     0.033     0.208     0.977     0.208     0.033     0.000
+     [  4,]     0.000     0.013     0.064     0.208     0.064     0.013     0.000
+     [  5,]     0.000     0.003     0.013     0.033     0.013     0.003     0.000
+     [  6,]     0.000     0.000     0.000     0.000     0.000     0.000     0.000
+----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----
+
+
+#NO_DIFF#XXX
+----
+- Number of rows    = 7
+- Number of columns = 7
+               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
+     [  0,]     0.000     0.000     0.000     1.000     1.000     1.000     1.000
+     [  1,]     0.000     0.000     1.000     1.000     1.000     1.000     1.000
+     [  2,]     0.000     1.000     1.000     1.000     1.000     1.000     1.000
+     [  3,]     1.000     1.000     1.000     1.000     1.000     1.000     1.000
+     [  4,]     1.000     1.000     1.000     1.000     1.000     1.000     1.000
+     [  5,]     1.000     1.000     1.000     1.000     1.000     1.000     1.000
+     [  6,]     1.000     1.000     1.000     1.000     1.000     1.000     1.000
+----
+
+
+#NO_DIFF#XXX
+----
+- Number of rows    = 7
+- Number of columns = 7
+               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
+     [  0,]     0.000     0.000     0.000     0.010     0.005     0.002     0.001
+     [  1,]     0.000     0.000     0.014     0.035     0.014     0.004     0.002
+     [  2,]     0.000     0.014     0.064     0.208     0.064     0.014     0.005
+     [  3,]     0.010     0.035     0.208     0.977     0.208     0.035     0.010
+     [  4,]     0.005     0.014     0.064     0.208     0.064     0.014     0.005
+     [  5,]     0.002     0.004     0.014     0.035     0.014     0.004     0.002
+     [  6,]     0.001     0.002     0.005     0.010     0.005     0.002     0.001
+----
+
+
+#NO_DIFF#XXX
+----
+- Number of rows    = 7
+- Number of columns = 7
+               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
+     [  0,]     0.000     0.000     0.000     0.000     0.000     0.000     0.000
+     [  1,]     0.000     0.000     0.013     0.033     0.013     0.003     0.000
+     [  2,]     0.000     0.013     0.064     0.208     0.064     0.013     0.000
+     [  3,]     0.000     0.033     0.208     0.977     0.208     0.033     0.000
+     [  4,]     0.000     0.013     0.064     0.208     0.064     0.013     0.000
+     [  5,]     0.000     0.003     0.013     0.033     0.013     0.003     0.000
+     [  6,]     0.000     0.000     0.000     0.000     0.000     0.000     0.000
+----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----
+
+
+#NO_DIFF#XXX
+----
+#NO_DIFF#XXX
+----


### PR DESCRIPTION
Before this commit, the test described in the issue produces this result (wrong):
```
               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]
     [  0,]     0.000     0.000     0.000     0.000     0.000
     [  1,]     0.000     0.000     0.000     0.000     0.000
     [  2,]     0.000     0.000     0.991     0.017     0.045
     [  3,]     0.000     0.000     0.000     0.017     0.091
     [  4,]     0.318     0.000     0.000     0.045     0.318
```

After this commit, the result is now (correct):
```
               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]
     [  0,]     0.000     0.000     0.000     0.000     0.000
     [  1,]     0.000     0.000     0.195     0.058     0.000
     [  2,]     0.000     0.195     0.977     0.203     0.000
     [  3,]     0.000     0.058     0.203     0.059     0.000
     [  4,]     0.000     0.000     0.000     0.000     0.000
```