### PR TITLE
Correction of bug 745

### DIFF
--- a/doc/courses/r/03_Graphics.Rmd
+++ b/doc/courses/r/03_Graphics.Rmd
@@ -2,11 +2,13 @@
 title: "Tutorial on Graphics"
 author: "gstlearn Team"
 output:
+  pdf_document:
+    toc: true
   html_document:
     df_print: paged
     toc: true
-  pdf_document:
-    toc: true
+editor_options: 
+  chunk_output_type: console
 ---
 
 <!-- SUMMARY: Use the library gtlearn.plot (based on matplotlib) to visualize all the objects of gstlearn library   -->
@@ -148,6 +150,24 @@ We create two layers containing the Point and the Grid representation. We then u
 p1 = plot.init(asp=1) + plot.raster(mygrid)
 p2 = plot.init(asp=1) + plot.symbol(mypoint)
 ggarrange(p1, p2, labels = c("Plot #1", "Plot #2"), ncol = 2, nrow = 1)
+```
+
+Following the same idea, we now want to display two simulations defined on Grid support (using raster representation type) on the same figure. If we want to keep the same size for the two views (despite the presence of one legend), we need to introduce a specific parameter in the **ggarrange** function, as demonstrated next.
+
+```{r}
+# Performing two simulations on a new grid
+mygrid = DbGrid_create(nx=c(100,150))
+mymodel = Model_createFromParam(ECov_SPHERICAL(), ranges = c(50, 30), angles = c(30, 0))
+simtub(NULL, mygrid, mymodel, nbsimu=2, nbtuba=1000, namconv=NamingConvention("Simu"))
+
+# Representing the two figures on the same pa
+p1 = plot.init(asp=1) + plot.raster(mygrid, name="Simu.1", 
+                                    flagLegend=TRUE, legendName="Colors #1")
+p1 = p1 + plot.decoration(title="Simulation 1", xlab="Easting", ylab="Northing")
+p2 = plot.init(asp=1) + plot.raster(mygrid, name="Simu.2", flagLegend=FALSE)
+p2 = p2 + plot.decoration(title="Simulation 2", xlab="Easting", ylab="")
+p = ggarrange(p1, p2, ncol = 2, nrow = 1, align="hv")
+plot.end(p)
 ```
 
 # Variograms and Models

--- a/r/modules/plot.R
+++ b/r/modules/plot.R
@@ -1082,6 +1082,7 @@ plot.raster <- function(dbgrid, name = NULL, useSel = TRUE, posX=0, posY=1, corn
   # Define the color Scale
   p <- append(p, .defineFill(palette, naColor = naColor, limits = limits, title = legendName))
   p <- .appendNewScale(p, "fill")
+  if (!flagLegend) p <- append(p, guides(fill = "none"))
   
   p
 }

--- a/tests/rmd/output/03_Graphics.out
+++ b/tests/rmd/output/03_Graphics.out
@@ -103,6 +103,7 @@ Column = 3 - Name = x2 - Locator = x2
 Column = 4 - Name = Simu.1 - Locator = z1
 Column = 5 - Name = Simu.2 - Locator = z2
 NULL
+[1] 0
 
 Data Base Grid Characteristics
 ==============================


### PR DESCRIPTION
Fix #745 

This branch check the reason of a strange dimensionning when cobining severalplots in the same figure, while producing a legend.
According to chatGPT, it is simply a matter of the way to call ggarrange() (which arranges the figures in the same plot).

In order to understand the conclusion, the tutorial 03_Graphic.Rmd has been amended with a specific example of this sort.