### PR TITLE
Replace Vector copies with const references

### DIFF
--- a/src/Anamorphosis/CalcAnamTransform.cpp
+++ b/src/Anamorphosis/CalcAnamTransform.cpp
@@ -619,7 +619,7 @@ Id CalcAnamTransform::_conditionalExpectation(Db* db,
 
   /* Analyzing the codes */
 
-  VectorDouble ycuts = anam_hermite->rawToTransformVec(selectivity->getZcut());
+  const auto& ycuts  = anam_hermite->rawToTransformVec(selectivity->getZcut());
   Id need_T          = selectivity->isNeededT();
 
   /* Computing the estimation */
@@ -739,7 +739,7 @@ Id CalcAnamTransform::_uniformConditioning(Db* db,
 
   /* Transform zcuts into gaussian equivalent */
 
-  VectorDouble ycuts = anam->rawToTransformVec(selectivity->getZcut());
+  const auto& ycuts = anam->rawToTransformVec(selectivity->getZcut());
 
   /* Fill the array phi_b_zc */
 

--- a/src/Basic/Law.cpp
+++ b/src/Basic/Law.cpp
@@ -755,7 +755,7 @@ double law_df_quadgaussian(VectorDouble& vect, MatrixSymmetric& correl)
 
   if (correl.computeEigen()) return TEST;
 
-  VectorDouble eigval = correl.getEigenValues();
+  const auto& eigval = correl.getEigenValues();
   for (Id ivar = 0; ivar < nvar; ivar++)
     density -= 0.5 * log(eigval[ivar]);
 
@@ -784,7 +784,7 @@ double law_df_multigaussian(VectorDouble& vect, MatrixSymmetric& correl)
   double density = -0.5 * nvar * log(2 * GV_PI);
 
   if (correl.computeEigen()) return TEST;
-  VectorDouble eigval = correl.getEigenValues();
+  const auto& eigval = correl.getEigenValues();
 
   for (Id i = 0; i < nvar; i++)
     density -= 0.5 * log(eigval[i]);

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -3047,7 +3047,7 @@ static Id st_sampling_krige_data(Db* db,
     tn1.linearCombination(1, &tn1, 1, tn2);
 
     if (tn1.computeEigen()) goto label_end;
-    VectorDouble eigval  = tn1.getEigenValues();
+    const auto& eigval   = tn1.getEigenValues();
     MatrixSquare* eigvec = tn1.getEigenVectors()->clone();
 
     eigvec->prodByDiagInPlace(3, eigval);

--- a/src/Core/model_auto.cpp
+++ b/src/Core/model_auto.cpp
@@ -1385,7 +1385,6 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
 {
   Id allpos;
   double temp, crit, crit_mem, value;
-  VectorDouble valpro;
   const MatrixSquare* vecpro;
 
   /*******************/
@@ -1498,7 +1497,7 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
       /* Computing and sorting the eigen values and eigen vectors */
 
       if (cc.computeEigen()) return 1;
-      valpro = cc.getEigenValues();
+      const auto& valpro = cc.getEigenValues();
       vecpro = cc.getEigenVectors();
 
       Id kvar = 0;
@@ -2410,7 +2409,7 @@ static Id st_truncate_negative_eigen(Id nvar,
   if (cc.computeEigen())
     messageAbort("st_truncate_negative_eigen");
 
-  VectorDouble valpro        = cc.getEigenValues();
+  const auto& valpro         = cc.getEigenValues();
   const MatrixSquare* vecpro = cc.getEigenVectors();
 
   /* Check positiveness */

--- a/src/Core/variopgs.cpp
+++ b/src/Core/variopgs.cpp
@@ -2096,7 +2096,7 @@ static Id invgen(MatrixSymmetric& a, MatrixSymmetric& tabout)
   /* Calculate the eigen vectors */
 
   if (a.computeEigen()) return 1;
-  VectorDouble eigval        = a.getEigenValues();
+  const auto& eigval         = a.getEigenValues();
   const MatrixSquare* eigvec = a.getEigenVectors();
 
   /* Calculate the generalized inverse */

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -510,7 +510,6 @@ double ACov::evalIsoIvarIpas(double step,
                              const CovCalcMode* mode) const
 {
   /// TODO : Not true whatever the space
-  VectorDouble center = getSpace()->getOrigin();
   VectorDouble dir    = getSpace()->getUnitaryVector();
   return evalIvarIpas(step, dir, ivar, jvar, mode);
 }

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -403,7 +403,7 @@ bool CorAniso::isValidForSpectral() const
 MatrixDense CorAniso::simulateSpectralOmega(Id nb) const
 {
   MatrixDense omega   = _corfunc->simulateSpectralOmega(nb);
-  MatrixSquare tensor = getAniso().getTensorInverse();
+  const auto& tensor  = getAniso().getTensorInverse();
   // omega = omega * tensor;
   omega.prodMat(&tensor);
   return omega;
@@ -641,9 +641,9 @@ double CorAniso::getFullCorrec() const
 
 double CorAniso::getDetTensor() const
 {
-  VectorDouble scales = getScales();
+  const auto& scales  = getScales();
   double detTensor    = 1.;
-  for (auto& e: scales)
+  for (const auto e: scales)
   {
     detTensor *= e;
   }

--- a/src/Covariances/CorGneiting.cpp
+++ b/src/Covariances/CorGneiting.cpp
@@ -216,10 +216,10 @@ MatrixDense CorGneiting::simulateSpectralOmega(Id nb) const
     omegaT.setValue(n, 0, val);
   }
   // applying the space anisotropy
-  MatrixSquare tensorS = _corS->getAniso().getTensorInverse();
+  const auto& tensorS = _corS->getAniso().getTensorInverse();
   omegaS.prodMat(&tensorS);
   // applying the time anisotropy
-  MatrixSquare tensorT = _corT->getAniso().getTensorInverse();
+  const auto& tensorT = _corT->getAniso().getTensorInverse();
   omegaT.prodMat(&tensorT);
   MatrixDense omegaST(nb, ndim + 1);
   for (Id icol = 0; icol < ndim; icol++)

--- a/src/Estimation/CalcKrigingFactors.cpp
+++ b/src/Estimation/CalcKrigingFactors.cpp
@@ -113,7 +113,7 @@ bool CalcKrigingFactors::_preprocess()
     if (getKrigopt().hasDiscs())
     {
       // Center the information in sub-blocks when the output grid defines panels
-      VectorInt ndiscs = getKrigopt().getDiscs();
+      const auto& ndiscs = getKrigopt().getDiscs();
       DbGrid* dbsmu    = DbGrid::createDivider(dbgrid, ndiscs, 1);
       _nameCoord       = getDbin()->getNamesByLocator(ELoc::X);
       Id error         = _centerDataToGrid(dbsmu);

--- a/src/Estimation/Likelihood.cpp
+++ b/src/Estimation/Likelihood.cpp
@@ -106,7 +106,7 @@ void Likelihood::evalGrad(vect res)
 {
   _temp.resize(_Yc.size());
   _gradCovMatTimesInvCov.resize(static_cast<Id>(_Yc.size()), static_cast<Id>(_Yc.size()));
-  auto invcov = _covChol.inverse();
+  const auto invcov = _covChol.inverse();
   RankHandler rkh(_db);
   rkh.defineSampleRanks();
   const auto &gradcov = _model->getCovGradients();
@@ -147,17 +147,17 @@ void Likelihood::_fillGradCovMat(RankHandler& rkh, const covmaptype& gradcov)
 
   for (Id jvar = 0; jvar < _model->getNVar(); jvar++)
   {
-    auto indsj = rkh.getSampleRanksByVariable(jvar);
+    const auto& indsj = rkh.getSampleRanksByVariable(jvar);
 
-    for (auto& j: indsj)
+    for (const auto j: indsj)
     {
       icur = 0;
       _db->getSampleAsSPInPlace(p1, j);
 
       for (Id ivar = 0; ivar < _model->getNVar(); ivar++)
       {
-        auto indsi = rkh.getSampleRanksByVariable(ivar);
-        for (auto& i: indsi)
+        const auto& indsi = rkh.getSampleRanksByVariable(ivar);
+        for (const auto i: indsi)
         {
           _db->getSampleAsSPInPlace(p2, i);
 

--- a/src/Estimation/Vecchia.cpp
+++ b/src/Estimation/Vecchia.cpp
@@ -632,7 +632,7 @@ Id krigingVecchia(Db* dbin,
   if (V.computeLower(Ranks, verbose)) return 1;
 
   // Extract sub-part of 'Diagonal' vector
-  VectorDouble DFull = V.getDFull();
+  const auto& DFull  = V.getDFull();
   auto nd            = V.getND();
   auto nt            = V.getNT();
   Id nvar            = model->getNVar();

--- a/src/LinearOp/InvNuggetOp.cpp
+++ b/src/LinearOp/InvNuggetOp.cpp
@@ -126,13 +126,12 @@ static Id _loadPositions(Id iech,
 double InvNuggetOp::_updateQuantities(MatrixSymmetric& sillsinv)
 {
   sillsinv.computeEigen();
-  auto eigenvals        = sillsinv.getEigenValues();
+  const auto& eigenvals = sillsinv.getEigenValues();
   auto rangevals        = std::minmax_element(eigenvals.begin(), eigenvals.end());
   _rangeEigenVal.first  = MIN(_rangeEigenVal.first, *rangevals.first);
   _rangeEigenVal.second = MAX(_rangeEigenVal.second, *rangevals.second);
-  std::transform(eigenvals.begin(), eigenvals.end(), eigenvals.begin(), [](double x)
-                 { return std::log(x); });
-  return std::accumulate(eigenvals.begin(), eigenvals.end(), 0.);
+  return std::accumulate(eigenvals.begin(), eigenvals.end(), 0., [](const double acc, const double x)
+                         { return acc + std::log(x); });
 }
 
 /**

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -542,7 +542,7 @@ VectorDouble PrecisionOp::extractDiag() const
   VectorDouble vec(size, 0.);
   const EPowerPT& power = EPowerPT::ONE;
 
-  VectorDouble lambdas = _shiftOp->getLambdas();
+  const auto& lambdas = _shiftOp->getLambdas();
 
   if (_preparePoly(power) != 0) return vec;
 

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -271,7 +271,7 @@ MatrixSparse* PrecisionOpMatrix::_build_Q()
 {
   // Preliminary checks
   auto* S           = ((ShiftOpMatrix*)getShiftOp())->getS();
-  auto Lambda       = getShiftOp()->getLambdas();
+  const auto& Lambda = getShiftOp()->getLambdas();
   VectorDouble blin = getPoly(EPowerPT::ONE)->getCoeffs();
   Id nblin         = static_cast<Id>(blin.size());
   Id nvertex       = S->getNCols();

--- a/src/Matrix/MatrixSymmetric.cpp
+++ b/src/Matrix/MatrixSymmetric.cpp
@@ -291,7 +291,7 @@ bool MatrixSymmetric::isDefinitePositive()
 
   // Get the Eigen values
 
-  VectorDouble valpro = getEigenValues();
+  const auto& valpro = getEigenValues();
 
   /* Check if the eigen values are all positive */
 
@@ -830,7 +830,7 @@ Id MatrixSymmetric::computeGeneralizedInverse(MatrixSymmetric& tabout,
 
   // Calculate the Eigen vectors
   if (computeEigen() != 0) return 1;
-  VectorDouble eigval        = getEigenValues();
+  const auto& eigval         = getEigenValues();
   const MatrixSquare* eigvec = getEigenVectors();
 
   // Compute the conditioning

--- a/src/Model/AModelFitSills.cpp
+++ b/src/Model/AModelFitSills.cpp
@@ -199,7 +199,7 @@ void AModelFitSills::_allocateInternalArrays(bool flag_exp)
 Id AModelFitSills::_goulardWithConstraints()
 {
   _score                = 0.;
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill  = _constraints->getConstantSills();
 
   /* Core allocation */
   std::vector<MatrixSymmetric> matcor;
@@ -252,7 +252,7 @@ void AModelFitSills::_initializeGoulard()
   MatrixDense Ai(_ncova, _ncova);
   VectorDouble bi(_ncova);
   VectorDouble res(_ncova);
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
 
   /* Initialize the constraints matrices */
 
@@ -337,7 +337,7 @@ Id AModelFitSills::_makeDefinitePositive(Id icov0, double eps)
 {
   VectorDouble muold(_nvar);
   VectorDouble norme1(_nvar);
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
 
   for (Id ivar = 0; ivar < _nvar; ivar++)
     muold[ivar] = _sill[icov0].getValue(ivar, ivar);
@@ -376,7 +376,7 @@ void AModelFitSills::_optimizeUnderConstraints()
 
   VectorDouble xr(_nvar);
   std::vector<MatrixSymmetric> alpha;
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
   alpha.reserve(_ncova);
   for (Id icova = 0; icova < _ncova; icova++)
     alpha.push_back(MatrixSymmetric(_nvar));
@@ -478,7 +478,7 @@ Id AModelFitSills::_truncateNegativeEigen(Id icov0)
 
   if (cc.computeEigen()) messageAbort("st_truncate_negative_eigen");
 
-  VectorDouble valpro        = cc.getEigenValues();
+  const auto& valpro         = cc.getEigenValues();
   const MatrixSquare* vecpro = cc.getEigenVectors();
 
   /* Check positiveness */
@@ -610,7 +610,7 @@ double AModelFitSills::_minimizeP4(Id icov0,
   VectorDouble xt(2);
   VectorDouble xest(2);
   VectorDouble x(3);
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
 
   Id irr = _combineVariables(ivar0, ivar0);
 
@@ -746,7 +746,7 @@ void AModelFitSills::_updateAlphaDiag(Id icov0,
                                       VectorDouble& xr,
                                       std::vector<MatrixSymmetric>& alpha)
 {
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill  = _constraints->getConstantSills();
   double srm            = _sumSills(ivar0, alpha) - alpha[icov0].getValue(ivar0, ivar0);
   double value          = consSill[ivar0] / (xr[ivar0] * xr[ivar0]) - srm;
   alpha[icov0].setValue(ivar0, ivar0, MAX(0., value));
@@ -772,7 +772,7 @@ void AModelFitSills::_updateOtherSills(Id icov0,
 void AModelFitSills::_updateCurrentSillGoulard(Id icov0, Id ivar0)
 {
   VectorDouble mv(_npadir);
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
 
   // Loop on the variables
 
@@ -828,7 +828,7 @@ void AModelFitSills::_updateAlphaNoDiag(Id icov0,
                                         VectorDouble& xr,
                                         std::vector<MatrixSymmetric>& alpha)
 {
-  VectorDouble consSill = _constraints->getConstantSills();
+  const auto& consSill = _constraints->getConstantSills();
   for (Id ivar = 0; ivar < _nvar; ivar++)
   {
     if (ivar == ivar0 && !FFFF(consSill[ivar0])) continue;
@@ -932,7 +932,6 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
 {
   Id allpos;
   double temp, crit, crit_mem, coeff;
-  VectorDouble valpro;
   const MatrixSquare* vecpro;
 
   /*******************/
@@ -1033,7 +1032,7 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
       /* Computing and sorting the eigen values and eigen vectors */
 
       if (cc.computeEigen()) return 1;
-      valpro = cc.getEigenValues();
+      const auto& valpro = cc.getEigenValues();
       vecpro = cc.getEigenVectors();
 
       Id kvar = 0;

--- a/src/Neigh/NeighMoving.cpp
+++ b/src/Neigh/NeighMoving.cpp
@@ -304,7 +304,7 @@ bool NeighMoving::_getAnisotropyElements(double* rx, double* ry, double* theta, 
 {
   double radius = _getRadius();
   if (FFFF(radius)) return false;
-  VectorDouble anisoRatio = getAnisoCoeffs();
+  const auto& anisoRatio  = getAnisoCoeffs();
   Id ndim                 = static_cast<Id>(anisoRatio.size());
   if (ndim != 2) return false;
   *rx = radius * anisoRatio[0];

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -883,7 +883,7 @@ double CalcSimuTurningBands::_irfProcessInit(Id ibs,
   if (type == ECov::ORDER3_GC) level = 1;
   if (type == ECov::ORDER5_GC) level = 2;
   auto nt        = operTB.getTsize();
-  VectorDouble t = operTB.getT();
+  const auto& t  = operTB.getT();
 
   /* Generation of the Wiener-Levy process and its integrations */
 
@@ -950,7 +950,7 @@ VectorDouble CalcSimuTurningBands::_createAIC()
     // Calculate the Eigen decomposition
 
     if (mat.computeEigen()) return VectorDouble();
-    VectorDouble valpro        = mat.getEigenValues();
+    const auto& valpro         = mat.getEigenValues();
     const MatrixSquare* vecpro = mat.getEigenVectors();
 
     /* Calculate the factor matrix */

--- a/src/Spatial/SpatialIndices.cpp
+++ b/src/Spatial/SpatialIndices.cpp
@@ -274,8 +274,8 @@ double SpatialIndices::getGIC(const String& name1, const String& name2)
   double inertia1      = getInertia();
   if (computeCGI(name2) != 0)
     return TEST;
-  VectorDouble center2 = getCenter();
-  double inertia2      = getInertia();
+  const auto& center2 = getCenter();
+  double inertia2     = getInertia();
 
   double dx  = center1[0] - center2[0];
   double dy  = center1[1] - center2[1];

--- a/src/Stats/Classical.cpp
+++ b/src/Stats/Classical.cpp
@@ -1327,7 +1327,7 @@ MatrixSquare* sphering(const AMatrix* X)
 
   prodsym->prodScalar(1. / static_cast<double>(nech));
   if (prodsym->computeEigen()) return nullptr;
-  VectorDouble eigen_values = prodsym->getEigenValues();
+  const auto& eigen_values  = prodsym->getEigenValues();
   MatrixSquare* S           = prodsym->getEigenVectors()->clone();
 
   // Invert the sign of the second Eigen vector (for compatibility with R output)

--- a/src/Stats/Selectivity.cpp
+++ b/src/Stats/Selectivity.cpp
@@ -1056,7 +1056,7 @@ void Selectivity::interpolateSelectivity(const Selectivity* selecin)
   VectorDouble zz(nclass + 2);
   VectorDouble TT(nclass + 2);
   VectorDouble QQ(nclass + 2);
-  VectorDouble zcuts = getZcut();
+  const auto& zcuts = getZcut();
 
   /* Load arrays */
 

--- a/tests/cpp/test_Matrix.cpp
+++ b/tests/cpp/test_Matrix.cpp
@@ -613,13 +613,13 @@ int main(int argc, char* argv[])
 
   // Extract the Eigen values and vectors (both matrix types)
   (void)MEig->computeEigen();
-  VectorDouble eigVal = MEig->getEigenValues();
+  const auto& eigVal = MEig->getEigenValues();
   VH::dump("Eigen Values (Eigen Library)", eigVal);
   const MatrixSquare* eigVec = MEig->getEigenVectors();
   eigVec->display();
 
   (void)MNoEig->computeEigen();
-  VectorDouble eigNoVal = MNoEig->getEigenValues();
+  const auto& eigNoVal = MNoEig->getEigenValues();
   VH::dump("Eigen Values (no Eigen Library)", eigNoVal);
   const MatrixSquare* eigNoVec = MNoEig->getEigenVectors();
   eigNoVec->display();
@@ -745,7 +745,7 @@ int main(int argc, char* argv[])
 
   // Extract the Generalized Eigen values and vectors (both matrix types)
   (void)MEig->computeGeneralizedEigen(*BEig);
-  VectorDouble genEigVal        = MEig->getEigenValues();
+  const auto& genEigVal         = MEig->getEigenValues();
   const MatrixSquare* genEigVec = MEig->getEigenVectors();
   VH::dump("Generalized Eigen Values (Eigen Library)", genEigVal);
   genEigVec->display();
@@ -758,7 +758,7 @@ int main(int argc, char* argv[])
   delete MRNoEigt;
 
   (void)MNoEig->computeGeneralizedEigen(*BNoEig);
-  VectorDouble genEigNoVal        = MNoEig->getEigenValues();
+  const auto& genEigNoVal         = MNoEig->getEigenValues();
   const MatrixSquare* genEigNoVec = MNoEig->getEigenVectors();
   VH::dump("Generalized Eigen Values (no Eigen Library)", genEigNoVal);
   genEigNoVec->display();


### PR DESCRIPTION
This PR replaces a few `VectorDouble` copies from methods returning references into full `const` references.

This should reduce the number of unwanted copies.

Pierre