### PR TITLE
Fix all calls to getAnisoAngles function

### DIFF
--- a/include/Covariances/CorAniso.hpp
+++ b/include/Covariances/CorAniso.hpp
@@ -172,7 +172,7 @@ public:
   const MatrixSquare& getAnisoRotMat() const { return _aniso.getMatrixDirect(); }
   const MatrixSquare& getAnisoInvMat() const { return _aniso.getMatrixInverse(); }
   VectorDouble getAnisoCoeffs() const;
-  double getAnisoAngles(Id idim) const { return getAnisoAngles()[idim]; }
+  double getAnisoAngle(Id idim) const { return getAnisoAngles()[idim]; }
   double getAnisoRotMat(Id idim, Id jdim) const { return _aniso.getMatrixDirect().getValue(idim, jdim); }
   double getAnisoCoeff(Id idim) const { return getAnisoCoeffs()[idim]; }
   const ECov& getType() const { return _corfunc->getType(); }

--- a/python/modules/gstmarimo.py
+++ b/python/modules/gstmarimo.py
@@ -67,7 +67,7 @@ def WdefineCovariance(ic = 0, ncovmax = 1, distmax = 100, varmax = 100, defmodel
         distRef   = defmodel.getRange(ic)
         varRef    = defmodel.getSill(ic,0,0)
         distAux   = defmodel.getRanges(ic)[1]
-        angRef    = defmodel.getCovAniso(ic).getAnisoAngles(1)
+        angRef    = defmodel.getCovAniso(ic).getAnisoAngle(1)
         flagAniso = defmodel.getCovAniso(ic).getFlagAniso()
 
     WUsed   = mo.ui.switch(True, label="Basic Structure Used")

--- a/python/modules/widgets.py
+++ b/python/modules/widgets.py
@@ -100,7 +100,7 @@ class WModel(ipw.VBox):
         rangeX = cova.getRange(0)
         rangeY = cova.getRange(1)
         param  = cova.getParam()
-        angle  = cova.getAnisoAngles()[0]
+        angle  = cova.getAnisoAngle(0)
         sill   = cova.getSill(0,0)
         self.value = "{},{},{},{},{},{}".format(type, rangeX, rangeY, param, angle, sill)
         

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -1322,7 +1322,7 @@ double CorAniso::getValue(const EConsElem& econs, Id iv1, Id iv2) const
   if (econs == EConsElem::SCALE)
     return getScale(iv1);
   if (econs == EConsElem::ANGLE)
-    return getAnisoAngles()[iv1];
+    return getAnisoAngle(iv1);
   if (econs == EConsElem::PARAM)
     return getParam();
   return TEST;


### PR DESCRIPTION
The calls to getAnisoAngles were not totally fixed (no more argument in the function).
This has been fixed in marimo and widgets python features.