### PR TITLE
Suppress std::vector calls

### DIFF
--- a/include/API/newAPIs.hpp
+++ b/include/API/newAPIs.hpp
@@ -11,18 +11,19 @@
 #pragma once
 
 #include "Basic/VectorT.hpp"
+#include "Db/Db.hpp"
 #include "Model/GaussianProcess.hpp"
 #include "gstlearn_export.hpp"
-#include "Db/Db.hpp"
 #include "vector"
 
-namespace gstlrn {
+namespace gstlrn
+{
 
 class GaussianProcess;
 class Db;
 class ECov;
 
-using DataFrame = std::map<std::string, std::vector<double>>;
+using DataFrame = std::map<std::string, VectorDouble>;
 
 GSTLEARN_EXPORT Db* createDbFromDataFrame(const DataFrame* dat,
                                           const VectorString& coordinates);
@@ -31,4 +32,4 @@ GSTLEARN_EXPORT GaussianProcess* createModelFromData(const Db* dat,
                                                      const VectorString& variables,
                                                      const std::vector<ECov>& structs,
                                                      bool addMeasurementError = false);
-}
+} // namespace gstlrn

--- a/include/Basic/Grid.hpp
+++ b/include/Basic/Grid.hpp
@@ -162,7 +162,7 @@ public:
 
   void iteratorInit(const VectorInt& order = VectorInt());
   VectorInt iteratorNext(void);
-  void iteratorNext(std::vector<Id>& indices);
+  void iteratorNext(VectorInt& indices);
   bool empty() const;
 
   void dilate(Id mode,
@@ -210,7 +210,7 @@ private:
 
   Id _iter;
   Id _nprod;
-  std::vector<Id> _counts;
+  VectorInt _counts;
   VectorInt _order;
   VectorInt _indices;
   mutable VectorInt _dummy;

--- a/include/Basic/ListParams.hpp
+++ b/include/Basic/ListParams.hpp
@@ -3,12 +3,13 @@
 #include "geoslib_define.h"
 #include "gstlearn_export.hpp"
 
-#include "Basic/AStringable.hpp"
 #include "Basic/AStringFormat.hpp"
+#include "Basic/AStringable.hpp"
 #include "Basic/ParamInfo.hpp"
+#include "Basic/VectorNumT.hpp"
 #include <cstddef>
-#include <vector>
 #include <functional>
+#include <vector>
 
 namespace gstlrn
 {
@@ -27,10 +28,10 @@ public:
   void clear();
   double getValue(Id index) const;
   void setValue(Id index, double value);
-  std::vector<double> getOptimizableValues() const;
-  void setValues(const std::vector<double>& values);
-  std::vector<double> getMinValues(double epsilon = 0.) const;
-  std::vector<double> getMaxValues(double epsilon = 0.) const;
+  VectorDouble getOptimizableValues() const;
+  void setValues(const VectorDouble& values);
+  VectorDouble getMinValues(double epsilon = 0.) const;
+  VectorDouble getMaxValues(double epsilon = 0.) const;
   void makeDispatchIndexFromDispatch();
   double getOptimizableValue(size_t index) const;
 
@@ -39,16 +40,16 @@ public:
   void updateDispatch();
   std::vector<size_t> getDispatch() const { return _dispatch; }
   std::vector<size_t> getDispatchIndex() const { return _dispatchIndex; }
+
 private:
-  
   // Example: The model has 6 parameters, but only 4 are used in the optimization.
   // [0, 1, 2, 3, 4, 5] with 1 = 3 and 4 = 5
   // _params will contain references to all 6 parameters (0, 1, 2, 3, 4, 5),
   // but the optimizable parameters will be [0, 1, 2, 4]
   // _dispatch = {0, 1, 2, 1, 3, 3} says how to get the value inside the vector of optimizable parameters
-  // _dispatchIndex = {0, 1, 2, 4} 
+  // _dispatchIndex = {0, 1, 2, 4}
   std::vector<std::reference_wrapper<ParamInfo>> _params; // List of parameters
   std::vector<size_t> _dispatch;
   std::vector<size_t> _dispatchIndex; // Indexes for dispatching parameters
 };
-}
+} // namespace gstlrn

--- a/include/Basic/Optim.hpp
+++ b/include/Basic/Optim.hpp
@@ -10,6 +10,7 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/VectorNumT.hpp"
 #include "geoslib_define.h"
 #include "gstlearn_export.hpp"
 #include <functional>
@@ -112,7 +113,7 @@ public:
   Optim& operator=(const Optim&) = delete;
   ~Optim();
 
-  void setObjective(std::function<double(const std::vector<double>&)> objective);
+  void setObjective(std::function<double(const VectorDouble&)> objective);
   void setGradient(std::function<void(vect)> gradient,
                    const std::vector<size_t>& dispatch      = {},
                    const std::vector<size_t>& dispatchIndex = {});
@@ -124,23 +125,23 @@ public:
   {
     return _authorizedAnalyticalGradients;
   }
-  void setGradientComponents(const std::vector<std::function<double(const std::vector<double>&)>>& partials);
+  void setGradientComponents(const std::vector<std::function<double(const VectorDouble&)>>& partials);
   void evalGrad(vect res);
   void setXtolRel(double tol);
-  void setLowerBounds(const std::vector<double>& lb,
+  void setLowerBounds(const VectorDouble& lb,
                       const std::vector<size_t>& dispatch = {});
-  void setUpperBounds(const std::vector<double>& ub,
+  void setUpperBounds(const VectorDouble& ub,
                       const std::vector<size_t>& dispatch = {});
-  double minimize(std::vector<double>& x);
+  double minimize(VectorDouble& x);
 
 private:
   static double callback(unsigned n, const double* x, double* grad, void* f_data);
 
   nlopt_opt_s* _opt;
-  std::shared_ptr<std::function<double(const std::vector<double>&)>> _objective;
+  std::shared_ptr<std::function<double(const VectorDouble&)>> _objective;
   std::shared_ptr<std::function<void(vect)>> _gradient;
-  std::vector<std::function<double(const std::vector<double>&)>> _gradientPartials;
-  mutable std::vector<double> _gradBuffer; // Buffer for gradient evaluation
+  std::vector<std::function<double(const VectorDouble&)>> _gradientPartials;
+  mutable VectorDouble _gradBuffer; // Buffer for gradient evaluation
   bool _authorizedAnalyticalGradients;
 };
 } // namespace gstlrn

--- a/include/Basic/VectorHelper.hpp
+++ b/include/Basic/VectorHelper.hpp
@@ -13,7 +13,6 @@
 #include "Basic/VectorNumT.hpp"
 #include "geoslib_define.h"
 #include "gstlearn_export.hpp"
-#include <vector>
 
 namespace gstlrn
 {
@@ -41,8 +40,6 @@ public:
   static void dumpRange(const String& title, const VectorInt& vect);
   static void dumpNNZ(const String& title, const VectorDouble& vect, Id nclass = 10);
 
-  static double maximum(const std::vector<std::vector<double>>& vec, bool flagAbs = false);
-  static double maximum(const VectorDouble& vec, bool flagAbs = false); // Kept for std::vector<std::vector<double>>
   static void capInPlace(VectorDouble& vec, double vmin = TEST, double vmax = TEST);
   static void capInPlaceVVD(VectorVectorDouble& vec, double vmin = TEST, double vmax = TEST);
   static double extensionDiagonal(const VectorDouble& mini, const VectorDouble& maxi);
@@ -83,26 +80,16 @@ public:
 
   static void addInPlace(constvect in, vect dest);
 #endif
-  static void addInPlace(std::vector<double>& dest, const std::vector<double>& src);
   static void addInPlace(const double* veca,
                          const double* vecb,
                          double* res,
                          Id size);
-  static void addInPlace(const std::vector<std::vector<double>>& in1,
-                         const std::vector<std::vector<double>>& in2,
-                         std::vector<std::vector<double>>& outv);
-
   static void addSquareInPlace(VectorDouble& dest, const VectorDouble& src);
 
 #ifndef SWIG
   static VectorDouble subtract(constvect veca, constvect vecb);
   static void subtractInPlace(const constvect in1, const constvect in2, vect outv);
 #endif
-  static void subtractInPlace(const std::vector<std::vector<double>>& in1,
-                              const std::vector<std::vector<double>>& in2,
-                              std::vector<std::vector<double>>& outv);
-
-  static void divideInPlace(std::vector<double>& vec, const std::vector<double>& v);
   static void multiplyComplexInPlace(const VectorDouble& vecaRe,
                                      const VectorDouble& vecaIm,
                                      const VectorDouble& vecbRe,
@@ -110,7 +97,6 @@ public:
                                      VectorDouble& resRe,
                                      VectorDouble& resIm);
 
-  static void multiplyConstantSelfInPlace(VectorDouble& vec, double v);
   static void addMultiplyConstantInPlace(double val1,
                                          const VectorDouble& in1,
                                          VectorDouble& outv,
@@ -121,7 +107,6 @@ public:
   static void copy(const VectorDouble& vecin, VectorDouble& vecout, Id size = -1);
   static void copy(const VectorInt& vecin, VectorInt& vecout, Id size = -1);
   static void copy(const VectorVectorDouble& inv, VectorVectorDouble& outv);
-  static void copy(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv);
 
   static void mean1AndMean2ToStdev(const VectorDouble& mean1,
                                    const VectorDouble& mean2,
@@ -146,7 +131,6 @@ public:
 #endif
   // Next line is kept only fr VVD compatibility
   static double innerProduct(const double* veca, const double* vecb, Id size = -1);
-  static double innerProductVec(const std::vector<double>& veca, const std::vector<double>& vecb, Id size = -1);
 
   static VectorDouble crossProduct3D(const VectorDouble& veca, const VectorDouble& vecb);
   static void crossProduct3DInPlace(const double* a, const double* b, double* v);
@@ -210,13 +194,10 @@ public:
   static VectorInt complement(const VectorInt& vec, const VectorInt& sel);
 
   static std::pair<double, double> rangeVals(const VectorDouble& vec);
-  static void unflattenInPlace(const std::vector<double>& vd, std::vector<std::vector<double>>& vvd);
-  static void flattenInPlace(const std::vector<std::vector<double>>& vvd, std::vector<double>& vd);
+  static void unflattenInPlace(const VectorDouble& vd, VectorVectorDouble& vvd);
+  static void flattenInPlace(const VectorVectorDouble& vvd, VectorDouble& vd);
   static VectorDouble flatten(const VectorVectorDouble& vvd);
   static VectorVectorDouble unflatten(const VectorDouble& vd, const VectorInt& sizes);
-  static std::vector<double> flatten(const std::vector<std::vector<double>>& vvd);
-  static std::vector<std::vector<double>> unflatten(const std::vector<double>& vd, const VectorInt& sizes);
-  static void flattenInPlace(const VectorVectorDouble& vvd, VectorDouble& vd);
   static void linearCombinationInPlace(double val1,
                                        const VectorDouble& vd1,
                                        double val2,
@@ -227,13 +208,6 @@ public:
                                           double val2,
                                           const VectorVectorDouble& vvd2,
                                           VectorVectorDouble& outv);
-  static double innerProductVVec(const std::vector<std::vector<double>>& x,
-                                 const std::vector<std::vector<double>>& y);
-  static void linearCombinationVVDInPlace(double val1,
-                                          const std::vector<std::vector<double>>& vvd1,
-                                          double val2,
-                                          const std::vector<std::vector<double>>& vvd2,
-                                          std::vector<std::vector<double>>& outv);
 
   static VectorDouble suppressTest(const VectorDouble& vecin);
   static void extractInPlace(const VectorDouble& vecin, VectorDouble& vecout, Id start);
@@ -258,7 +232,6 @@ public:
   static Id whereMaximum(const VectorDouble& tab);
   static Id whereElement(const VectorInt& tab, Id target);
   static Id whereElement(const VectorInt& tab, Id target, Id start);
-  static double norm(const std::vector<double>& vec);
   static bool isIsotropic(const VectorVectorInt& sampleRanks);
 
   static VectorDouble reduceOne(const VectorDouble& vecin, Id index);
@@ -266,9 +239,6 @@ public:
   static VectorDouble compress(const VectorDouble& vecin, const VectorInt& vindex);
   static void truncateDecimalsInPlace(VectorDouble& vec, Id ndec);
   static void truncateDigitsInPlace(VectorDouble& vec, Id ndec);
-  static void simulateGaussianInPlace(std::vector<double>& vec,
-                                      double mean  = 0.,
-                                      double sigma = 1.);
 };
 
 // typedef VectorHelper VH;

--- a/include/Basic/VectorNumT.hpp
+++ b/include/Basic/VectorNumT.hpp
@@ -205,7 +205,7 @@ public:
   /** @addtogroup Operate_4
    * \ingroup VectorNumT
    *
-   * Action: 'this' = 'this' %op% 'val'
+   * Action: 'this' = 'this' %op% 'value'
    *  @{
    */
   // Prototype dans la classe

--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -88,11 +88,11 @@ public:
   virtual bool isValidForSpectral() const;
   virtual MatrixDense simulateSpectralOmega(Id ns) const;
 
-  std::vector<double> evalCovGrad(const SpacePoint& p1,
-                                  const SpacePoint& p2,
-                                  Id ivar                 = 0,
-                                  Id jvar                 = 0,
-                                  const CovCalcMode* mode = nullptr);
+  VectorDouble evalCovGrad(const SpacePoint& p1,
+                           const SpacePoint& p2,
+                           Id ivar                 = 0,
+                           Id jvar                 = 0,
+                           const CovCalcMode* mode = nullptr);
   virtual double evalCovOnSphere(double alpha,
                                  Id degree               = 50,
                                  bool flagScaleDistance  = false,

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -238,7 +238,7 @@ public:
 
   /**@}*/
 
-  const std::vector<double>& getArrays() const { return _array; }
+  const VectorDouble& getArrays() const { return _array; }
 
   /** @addtogroup DB_Names Manipulating Names of the variables contained in a Db
    * \ingroup DB
@@ -489,7 +489,7 @@ public:
   void updArrayVec(const VectorInt& iechs, Id iuid, const EOperator& oper, VectorDouble& values);
   VectorDouble getArrayByUID(Id iuid, bool useSel = false) const;
   void setArrayByUID(const VectorDouble& tab, Id iuid);
-  void getArrayBySample(std::vector<double>& vals, Id iech) const;
+  void getArrayBySample(VectorDouble& vals, Id iech) const;
   void setArrayBySample(Id iech, const VectorDouble& vec);
 
   void getSamplesAsSP(std::vector<SpacePoint>& pvec,
@@ -981,7 +981,7 @@ protected:
 
 private:
   Id _getNextLocator(const ELoc& locatorType) const;
-  const std::vector<Id>& _getUIDcol() const { return _uidcol; }
+  const VectorInt& _getUIDcol() const { return _uidcol; }
   VectorString _getNames() const { return _colNames; }
   Id _getUIDcol(Id iuid) const;
   Id _getAddress(Id iech, Id icol) const;
@@ -1031,12 +1031,12 @@ protected:
   void _loadValues(const Db* db, const VectorString& names, const VectorInt& ranks, Id shift = 0);
 
 private:
-  Id _ncol;                   //!< Number of Columns of data
-  Id _nech;                   //!< Number of samples
-  std::vector<double> _array; //!< Array of values
-  std::vector<Id> _uidcol;    //!< UID to Column
-  VectorString _colNames;     //!< Names of the variables
-  std::vector<PtrGeos> _p;    //!< Locator characteristics
+  Id _ncol;                //!< Number of Columns of data
+  Id _nech;                //!< Number of samples
+  VectorDouble _array;     //!< Array of values
+  VectorInt _uidcol;       //!< UID to Column
+  VectorString _colNames;  //!< Names of the variables
+  std::vector<PtrGeos> _p; //!< Locator characteristics
 
   /// factor allocations
   mutable VectorInt _uids;

--- a/include/Estimation/AModelOptim.hpp
+++ b/include/Estimation/AModelOptim.hpp
@@ -27,10 +27,9 @@ class GSTLEARN_EXPORT AModelOptim
 public:
   AModelOptim(ModelGeneric* model = nullptr,
               bool verbose        = false);
-  #ifndef SWIG
-  void setEnvironment(const MatrixSymmetric& vars, double href, double epsilon = EPSILON6,
-                      double min = 0., double max = INF);
-  #endif
+#ifndef SWIG
+  void setEnvironment(const MatrixSymmetric& vars, double href, double epsilon = EPSILON6, double min = 0., double max = INF);
+#endif
   AModelOptim& operator=(const AModelOptim& r);
 
   void setAuthorizedAnalyticalGradients(bool authorized);
@@ -39,11 +38,11 @@ public:
 
   virtual ~AModelOptim();
 
-  void setGradients(std::vector<std::function<double(const std::vector<double>&)>>& gradients);
+  void setGradients(std::vector<std::function<double(const VectorDouble&)>>& gradients);
 
   void setVerbose(bool verbose = false, bool trace = false);
 
-  double eval(const std::vector<double>& x);
+  double eval(const VectorDouble& x);
 
   virtual void evalGrad(vect res);
   double run();
@@ -55,7 +54,7 @@ public:
   void evalGradInEffectiveDimension(vect res);
 
 private:
-  void _printSummary(double minf, const std::vector<double>& x) const;
+  void _printSummary(double minf, const VectorDouble& x) const;
 
 protected:
   ModelGeneric* _model; // Pointer to the model being optimized
@@ -65,7 +64,7 @@ private:
   Optim* _opt;
   bool _verbose;
   bool _trace;
-  std::vector<double> _x;
+  VectorDouble _x;
   Id _iter;
 };
 } // namespace gstlrn

--- a/include/LinearOp/ALinearOpMulti.hpp
+++ b/include/LinearOp/ALinearOpMulti.hpp
@@ -10,24 +10,25 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/VectorNumT.hpp"
 #include "LinearOp/LogStats.hpp"
-#include <vector>
 #include "geoslib_define.h"
 
 namespace gstlrn
 {
-  class LogStats;
+class LogStats;
 
-class GSTLEARN_EXPORT ALinearOpMulti {
+class GSTLEARN_EXPORT ALinearOpMulti
+{
 
 public:
   ALinearOpMulti(Id nitermax = 1000, double eps = EPSILON8);
-  ALinearOpMulti(const ALinearOpMulti &m);
-  ALinearOpMulti& operator=(const ALinearOpMulti &m);
+  ALinearOpMulti(const ALinearOpMulti& m);
+  ALinearOpMulti& operator=(const ALinearOpMulti& m);
   virtual ~ALinearOpMulti();
 
-  void initLk(const std::vector<std::vector<double>> &inv, std::vector<std::vector<double>> &outv) const;
-  virtual Id sizes() const = 0;
+  void initLk(const VectorVectorDouble& inv, VectorVectorDouble& outv) const;
+  virtual Id sizes() const  = 0;
   virtual Id size(Id) const = 0;
 
   void setNIterMax(Id nitermax) { _nIterMax = nitermax; }
@@ -44,38 +45,38 @@ public:
 #ifndef SWIG
 
 protected:
-  virtual void _evalDirect(const std::vector<std::vector<double>>& inv,
-                           std::vector<std::vector<double>>& outv) const = 0;
+  virtual void _evalDirect(const VectorVectorDouble& inv,
+                           VectorVectorDouble& outv) const = 0;
 
 public:
-  void evalDirect(const std::vector<std::vector<double>>& inv,
-                  std::vector<std::vector<double>>& outv) const;
-  virtual void evalInverse(const std::vector<std::vector<double>>& vecin,
-                           std::vector<std::vector<double>>& vecout) const;
+  void evalDirect(const VectorVectorDouble& inv,
+                  VectorVectorDouble& outv) const;
+  virtual void evalInverse(const VectorVectorDouble& vecin,
+                           VectorVectorDouble& vecout) const;
 #endif
 
 protected:
   void _updated() const;
 
 private:
-  Id                       _nIterMax;
-  Id                       _nIterRestart;
-  double                    _eps;
-  bool                      _precondStatus;
-  bool                      _userInitialValue;
-  const ALinearOpMulti*     _precond;
+  Id _nIterMax;
+  Id _nIterRestart;
+  double _eps;
+  bool _precondStatus;
+  bool _userInitialValue;
+  const ALinearOpMulti* _precond;
 
   // Work arrays
-  mutable bool                         _initialized;
-  mutable std::vector<std::vector<double>> _r;
+  mutable bool _initialized;
+  mutable VectorVectorDouble _r;
 
 public:
-  mutable std::vector<std::vector<double>> _temp;
-  mutable std::vector<std::vector<double>> _p;
-  mutable std::vector<std::vector<double>> _z;
+  mutable VectorVectorDouble _temp;
+  mutable VectorVectorDouble _p;
+  mutable VectorVectorDouble _z;
   mutable double _nb;
 
 protected:
-  LogStats                   _logStats;
+  LogStats _logStats;
 };
-}
+} // namespace gstlrn

--- a/include/LinearOp/HessianOp.hpp
+++ b/include/LinearOp/HessianOp.hpp
@@ -69,14 +69,14 @@ private:
   PrecisionOp* _pMat;          // External pointer
   const ProjMatrix* _projData; // External pointer
   const ProjMatrix* _projSeis; // External pointer
-  std::vector<double> _indic;
-  std::vector<double> _propSeis;
-  std::vector<double> _varSeis;
-  std::vector<double> _lambda;
-  mutable std::vector<double> _workp;
-  mutable std::vector<double> _workx;
-  mutable std::vector<double> _workv;
-  mutable std::vector<double> _works;
+  VectorDouble _indic;
+  VectorDouble _propSeis;
+  VectorDouble _varSeis;
+  VectorDouble _lambda;
+  mutable VectorDouble _workp;
+  mutable VectorDouble _workx;
+  mutable VectorDouble _workv;
+  mutable VectorDouble _works;
 #endif
 };
 

--- a/include/LinearOp/PrecisionOp.hpp
+++ b/include/LinearOp/PrecisionOp.hpp
@@ -46,9 +46,9 @@ public:
   // Interface functions for using PrecisionOp
 
 #ifndef SWIG
-  virtual void evalInverse(const constvect vecin, std::vector<double>& vecout);
+  virtual void evalInverse(const constvect vecin, VectorDouble& vecout);
 #endif
-  std::vector<double> evalInverse(const VectorDouble& vecin);
+  VectorDouble evalInverse(const VectorDouble& vecin);
   virtual std::pair<double, double> getRangeEigenVal(Id ndiscr = 100);
 
   static PrecisionOp* createFromShiftOp(AShiftOp* shiftop    = nullptr,
@@ -147,12 +147,12 @@ private:
 #ifndef SWIG
 
 protected:
-  mutable std::vector<double> _work;
-  mutable std::vector<double> _work2;
-  mutable std::vector<double> _work3;
-  mutable std::vector<double> _work4;
-  mutable std::vector<double> _work5;
-  mutable std::vector<std::vector<double>> _workPoly;
+  mutable VectorDouble _work;
+  mutable VectorDouble _work2;
+  mutable VectorDouble _work3;
+  mutable VectorDouble _work4;
+  mutable VectorDouble _work5;
+  mutable VectorVectorDouble _workPoly;
 #endif
 };
 } // namespace gstlrn

--- a/include/LinearOp/PrecisionOpMatrix.hpp
+++ b/include/LinearOp/PrecisionOpMatrix.hpp
@@ -13,7 +13,6 @@
 #include "LinearOp/CholeskySparse.hpp"
 #include "LinearOp/PrecisionOp.hpp"
 
-
 namespace gstlrn
 {
 class AMesh;
@@ -22,22 +21,22 @@ class Model;
 class ShiftOpMatrix;
 
 /** This class is just a specialization of PrecisionOp when the shift
-* Operator is built with sparse matrices and therefore algebra can be performed with Cholesky.
-* It allows to return the precision matrix as a Sparse Matrix. */
-class GSTLEARN_EXPORT PrecisionOpMatrix : public PrecisionOp
+ * Operator is built with sparse matrices and therefore algebra can be performed with Cholesky.
+ * It allows to return the precision matrix as a Sparse Matrix. */
+class GSTLEARN_EXPORT PrecisionOpMatrix: public PrecisionOp
 {
 public:
   PrecisionOpMatrix(ShiftOpMatrix* shiftop = nullptr,
-                const CovAniso* cova = nullptr,
-                bool verbose = false);
+                    const CovAniso* cova   = nullptr,
+                    bool verbose           = false);
   PrecisionOpMatrix(const AMesh* mesh,
-                CovAniso* cova,
-                bool verbose = false);
+                    CovAniso* cova,
+                    bool verbose = false);
   virtual ~PrecisionOpMatrix();
 
   // Interface for PrecisionOp class
 #ifndef SWIG
-  void evalInverse(const constvect vecin, std::vector<double>& vecout) override;
+  void evalInverse(const constvect vecin, VectorDouble& vecout) override;
   Id _addSimulateToDest(const constvect whitenoise, vect outv) const override;
   Id _addToDest(const constvect inv, vect outv) const override;
 #endif
@@ -45,7 +44,7 @@ public:
   double computeLogDet(Id nMC = 1) const override;
   VectorDouble extractDiag() const override;
 
-  //void evalDerivPoly(const VectorDouble& inv, VectorDouble& outv,Id iapex,Id igparam) override;
+  // void evalDerivPoly(const VectorDouble& inv, VectorDouble& outv,Id iapex,Id igparam) override;
 #ifndef SWIG
   void evalDeriv(const constvect inv,
                  vect outv,
@@ -77,4 +76,4 @@ private:
   mutable CholeskySparse* _chol;
 };
 
-}
+} // namespace gstlrn

--- a/include/LinearOp/PrecisionOpMultiConditional.hpp
+++ b/include/LinearOp/PrecisionOpMultiConditional.hpp
@@ -67,17 +67,17 @@ protected:
 #ifndef SWIG
 
 private:
-  void _AtA(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv) const;
-  void _evalDirect(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv) const override;
+  void _AtA(const VectorVectorDouble& inv, VectorVectorDouble& outv) const;
+  void _evalDirect(const VectorVectorDouble& inv, VectorVectorDouble& outv) const override;
 
 public:
-  std::vector<std::vector<double>> computeRhs(const std::vector<double>& datVal) const;
-  void computeRhsInPlace(const std::vector<double>& datVal, std::vector<std::vector<double>>& rhs) const;
-  void simulateOnMeshings(std::vector<std::vector<double>>& result) const;
-  void simulateOnMeshing(std::vector<double>& result, Id icov = 0) const;
-  void simulateOnDataPointFromMeshings(const std::vector<std::vector<double>>& simus, std::vector<double>& result) const;
-  void evalInvCov(const constvect inv, std::vector<double>& result) const;
-  double computeQuadratic(const std::vector<double>& x) const;
+  VectorVectorDouble computeRhs(const VectorDouble& datVal) const;
+  void computeRhsInPlace(const VectorDouble& datVal, VectorVectorDouble& rhs) const;
+  void simulateOnMeshings(VectorVectorDouble& result) const;
+  void simulateOnMeshing(VectorDouble& result, Id icov = 0) const;
+  void simulateOnDataPointFromMeshings(const VectorVectorDouble& simus, VectorDouble& result) const;
+  void evalInvCov(const constvect inv, VectorDouble& result) const;
+  double computeQuadratic(const VectorDouble& x) const;
 
 #endif
 
@@ -87,11 +87,11 @@ private:
   VectorDouble _varianceData;                          // Dimension: _ndat
   Id _ndat;
   Id _ncova;
-  mutable std::vector<double> _work1;
-  mutable std::vector<double> _work1bis;
-  mutable std::vector<double> _work1ter;
-  mutable std::vector<double> _workdata;
-  mutable std::vector<std::vector<double>> _work2;
-  mutable std::vector<std::vector<double>> _work3;
+  mutable VectorDouble _work1;
+  mutable VectorDouble _work1bis;
+  mutable VectorDouble _work1ter;
+  mutable VectorDouble _workdata;
+  mutable VectorVectorDouble _work2;
+  mutable VectorVectorDouble _work3;
 };
 } // namespace gstlrn

--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -10,22 +10,23 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
 #include "LinearOp/IProj.hpp"
+#include "gstlearn_export.hpp"
 
 #include <memory>
 
 namespace gstlrn
 {
-class GSTLEARN_EXPORT ProjComposition : public IProj
+class GSTLEARN_EXPORT ProjComposition: public IProj
 {
 public:
   ProjComposition(std::vector<const IProj*> projs);
-  ProjComposition(const ProjComposition&) = delete;
+  ProjComposition(const ProjComposition&)            = delete;
   ProjComposition& operator=(const ProjComposition&) = delete;
-  ~ProjComposition() override = default;
+  ~ProjComposition() override                        = default;
 
 #ifndef SWIG
+
 protected:
   Id _addPoint2mesh(const constvect in, vect out) const override;
   Id _addMesh2point(const constvect in, vect out) const override;
@@ -37,6 +38,6 @@ public:
 
 private:
   std::vector<std::unique_ptr<const IProj>> _projs;
-  mutable std::vector<std::vector<double>> _works;
+  mutable VectorVectorDouble _works;
 };
-}
+} // namespace gstlrn

--- a/include/LinearOp/ProjConvolution.hpp
+++ b/include/LinearOp/ProjConvolution.hpp
@@ -81,7 +81,7 @@ private:
   DbGrid* _gridSeis2D;
   DbGrid* _gridRes2D;
   MatrixSparse* _AProjHoriz;
-  mutable std::vector<double> _work;
+  mutable VectorDouble _work;
 };
 
 } // namespace gstlrn

--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -11,26 +11,26 @@
 #pragma once
 
 #include "Basic/AStringable.hpp"
-#include "gstlearn_export.hpp"
 #include "LinearOp/IProj.hpp"
+#include "gstlearn_export.hpp"
 #include <vector>
 
 namespace gstlrn
 {
-class GSTLEARN_EXPORT ProjMulti : public IProj, public AStringable
+class GSTLEARN_EXPORT ProjMulti: public IProj, public AStringable
 {
 public:
-  ProjMulti(const std::vector<std::vector<const IProj*>> &projs, bool silent = false);
+  ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool silent = false);
 
   /// AStringable Interface
   String toString(const AStringFormat* strfmt = nullptr) const override;
-  
+
   Id getNApex() const override;
   Id getNPoint() const override;
   Id getNVariable() const { return _nvariable; }
   Id getNLatent() const { return _nlatent; }
   virtual ~ProjMulti();
-  bool empty() const { return _projs.empty();}
+  bool empty() const { return _projs.empty(); }
 
 #ifndef SWIG
 
@@ -47,21 +47,21 @@ private:
 protected:
   Id findFirstNoNullOnRow(Id j) const;
   Id findFirstNoNullOnCol(Id j) const;
-  const std::vector<Id>& getNPoints() const { return _pointNumbers; }
-  const std::vector<Id>& getNApexs() const { return _apexNumbers; }
+  const VectorInt& getNPoints() const { return _pointNumbers; }
+  const VectorInt& getNApexs() const { return _apexNumbers; }
 
 protected:
-std::vector<std::vector<const IProj*>> _projs; // NOT TO BE DELETED
+  std::vector<std::vector<const IProj*>> _projs; // NOT TO BE DELETED
 
 private:
-Id _pointNumber;
-Id _apexNumber;
-Id _nlatent;
-Id _nvariable;
-std::vector<Id> _pointNumbers;
-std::vector<Id> _apexNumbers;
-bool _silent;
-mutable std::vector<double> _work;
-mutable std::vector<double> _workmesh;
+  Id _pointNumber;
+  Id _apexNumber;
+  Id _nlatent;
+  Id _nvariable;
+  VectorInt _pointNumbers;
+  VectorInt _apexNumbers;
+  bool _silent;
+  mutable VectorDouble _work;
+  mutable VectorDouble _workmesh;
 };
-}
+} // namespace gstlrn

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -80,7 +80,7 @@ public:
   void simNonCond(vect outv) const;
 #endif
   virtual double computeLogDetOp(Id nbsimu = 1) const;
-  double computeQuadratic(const std::vector<double>& x) const;
+  double computeQuadratic(const VectorDouble& x) const;
   double computeTotalLogDet(Id nMC = 5, Id seed = 13132) const;
   double computeLogDetQ(Id nMC = 5) const;
   double computeLogDetInvNoise() const;

--- a/include/LinearOp/ShiftOpMatrix.hpp
+++ b/include/LinearOp/ShiftOpMatrix.hpp
@@ -110,17 +110,17 @@ private:
                            double coeff[3][2]);
   Id _preparMatrices(const AMesh* amesh, Id imesh, MatrixSquare& matu, MatrixDense& matw) const;
   Id _prepareMatricesSVariety(const AMesh* amesh,
-                               Id imesh,
-                               VectorVectorDouble& coords,
-                               MatrixDense& matM,
-                               MatrixSymmetric& matMtM,
-                               MatrixDense& matP,
-                               double* deter) const;
+                              Id imesh,
+                              VectorVectorDouble& coords,
+                              MatrixDense& matM,
+                              MatrixSymmetric& matMtM,
+                              MatrixDense& matP,
+                              double* deter) const;
   Id _prepareMatricesSphere(const AMesh* amesh,
-                             Id imesh,
-                             VectorVectorDouble& coords,
-                             MatrixSquare& matMs,
-                             double* deter) const;
+                            Id imesh,
+                            VectorVectorDouble& coords,
+                            MatrixSquare& matMs,
+                            double* deter) const;
   static void _updateCova(std::shared_ptr<CovAniso>& cova, Id imesh);
   VectorT<std::map<Id, double>> _mapCreate() const;
   VectorT<VectorT<std::map<Id, double>>> _mapVectorCreate() const;
@@ -153,7 +153,7 @@ private:
   VectorT<MatrixSparse*> _TildeCGrad;
   VectorVectorDouble _LambdaGrad;
   bool _flagNoStatByHH;
-  std::vector<double> _detHH;
+  VectorDouble _detHH;
   mutable VectorDouble _diag;
 
   Id _ndim;

--- a/include/Mesh/MeshETurbo.hpp
+++ b/include/Mesh/MeshETurbo.hpp
@@ -161,11 +161,11 @@ private:
   Indirection _gridIndirect;
 
   /// factor allocations
-  mutable std::vector<Id> _indg;
-  mutable std::vector<Id> _indices;
-  mutable std::vector<double> _lambdas;
-  mutable std::vector<double> _rhs;
-  mutable std::vector<Id> _indgg;
+  mutable VectorInt _indg;
+  mutable VectorInt _indices;
+  mutable VectorDouble _lambdas;
+  mutable VectorDouble _rhs;
+  mutable VectorInt _indgg;
 
   friend class DbMeshTurbo;
 };

--- a/include/Polynomials/APolynomial.hpp
+++ b/include/Polynomials/APolynomial.hpp
@@ -20,8 +20,8 @@
 
 #include <functional>
 
-
-namespace gstlrn {
+namespace gstlrn
+{
 class MatrixSparse;
 
 class GSTLEARN_EXPORT APolynomial: public AStringable, public ICloneable
@@ -30,7 +30,7 @@ public:
   APolynomial();
   APolynomial(const VectorDouble& coeffs);
   APolynomial(const APolynomial& m);
-  APolynomial & operator=(const APolynomial& p);
+  APolynomial& operator=(const APolynomial& p);
   virtual ~APolynomial();
 
   /// Interface for AStringable
@@ -43,8 +43,8 @@ public:
   VectorDouble evalOp(MatrixSparse* Op, const constvect inv) const;
   virtual void evalOpTraining(MatrixSparse* Op,
                               const constvect inv,
-                              std::vector<std::vector<double>>& outv,
-                              std::vector<double>& work) const
+                              VectorVectorDouble& outv,
+                              VectorDouble& work) const
   {
     DECLARE_UNUSED(Op, inv, outv, work);
   };
@@ -56,27 +56,29 @@ public:
     return 0.;
   }
 
-  //virtual void evalOp(const ALinearOpMulti* Op,const std::vector<Eigen::VectorXd>& inv, std::vector<Eigen::VectorXd>& outv) const;
-    void addEvalOp(const ALinearOp* Op, const constvect inv, vect outv) const;
-  protected:
-    virtual void _addEvalOp(const ALinearOp* Op, const constvect inv, vect outv) const = 0;
+  // virtual void evalOp(const ALinearOpMulti* Op,const std::vector<Eigen::VectorXd>& inv, std::vector<Eigen::VectorXd>& outv) const;
+  void addEvalOp(const ALinearOp* Op, const constvect inv, vect outv) const;
+
+protected:
+  virtual void _addEvalOp(const ALinearOp* Op, const constvect inv, vect outv) const = 0;
 
 #endif
-  public:
-    VectorDouble getCoeffs() const { return _coeffs; }
-    void setCoeffs(const VectorDouble& coeffs) {_coeffs = coeffs;}
 
-    Id getDegree() const { return static_cast<Id>(_coeffs.size());}
-    virtual Id fit(const std::function<double(double)>& f,
-                  double from = 0.,
-                  double to = 1.,
-                  double tol = EPSILON5)
-    {
-     DECLARE_UNUSED(f,from,to,tol);
-     return 1;
-    }
+public:
+  VectorDouble getCoeffs() const { return _coeffs; }
+  void setCoeffs(const VectorDouble& coeffs) { _coeffs = coeffs; }
+
+  Id getDegree() const { return static_cast<Id>(_coeffs.size()); }
+  virtual Id fit(const std::function<double(double)>& f,
+                 double from = 0.,
+                 double to   = 1.,
+                 double tol  = EPSILON5)
+  {
+    DECLARE_UNUSED(f, from, to, tol);
+    return 1;
+  }
 
 protected:
   VectorDouble _coeffs;
 };
-}
+} // namespace gstlrn

--- a/include/Polynomials/ClassicalPolynomial.hpp
+++ b/include/Polynomials/ClassicalPolynomial.hpp
@@ -12,19 +12,17 @@
 
 #include "LinearOp/ALinearOp.hpp"
 
-#include "Polynomials/APolynomial.hpp"
 #include "Basic/ICloneable.hpp"
 #include "Basic/VectorNumT.hpp"
-
-#include <vector>
+#include "Polynomials/APolynomial.hpp"
 
 class AShiftOp;
 
-namespace gstlrn {
+namespace gstlrn
+{
 class ALinearOp;
 
-
-class GSTLEARN_EXPORT ClassicalPolynomial : public APolynomial
+class GSTLEARN_EXPORT ClassicalPolynomial: public APolynomial
 {
 public:
   ClassicalPolynomial();
@@ -48,9 +46,9 @@ public:
   //                              Id iapex,
   //                              Id igparam);
 #ifndef SWIG
-  // void evalDerivOp(ShiftOpMatrix* shiftOp,const std::vector<double>& inv,
-  //                  std::vector<double>& outv,Id iapex,Id igparam)const;
-  
+  // void evalDerivOp(ShiftOpMatrix* shiftOp,const VectorDouble& inv,
+  //                  VectorDouble& outv,Id iapex,Id igparam)const;
+
   // void evalDerivOpOptim(ShiftOpMatrix* shiftOp,Eigen::VectorXd& temp1,Eigen::VectorXd& temp2,
   //                      Eigen::VectorXd& outv,const std::vector<Eigen::VectorXd>& workpoly,Id iapex,Id igparam)const;
   // void evalOp(const ALinearOpMulti* /*Op*/,
@@ -59,13 +57,13 @@ public:
 
   void evalOpTraining(MatrixSparse* Op,
                       const constvect inv,
-                      std::vector<std::vector<double>>& store,
-                      std::vector<double>& work) const override;
+                      VectorVectorDouble& store,
+                      VectorDouble& work) const override;
   void evalOpCumul(MatrixSparse* Op, const constvect inv, vect outv) const;
   void evalOp(MatrixSparse* Op, const constvect inv, vect outv) const override;
   double evalOpByRank(MatrixSparse* S, Id rank) const override;
 #endif
-  
+
 #ifndef SWIG
 
   void _addEvalOp(const ALinearOp* Op, const constvect inv, vect outv) const override;
@@ -73,10 +71,10 @@ public:
 #endif
 
 #ifndef SWIG
-  
+
 private:
-  mutable std::vector<double> _work;
-  mutable std::vector<double> _work2;
+  mutable VectorDouble _work;
+  mutable VectorDouble _work2;
 #endif
 };
-}
+} // namespace gstlrn

--- a/src/Basic/Grid.cpp
+++ b/src/Basic/Grid.cpp
@@ -913,11 +913,11 @@ VectorInt Grid::iteratorNext(void)
 {
 
   VectorInt indices(_nDim);
-  iteratorNext(indices.getVector());
+  iteratorNext(indices);
   return indices;
 }
 
-void Grid::iteratorNext(std::vector<Id>& indices)
+void Grid::iteratorNext(VectorInt& indices)
 {
   Id idim;
   Id iech = _iter;

--- a/src/Basic/ListParams.cpp
+++ b/src/Basic/ListParams.cpp
@@ -13,7 +13,7 @@ namespace gstlrn
 
 struct DSU
 {
-  std::vector<Id> parent;
+  VectorInt parent;
   DSU(Id n)
     : parent(n)
   {
@@ -160,10 +160,10 @@ void ListParams::makeDispatchIndexFromDispatch()
     }
   }
 }
-std::vector<double> ListParams::getOptimizableValues() const
+VectorDouble ListParams::getOptimizableValues() const
 {
   size_t nparam = getNOptimizableParams();
-  std::vector<double> values(nparam);
+  VectorDouble values(nparam);
   for (size_t i = 0; i < nparam; ++i)
   {
     values[i] = getOptimizableValue(i);
@@ -171,10 +171,10 @@ std::vector<double> ListParams::getOptimizableValues() const
   return values;
 }
 
-std::vector<double> ListParams::getMinValues(double epsilon) const
+VectorDouble ListParams::getMinValues(double epsilon) const
 {
   size_t nparam = _params.size();
-  std::vector<double> values(nparam);
+  VectorDouble values(nparam);
   for (size_t i = 0; i < nparam; ++i)
   {
     values[i] = _params[i].get().getUserMin() + epsilon;
@@ -182,10 +182,10 @@ std::vector<double> ListParams::getMinValues(double epsilon) const
   return values;
 }
 
-std::vector<double> ListParams::getMaxValues(double epsilon) const
+VectorDouble ListParams::getMaxValues(double epsilon) const
 {
   size_t nparam = _params.size();
-  std::vector<double> values(nparam);
+  VectorDouble values(nparam);
   for (size_t i = 0; i < nparam; ++i)
   {
     values[i] = _params[i].get().getUserMax() - epsilon;
@@ -193,7 +193,7 @@ std::vector<double> ListParams::getMaxValues(double epsilon) const
   return values;
 }
 
-void ListParams::setValues(const std::vector<double>& values)
+void ListParams::setValues(const VectorDouble& values)
 {
   size_t size = _dispatch.size();
   for (size_t i = 0; i < size; i++)

--- a/src/Basic/Optim.cpp
+++ b/src/Basic/Optim.cpp
@@ -27,9 +27,9 @@ Optim::~Optim()
   nlopt_destroy(_opt);
 }
 
-void Optim::setObjective(std::function<double(const std::vector<double>&)> objective)
+void Optim::setObjective(std::function<double(const VectorDouble&)> objective)
 {
-  _objective = std::make_shared<std::function<double(const std::vector<double>&)>>(
+  _objective = std::make_shared<std::function<double(const VectorDouble&)>>(
     std::move(objective));
   nlopt_set_min_objective(_opt, &Optim::callback, this);
 }
@@ -72,7 +72,7 @@ void Optim::evalGrad(vect res)
     throw std::runtime_error("Gradient function not set");
 }
 
-void Optim::setGradientComponents(const std::vector<std::function<double(const std::vector<double>&)>>& partials)
+void Optim::setGradientComponents(const std::vector<std::function<double(const VectorDouble&)>>& partials)
 {
   _gradientPartials = partials;
 }
@@ -81,7 +81,7 @@ void Optim::setXtolRel(double tol)
 {
   nlopt_set_xtol_rel(_opt, tol);
 }
-void Optim::setLowerBounds(const std::vector<double>& lb,
+void Optim::setLowerBounds(const VectorDouble& lb,
                            const std::vector<size_t>& dispatch)
 {
   if (dispatch.empty())
@@ -95,7 +95,7 @@ void Optim::setLowerBounds(const std::vector<double>& lb,
   for (auto j: dispatch) n_reduced = std::max(n_reduced, static_cast<Id>(j));
   n_reduced += 1; // indices 0-based
 
-  std::vector<double> lb_reduced(n_reduced, -HUGE_VAL);
+  VectorDouble lb_reduced(n_reduced, -HUGE_VAL);
 
   for (size_t i = 0; i < lb.size(); ++i)
   {
@@ -106,7 +106,7 @@ void Optim::setLowerBounds(const std::vector<double>& lb,
   nlopt_set_lower_bounds(_opt, lb_reduced.data());
 }
 
-void Optim::setUpperBounds(const std::vector<double>& ub,
+void Optim::setUpperBounds(const VectorDouble& ub,
                            const std::vector<size_t>& dispatch)
 {
   if (dispatch.empty())
@@ -120,7 +120,7 @@ void Optim::setUpperBounds(const std::vector<double>& ub,
   for (auto j: dispatch) n_reduced = std::max(n_reduced, static_cast<Id>(j));
   n_reduced += 1; // indices 0-based
 
-  std::vector<double> ub_reduced(n_reduced, HUGE_VAL);
+  VectorDouble ub_reduced(n_reduced, HUGE_VAL);
 
   for (size_t i = 0; i < ub.size(); ++i)
   {
@@ -131,12 +131,12 @@ void Optim::setUpperBounds(const std::vector<double>& ub,
   nlopt_set_upper_bounds(_opt, ub_reduced.data());
 }
 
-double Optim::minimize(std::vector<double>& x)
+double Optim::minimize(VectorDouble& x)
 {
 
   // This part checks that the initial guess is within bounds
-  std::vector<double> lb(nlopt_get_dimension(_opt));
-  std::vector<double> ub(nlopt_get_dimension(_opt));
+  VectorDouble lb(nlopt_get_dimension(_opt));
+  VectorDouble ub(nlopt_get_dimension(_opt));
 
   nlopt_get_lower_bounds(_opt, lb.data());
   nlopt_get_upper_bounds(_opt, ub.data());
@@ -171,7 +171,7 @@ double Optim::callback(unsigned n, const double* x, double* grad, void* f_data)
 {
   auto* that        = static_cast<Optim*>(f_data);
   bool gradAnalytic = that->_authorizedAnalyticalGradients;
-  std::vector<double> xvec(x, x + n);
+  VectorDouble xvec(x, x + n);
 
   // ---- Objectif ----
   double result = (*(that->_objective))(xvec);
@@ -203,8 +203,8 @@ double Optim::callback(unsigned n, const double* x, double* grad, void* f_data)
     }
     else
     {
-      const double eps          = EPSILON8;
-      std::vector<double> x_cur = xvec;
+      const double eps   = EPSILON8;
+      VectorDouble x_cur = xvec;
       for (unsigned i = 0; i < n; ++i)
       {
         x_cur[i] += eps;

--- a/src/Basic/Utilities.cpp
+++ b/src/Basic/Utilities.cpp
@@ -173,7 +173,7 @@ void ut_sort_double(Id safe, Id nech, Id* ind, double* value)
   static Id LISTE_L[LSTACK];
   static Id LISTE_R[LSTACK];
   Id i, j, p, l, r, pstack, inddev, inddeu;
-  std::vector<double> tab;
+  VectorDouble tab;
   double tablev, tableu;
 
   /* Initialization */

--- a/src/Basic/VectorHelper.cpp
+++ b/src/Basic/VectorHelper.cpp
@@ -19,7 +19,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <vector>
 
 namespace gstlrn
 {
@@ -92,7 +91,6 @@ VectorString VectorHelper::initVString(Id ntab, char** names)
   for (Id i = 0; i < ntab; i++) rettab[i] = names[i];
   return rettab;
 }
-
 
 void VectorHelper::dumpStats(const String& title, constvect vect, Id nmax)
 {
@@ -228,27 +226,6 @@ void VectorHelper::dumpNNZ(const String& title, const VectorDouble& vect, Id ncl
     message("Count below 10.e-%d = %d\n", ic + 1, total[ic]);
 }
 
-double VectorHelper::maximum(const std::vector<std::vector<double>>& vec, bool flagAbs)
-{
-  double val = VH::maximum(vec[0]);
-  for (Id i = 1, n = static_cast<Id>(vec.size()); i < n; i++)
-    val = MAX(val, VH::maximum(vec[i], flagAbs));
-  return val;
-}
-
-double VectorHelper::maximum(const VectorDouble& vec, bool flagAbs)
-{
-  if (vec.empty()) return TEST;
-  double max = MINIMUM_BIG;
-  for (auto v: vec)
-  {
-    if (FFFF(v)) continue;
-    if (flagAbs) v = ABS(v);
-    if (v > max) max = v;
-  }
-  return (max);
-}
-
 Id VectorHelper::count(const VectorVectorInt& vec)
 {
   Id total = 0.;
@@ -325,12 +302,6 @@ VectorDouble VectorHelper::quantiles(const VectorDouble& vec,
     retval[ip] = value;
   }
   return retval;
-}
-
-double VectorHelper::norm(const std::vector<double>& vec)
-{
-  double ip = innerProductVec(vec, vec);
-  return sqrt(ip);
 }
 
 void VectorHelper::normalize(double* tab, Id ntab)
@@ -565,18 +536,6 @@ void VectorHelper::simulateGaussianInPlace(VectorDouble& vec,
   }
 }
 
-void VectorHelper::simulateGaussianInPlace(std::vector<double>& vec,
-                                           double mean,
-                                           double sigma)
-{
-  auto it(vec.begin());
-  while (it < vec.end())
-  {
-    *it = mean + sigma * law_gaussian();
-    it++;
-  }
-}
-
 VectorDouble VectorHelper::concatenate(const VectorDouble& veca,
                                        const VectorDouble& vecb)
 {
@@ -724,7 +683,7 @@ VectorInt VectorHelper::sampleRanks(Id ntotal,
   else if (optSort < 0)
     ranks = sort(ranks, false);
 
-  std::vector<Id>::iterator it;
+  VectorInt::iterator it;
   it = std::unique(ranks.begin(), ranks.end());
   ranks.resize(distance(ranks.begin(), it));
 
@@ -738,23 +697,6 @@ void VectorHelper::addInPlace(constvect in, vect dest)
   for (Id i = 0; i < static_cast<Id>(in.size()); i++)
   {
     *(outp++) += *(inp++);
-  }
-}
-void VectorHelper::addInPlace(std::vector<double>& dest, const std::vector<double>& src)
-{
-  if (dest.size() != src.size())
-  {
-    messerr("Arguments 'dest' and 'src' should have the same dimension. Nothing is done");
-    return;
-  }
-
-  auto itd(dest.begin());
-  auto its(src.begin());
-  while (itd < dest.end())
-  {
-    *itd += *its;
-    itd++;
-    its++;
   }
 }
 
@@ -807,19 +749,6 @@ VectorDouble VectorHelper::subtract(constvect veca,
   return res;
 }
 
-void VectorHelper::addInPlace(const std::vector<std::vector<double>>& in1,
-                              const std::vector<std::vector<double>>& in2,
-                              std::vector<std::vector<double>>& outv)
-{
-  for (Id is = 0, ns = static_cast<Id>(in1.size()); is < ns; is++)
-  {
-    for (Id i = 0, n = static_cast<Id>(in1[is].size()); i < n; i++)
-    {
-      outv[is][i] = in2[is][i] + in1[is][i];
-    }
-  }
-}
-
 /**
  * Performs: outv = in2 - in1
  * @param in1 Input vector
@@ -833,36 +762,6 @@ void VectorHelper::subtractInPlace(const constvect in1,
   for (Id is = 0, ns = static_cast<Id>(in1.size()); is < ns; is++)
   {
     outv[is] = in2[is] - in1[is];
-  }
-}
-
-// TODO: check why we cannot replace std::vector<std::vecot<double>> by VectorVectorDouble
-void VectorHelper::subtractInPlace(const std::vector<std::vector<double>>& in1,
-                                   const std::vector<std::vector<double>>& in2,
-                                   std::vector<std::vector<double>>& outv)
-{
-  for (Id is = 0, ns = static_cast<Id>(in1.size()); is < ns; is++)
-  {
-    for (Id i = 0, n = static_cast<Id>(in1[is].size()); i < n; i++)
-    {
-      outv[is][i] = in2[is][i] - in1[is][i];
-    }
-  }
-}
-
-void VectorHelper::divideInPlace(std::vector<double>& vec, const std::vector<double>& v)
-{
-  if (vec.size() != v.size())
-    my_throw("Arguments 'vec' and 'v' should have same dimension");
-
-  auto it(vec.begin());
-  auto itv(v.begin());
-  while (it < vec.end())
-  {
-    if (ABS(*itv) >= EPSILON20)
-      *it /= (*itv);
-    it++;
-    itv++;
   }
 }
 
@@ -882,16 +781,6 @@ void VectorHelper::multiplyComplexInPlace(const VectorDouble& vecaRe,
   vecaRe.multiplyVecInPlace(vecbIm, resIm);
   vecaIm.multiplyVecInPlace(vecbRe, temp);
   resIm.add(temp);
-}
-
-void VectorHelper::multiplyConstantSelfInPlace(VectorDouble& vec, double v)
-{
-  auto it(vec.begin());
-  while (it < vec.end())
-  {
-    *it = (*it) * v;
-    it++;
-  }
 }
 
 void VectorHelper::addMultiplyConstantInPlace(double val1,
@@ -974,16 +863,6 @@ void VectorHelper::copy(const VectorInt& vecin, VectorInt& vecout, Id size)
     (*itout) = (*itin);
     itin++;
     itout++;
-  }
-}
-void VectorHelper::copy(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv)
-{
-  for (Id is = 0, ns = static_cast<Id>(inv.size()); is < ns; is++)
-  {
-    for (Id i = 0, n = static_cast<Id>(inv[is].size()); i < n; i++)
-    {
-      outv[is][i] = inv[is][i];
-    }
   }
 }
 void VectorHelper::copy(const VectorVectorDouble& inv, VectorVectorDouble& outv)
@@ -1197,7 +1076,7 @@ VectorInt VectorHelper::filter(const VectorInt& vecin, Id vmin, Id vmax, bool as
     std::reverse(vecout.begin(), vecout.end());
 
   // Unique occurrence
-  std::vector<Id>::iterator it;
+  VectorInt::iterator it;
   it = std::unique(vecout.begin(), vecout.end());
   vecout.resize(distance(vecout.begin(), it));
 
@@ -1453,17 +1332,6 @@ std::pair<double, double> VectorHelper::rangeVals(const VectorDouble& vec)
   return res;
 }
 
-double VectorHelper::innerProductVec(const std::vector<double>& veca,
-                                     const std::vector<double>& vecb,
-                                     Id size)
-{
-  if (size < 0) size = static_cast<Id>(veca.size());
-  if (size > static_cast<Id>(veca.size()) || size > static_cast<Id>(vecb.size()))
-    my_throw("Incompatible sizes");
-
-  return innerProduct(veca.data(), vecb.data(), size);
-}
-
 double VectorHelper::innerProductCV(const constvect veca, const constvect vecb)
 {
   return innerProduct(veca.data(), vecb.data(), static_cast<Id>(veca.size()));
@@ -1483,15 +1351,6 @@ double VectorHelper::innerProduct(const double* veca,
     ptrb++;
   }
   return prod;
-}
-
-double VectorHelper::innerProductVVec(const std::vector<std::vector<double>>& x,
-                                      const std::vector<std::vector<double>>& y)
-{
-  double s = 0.;
-  for (Id i = 0, n = static_cast<Id>(x.size()); i < n; i++)
-    s += VH::innerProductVec(x[i], y[i]);
-  return s;
 }
 
 /**
@@ -1541,6 +1400,14 @@ void VectorHelper::flattenInPlace(const VectorVectorDouble& vvd, VectorDouble& v
       vd[ecr++] = (vvd[i][j]);
 }
 
+void VectorHelper::unflattenInPlace(const VectorDouble& vd, VectorVectorDouble& vvd)
+{
+  Id lec = 0;
+  for (Id i = 0, n = static_cast<Id>(vvd.size()); i < n; i++)
+    for (Id j = 0; j < static_cast<Id>(vvd[i].size()); j++)
+      vvd[i][j] = vd[lec++];
+}
+
 VectorVectorDouble VectorHelper::unflatten(const VectorDouble& vd, const VectorInt& sizes)
 {
   VectorVectorDouble vvd;
@@ -1557,48 +1424,6 @@ VectorVectorDouble VectorHelper::unflatten(const VectorDouble& vd, const VectorI
   return vvd;
 }
 
-void VectorHelper::flattenInPlace(const std::vector<std::vector<double>>& vvd, std::vector<double>& vd)
-{
-  Id ecr = 0;
-  for (Id i = 0; i < static_cast<Id>(vvd.size()); i++)
-    for (Id j = 0; j < static_cast<Id>(vvd[i].size()); j++)
-      vd[ecr++] = (vvd[i][j]);
-}
-
-void VectorHelper::unflattenInPlace(const std::vector<double>& vd, std::vector<std::vector<double>>& vvd)
-{
-  Id lec = 0;
-  for (Id i = 0, n = static_cast<Id>(vvd.size()); i < n; i++)
-    for (Id j = 0; j < static_cast<Id>(vvd[i].size()); j++)
-      vvd[i][j] = vd[lec++];
-}
-
-std::vector<double> VectorHelper::flatten(const std::vector<std::vector<double>>& vvd)
-{
-  std::vector<double> vd;
-
-  for (Id i = 0; i < static_cast<Id>(vvd.size()); i++)
-    for (Id j = 0; j < static_cast<Id>(vvd[i].size()); j++)
-      vd.push_back(vvd[i][j]);
-
-  return vd;
-}
-
-std::vector<std::vector<double>> VectorHelper::unflatten(const std::vector<double>& vd, const VectorInt& sizes)
-{
-  std::vector<std::vector<double>> vvd;
-
-  Id lec = 0;
-  for (Id i = 0, n = static_cast<Id>(sizes.size()); i < n; i++)
-  {
-    Id lng = sizes[i];
-    VectorDouble local(lng);
-    for (Id j = 0; j < lng; j++)
-      local[j] = vd[lec++];
-    vvd.push_back(local);
-  }
-  return vvd;
-}
 VectorDouble VectorHelper::suppressTest(const VectorDouble& vecin)
 {
   VectorDouble vecout;
@@ -1624,25 +1449,7 @@ void VectorHelper::linearCombinationInPlace(double val1,
     outv[i] = value;
   }
 }
-void VectorHelper::linearCombinationVVDInPlace(double val1,
-                                               const std::vector<std::vector<double>>& vvd1,
-                                               double val2,
-                                               const std::vector<std::vector<double>>& vvd2,
-                                               std::vector<std::vector<double>>& outv)
-{
-  if (vvd1.empty() || vvd2.empty()) return;
 
-  for (Id is = 0, ns = static_cast<Id>(vvd1.size()); is < ns; is++)
-  {
-    for (Id i = 0, n = static_cast<Id>(vvd1[is].size()); i < n; i++)
-    {
-      double value = 0.;
-      if (val1 != 0. && !vvd1.empty()) value += val1 * vvd1[is][i];
-      if (val2 != 0. && !vvd2.empty()) value += val2 * vvd2[is][i];
-      outv[is][i] = value;
-    }
-  }
-}
 void VectorHelper::linearCombinationVVDInPlace(double val1,
                                                const VectorVectorDouble& vvd1,
                                                double val2,

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -102,11 +102,11 @@ double ACov::evalCov(const SpacePoint& p1,
   return _eval(p1, p2, ivar, jvar, mode);
 }
 
-std::vector<double> ACov::evalCovGrad(const SpacePoint& p1,
-                                      const SpacePoint& p2,
-                                      Id ivar,
-                                      Id jvar,
-                                      const CovCalcMode* mode)
+VectorDouble ACov::evalCovGrad(const SpacePoint& p1,
+                               const SpacePoint& p2,
+                               Id ivar,
+                               Id jvar,
+                               const CovCalcMode* mode)
 {
   std::vector<covmaptype> gradFuncs;
   auto listParams = std::make_shared<ListParams>();
@@ -510,7 +510,7 @@ double ACov::evalIsoIvarIpas(double step,
                              const CovCalcMode* mode) const
 {
   /// TODO : Not true whatever the space
-  VectorDouble dir    = getSpace()->getUnitaryVector();
+  VectorDouble dir = getSpace()->getUnitaryVector();
   return evalIvarIpas(step, dir, ivar, jvar, mode);
 }
 

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -14,7 +14,6 @@
 #include "Basic/AException.hpp"
 #include "Basic/AFunctional.hpp"
 #include "Basic/AStringFormat.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/FFT.hpp"
 #include "Basic/ListParams.hpp"
 #include "Basic/ParamInfo.hpp"
@@ -58,9 +57,9 @@ struct DerivCache
   mutable const SpacePoint* cachedP2ptr = nullptr;
   mutable SpacePoint cachedP1;
   mutable SpacePoint cachedP2;
-  mutable double deriv               = 0.0;
-  mutable std::vector<double> angles = {};
-  mutable bool isInitialized         = false;
+  mutable double deriv        = 0.0;
+  mutable VectorDouble angles = {};
+  mutable bool isInitialized  = false;
 
   double get(CorAniso* cor,
              const SpacePoint& p1,
@@ -407,8 +406,8 @@ bool CorAniso::isValidForSpectral() const
 }
 MatrixDense CorAniso::simulateSpectralOmega(Id nb) const
 {
-  MatrixDense omega   = _corfunc->simulateSpectralOmega(nb);
-  const auto& tensor  = getAniso().getTensorInverse();
+  MatrixDense omega  = _corfunc->simulateSpectralOmega(nb);
+  const auto& tensor = getAniso().getTensorInverse();
   // omega = omega * tensor;
   omega.prodMat(&tensor);
   return omega;
@@ -646,8 +645,8 @@ double CorAniso::getFullCorrec() const
 
 double CorAniso::getDetTensor() const
 {
-  const auto& scales  = getScales();
-  double detTensor    = 1.;
+  const auto& scales = getScales();
+  double detTensor   = 1.;
   for (const auto e: scales)
   {
     detTensor *= e;
@@ -1401,7 +1400,7 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
 
   auto ndim = getNDim();
 
-  const auto &paramsnostat = getTabNoStatCovAniso()->getTable();
+  const auto& paramsnostat = getTabNoStatCovAniso()->getTable();
   // Loop on the elements that can be updated one-by-one
 
   for (const auto& e: paramsnostat)
@@ -1497,13 +1496,13 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
     thread_local MatrixSymmetric direct1, direct2;
     // Extract the direct tensor at first point and square it
     setRotationAnglesAndRadius(angle1, range1, scale1);
-    direct1 = getAniso().getTensorDirect2();
-    double det1             = sqrt(sqrt(direct1.determinant()));
+    direct1     = getAniso().getTensorDirect2();
+    double det1 = sqrt(sqrt(direct1.determinant()));
 
     // Extract the direct tensor at second point and square it
     setRotationAnglesAndRadius(angle2, range2, scale2);
-    direct2 = getAniso().getTensorDirect2();
-    double det2             = sqrt(sqrt(direct2.determinant()));
+    direct2     = getAniso().getTensorDirect2();
+    double det2 = sqrt(sqrt(direct2.determinant()));
 
     // Calculate average squared tensor
     direct2.addMatNoCheck(direct1, 0.5, 0.5);

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -654,7 +654,7 @@ void Db::setArrayByUID(const VectorDouble& tab, Id iuid)
   }
 }
 
-void Db::getArrayBySample(std::vector<double>& vals, Id iech) const
+void Db::getArrayBySample(VectorDouble& vals, Id iech) const
 {
   getAllUIDs(_uids);
   vals.resize(_uids.size());
@@ -4689,7 +4689,7 @@ VectorInt Db::getColIdxsByLocator(const ELoc& locatorType) const
  */
 Id Db::getUID(const String& name) const
 {
-  std::vector<Id> iuids = _ids(name, true);
+  VectorInt iuids = _ids(name, true);
   if (iuids.empty()) return -1;
   auto icol = getColIdxByUID(iuids[0]);
   return getUIDByColIdx(icol);
@@ -4966,7 +4966,7 @@ bool Db::_serializeAscii(std::ostream& os, bool /*verbose*/) const
   auto ncol             = getNColumn();
   VectorString locators = getLocators(true);
   VectorString names    = getName("*");
-  std::vector<double> vals;
+  VectorDouble vals;
 
   bool ret = true;
   ret      = ret && _recordWrite<Id>(os, "Number of variables", ncol);

--- a/src/Db/DbGrid.cpp
+++ b/src/Db/DbGrid.cpp
@@ -657,8 +657,8 @@ void DbGrid::_createGridCoordinates(Id icol0)
 
   // Generate the vector of coordinates
 
-  std::vector<double> coors(ndim);
-  std::vector<Id> indices;
+  VectorDouble coors(ndim);
+  VectorInt indices;
   _grid.iteratorInit();
   for (Id iech = 0; iech < getNSample(); iech++)
   {

--- a/src/Estimation/ALikelihood.cpp
+++ b/src/Estimation/ALikelihood.cpp
@@ -70,7 +70,7 @@ void ALikelihood::_initLikelihood(bool verbose)
 {
   MatrixSymmetric vars = dbVarianceMatrix(_db);
   double hmax          = _db->getExtensionDiagonal();
-  double vmax          = VH::maximum(_db->getColumnByLocator(ELoc::Z, 0));
+  double vmax          = _db->getColumnByLocator(ELoc::Z, 0).maximum();
   setEnvironment(vars, hmax, EPSILON6, 0., vmax);
   Id nvar = _db->getNLoc(ELoc::Z);
   if (nvar < 1)

--- a/src/Estimation/AModelOptim.cpp
+++ b/src/Estimation/AModelOptim.cpp
@@ -37,7 +37,7 @@ AModelOptim::AModelOptim(ModelGeneric* model, bool verbose)
     _opt = new Optim(NELDERMEAD, static_cast<Id>(_x.size()));
 
   _opt->setXtolRel(EPSILON6);
-  _opt->setObjective([this](const std::vector<double>& x)
+  _opt->setObjective([this](const VectorDouble& x)
                      { return this->eval(x); });
   _opt->setGradient([this](vect grad)
                     { this->evalGrad(grad); },
@@ -89,7 +89,7 @@ AModelOptim::~AModelOptim()
   delete _opt;
 }
 
-void AModelOptim::setGradients(std::vector<std::function<double(const std::vector<double>&)>>& gradients)
+void AModelOptim::setGradients(std::vector<std::function<double(const VectorDouble&)>>& gradients)
 {
   if (_opt == nullptr)
   {
@@ -123,7 +123,7 @@ void AModelOptim::setVerbose(bool verbose, bool trace)
     _params->display();
 }
 
-double AModelOptim::eval(const std::vector<double>& x)
+double AModelOptim::eval(const VectorDouble& x)
 {
   _iter++;
 
@@ -158,7 +158,7 @@ void AModelOptim::evalGradInEffectiveDimension(vect res)
 void AModelOptim::evalGrad(vect res) {
   DECLARE_UNUSED(res)
 };
-void AModelOptim::_printSummary(double minf, const std::vector<double>& x) const
+void AModelOptim::_printSummary(double minf, const VectorDouble& x) const
 {
   message("Summary of Optimization procedure:\n");
   message("Count of Iterations = %4d - Final Cost = %lf\n",

--- a/src/Estimation/KrigingAlgebraSimpleCase.cpp
+++ b/src/Estimation/KrigingAlgebraSimpleCase.cpp
@@ -746,7 +746,7 @@ double KrigingAlgebraSimpleCase::getLTerm()
   if (_needDual()) return 1;
   if (_notFindZ()) return 1;
 
-  return VH::innerProductVec(*_bDual, *_Z);
+  return (*_bDual).innerProduct(*_Z);
 }
 
 Id KrigingAlgebraSimpleCase::prepare()

--- a/src/LinearOp/ALinearOpMulti.cpp
+++ b/src/LinearOp/ALinearOpMulti.cpp
@@ -14,7 +14,6 @@
 #include "Basic/OptDbg.hpp"
 #include "Basic/Timer.hpp"
 #include "Basic/VectorHelper.hpp"
-#include <vector>
 
 namespace gstlrn
 {
@@ -26,7 +25,7 @@ ALinearOpMulti::ALinearOpMulti(Id nitermax, double eps)
   , _userInitialValue(false)
   , _precond(nullptr)
   , _initialized(false)
-  , _r(std::vector<std::vector<double>>())
+  , _r(VectorVectorDouble())
   , _temp()
   , _p()
   , _z()
@@ -112,8 +111,8 @@ void ALinearOpMulti::prepare() const
  ** \param[out] outv    Array of output values
  **
  *****************************************************************************/
-void ALinearOpMulti::evalDirect(const std::vector<std::vector<double>>& inv,
-                                std::vector<std::vector<double>>& outv) const
+void ALinearOpMulti::evalDirect(const VectorVectorDouble& inv,
+                                VectorVectorDouble& outv) const
 {
   try
   {
@@ -136,8 +135,8 @@ void ALinearOpMulti::evalDirect(const std::vector<std::vector<double>>& inv,
  **                    _userInitialValue is true.
  **
  *****************************************************************************/
-void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
-                                 std::vector<std::vector<double>>& vecout) const
+void ALinearOpMulti::evalInverse(const VectorVectorDouble& vecin,
+                                 VectorVectorDouble& vecout) const
 {
   prepare();
   Id n = sizes();
@@ -152,14 +151,14 @@ void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
   nb = 0.;
   for (const auto& e: vecin)
   {
-    nb += VH::norm(e);
+    nb += e.norm();
   }
 
   if (_userInitialValue)
   {
-    evalDirect(vecout, _temp);                       // temp = Ax0 (x0 est stocké dans outv)
-    VectorHelper::subtractInPlace(_temp, vecin, _r); // r=b-Ax0
-    nb = VectorHelper::innerProductVVec(_r, _r);
+    evalDirect(vecout, _temp);           // temp = Ax0 (x0 est stocké dans outv)
+    vecin.subtractVecInPlace(_temp, _r); // r=b-Ax0
+    nb = _r.innerProduct(_r);
 
     // If _nb is not set, then initialize the internal state from scratch.
     // If _nb is set, reuse the internal state of the solver (_p) to add
@@ -181,19 +180,19 @@ void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
   }
 
   if (OptDbg::query(EDbg::CONVERGE))
-    message("initial crit %lg \n", VectorHelper::innerProductVVec(_r, _r));
+    message("initial crit %lg \n", _r.innerProduct(_r));
 
   if (_precondStatus)
   {
-    _precond->evalDirect(_r, _temp);                   // z=Mr
-    VectorHelper::copy(_temp, _p);                     // p=z
-    rsold = VectorHelper::innerProductVVec(_r, _temp); //<r, z>
-    crit  = VectorHelper::innerProductVVec(_r, _r);    //<r,r>
+    _precond->evalDirect(_r, _temp); // z=Mr
+    VectorHelper::copy(_temp, _p);   // p=z
+    rsold = _r.innerProduct(_temp);  //<r, z>
+    crit  = _r.innerProduct(_r);     //<r,r>
   }
   else if (!_userInitialValue || isNA(_nb)) // _p, rsold and crit are already set (see above)
   {
     VectorHelper::copy(_r, _p); // p=r (=z)
-    crit = rsold = VectorHelper::innerProductVVec(_r, _r);
+    crit = rsold = _r.innerProduct(_r);
   }
 
   crit /= nb;
@@ -204,13 +203,13 @@ void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
   {
     niter++;
     evalDirect(_p, _temp);                                                    // temp = Ap
-    alpha = rsold / VectorHelper::innerProductVVec(_temp, _p);                // r'r/p'Ap
+    alpha = rsold / _temp.innerProduct(_p);                                   // r'r/p'Ap
     VectorHelper::linearCombinationVVDInPlace(1., vecout, alpha, _p, vecout); // x = x + alpha * p
 
     if (_nIterRestart > 0 && (niter + 1) % _nIterRestart == 0)
     {
-      evalDirect(vecout, _temp);                       // temp = Ax
-      VectorHelper::subtractInPlace(_temp, vecin, _r); // r = b - Ax
+      evalDirect(vecout, _temp);           // temp = Ax
+      vecin.subtractVecInPlace(_temp, _r); // r = b - Ax
       if (OptDbg::query(EDbg::CONVERGE))
         message("Recomputing exact residuals after %d iterations (max=%d)\n", niter, _nIterMax);
     }
@@ -220,12 +219,12 @@ void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
     if (_precondStatus)
     {
       _precond->evalDirect(_r, _temp);                                             // z = Mr
-      rsnew = VectorHelper::innerProductVVec(_r, _temp);                           // r'z
+      rsnew = _r.innerProduct(_temp);                           // r'z
       VectorHelper::linearCombinationVVDInPlace(1., _temp, rsnew / rsold, _p, _p); // p = z+beta p
     }
     else
     {
-      rsnew = VectorHelper::innerProductVVec(_r, _r);
+      rsnew = _r.innerProduct(_r);
       VectorHelper::linearCombinationVVDInPlace(1., _r, rsnew / rsold, _p, _p); // p = r+beta p
     }
     crit = rsnew / nb;
@@ -247,8 +246,8 @@ void ALinearOpMulti::evalInverse(const std::vector<std::vector<double>>& vecin,
   getLogStats().incrementStatsInverseCG(niter, time.getIntervalSeconds());
 }
 
-void ALinearOpMulti::initLk(const std::vector<std::vector<double>>& inv,
-                            std::vector<std::vector<double>>& outv) const
+void ALinearOpMulti::initLk(const VectorVectorDouble& inv,
+                            VectorVectorDouble& outv) const
 {
   prepare();
   Id n = sizes();

--- a/src/LinearOp/InvNuggetOp.cpp
+++ b/src/LinearOp/InvNuggetOp.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 
 #include "LinearOp/InvNuggetOp.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "Db/Db.hpp"
@@ -229,7 +228,7 @@ void InvNuggetOp::_buildInvNugget(const Db* db, Model* model, const SPDEParam& p
 
   // Pre-calculate the inverse of the sill matrix (if constant)
 
-  std::vector<double> cacheLogDet;
+  VectorDouble cacheLogDet;
   std::vector<CholeskyDense> cholcache;
 
   if (flag_constant)

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "LinearOp/PrecisionOp.hpp"
 #include "Basic/AException.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/CovAniso.hpp"
@@ -174,9 +173,9 @@ PrecisionOp::~PrecisionOp()
   }
 }
 
-std::vector<double> PrecisionOp::evalInverse(const VectorDouble& vecin)
+VectorDouble PrecisionOp::evalInverse(const VectorDouble& vecin)
 {
-  std::vector<double> vecout(vecin.size());
+  VectorDouble vecout(vecin.size());
   constvect vecinconst(vecin);
   evalInverse(vecinconst, vecout);
   return vecout;
@@ -391,7 +390,7 @@ Id PrecisionOp::_addEvalPoly(const EPowerPT& power,
 
     if (_workPoly.empty())
     {
-      _workPoly = std::vector<std::vector<double>>(degree);
+      _workPoly = VectorVectorDouble(degree);
       for (auto& e: _workPoly)
       {
         e.resize(inv.size());
@@ -422,7 +421,7 @@ Id PrecisionOp::_addEvalPoly(const EPowerPT& power,
 }
 
 void PrecisionOp::evalInverse(const constvect vecin,
-                              std::vector<double>& vecout)
+                              VectorDouble& vecout)
 {
   if (_work.size() != vecin.size()) _work.resize(vecin.size());
   vect vecouts(vecout);
@@ -437,7 +436,7 @@ VectorDouble PrecisionOp::computeCov(Id imesh)
 
   auto n = getSize();
   VectorDouble result(n);
-  std::vector<double> ei(n);
+  VectorDouble ei(n);
   vect eis(ei);
   vect results(result);
 

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -8,7 +8,6 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
-#include "Basic/AStringable.hpp"
 #include "LinearOp/AShiftOp.hpp"
 #include "Matrix/MatrixSparse.hpp"
 #include "geoslib_define.h"
@@ -157,7 +156,7 @@ Id PrecisionOpMatrix::_addToDest(const constvect inv, vect outv) const
 }
 
 Id PrecisionOpMatrix::_addSimulateToDest(const constvect whitenoise,
-                                          vect outv) const
+                                         vect outv) const
 {
   if (_chol == nullptr) _chol = new CholeskySparse(*_Q);
   _chol->addSimulateToDest(whitenoise, outv);
@@ -165,7 +164,7 @@ Id PrecisionOpMatrix::_addSimulateToDest(const constvect whitenoise,
 }
 
 void PrecisionOpMatrix::evalInverse(const constvect vecin,
-                                    std::vector<double>& vecout)
+                                    VectorDouble& vecout)
 {
   if (_chol == nullptr) _chol = new CholeskySparse(*_Q);
   _chol->solve(vecin, vecout);
@@ -270,11 +269,11 @@ void PrecisionOpMatrix::_buildQ()
 MatrixSparse* PrecisionOpMatrix::_build_Q()
 {
   // Preliminary checks
-  auto* S           = ((ShiftOpMatrix*)getShiftOp())->getS();
+  auto* S            = ((ShiftOpMatrix*)getShiftOp())->getS();
   const auto& Lambda = getShiftOp()->getLambdas();
-  VectorDouble blin = getPoly(EPowerPT::ONE)->getCoeffs();
-  Id nblin         = static_cast<Id>(blin.size());
-  Id nvertex       = S->getNCols();
+  VectorDouble blin  = getPoly(EPowerPT::ONE)->getCoeffs();
+  Id nblin           = static_cast<Id>(blin.size());
+  Id nvertex         = S->getNCols();
   if (nvertex <= 0)
   {
     messerr("You must define a valid Meshing beforehand");

--- a/src/LinearOp/PrecisionOpMultiConditional.cpp
+++ b/src/LinearOp/PrecisionOpMultiConditional.cpp
@@ -9,7 +9,6 @@
 /*                                                                            */
 /******************************************************************************/
 #include "LinearOp/PrecisionOpMultiConditional.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Basic/VectorNumT.hpp"
@@ -42,9 +41,9 @@ PrecisionOpMultiConditional::~PrecisionOpMultiConditional()
 {
 }
 
-std::vector<std::vector<double>> PrecisionOpMultiConditional::computeRhs(const std::vector<double>& datVal) const
+VectorVectorDouble PrecisionOpMultiConditional::computeRhs(const VectorDouble& datVal) const
 {
-  std::vector<std::vector<double>> rhs(sizes());
+  VectorVectorDouble rhs(sizes());
   for (Id i = 0, n = sizes(); i < n; i++)
   {
     rhs[i].resize(size(i));
@@ -53,9 +52,9 @@ std::vector<std::vector<double>> PrecisionOpMultiConditional::computeRhs(const s
   return rhs;
 }
 
-void PrecisionOpMultiConditional::computeRhsInPlace(const std::vector<double>& datVal, std::vector<std::vector<double>>& rhs) const
+void PrecisionOpMultiConditional::computeRhsInPlace(const VectorDouble& datVal, VectorVectorDouble& rhs) const
 {
-  std::vector<double> temp(datVal.size());
+  VectorDouble temp(datVal.size());
 
   for (Id i = 0; i < static_cast<Id>(datVal.size()); i++)
   {
@@ -94,7 +93,7 @@ Id PrecisionOpMultiConditional::push_back(PrecisionOp* pmatElem,
     }
   }
   _multiPrecisionOp.push_back(pmatElem);
-  _work2.push_back(std::vector<double>(pmatElem->getSize()));
+  _work2.push_back(VectorDouble(pmatElem->getSize()));
   _multiProjData.push_back(projDataElem);
   _updated();
   _ncova++;
@@ -125,7 +124,7 @@ double PrecisionOpMultiConditional::getMaxEigenValProj() const
     std::fill(e.begin(), e.end(), 1.);
   }
   _AtA(_work3, _work2);
-  return VectorHelper::maximum(_work2);
+  return _work2.maximum();
 }
 
 std::pair<double, double> PrecisionOpMultiConditional::computeRangeEigenVal() const
@@ -163,7 +162,7 @@ double PrecisionOpMultiConditional::computeLogDetOp(Id nbsimu) const
       vect w1s(_work1);
       vect w1bis(_work1bis);
       logPoly.addEvalOp(_multiPrecisionOp[j], w1s, w1bis);
-      val += VH::innerProductVec(_work1bis, _work1);
+      val += _work1bis.innerProduct(_work1);
     }
   }
   return val / nbsimu;
@@ -213,13 +212,13 @@ double PrecisionOpMultiConditional::computeTotalLogDet(Id nMC, bool verbose, Id 
   return result;
 }
 
-double PrecisionOpMultiConditional::computeQuadratic(const std::vector<double>& x) const
+double PrecisionOpMultiConditional::computeQuadratic(const VectorDouble& x) const
 {
   evalInvCov(x, _work1ter);
-  return VH::innerProductVec(_work1ter, x);
+  return _work1ter.innerProduct(x);
 }
 
-void PrecisionOpMultiConditional::_AtA(const std::vector<std::vector<double>>& inv, std::vector<std::vector<double>>& outv) const
+void PrecisionOpMultiConditional::_AtA(const VectorVectorDouble& inv, VectorVectorDouble& outv) const
 {
   std::fill(_workdata.begin(), _workdata.end(), 0.);
 
@@ -228,10 +227,10 @@ void PrecisionOpMultiConditional::_AtA(const std::vector<std::vector<double>>& i
     constvect invs(inv[imod]);
     vect w1s(_work1);
     _multiProjData[imod]->mesh2point(invs, w1s);
-    VH::addInPlace(_workdata, _work1);
+    _workdata.add(_work1);
   }
 
-  VH::divideInPlace(_workdata, _varianceData);
+  _workdata.divide(_varianceData);
 
   for (Id imod = 0; imod < sizes(); imod++)
   {
@@ -253,8 +252,8 @@ void PrecisionOpMultiConditional::_AtA(const std::vector<std::vector<double>>& i
 ** \param[out] outv    Array of output values
 **
 *******************************************************************************/
-void PrecisionOpMultiConditional::_evalDirect(const std::vector<std::vector<double>>& inv,
-                                              std::vector<std::vector<double>>& outv) const
+void PrecisionOpMultiConditional::_evalDirect(const VectorVectorDouble& inv,
+                                              VectorVectorDouble& outv) const
 {
   prepare();
   _AtA(inv, _work2);
@@ -264,17 +263,16 @@ void PrecisionOpMultiConditional::_evalDirect(const std::vector<std::vector<doub
     vect outm(outv[imod]);
     _multiPrecisionOp[imod]->evalDirect(invm, outm);
   }
-  VH::addInPlace(_work2, outv, outv);
+  _work2.addVecInPlace(outv, outv);
 }
 
-void PrecisionOpMultiConditional::simulateOnMeshings(std::vector<std::vector<double>>& result) const
+void PrecisionOpMultiConditional::simulateOnMeshings(VectorVectorDouble& result) const
 {
   for (Id icov = 0, ncov = static_cast<Id>(_multiPrecisionOp.size()); icov < ncov; icov++)
     simulateOnMeshing(result[icov], icov);
 }
 
-void PrecisionOpMultiConditional::simulateOnMeshing(std::vector<double>& result,
-                                                    Id icov) const
+void PrecisionOpMultiConditional::simulateOnMeshing(VectorDouble& result, Id icov) const
 {
   VectorDouble gauss(_multiPrecisionOp[icov]->getSize());
   VH::simulateGaussianInPlace(gauss);
@@ -284,8 +282,8 @@ void PrecisionOpMultiConditional::simulateOnMeshing(std::vector<double>& result,
   _multiPrecisionOp[icov]->evalSimulate(gaussm, resultm);
 }
 
-void PrecisionOpMultiConditional::simulateOnDataPointFromMeshings(const std::vector<std::vector<double>>& simus,
-                                                                  std::vector<double>& result) const
+void PrecisionOpMultiConditional::simulateOnDataPointFromMeshings(const VectorVectorDouble& simus,
+                                                                  VectorDouble& result) const
 {
   result.resize(_ndat);
   std::fill(result.begin(), result.end(), 0.);
@@ -295,7 +293,7 @@ void PrecisionOpMultiConditional::simulateOnDataPointFromMeshings(const std::vec
     constvect simuss(simus[icov]);
     vect w1s(_work1);
     _multiProjData[icov]->mesh2point(simuss, w1s);
-    VH::addInPlace(result, _work1);
+    result.add(_work1);
   }
 
   for (Id idat = 0; idat < _ndat; idat++)
@@ -349,7 +347,7 @@ void PrecisionOpMultiConditional::_allocate(Id i) const
 }
 
 void PrecisionOpMultiConditional::evalInvCov(const constvect inv,
-                                             std::vector<double>& result) const
+                                             VectorDouble& result) const
 {
   _allocate(0);
   _allocate(1);

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -417,7 +417,7 @@ double ASPDEOp::computeLogDetOp(Id nbsimu) const
   return val / nbsimu;
 }
 
-double ASPDEOp::computeQuadratic(const std::vector<double>& x) const
+double ASPDEOp::computeQuadratic(const VectorDouble& x) const
 {
   _workdat4.resize(_getNDat());
   vect w1s(_workdat4);

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -132,7 +132,7 @@ void ClassicalPolynomial::evalOp(MatrixSparse* Op,
                                  vect outv) const
 {
   Id n = static_cast<Id>(inv.size());
-  std::vector<double> work(n);
+  VectorDouble work(n);
   vect ws(work);
   for (Id i = 0; i < n; i++)
     outv[i] = _coeffs.back() * inv[i];
@@ -182,8 +182,8 @@ double ClassicalPolynomial::evalOpByRank(MatrixSparse* S, Id rank) const
 void ClassicalPolynomial::evalOpTraining(
   MatrixSparse* Op,
   const constvect inv,
-  std::vector<std::vector<double>>& store,
-  std::vector<double>& work) const
+  VectorVectorDouble& store,
+  VectorDouble& work) const
 {
   Id n = static_cast<Id>(inv.size());
 

--- a/tests/cpp/test_Nlopt.cpp
+++ b/tests/cpp/test_Nlopt.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "Basic/ASerializable.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/Optim.hpp"
 #include "Basic/VectorNumT.hpp"
 
@@ -30,7 +29,7 @@
 using namespace gstlrn;
 
 // Function to minimize
-double myfunc2(const std::vector<double>& x)
+double myfunc2(const VectorDouble& x)
 {
   // if (grad)
   //   grad[0] = 2 * (x[0] - 3);
@@ -44,15 +43,15 @@ double myfunc2(const std::vector<double>& x)
 static void _firstTest()
 {
   mestitle(0, "Minimization of a Function");
-  std::vector<double> x = {1.};
-  auto* opt             = new Optim(NELDERMEAD, static_cast<Id>(x.size()));
+  VectorDouble x = {1.};
+  auto* opt      = new Optim(NELDERMEAD, static_cast<Id>(x.size()));
 
   // Bounds for each parameter
   VectorDouble lb = {1., 10.};
   opt->setLowerBounds(lb);
   VectorDouble ub = {5., 10.};
   opt->setUpperBounds(ub);
-  auto func = [](const std::vector<double>& x)
+  auto func = [](const VectorDouble& x)
   { return myfunc2(x); };
   opt->setObjective(func);
   opt->setXtolRel(EPSILON4);

--- a/tests/cpp/test_SPDEManual.cpp
+++ b/tests/cpp/test_SPDEManual.cpp
@@ -24,7 +24,6 @@
 #include "Mesh/AMesh.hpp"
 #include "Mesh/MeshETurbo.hpp"
 #include "Model/Model.hpp"
-#include <vector>
 
 #define __USE_MATH_DEFINES
 #include <cmath>
@@ -103,7 +102,7 @@ int main(int argc, char* argv[])
   A.push_back(&Qkriging, &B);
   A.setVarianceData(vardata);
 
-  std::vector<std::vector<double>> Rhs, resultvc;
+  VectorVectorDouble Rhs, resultvc;
   VectorDouble vc(napices);
 
   resultvc.push_back(vc);


### PR DESCRIPTION
This branch is meant to:
- replace std::vector<std::vector<double>> by VectorVectorDouble
- replace std::vector<std::vector<Id>> by VectorVtecorInt
-  replace std::vector<double> by VectorDouble
- replace std::vector<Id> by VectorInt

This also allows some cleaning of redundant methods in VectorHelper class.