### PR TITLE
GitHub Actions: Update macOS images in publish workflows

### DIFF
--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -20,7 +20,7 @@ jobs:
         # Double quote for version is needed otherwise 3.10 => 3.1
         python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
         exclude:
           - os: macos-14
             python: "3.9"

--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -20,18 +20,12 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
         exclude:
           - os: ubuntu-22.04
             r_version: 4.2.3  # ggpubr install fails
           - os: ubuntu-24.04
             r_version: 4.2.3  # ggpubr install fails
-          - os: macos-13
-            r_version: 4.3.3
-          - os: macos-13
-            r_version: 4.4.3
-          - os: macos-13
-            r_version: 4.5.2
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -34,7 +34,6 @@ jobs:
         # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},
@@ -42,15 +41,11 @@ jobs:
             {py: "3.14"}
           ]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
+            {ar: x86_64, os: macos-15-intel, pat: /usr/local},
+            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
           ]
-        exclude:
-          - arch: {os: macos-14}
-            python: {py: "3.9"}
-          - arch: {os: macos-15}
-            python: {py: "3.9"}
 
     steps:
     - uses: actions/checkout@v4
@@ -120,7 +115,6 @@ jobs:
       matrix:
         python: [
         # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},
@@ -128,15 +122,11 @@ jobs:
             {py: "3.14"}
           ]
         arch: [
-            {ar: x86_64, os: macos-13},
             {ar: arm64,  os: macos-14},
-            {ar: arm64,  os: macos-15}
+            {ar: arm64,  os: macos-15},
+            {ar: x86_64, os: macos-15-intel},
+            {ar: arm64,  os: macos-26},
           ]
-        exclude:
-          - arch: {os: macos-14}
-            python: {py: "3.9"}
-          - arch: {os: macos-15}
-            python: {py: "3.9"}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -38,14 +38,11 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
             {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
+            {ar: x86_64, os: macos-15-intel, pat: /usr/local},
+            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
          ]
-        exclude:
-          - {arch: {os: macos-13}, r_version: 4.3.3}
-          - {arch: {os: macos-13}, r_version: 4.4.3}
-          - {arch: {os: macos-13}, r_version: 4.5.2}
 
     steps:
     - uses: actions/checkout@v4
@@ -133,14 +130,11 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         arch: [
-            {ar: x86_64, os: macos-13, pat: /usr/local},
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew}
+            {ar: arm64,  os: macos-14},
+            {ar: arm64,  os: macos-15},
+            {ar: x86_64, os: macos-15-intel},
+            {ar: arm64,  os: macos-26},
          ]
-        exclude:
-          - {arch: {os: macos-13}, r_version: 4.3.3}
-          - {arch: {os: macos-13}, r_version: 4.4.3}
-          - {arch: {os: macos-13}, r_version: 4.5.2}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR gets rid of the `macos-13` VM images, which are no longer provided by GitHub. They

They have been replaced by 2 other images:
- `macos-15-intel` (x86_64) and
- `macos-26`.

The two `publish` workflows have been tested with these changes:
- `publish_python_macos`: https://github.com/pierre-guillou/gstlearn/actions/runs/19903628542
- `publish_r_macos`: https://github.com/pierre-guillou/gstlearn/actions/runs/19900375047

Pierre