### PR TITLE
Bayesian info (prior) is passed through Model

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.10.0
 ==============
+- Bayesian prior information (mean and Cov) are now hosted in DriftList within ModelGeneric. They are not passed as arguments in: kribayes(), simbayes, krigsim(), multilayers_kriging().
 - An additional shortcut for Variogram Cloud calculation
 - Some verbose additional outputs for Variogram Cloud calculations
 - New modes for combining selections (in methods of Db.hpp).

--- a/doc/demo/python/Tuto_MLayers.ipynb
+++ b/doc/demo/python/Tuto_MLayers.ipynb
@@ -368,7 +368,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,\n",
-    "                          namconv=gl.NamingConvention(\"MLKriging\"))"
+    "                             namconv=gl.NamingConvention(\"MLKriging\"))"
    ]
   },
   {
@@ -435,7 +435,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,namerefd=\"reference\",\n",
-    "                           namconv=gl.NamingConvention(\"MLKrigRef\"))"
+    "                             namconv=gl.NamingConvention(\"MLKrigRef\"))"
    ]
   },
   {
@@ -498,7 +498,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,namerefd=\"reference\", flag_vel=True,\n",
-    "                           namconv=gl.NamingConvention(\"MLKrigVel\"))"
+    "                             namconv=gl.NamingConvention(\"MLKrigVel\"))"
    ]
   },
   {
@@ -530,7 +530,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,namerefd=\"reference\", flag_vel=True, flag_Z=False,\n",
-    "                           namconv=gl.NamingConvention(\"MLKrigVel\"))"
+    "                             namconv=gl.NamingConvention(\"MLKrigVel\"))"
    ]
   },
   {
@@ -561,7 +561,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,namerefd=\"reference\", namerefb = \"bottom\",\n",
-    "                           namconv=gl.NamingConvention(\"MLKrigRefBot\"))"
+    "                             namconv=gl.NamingConvention(\"MLKrigRefBot\"))"
    ]
   },
   {
@@ -665,7 +665,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,flag_vel=False,\n",
-    "                          namconv=gl.NamingConvention(\"MLTest\"))"
+    "                             namconv=gl.NamingConvention(\"MLTest\"))"
    ]
   },
   {
@@ -684,7 +684,7 @@
    "outputs": [],
    "source": [
     "err = gl.multilayers_kriging(db,grid,model,flag_vel=True,\n",
-    "                          namconv=gl.NamingConvention(\"MLTest\"))"
+    "                             namconv=gl.NamingConvention(\"MLTest\"))"
    ]
   },
   {

--- a/include/Drifts/DriftF.hpp
+++ b/include/Drifts/DriftF.hpp
@@ -10,35 +10,32 @@
 /******************************************************************************/
 #pragma once
 
-#include "gstlearn_export.hpp"
 #include "Drifts/ADrift.hpp"
+#include "gstlearn_export.hpp"
 
 namespace gstlrn
 {
-class GSTLEARN_EXPORT DriftF : public ADrift
+class GSTLEARN_EXPORT DriftF: public ADrift
 {
 public:
   DriftF(Id rank_fex = 0);
-  DriftF(const DriftF &r);
-  DriftF& operator= (const DriftF &r);
+  DriftF(const DriftF& r);
+  DriftF& operator=(const DriftF& r);
   virtual ~DriftF();
 
   /// ICloneable interface
   IMPLEMENT_CLONING(DriftF)
 
   String getDriftName() const override;
-  Id    getOrderIRF() const override { return -1; }
-  Id    getOrderIRFIdim(Id idim) const override {
-    DECLARE_UNUSED(idim);
-    return -1;
-  }
-  bool   isDriftExternal() const override { return true; }
+  Id getOrderIRF() const override { return -1; }
+  Id getOrderIRFIdim(Id /*idim*/) const override { return -1; }
+  bool isDriftExternal() const override { return true; }
   double eval(const Db* db, Id iech) const override;
-  Id    getRankFex() const override { return _rankFex; }
+  Id getRankFex() const override { return _rankFex; }
 
-  static DriftF* createByIdentifier(const String &driftname);
+  static DriftF* createByIdentifier(const String& driftname);
 
 private:
-  Id _rankFex;       /* Rank of the external drift */
+  Id _rankFex; /* Rank of the external drift */
 };
-}
+} // namespace gstlrn

--- a/include/Drifts/DriftList.hpp
+++ b/include/Drifts/DriftList.hpp
@@ -156,7 +156,13 @@ public:
   void setMean(const double mean, Id ivar = 0);
   double getMean(Id ivar) const;
   const VectorDouble& getMeans() const { return _mean; }
+  void setPriorMeans(const VectorDouble& priorMeans);
+  void setPriorCovs(const MatrixSymmetric& priorCovs);
   const DriftList* createReduce(const VectorInt& validVars) const;
+
+  const VectorDouble& getPriorMeans() const { return _priorMeans; }
+  const MatrixSymmetric& getPriorCovs() const { return _priorCovs; }
+  double getPriorCov(Id i1, Id i2) const;
 
   double evalDriftVarCoef(const Db* db,
                           Id iech,
@@ -201,6 +207,8 @@ protected:
   VectorBool _filtered;         /* Vector of filtered flags (Dimension: as _drifts) */
   CovContext _ctxt;             /* Context (space, number of variables, ...) */
   VectorDouble _mean;           /*  Mean vector */
+  VectorDouble _priorMeans;     /* Prior mean vector (only for Bayesian hypothesis) */
+  MatrixSymmetric _priorCovs;   /* Prior covariance matrix (only for Bayesian hypothesis) */
 #endif
 };
 } // namespace gstlrn

--- a/include/Estimation/CalcKriging.hpp
+++ b/include/Estimation/CalcKriging.hpp
@@ -58,8 +58,6 @@ public:
   CalcKriging& operator=(const CalcKriging& r) = delete;
   virtual ~CalcKriging();
 
-  void setPriorCov(const MatrixSymmetric& priorCov) { _priorCov = priorCov; }
-  void setPriorMean(const VectorDouble& priorMean) { _priorMean = priorMean; }
   void setFlagBayes(bool flagBayes) { _flagBayes = flagBayes; }
   void setIechSingleTarget(Id iechSingleTarget) { _iechSingleTarget = iechSingleTarget; }
   void setVerboseSingleTarget(bool verbose) { _verboseSingleTarget = verbose; }
@@ -91,8 +89,6 @@ private:
   VectorString _nameCoord;
 
   bool _flagBayes;
-  VectorDouble _priorMean;
-  MatrixSymmetric _priorCov;
 
   Id _iechSingleTarget;
   bool _verboseSingleTarget;
@@ -137,12 +133,10 @@ GSTLEARN_EXPORT Id krigcell(Db* dbin,
 GSTLEARN_EXPORT Id kribayes(Db* dbin,
                             Db* dbout,
                             ModelGeneric* model,
-                            ANeigh* neigh                    = nullptr,
-                            const VectorDouble& prior_mean   = VectorDouble(),
-                            const MatrixSymmetric& prior_cov = MatrixSymmetric(),
-                            bool flag_est                    = true,
-                            bool flag_std                    = true,
-                            const NamingConvention& namconv  = NamingConvention("Bayes"));
+                            ANeigh* neigh                   = nullptr,
+                            bool flag_est                   = true,
+                            bool flag_std                   = true,
+                            const NamingConvention& namconv = NamingConvention("Bayes"));
 GSTLEARN_EXPORT Id kriggam(Db* dbin,
                            Db* dbout,
                            ModelGeneric* model,

--- a/include/Estimation/KrigingAlgebra.hpp
+++ b/include/Estimation/KrigingAlgebra.hpp
@@ -11,9 +11,9 @@
 
 #include "gstlearn_export.hpp"
 
-#include "Matrix/MatrixSymmetric.hpp"
-#include "Matrix/MatrixDense.hpp"
 #include "Matrix/AMatrix.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
 
 namespace gstlrn
 {
@@ -32,32 +32,33 @@ namespace gstlrn
  * - the vector *Z* must be centered by the drift beforehand
  * - the vector *beta* corresponds to the vector of Means.
  */
-class GSTLEARN_EXPORT KrigingAlgebra {
+class GSTLEARN_EXPORT KrigingAlgebra
+{
 public:
-  KrigingAlgebra(bool flagDual                        = false,
-                 const VectorVectorInt* sampleRanks   = nullptr,
-                 const VectorDouble* Z                = nullptr,
-                 const MatrixSymmetric* Sigma   = nullptr,
-                 const MatrixDense* X           = nullptr,
-                 const MatrixSymmetric* Sigma00 = nullptr,
-                 const VectorDouble* Means            = nullptr);
+  KrigingAlgebra(bool flagDual                      = false,
+                 const VectorVectorInt* sampleRanks = nullptr,
+                 const VectorDouble* Z              = nullptr,
+                 const MatrixSymmetric* Sigma       = nullptr,
+                 const MatrixDense* X               = nullptr,
+                 const MatrixSymmetric* Sigma00     = nullptr,
+                 const VectorDouble* Means          = nullptr);
 
   void setDual(bool status);
   void resetNewData();
   Id setData(const VectorDouble* Z          = nullptr,
-              const VectorVectorInt* indices = nullptr,
-              const VectorDouble* Means      = nullptr);
+             const VectorVectorInt* indices = nullptr,
+             const VectorDouble* Means      = nullptr);
   Id setLHS(const MatrixSymmetric* Sigma = nullptr,
-             const MatrixDense* X         = nullptr);
+            const MatrixDense* X         = nullptr);
   Id setRHS(const MatrixDense* Sigma0 = nullptr,
-             const MatrixDense* X0     = nullptr);
+            const MatrixDense* X0     = nullptr);
   Id setVariance(const MatrixSymmetric* Sigma00 = nullptr);
-  Id setBayes(const VectorDouble* PriorMean         = nullptr,
-               const MatrixSymmetric* PriorCov = nullptr);
+  Id setBayes(const VectorDouble* PriorMeans   = nullptr,
+              const MatrixSymmetric* PriorCovs = nullptr);
   Id setXvalidUnique(const VectorInt* rankXvalidEqs  = nullptr,
-                      const VectorInt* rankXvalidVars = nullptr);
+                     const VectorInt* rankXvalidVars = nullptr);
   Id setColCokUnique(const VectorDouble* Zp      = nullptr,
-                      const VectorInt* rankColCok = nullptr);
+                     const VectorInt* rankColCok = nullptr);
 
   void printStatus() const;
   void dumpLHS(Id nbypas = 5) const;
@@ -72,9 +73,9 @@ public:
   const MatrixSymmetric* getStdvMat();
   const MatrixSymmetric* getVarianceZstarMat();
   const MatrixSymmetric* getPostCov();
-  const MatrixDense*     getLambda();
-  const MatrixDense*     getLambda0();
-  const MatrixDense*     getMu();
+  const MatrixDense* getLambda();
+  const MatrixDense* getLambda0();
+  const MatrixDense* getMu();
   double getLTerm();
   bool isDual() const { return _flagDual; }
 
@@ -180,30 +181,30 @@ private:
 
 private:
   // Following information should not be removed in destructor
-  const MatrixSymmetric* _Sigma00;  // Variance at Target (Dim: _nrhs * _nrhs)
-  const MatrixSymmetric* _Sigma;    // Covariance Matrix (Dim: _neq * _neq)
-  const MatrixDense* _Sigma0;       // Covariance at Target (Dim: _neq * _nrhs)
-  const MatrixDense* _X;            // Drift at Data (Dim: _neq * _nbfl)
-  const MatrixSymmetric* _PriorCov; // Bayesian Prior Covariance (Dim: _nbfl * _nbfl)
-  const VectorDouble* _Z;                 // Data [flattened] (Dim: _neq)
-  const MatrixDense* _X0;           // Drift at Target (Dim: _nrhs * _nbfl)
-  const VectorDouble* _PriorMean;         // Prior Bayesian Mean (Dim: _nbfl)
-  const VectorDouble* _Means;             // Fixed drift coefficients
-  const VectorDouble* _Zp;                // Vector of values for collocation
-  const VectorInt* _rankColCok;           // Ranks of collocated variables
-  const VectorInt* _rankXvalidEqs;        // Ranks of the cross-validated Equations
-  const VectorInt* _rankXvalidVars;       // Ranks of the cross-validated Variables
-  const VectorVectorInt* _sampleRanks;    // Vector of Vector of sampl indices per variable
+  const MatrixSymmetric* _Sigma00;     // Variance at Target (Dim: _nrhs * _nrhs)
+  const MatrixSymmetric* _Sigma;       // Covariance Matrix (Dim: _neq * _neq)
+  const MatrixDense* _Sigma0;          // Covariance at Target (Dim: _neq * _nrhs)
+  const MatrixDense* _X;               // Drift at Data (Dim: _neq * _nbfl)
+  const MatrixSymmetric* _PriorCovs;   // Bayesian Prior Covariance (Dim: _nbfl * _nbfl)
+  const VectorDouble* _Z;              // Data [flattened] (Dim: _neq)
+  const MatrixDense* _X0;              // Drift at Target (Dim: _nrhs * _nbfl)
+  const VectorDouble* _PriorMeans;     // Prior Bayesian Mean (Dim: _nbfl)
+  const VectorDouble* _Means;          // Fixed drift coefficients
+  const VectorDouble* _Zp;             // Vector of values for collocation
+  const VectorInt* _rankColCok;        // Ranks of collocated variables
+  const VectorInt* _rankXvalidEqs;     // Ranks of the cross-validated Equations
+  const VectorInt* _rankXvalidVars;    // Ranks of the cross-validated Variables
+  const VectorVectorInt* _sampleRanks; // Vector of Vector of sampl indices per variable
 
   // Following elements can be retrieved by Interface functions
-  VectorDouble _Zstar;            // Estimated values (Dim: _nrhs)
-  VectorDouble _Beta;             // Drift coefficients (Dim: _nbfl)
-  MatrixDense _LambdaSK;          // Weights for SK (Dim: _neq * _nrhs)
-  MatrixDense _LambdaUK;          // Weights for UK (Dim: _neq * _nrhs)
-  MatrixDense _MuUK;              // Lagrange multipliers (Dim: _nbfl * _nrhs)
-  MatrixSymmetric _Stdv;          // Estimation stdv. (Dim: _nrhs * _nrhs)
-  MatrixSymmetric _VarZSK;        // Estimator variance in SK (Dim: _nrhs * _nrhs)
-  MatrixSymmetric _VarZUK;        // Estimator variance in UK (Dim: _nrhs * _nrhs)
+  VectorDouble _Zstar;     // Estimated values (Dim: _nrhs)
+  VectorDouble _Beta;      // Drift coefficients (Dim: _nbfl)
+  MatrixDense _LambdaSK;   // Weights for SK (Dim: _neq * _nrhs)
+  MatrixDense _LambdaUK;   // Weights for UK (Dim: _neq * _nrhs)
+  MatrixDense _MuUK;       // Lagrange multipliers (Dim: _nbfl * _nrhs)
+  MatrixSymmetric _Stdv;   // Estimation stdv. (Dim: _nrhs * _nrhs)
+  MatrixSymmetric _VarZSK; // Estimator variance in SK (Dim: _nrhs * _nrhs)
+  MatrixSymmetric _VarZUK; // Estimator variance in UK (Dim: _nrhs * _nrhs)
 
   // Following elements are defined for internal storage
   MatrixDense _XtInvSigma;      // X^t * Inv{Sigma} (Dim: _nbfl * _neq);
@@ -211,17 +212,17 @@ private:
   MatrixDense _InvSigmaSigma0;  // Inv{Sigma} * Sigma0 (Dim: _neq * _nrhs)
   MatrixSymmetric _InvSigma;    // Inv{Sigma} (Dim: _neq * _neq)
   MatrixSymmetric _Sigmac;      // Inv{X^t * Inv{Sigma} * X} (Dim: _nbfl * _nbfl)
-  MatrixSymmetric _InvPriorCov; // Inv{PriorCov} (Dim: _nbfl * _nbfl)
+  MatrixSymmetric _InvPriorCov; // Inv{PriorCovs} (Dim: _nbfl * _nbfl)
 
   // Following elements are defined for internal storage (collocated case in UN)
-  MatrixSymmetric _Sigma00pp;        // ColCok Variance T-T (Dim: _ncck * _ncck)
-  MatrixDense _Sigma00p;             // ColCok Variance D-T (Dim: _ncck * _nrhs)
-  MatrixDense _Sigma0p;              // Collocated Covariance (Dim: _neq * _ncck)
-  MatrixDense _X0p;                  // Collocated Drift (Dim: _ncck * _nbfl)
-  MatrixDense _Y0p;                  // X0p - Sigma0p^t * Inv{Sigma} * X (Dim: _ncck *_nbfl)
-  VectorInt _rankColVars;            // Ranks of active collocated variables
-  VectorDouble _Z0p;                 // Vector of (active) collocated values
-  MatrixDense _Lambda0;              // Collocated weights (Dim: _ncck * _nrhs)
+  MatrixSymmetric _Sigma00pp; // ColCok Variance T-T (Dim: _ncck * _ncck)
+  MatrixDense _Sigma00p;      // ColCok Variance D-T (Dim: _ncck * _nrhs)
+  MatrixDense _Sigma0p;       // Collocated Covariance (Dim: _neq * _ncck)
+  MatrixDense _X0p;           // Collocated Drift (Dim: _ncck * _nbfl)
+  MatrixDense _Y0p;           // X0p - Sigma0p^t * Inv{Sigma} * X (Dim: _ncck *_nbfl)
+  VectorInt _rankColVars;     // Ranks of active collocated variables
+  VectorDouble _Z0p;          // Vector of (active) collocated values
+  MatrixDense _Lambda0;       // Collocated weights (Dim: _ncck * _nrhs)
 
   // Following elements are defined for Dual programming
   VectorDouble _bDual; // Fake Covariance part in Dual (Dim: _neq)
@@ -242,4 +243,4 @@ private:
   bool _flagBayes;
   bool _flagDual;
 };
-}
+} // namespace gstlrn

--- a/include/Estimation/KrigingSystem.hpp
+++ b/include/Estimation/KrigingSystem.hpp
@@ -62,9 +62,7 @@ public:
                       bool optionXValidEstim = false,
                       bool optionXValidStdev = false,
                       bool optionXValidVarZ  = false);
-  Id setKrigOptBayes(bool flag_bayes,
-                     const VectorDouble& prior_mean,
-                     const MatrixSymmetric& prior_cov);
+  Id setKrigOptBayes(bool flag_bayes);
   Id setKrigOptDataWeights(Id iptrWeights, bool flagSet = true);
   Id setKrigOptFlagSimu(bool flagSimu, Id nbsimu = 0, Id rankPGS = -1);
   Id setKrigOptFlagGlobal(bool flag_global);
@@ -189,8 +187,6 @@ private:
 
   /// Option for Bayesian
   bool _flagBayes;
-  VectorDouble _priorMean;
-  MatrixSymmetric _priorCov;
   VectorDouble _postMean;
   MatrixSymmetric _postCov;
   MatrixDense _postSimu;

--- a/include/MLayers/MLayers.hpp
+++ b/include/MLayers/MLayers.hpp
@@ -42,10 +42,9 @@ public:
                   bool flag_cumul,
                   bool flag_ext,
                   bool flag_Z,
+                  bool flag_bayes,
                   bool match_time,
                   Id irf_rank,
-                  const VectorDouble& prior_mean,
-                  const VectorDouble& prior_vars,
                   const String& namerefd,
                   const String& namereft,
                   const String& namerefb);
@@ -150,7 +149,6 @@ private:
                  MatrixSquare* a,
                  VectorDouble& zval,
                  VectorDouble& dual,
-                 const VectorDouble& prior_mean,
                  VectorDouble& prop1,
                  VectorDouble& prop2,
                  MatrixSquare& covtab,
@@ -168,8 +166,6 @@ private:
   void _checkAuxiliaryVariables(VectorInt& seltab);
   void _convertResults();
   Id _calculateDriftBayes(bool verbose,
-                          const VectorDouble& prior_mean,
-                          const VectorDouble& prior_vars,
                           MatrixSquare* acov,
                           VectorDouble& zval,
                           MatrixDense& fftab,
@@ -222,8 +218,6 @@ private:
   Id _npar;        /* Nb. of layers * Nb. of drift functions */
   Id _neq;         /* Total count of equations */
   Id _irfRank;     /* Rank of the IRF */
-  VectorDouble _priorMean;
-  VectorDouble _priorVars;
   Db* _dbin;
   DbGrid* _dbout;
   const Model* _model;
@@ -237,11 +231,10 @@ GSTLEARN_EXPORT Id multilayers_kriging(Db* dbin,
                                        bool flag_vel                   = false,
                                        bool flag_cumul                 = false,
                                        bool flag_ext                   = false,
+                                       bool flag_bayes                 = false,
                                        bool flag_std                   = false,
                                        bool match_time                 = false,
                                        Id irf_rank                     = 0,
-                                       const VectorDouble& prior_mean  = VectorDouble(),
-                                       const VectorDouble& prior_vars  = VectorDouble(),
                                        const String& namerefd          = String(),
                                        const String& namereft          = String(),
                                        const String& namerefb          = String(),

--- a/include/Model/ModelGeneric.hpp
+++ b/include/Model/ModelGeneric.hpp
@@ -120,8 +120,8 @@ public:
   FORWARD_METHOD(getCov, manage)
   FORWARD_METHOD(getCov, optimizationPreProcessForData)
   FORWARD_METHOD(getCov, optimizationPostProcess)
-  FORWARD_METHOD(getCov,  simulateSpectralOmega, MatrixDense())
-  
+  FORWARD_METHOD(getCov, simulateSpectralOmega, MatrixDense())
+
   FORWARD_METHOD_NON_CONST(_getCovModify, setOptimEnabled)
   FORWARD_METHOD_NON_CONST(_getCovModify, attachNoStatDb)
   FORWARD_METHOD_NON_CONST(_getCovModify, makeStationary)
@@ -159,6 +159,9 @@ public:
   FORWARD_METHOD(getDriftList, getMeans)
   FORWARD_METHOD(getDriftList, evalDriftVarCoef, TEST)
   FORWARD_METHOD(getDriftList, evalDriftVarCoefs)
+  FORWARD_METHOD(getDriftList, getPriorMeans)
+  FORWARD_METHOD(getDriftList, getPriorCovs)
+  FORWARD_METHOD(getDriftList, getPriorCov, TEST)
 
   FORWARD_METHOD_NON_CONST(_getDriftListModify, setFlagLinked)
   FORWARD_METHOD_NON_CONST(_getDriftListModify, setBetaHat)
@@ -168,6 +171,8 @@ public:
   FORWARD_METHOD_NON_CONST(_getDriftListModify, copyCovContext)
   FORWARD_METHOD_NON_CONST(_getDriftListModify, setMeans)
   FORWARD_METHOD_NON_CONST(_getDriftListModify, setMean)
+  FORWARD_METHOD_NON_CONST(_getDriftListModify, setPriorMeans)
+  FORWARD_METHOD_NON_CONST(_getDriftListModify, setPriorCovs)
 
   // Forwarding the methods from _ctxt
   FORWARD_METHOD(getContext, getNVar, -1)
@@ -196,9 +201,9 @@ public:
   void addDrift(const ADrift* drift); // TODO: check that the same driftM has not been already defined
   void setDrifts(const VectorString& driftSymbols);
 
-  #ifndef SWIG
+#ifndef SWIG
   void initParams(const MatrixSymmetric& vars, double href = 1., double min = 0., double max = INF);
-  #endif
+#endif
   const ATransform* getTransform() const { return _transform; }
   ATransform* getTransformModify() { return _transform; }
   void setTransform(const ATransform* transform);
@@ -217,15 +222,16 @@ public:
               bool verbose               = false,
               bool trace                 = false,
               bool reml                  = false);
-bool hasTransform() const { return (_transform != nullptr); }
+  bool hasTransform() const { return (_transform != nullptr); }
+
 private:
   virtual bool _isValid() const;
 
 protected:                     // TODO : pass into private to finish clean
   std::shared_ptr<ACov> _cova; /* Generic Covariance structure */
   mutable std::vector<covmaptype> _gradCovFuncs;
-  DriftList* _driftList; /* Series of Drift functions */
-  CovContext _ctxt;      /* Context */
+  DriftList* _driftList;  /* Series of Drift functions */
+  CovContext _ctxt;       /* Context */
   ATransform* _transform; /* Transformation associated to the Model */
 };
 

--- a/include/Simulation/CalcSimuTurningBands.hpp
+++ b/include/Simulation/CalcSimuTurningBands.hpp
@@ -45,12 +45,10 @@ public:
               Model* model,
               ANeigh* neigh,
               Id icase,
-              Id flag_bayes               = false,
-              const VectorDouble& dmean   = VectorDouble(),
-              const MatrixSymmetric& dcov = MatrixSymmetric(),
-              bool flag_pgs               = false,
-              bool flag_gibbs             = false,
-              bool flag_dgm               = false);
+              Id flag_bayes   = false,
+              bool flag_pgs   = false,
+              bool flag_gibbs = false,
+              bool flag_dgm   = false);
   Id simulatePotential(Db* dbiso,
                        Db* dbgrd,
                        Db* dbtgt,
@@ -60,10 +58,6 @@ public:
 
   static bool isValidForTurningBands(const Model* model);
 
-  const MatrixSymmetric& getBayesCov() const { return _bayesCov; }
-  void setBayesCov(const MatrixSymmetric& bayes_cov) { _bayesCov = bayes_cov; }
-  const VectorDouble& getBayesMean() const { return _bayesMean; }
-  void setBayesMean(const VectorDouble& dmean) { _bayesMean = dmean; }
   bool isFlagCheck() const { return _flagCheck; }
   void setFlagCheck(bool flag_check) { _flagCheck = flag_check; }
   bool isFlagBayes() const { return _flagBayes; }
@@ -206,8 +200,6 @@ private:
   bool _flagDGM;
   bool _flagAllocationAlreadyDone;
   VectorString _nameCoord;
-  VectorDouble _bayesMean;
-  MatrixSymmetric _bayesCov;
   Id _npointSimulated;
   double _field;
   double _theta;
@@ -232,8 +224,6 @@ GSTLEARN_EXPORT Id simbayes(Db* dbin,
                             ANeigh* neigh,
                             Id nbsimu                       = 1,
                             Id seed                         = 132141,
-                            const VectorDouble& dmean       = VectorDouble(),
-                            const MatrixSymmetric& dcov     = MatrixSymmetric(),
                             Id nbtuba                       = 100,
                             bool flag_check                 = false,
                             const NamingConvention& namconv = NamingConvention("SimBayes"));

--- a/include/geoslib_f_private.h
+++ b/include/geoslib_f_private.h
@@ -41,8 +41,6 @@ Id _krigsim(Db* dbin,
              const Model* model,
              ANeigh* neigh,
              bool flag_bayes,
-             const VectorDouble& dmean,
-             const MatrixSymmetric& dcov,
              Id icase,
              Id nbsimu,
              bool flag_dgm);

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -1410,9 +1410,6 @@ static void st_result_kriging_print(Id flag_xvalid, Id nvar, Id status)
  ** \param[in]  model      Model structure
  ** \param[in]  neigh      ANeigh structure
  ** \param[in]  flag_bayes 1 if Bayes option is switched ON
- ** \param[in]  dmean      Array giving the prior means for the drift terms
- ** \param[in]  dcov       Array containing the prior covariance matrix
- **                        for the drift terms
  ** \param[in]  icase      Case for PGS and GRF (or -1)
  ** \param[in]  nbsimu     Number of simulations
  ** \param[in]  flag_dgm   1 if the DGM version of kriging should be used
@@ -1426,8 +1423,6 @@ Id _krigsim(Db* dbin,
             const Model* model,
             ANeigh* neigh,
             bool flag_bayes,
-            const VectorDouble& dmean,
-            const MatrixSymmetric& dcov,
             Id icase,
             Id nbsimu,
             bool flag_dgm)
@@ -1453,7 +1448,7 @@ Id _krigsim(Db* dbin,
   KrigingSystem ksys(dbin, dbout, model, neigh, krigopt);
   if (ksys.setKrigOptFlagSimu(true, nbsimu, icase)) return 1;
   if (ksys.updKrigOptEstim(iptr_est, -1, -1, true)) return 1;
-  if (ksys.setKrigOptBayes(flag_bayes, dmean, dcov)) return 1;
+  if (ksys.setKrigOptBayes(flag_bayes)) return 1;
   if (!ksys.isReady()) return 1;
 
   /* Loop on the targets to be processed */

--- a/src/Core/simtub.cpp
+++ b/src/Core/simtub.cpp
@@ -839,7 +839,7 @@ Id simpgs(Db* dbin,
     situba.setFlagAllocationAlreadyDone(true);
     local_seed = 0;
     if (situba.simulate(dbin, dbout, models[igrf], neigh, icase, false,
-                        VectorDouble(), MatrixSymmetric(), true)) goto label_end;
+                        true)) goto label_end;
   }
 
   /* Convert gaussian to facies at target point */
@@ -1267,7 +1267,7 @@ Id simbipgs(Db* dbin,
       situba.setFlagAllocationAlreadyDone(true);
       local_seed = 0;
       if (situba.simulate(dbin, dbout, models[ipgs][igrf], neigh, icase, false,
-                          VectorDouble(), MatrixSymmetric(), true)) goto label_end;
+                          true)) goto label_end;
     }
 
     /* Convert gaussian to facies at target point */
@@ -2386,7 +2386,7 @@ Id simcond(Db* dbin,
   {
     CalcSimuTurningBands situba(nbsimu, nbtuba, flag_check, seed);
     if (situba.simulate(dbin, dbout, model, neighU, 0, false,
-                        VectorDouble(), MatrixSymmetric(), false, true)) goto label_end;
+                        false, true)) goto label_end;
   }
 
   /* Free the temporary variables not used anymore */

--- a/src/Drifts/DriftList.cpp
+++ b/src/Drifts/DriftList.cpp
@@ -15,6 +15,7 @@
 #include "Db/Db.hpp"
 #include "Drifts/ADrift.hpp"
 #include "Drifts/DriftFactory.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
 
 namespace gstlrn
 {
@@ -28,7 +29,14 @@ DriftList::DriftList(const CovContext& ctxt)
   , _filtered()
   , _ctxt(ctxt)
   , _mean(VectorDouble(ctxt.getNVar(), 0.))
+  , _priorMeans()
+  , _priorCovs()
 {
+  auto nfeq   = getNDriftEquation();
+  _priorMeans = VectorDouble(nfeq, 0.);
+  MatrixSymmetric pcov(nfeq);
+  pcov.setIdentity();
+  _priorCovs = pcov;
 }
 
 DriftList::DriftList(const DriftList& r)
@@ -41,6 +49,8 @@ DriftList::DriftList(const DriftList& r)
   , _filtered(r._filtered)
   , _ctxt(r._ctxt)
   , _mean(r._mean)
+  , _priorMeans(r._priorMeans)
+  , _priorCovs(r._priorCovs)
 {
   for (const auto& e: r._drifts)
   {
@@ -57,6 +67,8 @@ DriftList& DriftList::operator=(const DriftList& r)
     _flagCombined = r._flagCombined;
     _driftCL      = r._driftCL;
     _mean         = r._mean;
+    _priorMeans   = r._priorMeans;
+    _priorCovs    = r._priorCovs;
     for (const auto& e: r._drifts)
     {
       _drifts.push_back(dynamic_cast<ADrift*>(e->clone()));
@@ -81,8 +93,17 @@ void DriftList::copyCovContext(const CovContext& ctxt)
 
 void DriftList::_update()
 {
-  if (static_cast<Id>(_mean.size()) != _ctxt.getNVar())
-    _mean = VectorDouble(_ctxt.getNVar(), 0.);
+  Id nvar = _ctxt.getNVar();
+  if (static_cast<Id>(_mean.size()) != nvar)
+    _mean = VectorDouble(nvar, 0.);
+  if (static_cast<Id>(_priorMeans.size()) != nvar)
+    _priorMeans = VectorDouble(nvar, 0.);
+  if (_priorCovs.getNRows() != nvar || _priorCovs.getNCols() != nvar)
+  {
+    MatrixSymmetric pcov(nvar);
+    pcov.setIdentity();
+    _priorCovs = pcov;
+  }
 }
 
 String DriftList::toString(const AStringFormat* /*strfmt*/) const
@@ -816,6 +837,41 @@ void DriftList::setMean(const double mean, Id ivar)
     return;
   }
   _mean[ivar] = mean;
+}
+
+void DriftList::setPriorMeans(const VectorDouble& priorMeans)
+{
+  Id nfeq = getNDriftEquation();
+  if (static_cast<Id>(priorMeans.size()) != nfeq)
+  {
+    messerr("Dimension of 'priorMeans' (%d) does not match number of drift equations (%d)",
+            static_cast<Id>(priorMeans.size()), nfeq);
+    return;
+  }
+  _priorMeans = priorMeans;
+}
+
+void DriftList::setPriorCovs(const MatrixSymmetric& priorCovs)
+{
+  Id nfeq = getNDriftEquation();
+  if (priorCovs.getNRows() != nfeq || priorCovs.getNCols() != nfeq)
+  {
+    messerr("Dimensions of 'priorCovs' (%d, %d) does not match number of drift equations (%d)",
+            priorCovs.getNRows(), priorCovs.getNCols(), nfeq);
+    return;
+  }
+  _priorCovs = priorCovs;
+}
+
+double DriftList::getPriorCov(Id i1, Id i2) const
+{
+  Id nfeq = getNDriftEquation();
+  if (_priorCovs.getNRows() != nfeq || _priorCovs.getNCols() != nfeq)
+  {
+    messerr("Prior covariance matrix is not defined");
+    return TEST;
+  }
+  return _priorCovs.getValue(i1, i2);
 }
 
 /****************************************************************************/

--- a/src/Estimation/CalcKriging.cpp
+++ b/src/Estimation/CalcKriging.cpp
@@ -34,8 +34,6 @@ CalcKriging::CalcKriging(bool flag_est, bool flag_std, bool flag_varZ)
   , _flagVarZ(flag_varZ)
   , _nameCoord()
   , _flagBayes(false)
-  , _priorMean()
-  , _priorCov()
   , _iechSingleTarget(-1)
   , _verboseSingleTarget(false)
   , _flagGam(false)
@@ -230,7 +228,7 @@ bool CalcKriging::_run()
   if (ksys.updKrigOptEstim(_iptrEst, _iptrStd, _iptrVarZ)) return false;
   if (_flagBayes)
   {
-    ksys.setKrigOptBayes(true, _priorMean, _priorCov);
+    ksys.setKrigOptBayes(true);
   }
   if (_flagGam)
   {
@@ -418,9 +416,6 @@ Id krigcell(Db* dbin,
  ** \param[in]  dbout      output Db structure
  ** \param[in]  model      ModelGeneric structure
  ** \param[in]  neigh      ANeigh structure
- ** \param[in]  prior_mean Array giving the prior means for the drift terms
- ** \param[in]  prior_cov  Array containing the prior covariance matrix
- **                        for the drift terms
  ** \param[in]  flag_est   Pointer for the storing the estimation
  ** \param[in]  flag_std   Pointer for the storing the standard deviation
  ** \param[in]  namconv     Naming convention
@@ -430,8 +425,6 @@ Id kribayes(Db* dbin,
             Db* dbout,
             ModelGeneric* model,
             ANeigh* neigh,
-            const VectorDouble& prior_mean,
-            const MatrixSymmetric& prior_cov,
             bool flag_est,
             bool flag_std,
             const NamingConvention& namconv)
@@ -445,8 +438,6 @@ Id kribayes(Db* dbin,
   krige.setNamingConvention(namconv);
 
   krige.setFlagBayes(true);
-  krige.setPriorMean(prior_mean);
-  krige.setPriorCov(prior_cov);
 
   // Run the calculator
   Id error = (krige.run()) ? 0 : 1;

--- a/src/Estimation/KrigingAlgebra.cpp
+++ b/src/Estimation/KrigingAlgebra.cpp
@@ -29,10 +29,10 @@ KrigingAlgebra::KrigingAlgebra(bool flagDual,
   , _Sigma(nullptr)
   , _Sigma0(nullptr)
   , _X(nullptr)
-  , _PriorCov(nullptr)
+  , _PriorCovs(nullptr)
   , _Z(nullptr)
   , _X0(nullptr)
-  , _PriorMean(nullptr)
+  , _PriorMeans(nullptr)
   , _Means(nullptr)
   , _Zp(nullptr)
   , _rankColCok(nullptr)
@@ -643,12 +643,12 @@ Id KrigingAlgebra::setXvalidUnique(const VectorInt* rankXvalidEqs,
   return _patchRHSForXvalidUnique();
 }
 
-Id KrigingAlgebra::setBayes(const VectorDouble* PriorMean,
-                            const MatrixSymmetric* PriorCov)
+Id KrigingAlgebra::setBayes(const VectorDouble* PriorMeans,
+                            const MatrixSymmetric* PriorCovs)
 {
   _resetLinkedToBayes();
 
-  if (PriorMean == nullptr || PriorCov == nullptr)
+  if (PriorMeans == nullptr || PriorCovs == nullptr)
   {
     _flagBayes = false;
     return 0;
@@ -659,10 +659,12 @@ Id KrigingAlgebra::setBayes(const VectorDouble* PriorMean,
     return 1;
   }
 
-  if (!_checkDimensionVD("PriorMean", PriorMean, &_nbfl)) return 1;
-  if (!_checkDimensionMatrix("PriorCov", PriorCov, &_nbfl, &_nbfl)) return 1;
-  _PriorMean = PriorMean;
-  _PriorCov  = PriorCov;
+  if (!_checkDimensionVD("PriorMeans", PriorMeans, &_nbfl)) return 1;
+  if (!_checkDimensionMatrix("PriorCovs", PriorCovs, &_nbfl, &_nbfl)) return 1;
+
+  // Store the arguments (const pointers) into internal storage
+  _PriorMeans = PriorMeans;
+  _PriorCovs  = PriorCovs;
   _flagBayes = true;
 
   return 0;
@@ -770,7 +772,7 @@ Id KrigingAlgebra::_needInvPriorCov()
 {
   if (!_InvPriorCov.empty()) return 0;
   if (_needPriorCov()) return 1;
-  _InvPriorCov = *_PriorCov;
+  _InvPriorCov = *_PriorCovs;
   if (_InvPriorCov.invert()) return 1;
   return 0;
 }
@@ -1076,7 +1078,7 @@ Id KrigingAlgebra::_needBeta()
   {
     if (_needPriorMean()) return 1;
     if (_needInvPriorCov()) return 1;
-    VectorDouble InvSMBayes = _InvPriorCov.prodMatVec(*_PriorMean);
+    VectorDouble InvSMBayes = _InvPriorCov.prodMatVec(*_PriorMeans);
     VH::linearCombinationInPlace(1., XtInvCZ, 1., InvSMBayes, XtInvCZ);
   }
 
@@ -1230,7 +1232,7 @@ Id KrigingAlgebra::_patchRHSForXvalidUnique()
 
 Id KrigingAlgebra::_needPriorCov()
 {
-  if (!_isPresentMatrix("PriorCov", _PriorCov)) return 1;
+  if (!_isPresentMatrix("PriorCovs", _PriorCovs)) return 1;
   return 0;
 }
 
@@ -1266,7 +1268,7 @@ Id KrigingAlgebra::_needXvalid()
 
 Id KrigingAlgebra::_needPriorMean()
 {
-  if (!_isPresentVector("PriorMean", _PriorMean)) return 1;
+  if (!_isPresentVector("PriorMeans", _PriorMeans)) return 1;
   return 0;
 }
 
@@ -1369,9 +1371,9 @@ void KrigingAlgebra::printStatus() const
   _printMatrix("Sigma0", _Sigma0);
   _printMatrix("X", _X);
   _printMatrix("X0", _X0);
-  _printMatrix("PriorCov", _PriorCov);
+  _printMatrix("PriorCovs", _PriorCovs);
   _printVector("Z", _Z);
-  _printVector("PriorMean", _PriorMean);
+  _printVector("PriorMeans", _PriorMeans);
   _printVector("Means", _Means);
   _printVector("Zp", _Zp);
 
@@ -1669,9 +1671,9 @@ void KrigingAlgebra::dumpAux()
   // In Bayesian case, dump the Prior and Posterior information
   if (_flagBayes)
   {
-    printVector(*_PriorMean, "Prior Mean:", true, false);
+    printVector(*_PriorMeans, "Prior Means:", true, false);
     message("Prior Covariance Matrix\n");
-    _PriorCov->display();
+    _PriorCovs->display();
 
     VectorDouble postmean = getPostMean();
     printVector(postmean, "Posterior Mean:", true, false);

--- a/src/Estimation/KrigingSystem.cpp
+++ b/src/Estimation/KrigingSystem.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Estimation/KrigingSystem.hpp"
 #include "Anamorphosis/AnamHermite.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Basic/VectorHelper.hpp"
@@ -79,8 +78,6 @@ KrigingSystem::KrigingSystem(Db* dbin,
   , _xvalidVarZ(false)
   , _valuesColcok()
   , _flagBayes(false)
-  , _priorMean()
-  , _priorCov()
   , _postMean()
   , _postCov()
   , _postSimu()
@@ -1142,36 +1139,19 @@ Id KrigingSystem::setKrigOptXValid(bool flag_xvalid,
   return 0;
 }
 
-Id KrigingSystem::setKrigOptBayes(bool flag_bayes,
-                                  const VectorDouble& prior_mean,
-                                  const MatrixSymmetric& prior_cov)
+Id KrigingSystem::setKrigOptBayes(bool flag_bayes)
 {
-  _isReady  = false;
-  auto nfeq = _getNFeq();
+  _isReady = false;
   if (flag_bayes)
   {
-    VectorDouble local_mean   = prior_mean;
-    MatrixSymmetric local_cov = prior_cov;
+    // Check that the Bayseian information contained in the Model is relevant
 
-    if (local_mean.empty())
-      local_mean.resize(nfeq, 0.);
-    if (local_cov.empty())
+    VectorDouble local_mean   = _model->getPriorMeans();
+    MatrixSymmetric local_cov = _model->getPriorCovs();
+    if (local_mean.empty() || local_cov.empty())
     {
-      local_cov.resetFromValue(nfeq, nfeq, 0.);
-      for (Id i = 0; i < nfeq; i++)
-        local_cov.setValue(i, i, 1.);
-    }
-    if (static_cast<Id>(local_mean.size()) != nfeq)
-    {
-      messerr("Size of argument 'prior_mean'(%d)", static_cast<Id>(local_mean.size()));
-      messerr("should be equal to the Number of Drift Equations(%d)", nfeq);
-      return 1;
-    }
-    if (local_cov.size() != nfeq * nfeq)
-    {
-      messerr("Size of argument 'prior_cov'(%d)", local_cov.size());
-      messerr("should be equal to the Number of Drift Equations (squared) (%d)",
-              nfeq * nfeq);
+      messerr("To run Bayesian Estimation of the drift coefficients");
+      messerr("you must provide prior Mean and Covariance within the Model");
       return 1;
     }
     if (_neigh->getType() != ENeigh::UNIQUE)
@@ -1182,12 +1162,10 @@ Id KrigingSystem::setKrigOptBayes(bool flag_bayes,
     }
 
     // Set the parameters
-    _priorMean = local_mean;
-    _priorCov  = local_cov;
     _varCorrec.resize(_nvarCL, _nvarCL);
 
     // Pass the Bayesian information to '_algebra'
-    if (_algebra.setBayes(&_priorMean, &_priorCov)) return 1;
+    if (_algebra.setBayes(&_model->getPriorMeans(), &_model->getPriorCovs())) return 1;
   }
   _flagBayes = flag_bayes;
   return 0;

--- a/src/MLayers/MLayers.cpp
+++ b/src/MLayers/MLayers.cpp
@@ -31,6 +31,8 @@ MLayers::MLayers()
   , _flagCumul(true)
   , _flagExt(false)
   , _flagZ(true)
+  , _flagBayes(false)
+  , _flagStd(false)
   , _colrefD(-1)
   , _colrefT(-1)
   , _colrefB(-1)
@@ -54,6 +56,8 @@ MLayers::MLayers(const MLayers& m)
   , _flagCumul(m._flagCumul)
   , _flagExt(m._flagExt)
   , _flagZ(m._flagZ)
+  , _flagBayes(m._flagBayes)
+  , _flagStd(m._flagStd)
   , _colrefD(m._colrefD)
   , _colrefT(m._colrefT)
   , _colrefB(m._colrefB)
@@ -80,6 +84,8 @@ MLayers& MLayers::operator=(const MLayers& m)
     _flagCumul = m._flagCumul;
     _flagExt   = m._flagExt;
     _flagZ     = m._flagZ;
+    _flagBayes = m._flagBayes;
+    _flagStd   = m._flagStd;
     _colrefD   = m._colrefD;
     _colrefT   = m._colrefT;
     _colrefB   = m._colrefB;
@@ -183,10 +189,9 @@ void MLayers::setGeneral(Db* dbin,
                          bool flag_cumul,
                          bool flag_ext,
                          bool flag_Z,
+                         bool flag_bayes,
                          bool match_time,
                          Id irf_rank,
-                         const VectorDouble& prior_means,
-                         const VectorDouble& prior_vars,
                          const String& namerefd,
                          const String& namereft,
                          const String& namerefb)
@@ -205,6 +210,7 @@ void MLayers::setGeneral(Db* dbin,
   _flagCumul = flag_cumul;
   _flagExt   = flag_ext;
   _flagZ     = flag_Z;
+  _flagBayes = flag_bayes;
   _colrefD   = colrefd;
   _colrefT   = colreft;
   _colrefB   = colrefb;
@@ -215,8 +221,6 @@ void MLayers::setGeneral(Db* dbin,
   _nech      = 0;
   _npar      = _nbfl * _nlayers;
   _neq       = _nechmax + _npar;
-  _priorMean = prior_means;
-  _priorVars = prior_vars;
 }
 
 /****************************************************************************/
@@ -1197,7 +1201,6 @@ void MLayers::_estimateBayes(double c00,
 ** \param[in]  a          L.H.S. (square) inverted matrix
 ** \param[in]  zval       Data vector (extended)
 ** \param[in]  dual       Dual vector
-** \param[in]  prior_mean Array of prior means
 **
 ** \param[out] prop1      Working array (Dimension: nlayers)
 ** \param[out] prop2      Working array (Dimension: nlayers)
@@ -1218,7 +1221,6 @@ void MLayers::_estimate(VectorInt& seltab,
                         MatrixSquare* a,
                         VectorDouble& zval,
                         VectorDouble& dual,
-                        const VectorDouble& prior_mean,
                         VectorDouble& prop1,
                         VectorDouble& prop2,
                         MatrixSquare& covtab,
@@ -1234,7 +1236,6 @@ void MLayers::_estimate(VectorInt& seltab,
                         MatrixSquare& gs,
                         VectorDouble& post_mean)
 {
-  DECLARE_UNUSED(prior_mean);
   double estim;
   VectorDouble coor(2);
 
@@ -1547,8 +1548,6 @@ Id MLayers::_fillDriftData(VectorInt& seltab,
  **
  *****************************************************************************/
 Id MLayers::_calculateDriftBayes(bool verbose,
-                                 const VectorDouble& prior_mean,
-                                 const VectorDouble& prior_vars,
                                  MatrixSquare* acov,
                                  VectorDouble& zval,
                                  MatrixDense& fftab,
@@ -1569,13 +1568,13 @@ Id MLayers::_calculateDriftBayes(bool verbose,
 
   for (Id ipar = 0; ipar < _npar; ipar++)
     for (Id jpar = 0; jpar < _npar; jpar++)
-      invS.setValue(ipar, jpar, (ipar == jpar) ? prior_vars[ipar] : 0.);
+      invS.setValue(ipar, jpar, (ipar == jpar) ? _model->getPriorCov(ipar, jpar) : 0.);
 
   /* Optional printout */
 
   if (verbose)
   {
-    printMatrix(prior_mean, _nlayers, _nbfl, "Prior Mean", 0, 1);
+    printMatrix(_model->getPriorMeans(), _nlayers, _nbfl, "Prior Mean", 0, 1);
     printMatrix(invS.getValues(), _npar, _npar, "Prior Variance", 0, 1);
   }
 
@@ -1598,7 +1597,7 @@ Id MLayers::_calculateDriftBayes(bool verbose,
 
   /* Calculate the Posterior Mean vector */
 
-  invS.prodMatVecInPlace(prior_mean, post_mean);
+  invS.prodMatVecInPlace(_model->getPriorMeans(), post_mean);
   for (Id i = 0; i < _npar; i++)
     fm1z[i] += post_mean[i];
   post_vars.prodMatVecInPlace(fm1z, post_mean);
@@ -1948,7 +1947,6 @@ bool MLayers::checkValid()
             get_LOCATOR_NITEM(_dbout, _ptime));
     return false;
   }
-  _flagBayes   = (!_priorMean.empty() && !_priorVars.empty());
   Id dim_prior = _getNDrift() * _nlayers;
   if (_flagBayes && dim_prior != _getNDrift() * _nlayers)
   {
@@ -2075,8 +2073,7 @@ Id MLayers::kriging(bool verbose)
   if (_flagBayes)
   {
     if (_fillDriftData(seltab, prop1, drift, fftab)) return -1;
-    if (_calculateDriftBayes(verbose, _priorMean, _priorVars, a, zval,
-                             fftab, a0, cc, ss, gs, postMean, postVars)) return -1;
+    if (_calculateDriftBayes(verbose, a, zval, fftab, a0, cc, ss, gs, postMean, postVars)) return -1;
   }
   else
   {
@@ -2086,7 +2083,7 @@ Id MLayers::kriging(bool verbose)
 
   /* Perform the estimation over the grid nodes */
 
-  _estimate(seltab, a, zval, dual, _priorMean, prop1, prop2, covtab, b, b2,
+  _estimate(seltab, a, zval, dual, prop1, prop2, covtab, b, b2,
             baux, wgt, c00, fftab, a0, cc, ss, gs, postMean);
 
   /* Reconstitute the surfaces (optional) */
@@ -2219,11 +2216,10 @@ label_end:
  ** \param[in]  flag_vel   True if work is performed in Velocity, False for Depth
  ** \param[in]  flag_cumul True if work is performed in Depth; False in Thickness
  ** \param[in]  flag_ext   True if external drift must be used; False otherwise
+ ** \param[in]  flag_bayes True if Bayesian hypothesis in Drift Coefficients
  ** \param[in]  flag_std   True if the estimation error must be calculated
  ** \param[in]  irf_rank   Rank of the Intrinsic Random Function (0 or 1)
  ** \param[in]  match_time True if external drift matches time; False otherwise
- ** \param[in]  prior_mean Vector of prior means for drift coefficients
- ** \param[in]  prior_vars Vector of prior variances for drift coefficients
  ** \param[in]  namerefd   Name of the reference Depth variable in Dbout
  ** \param[in]  namereft   Name of the reference Time variable in Dbout
  ** \param[in]  namerefb   Name of the Bottom Depth variable in Dbout (or -1)
@@ -2239,11 +2235,10 @@ Id multilayers_kriging(Db* dbin,
                        bool flag_vel,
                        bool flag_cumul,
                        bool flag_ext,
+                       bool flag_bayes,
                        bool flag_std,
                        bool match_time,
                        Id irf_rank,
-                       const VectorDouble& prior_mean,
-                       const VectorDouble& prior_vars,
                        const String& namerefd,
                        const String& namereft,
                        const String& namerefb,
@@ -2252,8 +2247,8 @@ Id multilayers_kriging(Db* dbin,
 {
   MLayers lmlayers = MLayers();
   lmlayers.setGeneral(dbin, dbout, model,
-                      flag_std, flag_same, flag_vel, flag_cumul, flag_ext, flag_Z,
-                      match_time, irf_rank, prior_mean, prior_vars, namerefd, namereft, namerefb);
+                      flag_std, flag_same, flag_vel, flag_cumul, flag_ext, flag_Z, flag_bayes,
+                      match_time, irf_rank, namerefd, namereft, namerefb);
 
   if (!lmlayers.checkValid()) return 1;
 
@@ -2297,8 +2292,8 @@ Id multilayers_vario(Db* dbin,
 {
   MLayers lmlayers = MLayers();
   lmlayers.setGeneral(dbin, dbout, nullptr,
-                      false, false, flag_vel, false, flag_ext, false,
-                      match_time, irf_rank, VectorDouble(), VectorDouble(), namerefd, namereft, String());
+                      false, false, flag_vel, false, flag_ext, false, false,
+                      match_time, irf_rank, namerefd, namereft, String());
 
   if (!lmlayers.checkValid()) return 1;
 
@@ -2338,8 +2333,8 @@ Id multilayers_getPrior(Db* dbin,
 {
   MLayers lmlayers = MLayers();
   lmlayers.setGeneral(dbin, dbout, model,
-                      false, flag_same, flag_vel, false, flag_ext, false,
-                      match_time, irf_rank, VectorDouble(), VectorDouble(), namerefd, namereft, namerefb);
+                      false, flag_same, flag_vel, false, flag_ext, false, false,
+                      match_time, irf_rank, namerefd, namereft, namerefb);
 
   if (!lmlayers.checkValid()) return 1;
 

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -45,8 +45,6 @@ CalcSimuTurningBands::CalcSimuTurningBands(Id nbsimu,
   , _flagDGM(false)
   , _flagAllocationAlreadyDone(false)
   , _nameCoord()
-  , _bayesMean()
-  , _bayesCov()
   , _npointSimulated(0)
   , _field(0.)
   , _theta(0.)
@@ -1961,8 +1959,7 @@ bool CalcSimuTurningBands::_run()
   if (flag_cond)
   {
     if (_krigsim(getDbin(), getDbout(), _modelLocal, getNeigh(),
-                 _flagBayes, _bayesMean, _bayesCov, _icase,
-                 nbsimu, _flagDGM)) return 1;
+                 _flagBayes, _icase, nbsimu, _flagDGM)) return 1;
   }
 
   /* Copy value from data to coinciding grid node */
@@ -1990,9 +1987,6 @@ bool CalcSimuTurningBands::_run()
  ** \param[in]  neigh      ANeigh structure
  ** \param[in]  icase      Case for PGS or -1
  ** \param[in]  flag_bayes 1 if the Bayes option is switched ON
- ** \param[in]  dmean      Array giving the prior means for the drift terms
- ** \param[in]  dcov       Array containing the prior covariance matrix
- **                        for the drift terms
  ** \param[in]  flag_pgs   1 if called from PGS
  ** \param[in]  flag_gibbs 1 if called from Gibbs
  ** \param[in]  flag_dgm   1 if the Discrete Gaussian Model is used
@@ -2004,8 +1998,6 @@ Id CalcSimuTurningBands::simulate(Db* dbin,
                                   ANeigh* neigh,
                                   Id icase,
                                   Id flag_bayes,
-                                  const VectorDouble& dmean,
-                                  const MatrixSymmetric& dcov,
                                   bool flag_pgs,
                                   bool flag_gibbs,
                                   bool flag_dgm)
@@ -2016,8 +2008,6 @@ Id CalcSimuTurningBands::simulate(Db* dbin,
   setNeigh(neigh);
   setIcase(icase);
   setFlagBayes(flag_bayes);
-  setBayesMean(dmean);
-  setBayesCov(dcov);
   setFlagPgs(flag_pgs);
   setFlagGibbs(flag_gibbs);
   setFlagDgm(flag_dgm);
@@ -2390,9 +2380,6 @@ Id simtub(Db* dbin,
  ** \param[in]  neigh      ANeigh structure (optional)
  ** \param[in]  nbsimu     Number of simulations
  ** \param[in]  seed       Seed for random number generator
- ** \param[in]  dmean      Array giving the prior means for the drift terms
- ** \param[in]  dcov       Array containing the prior covariance matrix
- **                        for the drift terms
  ** \param[in]  nbtuba     Number of turning bands
  ** \param[in]  flag_check 1 to check the proximity in Gaussian scale
  ** \param[in]  namconv    Naming convention
@@ -2407,8 +2394,6 @@ Id simbayes(Db* dbin,
             ANeigh* neigh,
             Id nbsimu,
             Id seed,
-            const VectorDouble& dmean,
-            const MatrixSymmetric& dcov,
             Id nbtuba,
             bool flag_check,
             const NamingConvention& namconv)
@@ -2424,8 +2409,6 @@ Id simbayes(Db* dbin,
   situba.setNamingConvention(namconv);
 
   situba.setFlagBayes(true);
-  situba.setBayesMean(dmean);
-  situba.setBayesCov(dcov);
 
   // Run the calculator
   Id error = (situba.run()) ? 0 : 1;

--- a/tests/cpp/bench_Bayes.cpp
+++ b/tests/cpp/bench_Bayes.cpp
@@ -16,19 +16,19 @@
 #include "Basic/NamingConvention.hpp"
 #include "Enum/ESpaceType.hpp"
 
-#include "Matrix/MatrixSymmetric.hpp"
-#include "Space/ASpace.hpp"
-#include "Space/ASpaceObject.hpp"
-#include "Db/Db.hpp"
-#include "Db/DbStringFormat.hpp"
-#include "Basic/Law.hpp"
-#include "Model/Model.hpp"
 #include "Basic/File.hpp"
+#include "Basic/Law.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Basic/VectorHelper.hpp"
-#include "Neigh/NeighUnique.hpp"
-#include "Neigh/NeighMoving.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbStringFormat.hpp"
 #include "Estimation/CalcKriging.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
+#include "Model/Model.hpp"
+#include "Neigh/NeighMoving.hpp"
+#include "Neigh/NeighUnique.hpp"
+#include "Space/ASpace.hpp"
+#include "Space/ASpaceObject.hpp"
 
 using namespace gstlrn;
 
@@ -44,9 +44,9 @@ int main(int argc, char* argv[])
   defineDefaultSpace(ESpaceType::RN, ndim);
 
   // Parameters
-  bool verbose    = false;
-  Id nech         = 3;
-  Id nvar         = 1;
+  bool verbose = false;
+  Id nech      = 3;
+  Id nvar      = 1;
 
   // Generate the data base
   Db* data = Db::createFillRandom(nech, ndim, nvar, 0);
@@ -70,15 +70,17 @@ int main(int argc, char* argv[])
   ANeigh* neigh = NeighUnique::create();
 
   // Create the Bayesian Priors for Drift coefficients
-  VectorDouble PriorMean = VH::simulateGaussian(nvar);
-  MatrixSymmetric PriorCov(nvar);
-  PriorCov.setDiagonal(VH::simulateUniform(nvar, 0.1, 0.5));
+  VectorDouble PriorMeans = VH::simulateGaussian(nvar);
+  MatrixSymmetric PriorCovs(nvar);
+  PriorCovs.setDiagonal(VH::simulateUniform(nvar, 0.1, 0.5));
 
   // Define the verbose option
   if (verbose) OptDbg::setReference(1);
 
   // Test on Bayesian
-  kribayes(data, target, model, neigh, PriorMean, PriorCov);
+  model->setPriorMeans(PriorMeans);
+  model->setPriorCovs(PriorCovs);
+  kribayes(data, target, model, neigh);
   dbfmt = DbStringFormat::create(FLAG_STATS, {"Kriging.*"});
   target->display(dbfmt);
 

--- a/tests/cpp/output/test_Krige.ref
+++ b/tests/cpp/output/test_Krige.ref
@@ -11,9 +11,9 @@ Total number of samples      = 2500
 
 Grid characteristics:
 ---------------------
-Origin :      0.000     0.000
-Mesh   :      1.000     1.000
-Number :         50        50
+Origin :       0.000      0.000
+Mesh   :       1.000      1.000
+Number :          50         50
 
 Variables
 ---------
@@ -29,37 +29,37 @@ Data Base Characteristics
 Data Base Statistics
 --------------------
 1 - Name rank - Locator NA
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =      1.000
- Maximum value       =    100.000
- Mean value          =     50.500
- Standard Deviation  =     28.866
- Variance            =    833.250
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =       1.000
+ Maximum value       =     100.000
+ Mean value          =      50.500
+ Standard Deviation  =      28.866
+ Variance            =     833.250
 2 - Name x1 - Locator x1
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =   -125.499
- Maximum value       =    107.194
- Mean value          =     -1.079
- Standard Deviation  =     44.459
- Variance            =   1976.595
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =    -125.499
+ Maximum value       =     107.194
+ Mean value          =      -1.079
+ Standard Deviation  =      44.459
+ Variance            =    1976.595
 3 - Name x2 - Locator x2
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =   -111.314
- Maximum value       =    132.575
- Mean value          =      2.316
- Standard Deviation  =     49.469
- Variance            =   2447.157
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =    -111.314
+ Maximum value       =     132.575
+ Mean value          =       2.316
+ Standard Deviation  =      49.469
+ Variance            =    2447.157
 4 - Name Var - Locator z1
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =     -2.168
- Maximum value       =      2.214
- Mean value          =      0.003
- Standard Deviation  =      0.986
- Variance            =      0.972
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =      -2.168
+ Maximum value       =       2.214
+ Mean value          =       0.003
+ Standard Deviation  =       0.986
+ Variance            =       0.972
 
 Model characteristics
 =====================
@@ -72,11 +72,11 @@ Number of drift equation(s)  = 1
 Covariance Part
 ---------------
 Spherical
-- Sill         =     45.000
-- Range        =     40.000
+- Sill         =      45.000
+- Range        =      40.000
 Nugget Effect
-- Sill         =     12.000
-Total Sill     =     57.000
+- Sill         =      12.000
+Total Sill     =      57.000
 
 Drift Part
 ----------
@@ -85,7 +85,7 @@ Universality_Condition
 Image Neighborhood
 ==================
 Skipping factor = 2
-Image radius :         2         2
+Image radius :          2          2
 
 Moving Neighborhood
 ===================
@@ -103,85 +103,85 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 1 - Name rank - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.000
- Maximum value       =   2500.000
- Mean value          =   1250.500
- Standard Deviation  =    721.688
- Variance            = 520833.250
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.000
+ Maximum value       =    2500.000
+ Mean value          =    1250.500
+ Standard Deviation  =     721.688
+ Variance            =  520833.250
 2 - Name x1 - Locator x1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.000
- Maximum value       =     49.000
- Mean value          =     24.500
- Standard Deviation  =     14.431
- Variance            =    208.250
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.000
+ Maximum value       =      49.000
+ Mean value          =      24.500
+ Standard Deviation  =      14.431
+ Variance            =     208.250
 3 - Name x2 - Locator x2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.000
- Maximum value       =     49.000
- Mean value          =     24.500
- Standard Deviation  =     14.431
- Variance            =    208.250
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.000
+ Maximum value       =      49.000
+ Mean value          =      24.500
+ Standard Deviation  =      14.431
+ Variance            =     208.250
 4 - Name Extend-1 - Locator dblk1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.000
- Maximum value       =      1.000
- Mean value          =      1.000
- Standard Deviation  =      0.000
- Variance            =      0.000
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.000
+ Maximum value       =       1.000
+ Mean value          =       1.000
+ Standard Deviation  =       0.000
+ Variance            =       0.000
 5 - Name Extend-2 - Locator dblk2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.000
- Maximum value       =      1.000
- Mean value          =      1.000
- Standard Deviation  =      0.000
- Variance            =      0.000
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.000
+ Maximum value       =       1.000
+ Mean value          =       1.000
+ Standard Deviation  =       0.000
+ Variance            =       0.000
 6 - Name Neigh.Var.Number - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     25.000
- Maximum value       =     25.000
- Mean value          =     25.000
- Standard Deviation  =      0.000
- Variance            =      0.000
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      25.000
+ Maximum value       =      25.000
+ Mean value          =      25.000
+ Standard Deviation  =       0.000
+ Variance            =       0.000
 7 - Name Neigh.Var.MaxDist - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     35.453
- Maximum value       =     53.389
- Mean value          =     43.790
- Standard Deviation  =      4.025
- Variance            =     16.197
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      35.453
+ Maximum value       =      53.389
+ Mean value          =      43.790
+ Standard Deviation  =       4.025
+ Variance            =      16.197
 8 - Name Neigh.Var.MinDist - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.163
- Maximum value       =     17.333
- Mean value          =      7.019
- Standard Deviation  =      3.235
- Variance            =     10.464
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.163
+ Maximum value       =      17.333
+ Mean value          =       7.019
+ Standard Deviation  =       3.235
+ Variance            =      10.464
 9 - Name Neigh.Var.NbNESect - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.000
- Maximum value       =      1.000
- Mean value          =      1.000
- Standard Deviation  =      0.000
- Variance            =      0.000
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.000
+ Maximum value       =       1.000
+ Mean value          =       1.000
+ Standard Deviation  =       0.000
+ Variance            =       0.000
 10 - Name Neigh.Var.NbCESect - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.000
- Maximum value       =      0.000
- Mean value          =      0.000
- Standard Deviation  =      0.000
- Variance            =      0.000
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.000
+ Maximum value       =       0.000
+ Mean value          =       0.000
+ Standard Deviation  =       0.000
+ Variance            =       0.000
 
 <----- Cross-Validation in Moving Neighborhood ----->
 
@@ -191,21 +191,21 @@ Data Base Characteristics
 Data Base Statistics
 --------------------
 5 - Name Xvalid.Var.estim - Locator z1
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =     -1.142
- Maximum value       =      1.404
- Mean value          =      0.004
- Standard Deviation  =      0.501
- Variance            =      0.251
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =      -1.142
+ Maximum value       =       1.404
+ Mean value          =       0.004
+ Standard Deviation  =       0.501
+ Variance            =       0.251
 6 - Name Xvalid.Var.stdev - Locator NA
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =      4.280
- Maximum value       =      7.952
- Mean value          =      5.963
- Standard Deviation  =      0.912
- Variance            =      0.831
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =       4.280
+ Maximum value       =       7.952
+ Mean value          =       5.963
+ Standard Deviation  =       0.912
+ Variance            =       0.831
 
 <----- Kriging in Moving Neighborhood ----->
 
@@ -215,21 +215,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Kriging.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.140
- Maximum value       =      0.644
- Mean value          =     -0.087
- Standard Deviation  =      0.382
- Variance            =      0.146
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.140
+ Maximum value       =       0.644
+ Mean value          =      -0.087
+ Standard Deviation  =       0.382
+ Variance            =       0.146
 7 - Name Kriging.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      4.273
- Maximum value       =      6.465
- Mean value          =      5.453
- Standard Deviation  =      0.410
- Variance            =      0.168
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       4.273
+ Maximum value       =       6.465
+ Mean value          =       5.453
+ Standard Deviation  =       0.410
+ Variance            =       0.168
 
 <----- Declustering in Moving Neighborhood ----->
 
@@ -255,11 +255,11 @@ Testing KrigTest facility
 - Number of Kriging System equations (covariance) = 25
 - Number of Kriging System equations (drift) = 1
 - Neighboring Sample Indices
-               [,  0]    [,  1]    [,  2]    [,  3]    [,  4]    [,  5]    [,  6]
-     [  0,]         4         5        21        22        30        32        33
-     [  7,]        34        40        45        46        51        56        63
-     [ 14,]        64        68        69        71        72        73        76
-     [ 21,]        79        86        88        94
+                 [,  0]     [,  1]     [,  2]     [,  3]     [,  4]     [,  5]     [,  6]
+      [  0,]          4          5         21         22         30         32         33
+      [  7,]         34         40         45         46         51         56         63
+      [ 14,]         64         68         69         71         72         73         76
+      [ 21,]         79         86         88         94
 
 <----- Cross-Validation in Unique Neighborhood ----->
 
@@ -269,21 +269,21 @@ Data Base Characteristics
 Data Base Statistics
 --------------------
 5 - Name Xvalid.Var.estim - Locator z1
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =     -1.070
- Maximum value       =      1.330
- Mean value          =      0.000
- Standard Deviation  =      0.470
- Variance            =      0.221
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =      -1.070
+ Maximum value       =       1.330
+ Mean value          =       0.000
+ Standard Deviation  =       0.470
+ Variance            =       0.221
 6 - Name Xvalid.Var.stdev - Locator NA
- Nb of data          =        100
- Nb of active values =        100
- Minimum value       =      4.277
- Maximum value       =      7.654
- Mean value          =      5.917
- Standard Deviation  =      0.857
- Variance            =      0.734
+ Nb of data          =         100
+ Nb of active values =         100
+ Minimum value       =       4.277
+ Maximum value       =       7.654
+ Mean value          =       5.917
+ Standard Deviation  =       0.857
+ Variance            =       0.734
 
 <----- Kriging in Unique Neighborhood ----->
 
@@ -293,21 +293,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Kriging.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.146
- Maximum value       =      0.691
- Mean value          =     -0.076
- Standard Deviation  =      0.392
- Variance            =      0.154
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.146
+ Maximum value       =       0.691
+ Mean value          =      -0.076
+ Standard Deviation  =       0.392
+ Variance            =       0.154
 7 - Name Kriging.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      4.272
- Maximum value       =      6.389
- Mean value          =      5.437
- Standard Deviation  =      0.400
- Variance            =      0.160
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       4.272
+ Maximum value       =       6.389
+ Mean value          =       5.437
+ Standard Deviation  =       0.400
+ Variance            =       0.160
 
 <----- Simulations in Unique Neighborhood ----->
 
@@ -317,29 +317,29 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Simu.Var.1 - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -17.688
- Maximum value       =     15.692
- Mean value          =     -0.043
- Standard Deviation  =      4.620
- Variance            =     21.346
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -17.688
+ Maximum value       =      15.692
+ Mean value          =      -0.043
+ Standard Deviation  =       4.620
+ Variance            =      21.346
 7 - Name Simu.Var.2 - Locator z2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -16.348
- Maximum value       =     13.752
- Mean value          =     -1.101
- Standard Deviation  =      4.912
- Variance            =     24.130
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -16.348
+ Maximum value       =      13.752
+ Mean value          =      -1.101
+ Standard Deviation  =       4.912
+ Variance            =      24.130
 8 - Name Simu.Var.3 - Locator z3
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -15.579
- Maximum value       =     14.975
- Mean value          =      0.370
- Standard Deviation  =      4.692
- Variance            =     22.016
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -15.579
+ Maximum value       =      14.975
+ Mean value          =       0.370
+ Standard Deviation  =       4.692
+ Variance            =      22.016
 
 <----- Bayesian Simulations in Unique Neighborhood ----->
 
@@ -349,29 +349,29 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name SimBayes.Var.1 - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -16.829
- Maximum value       =     16.512
- Mean value          =      0.800
- Standard Deviation  =      4.618
- Variance            =     21.330
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -16.829
+ Maximum value       =      16.512
+ Mean value          =       0.800
+ Standard Deviation  =       4.618
+ Variance            =      21.330
 7 - Name SimBayes.Var.2 - Locator z2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -17.096
- Maximum value       =     13.052
- Mean value          =     -1.776
- Standard Deviation  =      4.910
- Variance            =     24.106
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -17.096
+ Maximum value       =      13.052
+ Mean value          =      -1.776
+ Standard Deviation  =       4.910
+ Variance            =      24.106
 8 - Name SimBayes.Var.3 - Locator z3
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =    -16.244
- Maximum value       =     14.361
- Mean value          =     -0.332
- Standard Deviation  =      4.696
- Variance            =     22.051
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =     -16.244
+ Maximum value       =      14.361
+ Mean value          =      -0.332
+ Standard Deviation  =       4.696
+ Variance            =      22.051
 
 <----- Declustering in Unique Neighborhood ----->
 
@@ -431,21 +431,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Kriging.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.139
- Maximum value       =      0.689
- Mean value          =     -0.076
- Standard Deviation  =      0.392
- Variance            =      0.153
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.139
+ Maximum value       =       0.689
+ Mean value          =      -0.076
+ Standard Deviation  =       0.392
+ Variance            =       0.153
 7 - Name Kriging.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      2.356
- Maximum value       =      5.289
- Mean value          =      4.074
- Standard Deviation  =      0.540
- Variance            =      0.291
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       2.356
+ Maximum value       =       5.289
+ Mean value          =       4.074
+ Standard Deviation  =       0.540
+ Variance            =       0.291
 
 <----- Block Kriging (variable size) ----->
 
@@ -455,21 +455,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name KrigCell.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.139
- Maximum value       =      0.689
- Mean value          =     -0.076
- Standard Deviation  =      0.392
- Variance            =      0.153
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.139
+ Maximum value       =       0.689
+ Mean value          =      -0.076
+ Standard Deviation  =       0.392
+ Variance            =       0.153
 7 - Name KrigCell.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      2.356
- Maximum value       =      5.289
- Mean value          =      4.074
- Standard Deviation  =      0.540
- Variance            =      0.291
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       2.356
+ Maximum value       =       5.289
+ Mean value          =       4.074
+ Standard Deviation  =       0.540
+ Variance            =       0.291
 
 Data Base Grid Characteristics
 ==============================
@@ -483,9 +483,9 @@ Total number of samples      = 2500
 
 Grid characteristics:
 ---------------------
-Origin :      0.000     0.000
-Mesh   :      1.000     1.000
-Number :         50        50
+Origin :       0.000      0.000
+Mesh   :       1.000      1.000
+Number :          50         50
 
 Variables
 ---------
@@ -505,12 +505,12 @@ Number of drift equation(s)  = 1
 Covariance Part
 ---------------
 Spherical
-- Sill         =     45.000
-- Range        =     40.000
+- Sill         =      45.000
+- Range        =      40.000
 Nugget Effect
-- Sill         =     12.000
+- Sill         =      12.000
   (This component is Filtered)
-Total Sill     =     57.000
+Total Sill     =      57.000
 
 Drift Part
 ----------
@@ -524,13 +524,13 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 5 - Name Filtering.Simu - Locator z1
- Nb of data          =       2500
- Nb of active values =       2116
- Minimum value       =     -6.780
- Maximum value       =     15.076
- Mean value          =      4.212
- Standard Deviation  =      3.672
- Variance            =     13.483
+ Nb of data          =        2500
+ Nb of active values =        2116
+ Minimum value       =      -6.780
+ Maximum value       =      15.076
+ Mean value          =       4.212
+ Standard Deviation  =       3.672
+ Variance            =      13.483
 
 Model characteristics
 =====================
@@ -543,7 +543,7 @@ Number of drift equation(s)  = 1
 Covariance Part
 ---------------
 Linear
-- Slope        =      1.000
+- Slope        =       1.000
 
 
 Drift Part
@@ -554,16 +554,16 @@ Universality_Condition
 
 Bayesian Drift coefficients
 ===========================
-Prior Mean:     0.000
+Prior Means:      0.000
 Prior Covariance Matrix
 - Number of rows    = 1
 - Number of columns = 1
-     1.000
-Posterior Mean:     0.001
+      1.000
+Posterior Mean:      0.001
 Posterior Covariance Matrix
 - Number of rows    = 1
 - Number of columns = 1
-     0.997
+      0.997
 
 Data Base Grid Characteristics
 ==============================
@@ -571,21 +571,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Bayes.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.745
- Maximum value       =      0.975
- Mean value          =     -0.088
- Standard Deviation  =      0.454
- Variance            =      0.206
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.745
+ Maximum value       =       0.975
+ Mean value          =      -0.088
+ Standard Deviation  =       0.454
+ Variance            =       0.206
 7 - Name Bayes.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.564
- Maximum value       =      3.770
- Mean value          =      2.772
- Standard Deviation  =      0.522
- Variance            =      0.272
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.564
+ Maximum value       =       3.770
+ Mean value          =       2.772
+ Standard Deviation  =       0.522
+ Variance            =       0.272
 
 <----- Test Kriging Printout ----->
 
@@ -600,7 +600,7 @@ Number of drift equation(s)  = 1
 Covariance Part
 ---------------
 Linear
-- Slope        =      1.000
+- Slope        =       1.000
 
 
 Drift Part
@@ -745,29 +745,29 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 7 - Name KrigSum.Var.1.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.195
- Maximum value       =      4.585
- Mean value          =      3.014
- Standard Deviation  =      0.687
- Variance            =      0.471
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.195
+ Maximum value       =       4.585
+ Mean value          =       3.014
+ Standard Deviation  =       0.687
+ Variance            =       0.471
 8 - Name KrigSum.Var.2.estim - Locator z2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      5.654
- Maximum value       =     11.977
- Mean value          =      8.694
- Standard Deviation  =      1.578
- Variance            =      2.489
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       5.654
+ Maximum value       =      11.977
+ Mean value          =       8.694
+ Standard Deviation  =       1.578
+ Variance            =       2.489
 9 - Name KrigSum.Var.3.estim - Locator z3
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      1.726
- Maximum value       =      4.836
- Mean value          =      3.244
- Standard Deviation  =      0.766
- Variance            =      0.587
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       1.726
+ Maximum value       =       4.836
+ Mean value          =       3.244
+ Standard Deviation  =       0.766
+ Variance            =       0.587
 
 <----- Test Kriging Anamorphosed Gaussian ----->
 
@@ -777,21 +777,21 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name KrigGam.Y.Var.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -1.182
- Maximum value       =      1.135
- Mean value          =     -0.405
- Standard Deviation  =      0.495
- Variance            =      0.245
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -1.182
+ Maximum value       =       1.135
+ Mean value          =      -0.405
+ Standard Deviation  =       0.495
+ Variance            =       0.245
 7 - Name KrigGam.Y.Var.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =      0.100
- Maximum value       =      0.624
- Mean value          =      0.464
- Standard Deviation  =      0.093
- Variance            =      0.009
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =       0.100
+ Maximum value       =       0.624
+ Mean value          =       0.464
+ Standard Deviation  =       0.093
+ Variance            =       0.009
 
 <----- Test Kriging Multiple Variables with matLC ----->
 
@@ -801,34 +801,34 @@ Data Base Grid Characteristics
 Data Base Statistics
 --------------------
 6 - Name Kriging.LC-1.estim - Locator z1
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -0.028
- Maximum value       =      0.843
- Mean value          =      0.631
- Standard Deviation  =      0.148
- Variance            =      0.022
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -0.028
+ Maximum value       =       0.843
+ Mean value          =       0.631
+ Standard Deviation  =       0.148
+ Variance            =       0.022
 7 - Name Kriging.LC-2.estim - Locator z2
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     -0.120
- Maximum value       =      0.698
- Mean value          =      0.611
- Standard Deviation  =      0.153
- Variance            =      0.023
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      -0.120
+ Maximum value       =       0.698
+ Mean value          =       0.611
+ Standard Deviation  =       0.153
+ Variance            =       0.023
 8 - Name Kriging.LC-1.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     13.947
- Maximum value       =     16.882
- Mean value          =     16.675
- Standard Deviation  =      0.418
- Variance            =      0.175
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      13.947
+ Maximum value       =      16.882
+ Mean value          =      16.675
+ Standard Deviation  =       0.418
+ Variance            =       0.175
 9 - Name Kriging.LC-2.stdev - Locator NA
- Nb of data          =       2500
- Nb of active values =       2500
- Minimum value       =     15.278
- Maximum value       =     18.493
- Mean value          =     18.267
- Standard Deviation  =      0.458
- Variance            =      0.210
+ Nb of data          =        2500
+ Nb of active values =        2500
+ Minimum value       =      15.278
+ Maximum value       =      18.493
+ Mean value          =      18.267
+ Standard Deviation  =       0.458
+ Variance            =       0.210

--- a/tests/cpp/output/test_Schur.ref
+++ b/tests/cpp/output/test_Schur.ref
@@ -11,100 +11,100 @@ Data Base Characteristics
 
 Data Base Contents
 ------------------
-                 rank       x-1       x-2       z-1       z-2       z-3
-     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
-     [  1,]     2.000     0.483     0.557    -0.774    -0.872     0.080
-     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
+                   rank        x-1        x-2        z-1        z-2        z-3
+      [  0,]      1.000      0.652      0.015      0.753     -0.454     -0.752
+      [  1,]      2.000      0.483      0.557     -0.774     -0.872      0.080
+      [  2,]      3.000      0.762      0.433      0.793      0.744      0.319
 
 Using Standard Kriging procedure
 --------------------------------
 
 Bayesian Drift coefficients
 ===========================
-Prior Mean:    -0.504    -1.222     0.290
+Prior Means:     -0.504     -1.222      0.290
 Prior Covariance Matrix
 - Number of rows    = 3
 - Number of columns = 3
-               [,  0]    [,  1]    [,  2]
-     [  0,]     0.223     0.000     0.000
-     [  1,]     0.000     0.173     0.000
-     [  2,]     0.000     0.000     0.213
-Posterior Mean:     0.289    -0.444    -0.294
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.223      0.000      0.000
+      [  1,]      0.000      0.173      0.000
+      [  2,]      0.000      0.000      0.213
+Posterior Mean:      0.289     -0.444     -0.294
 Posterior Covariance Matrix
 - Number of rows    = 3
 - Number of columns = 3
-               [,  0]    [,  1]    [,  2]
-     [  0,]     0.138    -0.074     0.056
-     [  1,]    -0.074     0.095     0.055
-     [  2,]     0.056     0.055     0.164
-Bayes.z-1.estim      0.190
-Bayes.z-2.estim      0.080
-Bayes.z-3.estim      0.189
-Bayes.z-1.stdev      1.028
-Bayes.z-2.stdev      0.885
-Bayes.z-3.stdev      1.118
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.138     -0.074      0.056
+      [  1,]     -0.074      0.095      0.055
+      [  2,]      0.056      0.055      0.164
+Bayes.z-1.estim       0.190
+Bayes.z-2.estim       0.080
+Bayes.z-3.estim       0.189
+Bayes.z-1.stdev       1.028
+Bayes.z-2.stdev       0.885
+Bayes.z-3.stdev       1.118
 
 Using Schur class
 -----------------
-Prior Mean
-    -0.504    -1.222     0.290
+Prior Means
+     -0.504     -1.222      0.290
 Prior Variance-Covariance Matrix
 - Number of rows    = 3
 - Number of columns = 3
-               [,  0]    [,  1]    [,  2]
-     [  0,]     0.223     0.000     0.000
-     [  1,]     0.000     0.173     0.000
-     [  2,]     0.000     0.000     0.213
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.223      0.000      0.000
+      [  1,]      0.000      0.173      0.000
+      [  2,]      0.000      0.000      0.213
 Posterior Mean
-     0.289    -0.444    -0.294
+      0.289     -0.444     -0.294
 Posterior Variance-Covariance Matrix
 - Number of rows    = 3
 - Number of columns = 3
-               [,  0]    [,  1]    [,  2]
-     [  0,]     0.138    -0.074     0.056
-     [  1,]    -0.074     0.095     0.055
-     [  2,]     0.056     0.055     0.164
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.138     -0.074      0.056
+      [  1,]     -0.074      0.095      0.055
+      [  2,]      0.056      0.055      0.164
 Kriging Value(s)
-     0.190     0.080     0.189
+      0.190      0.080      0.189
 Standard Deviation of Estimation Error
-     1.028     0.885     1.118
+      1.028      0.885      1.118
 Variance of Estimator
-     4.113     3.049     4.864
+      4.113      3.049      4.864
 
 Collocated Option (in Unique Neighborhood):
 ===========================================
 - using 'KrigingAlgebra' on the Complemented Data Set
 - using 'KrigingAlgebra' on Standard Data Set adding Collocated Option
-- Collocated Variable ranks:         0        -1         2
+- Collocated Variable ranks:          0         -1          2
 
 Data Base Characteristics
 =========================
 
 Data Base Contents
 ------------------
-                 rank       x-1       x-2       z-1       z-2       z-3
-     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
-     [  1,]     2.000     0.483     0.557    -0.774    -0.872     0.080
-     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
-     [  3,]       N/A     0.652     0.483     0.438       N/A     0.186
+                   rank        x-1        x-2        z-1        z-2        z-3
+      [  0,]      1.000      0.652      0.015      0.753     -0.454     -0.752
+      [  1,]      2.000      0.483      0.557     -0.774     -0.872      0.080
+      [  2,]      3.000      0.762      0.433      0.793      0.744      0.319
+      [  3,]        N/A      0.652      0.483      0.438        N/A      0.186
 
 With Complemented input Data Base
 ---------------------------------
 Kriging Value(s)
-     0.438    -0.121     0.186
+      0.438     -0.121      0.186
 Standard Deviation of Estimation Error
-     0.000     0.040     0.000
+      0.000      0.040      0.000
 Variance of Estimator
-     5.167     3.830     6.110
+      5.167      3.830      6.110
 
 With Collocated Option
 ----------------------
 Kriging Value(s)
-     0.438    -0.121     0.186
+      0.438     -0.121      0.186
 Standard Deviation of Estimation Error
-     0.000     0.040     0.000
+      0.000      0.040      0.000
 Variance of Estimator
-     5.167     3.830     6.110
+      5.167      3.830      6.110
 
 Cross-Validation (in Unique Neighborhood)
 =========================================
@@ -117,28 +117,28 @@ Data Base Characteristics
 
 Data Base Contents
 ------------------
-                 rank       x-1       x-2       z-1       z-2       z-3
-     [  0,]     1.000     0.652     0.015     0.753    -0.454    -0.752
-     [  1,]     2.000     0.483     0.557    -0.774       N/A       N/A
-     [  2,]     3.000     0.762     0.433     0.793     0.744     0.319
+                   rank        x-1        x-2        z-1        z-2        z-3
+      [  0,]      1.000      0.652      0.015      0.753     -0.454     -0.752
+      [  1,]      2.000      0.483      0.557     -0.774        N/A        N/A
+      [  2,]      3.000      0.762      0.433      0.793      0.744      0.319
 
 With Deplemented input Data Base
 --------------------------------
 Kriging Value(s)
-    -0.774     1.311    -0.536
+     -0.774      1.311     -0.536
 Standard Deviation of Estimation Error
-     0.000     1.150     1.858
+      0.000      1.150      1.858
 Variance of Estimator
-     5.167     3.442     5.096
+      5.167      3.442      5.096
 
 With Cross-Validation Option
 ----------------------------
 Kriging Value(s)
-     1.311    -0.536
+      1.311     -0.536
 Standard Deviation of Estimation Error
-     1.150     1.858
+      1.150      1.858
 Variance of Estimator
-     3.442     5.096
+      3.442      5.096
 
 Estimation using Dual option or not (in Unique Neighborhood):
 =============================================================
@@ -146,13 +146,13 @@ Estimation using Dual option or not (in Unique Neighborhood):
 Without Dual option
 -------------------
 Kriging Value(s)
-     0.189     0.081     0.190
+      0.189      0.081      0.190
 Standard Deviation of Estimation Error
-     1.028     0.885     1.118
+      1.028      0.885      1.118
 Variance of Estimator
-     4.180     3.099     4.943
+      4.180      3.099      4.943
 
 With Dual Option (only Estimation is available)
 -----------------------------------------------
 Kriging Value(s)
-     0.189     0.081     0.190
+      0.189      0.081      0.190

--- a/tests/cpp/test_MLayers.cpp
+++ b/tests/cpp/test_MLayers.cpp
@@ -106,6 +106,7 @@ int main(int argc, char* argv[])
   bool flag_cumul = false;
   bool flag_ext   = false;
   bool flag_std   = false;
+  bool flag_bayes = false;
   bool match_time = false;
   Id irf_rank     = 0;
 
@@ -113,8 +114,7 @@ int main(int argc, char* argv[])
 
   (void)multilayers_getPrior(db, grid, model, flag_same, flag_vel, flag_ext);
   (void)multilayers_kriging(db, grid, model, flag_same, flag_Z, flag_vel, flag_cumul,
-                            flag_ext, flag_std, match_time, irf_rank,
-                            VectorDouble(), VectorDouble(),
+                            flag_ext, flag_bayes, flag_std, match_time, irf_rank,
                             "reference", String(), "bottom");
 
   // MatrixDense* trace = MatrixDense::createFromVD({0, 50, 100, 0, 50, 100}, 3, 2);

--- a/tests/cpp/test_Schur.cpp
+++ b/tests/cpp/test_Schur.cpp
@@ -79,12 +79,9 @@ static Db* _dataAsIs(Db* data)
 static void _firstTest(Db* data,
                        Db* target,
                        ModelGeneric* model,
-                       ANeigh* neigh,
-                       const VectorDouble& means,
-                       const VectorDouble& PriorMean,
-                       MatrixSymmetric& PriorCov)
+                       ANeigh* neigh)
 {
-  Model* modelc = dynamic_cast<Model*>(model);
+  auto* modelc = dynamic_cast<Model*>(model);
   if (!modelc->hasDrift())
   {
     messerr("The 'Model' must have drift defined to check 'Bayesian' option");
@@ -110,7 +107,7 @@ static void _firstTest(Db* data,
   // ---------------------- Using Standard Kriging procedure ---------------
   mestitle(1, "Using Standard Kriging procedure");
   Table table;
-  kribayes(dataP, target, modelc, neigh, PriorMean, PriorCov, true, true);
+  kribayes(dataP, target, modelc, neigh, true, true);
   table = target->printOneSample(iech0, {"Bayes*"}, true, true);
   target->deleteColumn("Bayes*");
   table.display();
@@ -124,18 +121,18 @@ static void _firstTest(Db* data,
   MatrixDense Sigma0          = model->evalCovMat(data, target);
   MatrixDense X0              = model->evalDriftMat(target);
   VectorVectorInt sampleRanks = data->getSampleRanks();
-  VectorDouble Z              = data->getValuesByRanks(sampleRanks, means);
+  VectorDouble Z              = data->getValuesByRanks(sampleRanks, model->getMeans());
 
   KrigingAlgebra Kcalc;
-  Kcalc.setData(&Z, &sampleRanks, &means);
+  Kcalc.setData(&Z, &sampleRanks, &model->getMeans());
   Kcalc.setLHS(&Sigma, &X);
   Kcalc.setVariance(&Sigma00);
   Kcalc.setRHS(&Sigma0, &X0);
-  Kcalc.setBayes(&PriorMean, &PriorCov);
+  Kcalc.setBayes(&model->getPriorMeans(), &model->getPriorCovs());
 
-  printVector(PriorMean, "Prior Mean", true, true);
+  printVector(model->getPriorMeans(), "Prior Means", true, true);
   message("Prior Variance-Covariance Matrix\n");
-  PriorCov.display();
+  model->getPriorCovs().display();
   VectorDouble beta = Kcalc.getPostMean();
   if (!beta.empty()) printVector(beta, "Posterior Mean", true, true);
   message("Posterior Variance-Covariance Matrix\n");
@@ -155,7 +152,7 @@ static void _firstTest(Db* data,
  ** Testing Collocated option
  **
  *****************************************************************************/
-static void _secondTest(Db* data, Db* target, ModelGeneric* model, const VectorDouble& means)
+static void _secondTest(Db* data, Db* target, ModelGeneric* model)
 {
   auto* modelc = dynamic_cast<Model*>(model);
   // Local parameters
@@ -192,10 +189,10 @@ static void _secondTest(Db* data, Db* target, ModelGeneric* model, const VectorD
   MatrixDense Sigma0P          = model->evalCovMat(dataP, target);
   MatrixDense X0P              = model->evalDriftMat(target);
   VectorVectorInt sampleRanksP = dataP->getSampleRanks();
-  VectorDouble ZP              = dataP->getValuesByRanks(sampleRanksP, means);
+  VectorDouble ZP              = dataP->getValuesByRanks(sampleRanksP, model->getMeans());
 
   KrigingAlgebra KcalcP;
-  KcalcP.setData(&ZP, &sampleRanksP, &means);
+  KcalcP.setData(&ZP, &sampleRanksP, &model->getMeans());
   KcalcP.setLHS(&SigmaP, &XP);
   KcalcP.setRHS(&Sigma0P, &X0P);
   KcalcP.setVariance(&Sigma00P);
@@ -215,15 +212,15 @@ static void _secondTest(Db* data, Db* target, ModelGeneric* model, const VectorD
   MatrixDense Sigma0          = model->evalCovMat(data, target);
   MatrixDense X0              = model->evalDriftMat(target);
   VectorVectorInt sampleRanks = data->getSampleRanks();
-  VectorDouble Z              = data->getValuesByRanks(sampleRanks, means);
+  VectorDouble Z              = data->getValuesByRanks(sampleRanks, model->getMeans());
 
   KrigingAlgebra Kcalc;
-  Kcalc.setData(&Z, &sampleRanks, &means);
+  Kcalc.setData(&Z, &sampleRanks, &model->getMeans());
   Kcalc.setLHS(&Sigma, &X);
   Kcalc.setRHS(&Sigma0, &X0);
   Kcalc.setVariance(&Sigma00);
   // Subtract the mean (non zero for SK only) from the Collocated values
-  valuesTarget.subtract(means);
+  valuesTarget.subtract(model->getMeans());
   Kcalc.setColCokUnique(&valuesTarget, &varColCok);
 
   printVector(Kcalc.getEstimation(), "Kriging Value(s)", true, true);
@@ -240,7 +237,7 @@ static void _secondTest(Db* data, Db* target, ModelGeneric* model, const VectorD
  ** Testing Cross-validation option
  **
  *****************************************************************************/
-static void _thirdTest(Db* data, ModelGeneric* model, const VectorDouble& means)
+static void _thirdTest(Db* data, ModelGeneric* model)
 {
   // Set of ranks of cross-validated information
   VectorInt varXvalid = {1, 2};
@@ -271,10 +268,10 @@ static void _thirdTest(Db* data, ModelGeneric* model, const VectorDouble& means)
   MatrixDense Sigma0P          = model->evalCovMat(dataP, targetP, -1, -1, VectorInt(), VectorInt({iech0}));
   MatrixDense X0P              = model->evalDriftMat(targetP, VectorInt {iech0});
   VectorVectorInt sampleRanksP = dataP->getSampleRanks();
-  VectorDouble ZP              = dataP->getValuesByRanks(sampleRanksP, means);
+  VectorDouble ZP              = dataP->getValuesByRanks(sampleRanksP, model->getMeans());
 
   KrigingAlgebra KcalcP;
-  KcalcP.setData(&ZP, &sampleRanksP, &means);
+  KcalcP.setData(&ZP, &sampleRanksP, &model->getMeans());
   KcalcP.setLHS(&SigmaP, &XP);
   KcalcP.setRHS(&Sigma0P, &X0P);
   KcalcP.setVariance(&Sigma00P);
@@ -294,10 +291,10 @@ static void _thirdTest(Db* data, ModelGeneric* model, const VectorDouble& means)
   MatrixDense Sigma0          = model->evalCovMat(data, targetP);
   MatrixDense X0              = model->evalDriftMat(targetP);
   VectorVectorInt sampleRanks = data->getSampleRanks();
-  VectorDouble Z              = data->getValuesByRanks(sampleRanks, means);
+  VectorDouble Z              = data->getValuesByRanks(sampleRanks, model->getMeans());
 
   KrigingAlgebra Kcalc;
-  Kcalc.setData(&Z, &sampleRanks, &means);
+  Kcalc.setData(&Z, &sampleRanks, &model->getMeans());
   Kcalc.setLHS(&Sigma, &X);
   Kcalc.setVariance(&Sigma00);
   Kcalc.setXvalidUnique(&rankXvalidEqs, &rankXvalidVars);
@@ -319,7 +316,7 @@ static void _thirdTest(Db* data, ModelGeneric* model, const VectorDouble& means)
  ** Note: Means are set to 0 to check SK option
  **
  *****************************************************************************/
-static void _fourthTest(Db* data, Db* target, ModelGeneric* model, const VectorDouble& means)
+static void _fourthTest(Db* data, Db* target, ModelGeneric* model)
 {
   // Title
   mestitle(0, "Estimation using Dual option or not (in Unique Neighborhood):");
@@ -332,10 +329,10 @@ static void _fourthTest(Db* data, Db* target, ModelGeneric* model, const VectorD
   MatrixDense Sigma0          = model->evalCovMat(data, target);
   MatrixDense X0              = model->evalDriftMat(target);
   VectorVectorInt sampleRanks = data->getSampleRanks();
-  VectorDouble Z              = data->getValuesByRanks(sampleRanks, means);
+  VectorDouble Z              = data->getValuesByRanks(sampleRanks, model->getMeans());
 
   KrigingAlgebra Kcalc1(false);
-  Kcalc1.setData(&Z, &sampleRanks, &means);
+  Kcalc1.setData(&Z, &sampleRanks, &model->getMeans());
   Kcalc1.setLHS(&Sigma, &X);
   Kcalc1.setRHS(&Sigma0, &X0);
   Kcalc1.setVariance(&Sigma00);
@@ -348,7 +345,7 @@ static void _fourthTest(Db* data, Db* target, ModelGeneric* model, const VectorD
   mestitle(1, "With Dual Option (only Estimation is available)");
 
   KrigingAlgebra Kcalc2(true);
-  Kcalc2.setData(&Z, &sampleRanks, &means);
+  Kcalc2.setData(&Z, &sampleRanks, &model->getMeans());
   Kcalc2.setLHS(&Sigma, &X);
   Kcalc2.setRHS(&Sigma0, &X0);
 
@@ -413,13 +410,17 @@ int main(int argc, char* argv[])
   model        = Model::createFromParam(ECov::EXPONENTIAL, scale, 0., 0., VectorDouble(),
                                         *sills, VectorDouble(), nullptr, false);
   auto* modelc = dynamic_cast<Model*>(model);
+
+  // Set the variable means
   modelc->setMeans(means);
   if (!flagSK) modelc->setDriftIRF(0, nfex);
 
   // Create the Bayesian Priors for Drift coefficients
-  VectorDouble PriorMean = VH::simulateGaussian(nbfl);
-  MatrixSymmetric PriorCov(nbfl);
-  PriorCov.setDiagonal(VH::simulateUniform(nbfl, 0.1, 0.5));
+  VectorDouble prior_means = VH::simulateGaussian(nbfl);
+  MatrixSymmetric prior_covs(nbfl);
+  prior_covs.setDiagonal(VH::simulateUniform(nbfl, 0.1, 0.5));
+  modelc->setPriorMeans(prior_means);
+  modelc->setPriorCovs(prior_covs);
 
   // Unique Neighborhood
   NeighUnique* neigh = NeighUnique::create();
@@ -432,7 +433,7 @@ int main(int argc, char* argv[])
   if (mode == 0 || mode == 1)
   {
     Db* dataLocal = data->clone();
-    _firstTest(dataLocal, target, model, neigh, means, PriorMean, PriorCov);
+    _firstTest(dataLocal, target, model, neigh);
     delete dataLocal;
   }
 
@@ -440,7 +441,7 @@ int main(int argc, char* argv[])
   if (mode == 0 || mode == 2)
   {
     Db* dataLocal = data->clone();
-    _secondTest(dataLocal, target, model, means);
+    _secondTest(dataLocal, target, model);
     delete dataLocal;
   }
 
@@ -448,7 +449,7 @@ int main(int argc, char* argv[])
   if (mode == 0 || mode == 3)
   {
     Db* dataLocal = data->clone();
-    _thirdTest(dataLocal, model, means);
+    _thirdTest(dataLocal, model);
     delete dataLocal;
   }
 
@@ -456,7 +457,7 @@ int main(int argc, char* argv[])
   if (mode == 0 || mode == 4)
   {
     Db* dataLocal = data->clone();
-    _fourthTest(dataLocal, target, model, means);
+    _fourthTest(dataLocal, target, model);
     delete dataLocal;
   }
 


### PR DESCRIPTION
Bayesian prior information (mean and var-covar) is stored in DriftList and passed to ModelGeneric (through the necessary pipes). The Bayesian calculation (of the Drift Coefficients) is simply triggered using a "flag_bayes" flag.

The next step could be to store the Posterior values (Mean and Var-Covar). But this definitely requires a sharper prior definition of Drift contents where the coefficients could be:
- free (means to be calculated)
- fixed (that is the case when the mean [coefficient of the constant term equal to 1] is defined ... as in the KS)
- to be derived prior to any calculation (Bayesian hypothesis).

We must also keep in mind that the number of drift coefficients is difficult to determine:
- when the drift conditions are totally or partially linked
- - then what are the status of the coefficients determined earlier?