### PR TITLE
Fix numpy==2.3.5 in CI

### DIFF
--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        uv pip install numpy
+        uv pip install numpy==2.3.5
         uv pip install jupyter
         uv pip install notebook==6.1.6
         uv pip install matplotlib

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        uv pip install numpy
+        uv pip install numpy==2.3.5
         uv pip install mlxtend
 
     - name: Setup R Version

--- a/.github/workflows/nonreg-tests_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-tests_ubuntu-latest.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        uv pip install numpy
+        uv pip install numpy==2.3.5
         uv pip install mlxtend
 
     - name: Setup R Version

--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        uv pip install numpy
+        uv pip install numpy==2.3.5
         uv pip install mlxtend
 
     - name: Run sccache-cache


### PR DESCRIPTION
Try to stick gstlearn CI to numpy 2.3.5 (waiting for a better fix regarding numpy 2.4.0 : tuto_Fluids.py and test_SPDEAPI.py)