### PR TITLE
Stick to terra 1.8-86 under MacOS (temporary fix)

### DIFF
--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -64,7 +64,8 @@ jobs:
     - name: Install R packages
       uses: r-lib/actions/setup-r-dependencies@v2
       with:
-        packages: ggpubr, ggplot2, ggnewscale, sf, terra
+        packages: ggpubr, ggplot2, ggnewscale, sf
+        extra-packages: cran::terra@1.8-86
         install-pandoc: false
 
     - name: Install the customized SWIG from source


### PR DESCRIPTION
Last version of terra R package seems to fail under MacOS.
See here: https://github.com/gstlearn/gstlearn/actions/runs/20938769063/job/60188982132
This PR aims at rolling back to previous terra version to test if the non-regression becomes operational.