### PR TITLE
Fix memory leaks

### DIFF
--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -20,7 +20,7 @@ namespace gstlrn
 class GSTLEARN_EXPORT ProjMulti: public IProj, public AStringable
 {
 public:
-  ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool silent = false);
+  ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool toClean = false, bool silent = false);
 
   /// AStringable Interface
   String toString(const AStringFormat* strfmt = nullptr) const override;
@@ -42,7 +42,7 @@ protected:
 private:
   bool _checkArg(const std::vector<std::vector<const IProj*>>& projs) const;
   void _init();
-  virtual void _clear() {};
+  virtual void _clear();
 
 protected:
   Id findFirstNoNullOnRow(Id j) const;
@@ -60,6 +60,7 @@ private:
   Id _nvariable;
   VectorInt _pointNumbers;
   VectorInt _apexNumbers;
+  bool _toClean;
   bool _silent;
   mutable VectorDouble _work;
   mutable VectorDouble _workmesh;

--- a/include/LinearOp/ProjMultiMatrix.hpp
+++ b/include/LinearOp/ProjMultiMatrix.hpp
@@ -46,9 +46,5 @@ protected:
 
 private:
   MatrixSparse _Proj;
-  void _clear() override;
-
-private:
-  bool _toClean;
 };
 } // namespace gstlrn

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -90,6 +90,7 @@ ACov& ACov::operator=(const ACov& r)
     _pAux                  = r._pAux;
     _pw1                   = r._pw1;
     _pw2                   = r._pw2;
+    delete _tabNoStat;
     _tabNoStat             = r._tabNoStat->clone();
   }
   return *this;

--- a/src/LinearOp/ProjMulti.cpp
+++ b/src/LinearOp/ProjMulti.cpp
@@ -144,17 +144,34 @@ void ProjMulti::_init()
   }
 }
 
+void ProjMulti::_clear()
+{
+  if (!_toClean || _projs.empty()) return;
+
+  for (auto& e: _projs)
+  {
+    for (auto& f: e)
+    {
+      delete const_cast<IProj*>(f);
+      f = nullptr;
+    }
+    e.clear();
+  }
+  _projs.clear();
+}
+
 ProjMulti::~ProjMulti()
 {
   _clear();
 }
 
-ProjMulti::ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool silent)
+ProjMulti::ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool toClean, bool silent)
   : _projs(projs)
   , _pointNumber(0)
   , _apexNumber(0)
   , _nlatent(0)
   , _nvariable(0)
+  , _toClean(toClean)
   , _silent(silent)
 {
   if (_checkArg(_projs))

--- a/src/LinearOp/ProjMultiMatrix.cpp
+++ b/src/LinearOp/ProjMultiMatrix.cpp
@@ -107,21 +107,6 @@ ProjMultiMatrix* ProjMultiMatrix::createFromDbAndMeshes(const Db* db,
   return new ProjMultiMatrix(stocker, true);
 }
 
-void ProjMultiMatrix::_clear()
-{
-  if (!_toClean || _projs.empty()) return;
-
-  for (auto& e: _projs)
-  {
-    for (auto& f: e)
-    {
-      delete const_cast<IProj*>(f);
-      f = nullptr;
-    }
-    e.clear();
-  }
-  _projs.clear();
-}
 ProjMultiMatrix::~ProjMultiMatrix()
 {
 }
@@ -136,7 +121,7 @@ std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<
   {
     if (vectproj[i] == nullptr)
     {
-      messerr("Projmatrix shouldn't be nullptr.");
+      messerr("ProjMatrix shouldn't be nullptr.");
       return result;
     }
   }
@@ -169,9 +154,8 @@ std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<
 ProjMultiMatrix::ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*>>& proj,
                                  bool toClean,
                                  bool silent)
-  : ProjMulti(castToBase(proj), silent)
+  : ProjMulti(castToBase(proj), toClean, silent)
   , _Proj(MatrixSparse(0, 0))
-  , _toClean(toClean)
 {
   if (ProjMulti::empty()) return;
   const VectorInt& pointNumbers = getNPoints();

--- a/tests/py/output/test_ProjMatrixMulti.ref
+++ b/tests/py/output/test_ProjMatrixMulti.ref
@@ -6,7 +6,7 @@ I. Creation of the vector<vector<Projmatrix*>> from a vector<ProjMatrix*>
 ---------------------------------------------------------------------
 Test1: with a nullptr element:
 --------
-Projmatrix shouldn't be nullptr.
+ProjMatrix shouldn't be nullptr.
 ---------------------
 Test2: with different Point Numbers:
 --------

--- a/tests/py/output/test_ProjMatrixMulti_clang.ref
+++ b/tests/py/output/test_ProjMatrixMulti_clang.ref
@@ -6,7 +6,7 @@ I. Creation of the vector<vector<Projmatrix*>> from a vector<ProjMatrix*>
 ---------------------------------------------------------------------
 Test1: with a nullptr element:
 --------
-Projmatrix shouldn't be nullptr.
+ProjMatrix shouldn't be nullptr.
 ---------------------
 Test2: with different Point Numbers:
 --------


### PR DESCRIPTION
This PR fixes two memory leaks.

The one in `ACov::operator=()` is pretty self-explanatory.

The other in `ProjMulti` may be discussed? From the commit message:

`ProjMultiMatrix` has a flag in the constructor to indicate that the destructor must delete all sub-matrices, but there is nothing similar in `ProjMulti` itself. So now the flag has been moved from `ProjMultiMatrix` to `ProjMulti` to fix this.

Note that, since there is one additional argument in constructor, if you were calling `new ProjMulti(..., true)` to set the `silent` flag, the same code will still compile but now will set the `clean` flag (and the `silent` flag will have its default value of false). I don't think this is an issue though since the silent flag is only used in one place (when the list of sub matrices is empty) and thus very unlikely to have ever been set (plus, in gstlearn itself `ProjMulti` is not used directly!).

Note however that the behaviour of `ProjMultiMatrix` is not changed, so I don't think it's a problem.

Overall, I would prefer if either the default was for objects to delete their components (rather than having to explicitly pass such a flag), or if the ownership (who must delete what?) was made more obvious. At the moment it is very hard to know if a pointer passed when creating an object is owned by the object or not, and if that pointer is requested to be valid for the whole life span of the object or not (sometimes it's only needed in the constructor). This is making memory management harder than it should be...