### PR TITLE
Fix memory leak in FFT

### DIFF
--- a/src/Core/fft.cpp
+++ b/src/Core/fft.cpp
@@ -1006,6 +1006,7 @@ Id fftn(Id ndim,
       Im_Data(i) *= scaling;
     }
   }
+  fft_free(); /* free-up memory */
   return 0;
 
 Dimension_Error:


### PR DESCRIPTION
This was detected by valgrind, the internal static arrays are not deleted and thus left dangling at the end of execution.

This is a fairly small memory leak, or more importantly it's one that only happens once no matter how many times the function is called, since this is about static variables. And also, by fixing it the code might actually become slower because every successive call will always reallocate memory, whereas before if the old size was correct it wouldn't do anything.

Added to the fact that this is very old code that is (presumably) used in many places, that makes me wonder if you really want to accept this change.

On the other hand, the intent in the code above the bit that I changed is very clear that memory cleaning should happen at every call, so to me this very much look like this was a bug.

Anyway, feel free to reject the PR if you prefer.