### PR TITLE
Add marimo as optional dependency of pygstlearn

### DIFF
--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -43,6 +43,11 @@ doc = [
     "IPython",
 ]
 all = ["gstlearn[plot,conv,doc]"]
+marimo = [
+     "gstlearn[all]",
+     "marimo[recommended]",
+     "contextily",
+]
 
 [project.urls]
 Homepage = "@PROJECT_HOMEPAGE_URL@"


### PR DESCRIPTION
This PR edits the `pyproject.toml` to add Marimo as an optional dependency of gstlearn.

To install gstlearn alongside marimo, use: `pip install "gstlearn[marimo]"`

Pierre