### PR TITLE
GitHub Actions: Update coverage workflows, retire Python 3.9

### DIFF
--- a/.github/workflows/coverage-tests_python.yml
+++ b/.github/workflows/coverage-tests_python.yml
@@ -18,14 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         # Double quote for version is needed otherwise 3.10 => 3.1
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # See the list here: https://github.com/actions/runner-images#available-images
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
-        exclude:
-          - os: macos-14
-            python: "3.9"
-          - os: macos-15
-            python: "3.9"
           
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -20,7 +20,8 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-26]
+        # macos15-intel not working with gstlearn packages (CRAN store issue?)
         exclude:
           - os: ubuntu-22.04
             r_version: 4.2.3  # ggpubr install fails

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -38,7 +38,6 @@ jobs:
         # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},
@@ -132,7 +131,6 @@ jobs:
       matrix:
         python: [
         # Double quote for version is needed otherwise 3.10 => 3.1
-            {py: "3.9"},
             {py: "3.10"},
             {py: "3.11"},
             {py: "3.12"},


### PR DESCRIPTION
This PR updates the `coverage-tests` workflows to remove the non-working platforms: the remaining Python 3.9 and `macos15-intel` for R.

Also, `publish_python_windows` no longer generates Python 3.9 wheels.

Pierre