### PR TITLE
Marimo editor width: No need for a custom CSS

### DIFF
--- a/doc/UI/python/Mo-Db.py
+++ b/doc/UI/python/Mo-Db.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.19.2"
-app = marimo.App(css_file="custom.css")
+app = marimo.App(width="full")
 
 
 @app.cell(hide_code=True)

--- a/doc/UI/python/Mo-Option.py
+++ b/doc/UI/python/Mo-Option.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.19.2"
-app = marimo.App(css_file="custom.css")
+app = marimo.App(width="full")
 
 
 @app.cell(hide_code=True)

--- a/doc/UI/python/Mo-SimuNC.py
+++ b/doc/UI/python/Mo-SimuNC.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.19.2"
-app = marimo.App(css_file="custom.css")
+app = marimo.App(width="full")
 
 
 @app.cell(hide_code=True)

--- a/doc/UI/python/custom.css
+++ b/doc/UI/python/custom.css
@@ -1,3 +1,0 @@
-:root {
-    --content-width: auto;
-}


### PR DESCRIPTION
According to https://docs.marimo.io/guides/editor_features/overview/#editor-widths, marimo editor width can be set directly as a parameter to the `marimo.App` class.

This PR replaces the `custom.css` file with this parameter.

Pierre