### PR TITLE
Fix crash at application exit with VS2017

### DIFF
--- a/include/Enum/ECalcVario.hpp
+++ b/include/Enum/ECalcVario.hpp
@@ -47,7 +47,7 @@ struct qualifier
   bool isFittable;  // True if this tool can be used for fitting a model
 };
 
-inline const std::map<std::string, qualifier> ECalcVarioAttr =
+const std::map<std::string, qualifier> ECalcVarioAttr =
   {
     {"UNDEFINED", {true, false, false, true}},
     {"VARIOGRAM", {true, false, false, true}},


### PR DESCRIPTION
With VS2017, gstlearn crashes when closing an application linked with it, with the trace showing this comes from the destruction of the global variable `ECalcVarioAttr` (in `include/Enum/ECalcVario.hpp`):

https://github.com/gstlearn/gstlearn/blob/e08d2995049646302f8adda88152ceb9d552c611/include/Enum/ECalcVario.hpp#L50

I think that this is due to a bug in VS2017 related to the use of the `inline` keyword for a global variable, see e.g., this issue and a related discussion that links to it:
https://developercommunity.visualstudio.com/t/static-inline-class-variables-have-their-destructo/300686
https://www.reddit.com/r/cpp_questions/comments/9yeiaq/deconstructor_crashes_on_application_exit/

An obvious fix is to stop using VS2017, however I believe there is an easy workaround, which is to just remove the `inline` keyword, and this is what this commit does.

`inline` is normally needed to allow having several definitions (not declarations!) of the same variable in different compilation units (i.e., in a header file included by several source files). However in this case, the variable is also `const` and the standard says that these are treated a bit differently (as far as I can tell this is all about "external" vs. "internal" linkage, see e.g., https://en.cppreference.com/w/cpp/language/storage_duration.html though I don't really understand clearly how both `const` and `inline` play).

In my tests, removing `inline` and keeping `const` results in code that compiles and runs correctly both with VS2017 and gcc. Removing the `const` (and removing also `inline`) causes linkage errors, both on VS2017 and gcc, which is expected (and therefore shows that I didn't totally misunderstand the standard, I guess).

I do not see any clear reason for having `inline` here, though of course I may have missed something and maybe it won't compile or work correctly on some other compiler (Mac?).