### PR TITLE
AIC is now incorporated in CovBase

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.11.0
 ==============
+- Incorporate the AIC information as a member of CovBase
 - Fix python non-regression compatibility with pandas >=3.0
 - flagLocator now deprecated in Db_toTL function in python packages
 

--- a/include/Covariances/CovBase.hpp
+++ b/include/Covariances/CovBase.hpp
@@ -59,8 +59,12 @@ public:
   virtual void setSill(const VectorDouble& sill) const;
   virtual void setSill(Id ivar, Id jvar, double sill) const;
   void initSill(double value = 0.);
+  void setAic(const MatrixSquare& aic) { _aic = aic; }
+  void setAic(Id ivar, Id jvar, double val);
+  void computeAic();
 
   const MatrixSymmetric& getSill() const { return _sillCur; }
+  const MatrixSquare& getAic() const { return _aic; }
   virtual void setCor(ACov* cor);
   const ACov* getCor() const { return _cor.get(); }
   ACov* getCorModify() { return _cor.get(); }
@@ -166,6 +170,7 @@ protected:
   mutable MatrixSquare _cholSills;
   mutable MatrixSymmetric _sillCur;
   mutable MatrixSquare _workMat;
+  mutable MatrixSymmetric _aic;
 
 private:
   std::shared_ptr<ACov> _cor;

--- a/include/Covariances/CovBase.hpp
+++ b/include/Covariances/CovBase.hpp
@@ -62,6 +62,7 @@ public:
   void setAic(const MatrixSquare& aic) { _aic = aic; }
   void setAic(Id ivar, Id jvar, double val);
   void computeAic();
+  void initializeAic();
 
   const MatrixSymmetric& getSill() const { return _sillCur; }
   const MatrixSquare& getAic() const { return _aic; }

--- a/include/Covariances/CovList.hpp
+++ b/include/Covariances/CovList.hpp
@@ -149,6 +149,7 @@ public:
   bool isValidForSpectral() const override;
   MatrixDense simulateSpectralOmega(Id ns) const override;
   void computeAic() const;
+  void initializeAic() const;
 
 protected:
   bool _isCovarianceIndexValid(Id icov) const;

--- a/include/Covariances/CovList.hpp
+++ b/include/Covariances/CovList.hpp
@@ -109,6 +109,7 @@ public:
   void setSills(Id icov, const MatrixSymmetric& sills);
   const MatrixSymmetric& getSills(Id icov) const;
   double getSill(Id icov, Id ivar, Id jvar) const;
+  double getAic(Id icov, Id ivar, Id jvar) const;
 
   // Methods necessary for Optimization
   void _optimizationPreProcess(Id mode, const std::vector<SpacePoint>& ps) const override;
@@ -147,6 +148,7 @@ public:
 
   bool isValidForSpectral() const override;
   MatrixDense simulateSpectralOmega(Id ns) const override;
+  void computeAic() const;
 
 protected:
   bool _isCovarianceIndexValid(Id icov) const;

--- a/include/Matrix/MatrixSymmetric.hpp
+++ b/include/Matrix/MatrixSymmetric.hpp
@@ -70,7 +70,8 @@ public:
                                double maxicond = 1.e20,
                                double eps      = EPSILON20);
   bool isDefinitePositive();
-  Id computeSquareRoot(MatrixSymmetric& tabout);
+  Id squareRootInPlace(MatrixSymmetric& tabout);
+  MatrixSymmetric squareRoot(double tol = EPSILON12);
   Id minimizeWithConstraintsInPlace(const VectorDouble& gmat,
                                     const MatrixDense& aemat,
                                     const VectorDouble& bemat,

--- a/include/Model/ModelCovList.hpp
+++ b/include/Model/ModelCovList.hpp
@@ -26,12 +26,12 @@ namespace gstlrn
  * The ModelCovList is essentially a container with two main contents:
  * - the **covariance** part: see CovList.hpp for more information
  */
-class GSTLEARN_EXPORT ModelCovList : public ModelGeneric
+class GSTLEARN_EXPORT ModelCovList: public ModelGeneric
 {
 public:
   ModelCovList(const CovContext& ctxt = CovContext());
-  ModelCovList(const ModelCovList &m);
-  ModelCovList& operator= (const ModelCovList &m);
+  ModelCovList(const ModelCovList& m);
+  ModelCovList& operator=(const ModelCovList& m);
   virtual ~ModelCovList();
 
   const CovList* getCovList() const { return static_cast<const CovList*>(getCov()); }
@@ -47,27 +47,29 @@ public:
   FORWARD_METHOD_NON_CONST(getCovListModify, setSill)
   FORWARD_METHOD_NON_CONST(getCovListModify, setSills)
   FORWARD_METHOD_NON_CONST(getCovListModify, normalize)
+  FORWARD_METHOD_NON_CONST(getCovListModify, computeAic)
 
   FORWARD_METHOD(getCovList, setFitSills)
   FORWARD_METHOD(getCovList, deleteFitSills)
   FORWARD_METHOD(getCovList, getNCov)
   FORWARD_METHOD(getCovList, getSills)
-  FORWARD_METHOD(getCovList, getSill, TEST) 
+  FORWARD_METHOD(getCovList, getSill, TEST)
+  FORWARD_METHOD(getCovList, getAic, TEST)
   FORWARD_METHOD(getCovList, getTotalSill)
   FORWARD_METHOD(getCovList, getTotalSills)
   FORWARD_METHOD(getCovList, isAllActiveCovList)
-  FORWARD_METHOD(getCovList, getFitSills,nullptr)
+  FORWARD_METHOD(getCovList, getFitSills, nullptr)
 
   void setCovList(const CovList* covs);
   virtual void addCov(const CovBase& cov);
   const CovBase* getCovBase(Id icov) const { return getCovList()->getCov(icov); }
   CovBase* getCovBase(Id icov) { return getCovListModify()->getCovModify(icov); }
 
-  void fitSills(Vario* vario = nullptr,
-                const DbGrid* dbmap = nullptr,
-                Constraints* constraints = nullptr,
+  void fitSills(Vario* vario               = nullptr,
+                const DbGrid* dbmap        = nullptr,
+                Constraints* constraints   = nullptr,
                 const ModelOptimParam& mop = ModelOptimParam(),
-                bool verbose = false,
-                bool trace = false);
+                bool verbose               = false,
+                bool trace                 = false);
 };
-}
+} // namespace gstlrn

--- a/include/Simulation/CalcSimuTurningBands.hpp
+++ b/include/Simulation/CalcSimuTurningBands.hpp
@@ -81,11 +81,11 @@ private:
   void _rollback() override;
 
   bool _resize();
-  void _simulatePoint(Db* db, const VectorDouble& aic, Id icase, Id shift);
-  void _simulateGrid(DbGrid* db, const VectorDouble& aic, Id icase, Id shift);
-  void _simulateNugget(Db* db, const VectorDouble& aic, Id icase);
-  void _simulateGradient(Db* dbgrd, const VectorDouble& aic, double delta);
-  void _simulateTangent(Db* dbtgt, const VectorDouble& aic, double delta);
+  void _simulatePoint(Db* db, Id icase, Id shift);
+  void _simulateGrid(DbGrid* db, Id icase, Id shift);
+  void _simulateNugget(Db* db, Id icase);
+  void _simulateGradient(Db* dbgrd, double delta);
+  void _simulateTangent(Db* dbtgt, double delta);
   void _meanCorrect(Db* dbout, Id icase);
   void _difference(Db* dbin,
                    Model* model,
@@ -129,8 +129,6 @@ private:
   void _setDensity();
   static ECov _particularCase(const ECov& type, double param);
   Id _initializeSeedBands();
-  VectorDouble _createAIC();
-  double _getAIC(const VectorDouble& aic, Id icov, Id ivar, Id jvar);
 
   static double _computeScale(double alpha, double scale);
   static double _computeScaleKB(double param, double scale);

--- a/src/Core/model_auto.cpp
+++ b/src/Core/model_auto.cpp
@@ -307,7 +307,7 @@ static Id st_parid_alloc(StrMod* strmod, Id npar0)
                                  &flag_aniso, &flag_rotation, &scalfac,
                                  &parmax);
 
-      /* AIC coefficients -> Sill */
+      /* Sill constraints (operated through the AIC matrix) */
       if (DEFINE_AIC)
         for (Id ivar = 0; ivar < nvar; ivar++)
           for (Id jvar = 0; jvar <= ivar; jvar++)
@@ -1404,10 +1404,10 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
   for (Id icova = 0; icova < ncova; icova++)
     fk.push_back(MatrixDense(nvs2, npadir));
 
-  std::vector<MatrixSymmetric> aic;
-  aic.reserve(ncova);
+  std::vector<MatrixSymmetric> aicLocal;
+  aicLocal.reserve(ncova);
   for (Id icova = 0; icova < ncova; icova++)
-    aic.push_back(MatrixSymmetric(nvar));
+    aicLocal.push_back(MatrixSymmetric(nvar));
 
   std::vector<MatrixSymmetric> alphak;
   alphak.reserve(ncova);
@@ -1435,7 +1435,7 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
       for (Id jvar = 0; jvar <= ivar; jvar++, ijvar++)
       {
         sum1 = sum2 = 0;
-        aic[icov].setValue(ivar, jvar, 0.);
+        aicLocal[icov].setValue(ivar, jvar, 0.);
         for (Id ipadir = 0; ipadir < npadir; ipadir++)
         {
           if (FFFF(WT(ijvar, ipadir))) continue;
@@ -1445,7 +1445,7 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
           sum2 += temp * ge[icov].getValue(ijvar, ipadir);
         }
         alphak[icov].setValue(ivar, jvar, 1. / sum2);
-        aic[icov].setValue(ivar, jvar, sum1 * alphak[icov].getValue(ivar, jvar));
+        aicLocal[icov].setValue(ivar, jvar, sum1 * alphak[icov].getValue(ivar, jvar));
       }
   }
 
@@ -1487,7 +1487,7 @@ static Id st_goulard_without_constraint(const Option_AutoFit& mauto,
             mp.setValue(ijvar, ipadir, mp.getValue(ijvar, ipadir) - sill[icov].getValue(ivar, jvar) * ge[icov].getValue(ijvar, ipadir));
             sum += fk[icov].getValue(ijvar, ipadir) * mp.getValue(ijvar, ipadir);
           }
-          value = aic[icov].getValue(ivar, jvar) - alphak[icov].getValue(ivar, jvar) * sum;
+          value = aicLocal[icov].getValue(ivar, jvar) - alphak[icov].getValue(ivar, jvar) * sum;
           cc.setValue(ivar, jvar, value);
           cc.setValue(jvar, ivar, value);
         }
@@ -3416,6 +3416,8 @@ static Id st_goulard_fitting(Id flag_title,
   /* Dispatch */
 
   Id status;
+  Id nvar  = model->getNVar();
+  Id ncova = model->getNCov();
   if (!optvar.getFlagIntrinsic())
   {
 
@@ -3425,8 +3427,7 @@ static Id st_goulard_fitting(Id flag_title,
     {
       /* Without constraint on the sill */
 
-      status = st_goulard_without_constraint(mauto, model->getNVar(),
-                                             model->getNCov(),
+      status = st_goulard_without_constraint(mauto, nvar, ncova,
                                              RECINT.npadir, RECINT.wt,
                                              RECINT.gg, RECINT.ge, RECINT.sill,
                                              &crit);

--- a/src/Covariances/CorMatern.cpp
+++ b/src/Covariances/CorMatern.cpp
@@ -124,11 +124,11 @@ CorMatern& CorMatern::operator=(const CorMatern& r)
   if (this != &r)
   {
     ACov::operator=(r);
-    _nVar      = r._nVar;
-    _cor = r._cor;
-    _C0        = r._C0;
-    _Kappa     = r._Kappa;
-    _Nu        = r._Nu;
+    _nVar  = r._nVar;
+    _cor   = r._cor;
+    _C0    = r._C0;
+    _Kappa = r._Kappa;
+    _Nu    = r._Nu;
   }
   return *this;
 }
@@ -175,7 +175,7 @@ CorMatern* CorMatern::create(
 
 double CorMatern::evalSpectrum(const VectorDouble& freq, Id ivar, Id jvar) const
 {
-  double kappa = _Kappa.getValue(ivar, jvar);
+  double kappa        = _Kappa.getValue(ivar, jvar);
   VectorDouble scales = _corRef->getScales();
   VectorDouble angles = _corRef->getAnisoAngles();
   for (size_t idim = 0; idim < getSpace()->getNDim(); idim++)
@@ -228,7 +228,7 @@ SpectrumRN CorMatern::simulateSpectrumRN(Id ns, const ACov* cov0) const
         }
       }
       // square root of the symmetric matrix
-      if (H.computeSquareRoot(H) != 0)
+      if (H.squareRootInPlace(H) != 0)
       {
         message("Error in computing square root matrix\n");
       }

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -180,6 +180,14 @@ void CovBase::computeAic()
   if (!_sillCur.empty()) _aic = _sillCur.squareRoot();
 }
 
+void CovBase::initializeAic()
+{
+  if (_sillCur.empty()) return;
+  Id nvar = _sillCur.getNCols();
+  _aic    = MatrixSymmetric(nvar);
+  _aic.setIdentity();
+}
+
 bool CovBase::_isVariableValid(Id ivar) const
 {
   return checkArg("Rank of the Variable", ivar, getNVar());

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -50,6 +50,7 @@ CovBase::CovBase(ACov* cor,
   createNoStatTab();
 
   _ctxt.setNVar(sill.getNSize());
+  _aic.clear();
 
   if (cor != nullptr)
   {
@@ -68,6 +69,7 @@ CovBase::CovBase(const CovBase& r)
   _cholSills     = r._cholSills;
   _sillCur       = r._sillCur;
   _workMat       = r._workMat;
+  _aic           = r._aic;
   _cor           = std::dynamic_pointer_cast<ACov>(r._cor->cloneShared());
 }
 
@@ -79,6 +81,7 @@ CovBase& CovBase::operator=(const CovBase& r)
     _cholSills     = r._cholSills;
     _sillCur       = r._sillCur;
     _workMat       = r._workMat;
+    _aic           = r._aic;
     _cor           = std::dynamic_pointer_cast<ACov>(r._cor->cloneShared());
     _itRange       = LowerTriangularRange(r._cholSills.getNRows());
   }
@@ -158,6 +161,23 @@ void CovBase::setCholSill(Id ivar, Id jvar, double val) const
     return;
   }
   _cholSills.setValue(ivar, jvar, val);
+}
+
+void CovBase::setAic(Id ivar, Id jvar, double val)
+{
+  if (!_isVariableValid(ivar)) return;
+  if (!_isVariableValid(jvar)) return;
+  _aic.setValue(ivar, jvar, val);
+}
+
+/**
+ * @brief Calculate the square root of the sill matrix.
+ * This decomposition requires the Sill matrix to be definite positive.
+ */
+void CovBase::computeAic()
+{
+  // Check that the sill matrix has been defined before squaring it
+  if (!_sillCur.empty()) _aic = _sillCur.squareRoot();
 }
 
 bool CovBase::_isVariableValid(Id ivar) const

--- a/src/Covariances/CovList.cpp
+++ b/src/Covariances/CovList.cpp
@@ -401,6 +401,11 @@ void CovList::setSills(Id icov, const MatrixSymmetric& sills)
   if (!_isCovarianceIndexValid(icov)) return;
   _covs[icov]->setSill(sills);
 }
+double CovList::getAic(Id icov, Id ivar, Id jvar) const
+{
+  if (!_isCovarianceIndexValid(icov)) return 0.;
+  return _covs[icov]->getAic().getValue(ivar, jvar);
+}
 /**
  * Calculate the total sill of the model for given pair of variables
  * @param ivar Rank of the first variable
@@ -626,6 +631,12 @@ bool CovList::isValidForSpectral() const
 MatrixDense CovList::simulateSpectralOmega(Id ns) const
 {
   return getCov(0)->simulateSpectralOmega(ns);
+}
+
+void CovList::computeAic() const
+{
+  for (const auto& e: _covs)
+    e->computeAic();
 }
 
 #ifdef HDF5

--- a/src/Covariances/CovList.cpp
+++ b/src/Covariances/CovList.cpp
@@ -639,6 +639,12 @@ void CovList::computeAic() const
     e->computeAic();
 }
 
+void CovList::initializeAic() const
+{
+  for (const auto& e: _covs)
+    e->initializeAic();
+}
+
 #ifdef HDF5
 bool CovList::deserializeH5(H5::Group& grp)
 {

--- a/src/Estimation/KrigingSystemSimpleCase.cpp
+++ b/src/Estimation/KrigingSystemSimpleCase.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Estimation/KrigingSystemSimpleCase.hpp"
 #include "Anamorphosis/AnamHermite.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/OptDbg.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Basic/VectorNumT.hpp"

--- a/src/Matrix/MatrixSymmetric.cpp
+++ b/src/Matrix/MatrixSymmetric.cpp
@@ -838,7 +838,7 @@ Id MatrixSymmetric::computeGeneralizedInverse(MatrixSymmetric& tabout,
  ** \remark The input and output matrices can match
  **
  *****************************************************************************/
-Id MatrixSymmetric::computeSquareRoot(MatrixSymmetric& tabout)
+Id MatrixSymmetric::squareRootInPlace(MatrixSymmetric& tabout)
 {
   if (!isSameSize(tabout))
   {
@@ -950,6 +950,49 @@ MatrixSymmetric* MatrixSymmetric::createFromDiagonal(const VectorDouble& vecdiag
     res->setValue(i, i, vecdiag[i]);
   }
   return res;
+}
+
+MatrixSymmetric MatrixSymmetric::squareRoot(double tol)
+{
+  Eigen::MatrixXd B = eigenMat();
+  Id n              = B.rows();
+
+  // Eigen-decomposition (symmetric)
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(B);
+  if (es.info() != Eigen::Success)
+  {
+    messerr("Eigen decomposition failed");
+    return MatrixSymmetric();
+  }
+
+  Eigen::VectorXd evals = es.eigenvalues();
+  Eigen::MatrixXd evecs = es.eigenvectors();
+
+  // Clamp small negative values due to numerical noise
+  for (int i = 0; i < evals.size(); ++i)
+  {
+    if (evals(i) < 0 && std::abs(evals(i)) < tol) evals(i) = 0.0;
+  }
+
+  // Look for negative eigen values
+  for (int i = 0; i < evals.size(); ++i)
+  {
+    if (evals(i) < 0)
+    {
+      messerr("Matrix has negative eigenvalues: no real symmetric square root exists");
+      return MatrixSymmetric();
+    }
+  }
+
+  // Racine carrée diagonale
+  Eigen::VectorXd sqrt_evals = evals.array().sqrt();
+
+  // Recomposition : A = Q * sqrt(Lambda) * Q^T
+  Eigen::MatrixXd A = evecs * sqrt_evals.asDiagonal() * evecs.transpose();
+
+  MatrixSymmetric mat(n);
+  mat.eigenMat() = A;
+  return mat;
 }
 
 } // namespace gstlrn

--- a/src/Model/AModelFitSills.cpp
+++ b/src/Model/AModelFitSills.cpp
@@ -951,10 +951,12 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
     fk.push_back(MatrixDense(nvs2Local, npadir));
   MatrixSymmetric cc(nvar);
 
-  std::vector<MatrixSymmetric> aic;
-  aic.reserve(ncova);
+  // The array 'aicLocal' is similar to '_aic' stored within CovBase class
+  // However it is not stored there as 'nvar' is defined locally.
+  std::vector<MatrixSymmetric> aicLocal;
+  aicLocal.reserve(ncova);
   for (Id icova = 0; icova < ncova; icova++)
-    aic.push_back(MatrixSymmetric(nvar));
+    aicLocal.push_back(MatrixSymmetric(nvar));
   std::vector<MatrixSymmetric> alphak;
   alphak.reserve(ncova);
   for (Id icova = 0; icova < ncova; icova++)
@@ -981,7 +983,7 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
       for (Id jvar = 0; jvar <= ivar; jvar++, ijvar++)
       {
         sum1 = sum2 = 0;
-        aic[icov].setValue(ivar, jvar, 0.);
+        aicLocal[icov].setValue(ivar, jvar, 0.);
         for (Id ipadir = 0; ipadir < npadir; ipadir++)
         {
           if (FFFF(WT(ijvar, ipadir))) continue;
@@ -991,7 +993,7 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
           sum2 += temp * ge[icov].getValue(ijvar, ipadir);
         }
         alphak[icov].setValue(ivar, jvar, 1. / sum2);
-        aic[icov].setValue(ivar, jvar, sum1 / sum2);
+        aicLocal[icov].setValue(ivar, jvar, sum1 / sum2);
       }
   crit = _calculateScoreMP(nvar, npadir, wt, gg, mp);
 
@@ -1022,7 +1024,7 @@ Id AModelFitSills::_goulardWithoutConstraint(Id niter,
                            ge[icov].getValue(ijvar, ipadir)));
             sum += fk[icov].getValue(ijvar, ipadir) * mp.getValue(ijvar, ipadir);
           }
-          coeff = aic[icov].getValue(ivar, jvar) -
+          coeff = aicLocal[icov].getValue(ivar, jvar) -
                   alphak[icov].getValue(ivar, jvar) * sum;
           cc.setValue(ivar, jvar, coeff);
           cc.setValue(jvar, ivar, coeff);

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -30,8 +30,6 @@
 namespace gstlrn
 {
 
-bool _internalNewStyle = true;
-
 CalcSimuTurningBands::CalcSimuTurningBands(Id nbsimu,
                                            Id nbtuba,
                                            bool flag_check,

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -18,7 +18,6 @@
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "Geometry/GeometryHelper.hpp"
-#include "Matrix/EigenVectors.hpp"
 #include "Model/Model.hpp"
 #include "Simulation/ACalcSimulation.hpp"
 #include "Simulation/TurningBandDirection.hpp"
@@ -30,6 +29,9 @@
 
 namespace gstlrn
 {
+
+bool _internalNewStyle = true;
+
 CalcSimuTurningBands::CalcSimuTurningBands(Id nbsimu,
                                            Id nbtuba,
                                            bool flag_check,
@@ -913,60 +915,6 @@ double CalcSimuTurningBands::_irfProcessInit(Id ibs,
   return _irfCorrec(type, theta1, scale);
 }
 
-/*****************************************************************************/
-/*!
- **  Calculate the linear model of coregionalization starting from the
- **  coregionalization matrix
- **
- ** \return  The Vector containing the AIC matrix
- **
- ** \remark  In case of error, the message is printed by the routine
- ** \remark  Warning: in the case of linked drift, the test of definite
- ** \remark  positiveness is bypassed as we are not in the scope of the
- ** \remark  linear model of coregionalization anymore.
- ** \remark  As a consequence the array "aic()" is not evaluated
- **
- *****************************************************************************/
-VectorDouble CalcSimuTurningBands::_createAIC()
-{
-  auto ncova = _getNCov();
-  auto nvar  = _getNVar();
-  Id nv2     = nvar * nvar;
-  VectorDouble aic(ncova * nv2);
-
-  /* Calculate the eigen values and vectors of the coregionalization matrix */
-
-  for (Id icov = 0; icov < ncova; icov++)
-  {
-    MatrixSymmetric mat = _modelLocal->getSills(icov);
-    if (!mat.isDefinitePositive())
-    {
-      messerr("Warning: the model is not authorized");
-      messerr("The coregionalization matrix for the structure %d is not definite positive",
-              icov + 1);
-      return VectorDouble();
-    }
-
-    // Calculate the Eigen decomposition
-
-    auto eigenvectors          = EigenVectors(mat);
-    const auto& valpro         = eigenvectors.getEigenValues();
-    const MatrixSquare* vecpro = &eigenvectors.getEigenVectors();
-
-    /* Calculate the factor matrix */
-
-    for (Id ivar = 0; ivar < nvar; ivar++)
-      for (Id jvar = 0; jvar < nvar; jvar++)
-      {
-        double value = 0.;
-        for (Id kvar = 0; kvar < nvar; kvar++)
-          value += vecpro->getValue(ivar, kvar) * sqrt(valpro[kvar]) * vecpro->getValue(jvar, kvar);
-        aic[icov * nv2 + ivar + nvar * jvar] = value;
-      }
-  }
-  return aic;
-}
-
 void CalcSimuTurningBands::_spreadRegularOnGrid(Id nx,
                                                 Id ny,
                                                 Id nz,
@@ -1094,13 +1042,11 @@ void CalcSimuTurningBands::_spreadSpectralOnPoint(const Db* db,
  **  Turning Bands method.
  **
  ** \param[in]  db         Db structure
- ** \param[in]  aic        Array 'aic'
  ** \param[in]  icase      Rank of PGS or GRF
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
 void CalcSimuTurningBands::_simulatePoint(Db* db,
-                                          const VectorDouble& aic,
                                           Id icase,
                                           Id shift)
 {
@@ -1220,7 +1166,7 @@ void CalcSimuTurningBands::_simulatePoint(Db* db,
                 {
                   db->updSimvar(ELoc::SIMU, iech, shift + isimu, jvar, icase,
                                 nbsimu, nvar, EOperator::ADD,
-                                tab[iech] * correc * _getAIC(aic, is, jvar, ivar));
+                                tab[iech] * correc * _modelLocal->getAic(is, ivar, jvar));
                 }
         }
   }
@@ -1244,13 +1190,11 @@ void CalcSimuTurningBands::_simulatePoint(Db* db,
  **  Turning Bands method
  **
  ** \param[in]  db         Db structure
- ** \param[in]  aic        Array 'aic'
  ** \param[in]  icase      Rank of PGS or GRF
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
 void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
-                                         const VectorDouble& aic,
                                          Id icase,
                                          Id shift)
 {
@@ -1373,7 +1317,7 @@ void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
                 for (Id jvar = 0; jvar < nvar; jvar++)
                   db->updSimvar(ELoc::SIMU, iech, shift + isimu, jvar, icase,
                                 nbsimu, nvar, EOperator::ADD,
-                                tab[iech] * correc * _getAIC(aic, is, jvar, ivar));
+                                tab[iech] * correc * _modelLocal->getAic(is, ivar, jvar));
         }
   }
 
@@ -1396,7 +1340,6 @@ void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
  **  Turning Bands method.
  **
  ** \param[in]  dbgrd      Gradient Db structure
- ** \param[in]  aic        Array 'aic'
  ** \param[in]  delta      Value of the increment
  **
  ** \remarks The simulated gradients are stored as follows:
@@ -1406,7 +1349,6 @@ void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
  **
  *****************************************************************************/
 void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
-                                             const VectorDouble& aic,
                                              double delta)
 {
   Id jsimu;
@@ -1423,7 +1365,7 @@ void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
     for (Id isimu = 0; isimu < nbsimu; isimu++)
     {
       jsimu = isimu + idim * nbsimu;
-      _simulatePoint(dbgrd, aic, icase, jsimu);
+      _simulatePoint(dbgrd, icase, jsimu);
     }
 
     /* Shift the information */
@@ -1438,7 +1380,7 @@ void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
     for (Id isimu = 0; isimu < nbsimu; isimu++)
     {
       jsimu = isimu + idim * nbsimu + ndim * nbsimu;
-      _simulatePoint(dbgrd, aic, icase, jsimu);
+      _simulatePoint(dbgrd, icase, jsimu);
     }
 
     /* Un-Shift the information */
@@ -1473,7 +1415,6 @@ void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
  **  Turning Bands method.
  **
  ** \param[in]  dbtgt      Tangent Db structure
- ** \param[in]  aic        Array 'aic'
  ** \param[in]  delta      Value of the increment
  **
  ** \remarks Warning: To perform the simulation of the tangent, we must
@@ -1482,7 +1423,6 @@ void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
  **
  *****************************************************************************/
 void CalcSimuTurningBands::_simulateTangent(Db* dbtgt,
-                                            const VectorDouble& aic,
                                             double delta)
 {
   Id icase               = 0;
@@ -1492,7 +1432,7 @@ void CalcSimuTurningBands::_simulateTangent(Db* dbtgt,
 
   /* Perform the simulation of the gradients at tangent points */
 
-  _simulateGradient(dbtgt, aic, delta);
+  _simulateGradient(dbtgt, delta);
 
   /* Calculate the simulated tangent */
 
@@ -1582,12 +1522,10 @@ void CalcSimuTurningBands::_getOmegaPhi(Id ibs,
  **  simulations
  **
  ** \param[in]  db         Db structure
- ** \param[in]  aic        Array 'aic'
  ** \param[in]  icase      Rank of PGS or GRF
  **
  *****************************************************************************/
 void CalcSimuTurningBands::_simulateNugget(Db* db,
-                                           const VectorDouble& aic,
                                            Id icase)
 {
   Id nech                = db->getNSample();
@@ -1623,22 +1561,12 @@ void CalcSimuTurningBands::_simulateNugget(Db* db,
           double nugget = law_gaussian();
           for (Id jvar = 0; jvar < nvar; jvar++)
             db->updSimvar(ELoc::SIMU, iech, isimu, jvar, icase, nbsimu, nvar,
-                          EOperator::ADD,
-                          nugget * _getAIC(aic, is, jvar, ivar));
+                          EOperator::ADD, nugget * _modelLocal->getAic(is, ivar, jvar));
         }
       }
 
   // Set the initial seed back
   law_set_random_seed(mem_seed);
-}
-
-double CalcSimuTurningBands::_getAIC(const VectorDouble& aic,
-                                     Id icov,
-                                     Id ivar,
-                                     Id jvar)
-{
-  auto nvar = _getNVar();
-  return aic[jvar + nvar * (ivar + nvar * icov)];
 }
 
 /*****************************************************************************/
@@ -1922,16 +1850,14 @@ bool CalcSimuTurningBands::_run()
   _minmax(getDbin());
   if (_initializeSeedBands()) return false;
 
-  // Calculate the 'aic' array
-
-  VectorDouble aic = _createAIC();
-  if (aic.empty()) return false;
+  // Factorize the matrix of sills
+  _modelLocal->computeAic();
 
   // Non conditional simulations on the data points
 
   if (flag_cond)
   {
-    _simulatePoint(getDbin(), aic, _icase, 0);
+    _simulatePoint(getDbin(), _icase, 0);
     _meanCorrect(getDbin(), _icase);
 
     // Calculate the simulated error
@@ -1944,18 +1870,18 @@ bool CalcSimuTurningBands::_run()
   if (getDbout()->isGrid())
   {
     auto* dbgrid = dynamic_cast<DbGrid*>(getDbout());
-    _simulateGrid(dbgrid, aic, _icase, 0);
+    _simulateGrid(dbgrid, _icase, 0);
     _meanCorrect(getDbout(), _icase);
   }
   else
   {
-    _simulatePoint(getDbout(), aic, _icase, 0);
+    _simulatePoint(getDbout(), _icase, 0);
     _meanCorrect(getDbout(), _icase);
   }
 
   /* Add the contribution of Nugget effect (optional) */
 
-  _simulateNugget(getDbout(), aic, _icase);
+  _simulateNugget(getDbout(), _icase);
 
   /* Conditional simulations */
 
@@ -2059,30 +1985,28 @@ Id CalcSimuTurningBands::simulatePotential(Db* dbiso,
   _minmax(dbtgt);
   if (_initializeSeedBands()) return 1;
 
-  /* Calculate the 'aic' array */
-
-  VectorDouble aic = _createAIC();
-  if (aic.empty()) return 1;
+  // Factorize the matrix of sills
+  _modelLocal->computeAic();
 
   /* Non conditional simulations on the data points */
 
   if (dbiso != nullptr)
   {
-    _simulatePoint(dbiso, aic, icase, 0);
+    _simulatePoint(dbiso, icase, 0);
   }
 
   /* Non conditional simulations on the gradient points */
 
   if (dbgrd != nullptr)
   {
-    _simulateGradient(dbgrd, aic, delta);
+    _simulateGradient(dbgrd, delta);
   }
 
   /* Non conditional simulations on the tangent points */
 
   if (dbtgt != nullptr)
   {
-    _simulateTangent(dbtgt, aic, delta);
+    _simulateTangent(dbtgt, delta);
   }
 
   /* Non conditional simulations on the grid */
@@ -2090,16 +2014,16 @@ Id CalcSimuTurningBands::simulatePotential(Db* dbiso,
   if (dbout->isGrid())
   {
     auto* dbgrid = dynamic_cast<DbGrid*>(dbout);
-    _simulateGrid(dbgrid, aic, icase, 0);
+    _simulateGrid(dbgrid, icase, 0);
   }
   else
   {
-    _simulatePoint(dbout, aic, icase, 0);
+    _simulatePoint(dbout, icase, 0);
   }
 
   /* Add the contribution of nugget effect (optional) */
 
-  _simulateNugget(dbout, aic, icase);
+  _simulateNugget(dbout, icase);
   return 0;
 }
 

--- a/src/Simulation/CalcSimuTurningBands.cpp
+++ b/src/Simulation/CalcSimuTurningBands.cpp
@@ -1046,9 +1046,7 @@ void CalcSimuTurningBands::_spreadSpectralOnPoint(const Db* db,
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulatePoint(Db* db,
-                                          Id icase,
-                                          Id shift)
+void CalcSimuTurningBands::_simulatePoint(Db* db, Id icase, Id shift)
 {
   Id nech       = db->getNSample();
   auto ncova    = _getNCov();
@@ -1194,9 +1192,7 @@ void CalcSimuTurningBands::_simulatePoint(Db* db,
  ** \param[in]  shift      Shift before writing the simulation result
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
-                                         Id icase,
-                                         Id shift)
+void CalcSimuTurningBands::_simulateGrid(DbGrid* db, Id icase, Id shift)
 {
   auto nbsimu            = getNbSimu();
   double theta1          = 1. / _theta;
@@ -1348,8 +1344,7 @@ void CalcSimuTurningBands::_simulateGrid(DbGrid* db,
  ** \remarks At the end, the simulated gradient is stored at first point
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
-                                             double delta)
+void CalcSimuTurningBands::_simulateGradient(Db* dbgrd, double delta)
 {
   Id jsimu;
   Id icase               = 0;
@@ -1422,8 +1417,7 @@ void CalcSimuTurningBands::_simulateGradient(Db* dbgrd,
  ** \remarks simulation outcome variables as for the gradients
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateTangent(Db* dbtgt,
-                                            double delta)
+void CalcSimuTurningBands::_simulateTangent(Db* dbtgt, double delta)
 {
   Id icase               = 0;
   auto nvar              = _getNVar();
@@ -1525,8 +1519,7 @@ void CalcSimuTurningBands::_getOmegaPhi(Id ibs,
  ** \param[in]  icase      Rank of PGS or GRF
  **
  *****************************************************************************/
-void CalcSimuTurningBands::_simulateNugget(Db* db,
-                                           Id icase)
+void CalcSimuTurningBands::_simulateNugget(Db* db, Id icase)
 {
   Id nech                = db->getNSample();
   auto ncova             = _getNCov();


### PR DESCRIPTION
This branch is dedicated to suppressing the AIC (square root of the sill matrix) as a free element.
It is now incorporated as a member within the CovBase structure.
Its impact:
- in the simulation procedure (visible currently in the Simulation using Turning Bands method)
- in the automatic fitting of the sills (which is performed through the fitting of the AIC matrix... easier as it does not have to carry the positive definitness condition)