### PR TITLE
GitHub Actions: Use Ubuntu for clang-check jobs

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -80,7 +80,7 @@ jobs:
   # Check compiler warnings #
   # ----------------------- #
   check-warnings:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         opt: [Debug, Release]
@@ -90,14 +90,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install macOS dependencies
+    - name: Install dependencies
       run: |
-        brew install llvm
-        brew install boost
-        brew install eigen
-        brew install nlopt
-        brew install hdf5
-        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update
+        sudo apt-get install -yq \
+          libhdf5-dev \
+          libopenmpi-dev \
+          libboost-dev \
+          libeigen3-dev \
+          libnlopt-dev \
+          libomp-dev \
+          clang-tools
 
     - name: Create & configure gstlearn build directory
       run: |
@@ -118,8 +122,8 @@ jobs:
         git ls-files \
         | grep -E "src|include" \
         | grep -E "\.cpp$|\.hpp$" \
-        | xargs -n1 -P$(sysctl -n hw.physicalcpu) -t \
-            xcrun clang-check -p build --extra-arg=-Werror
+        | xargs -n1 -P$(nproc) -t \
+            clang-check -p build --extra-arg=-Werror
 
 
   # ------------- #


### PR DESCRIPTION
The `check_code` workflow launches a few (8) `clang-check` jobs that ensure `gstlearn` builds on different configurations (with or without HDF5, with or without Boost `span`) without warnings.

The jobs are currently run under `macos-latest` for improved performance. Unfortunately, this slows down the whole CI since the number of parallel `macos` jobs on GitHub Actions for a given project is limited to 5.

In order to circumvent this limitation, this PR switches back to `ubuntu-latest` for these jobs. They are a few minutes of run-time slower (15 min instead of 12) but there is no limitation on their number (for now).

This should make the CI faster, especially if several workflows (from several PR) are launched concurrently.

Pierre