### PR TITLE
Correction bug de Meryem

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.11.0
 ==============
-
+- Adding test to avoid Kriging with too few data (KrigingSimpleCase)
+- Adding a test to check that Matrix Inversion was performed correctly
 
 Release 1.10.1
 ==============

--- a/include/Db/PtrGeos.hpp
+++ b/include/Db/PtrGeos.hpp
@@ -37,7 +37,7 @@ public:
   Id findUIDInLocator(Id iuid) const;
   void erase(Id locatorIndex);
   void clear();
-  void resize(Id count) { _r.resize(count, 0); }
+  void resize(Id count) { _r.resize(count, -1); }
   String dumpLocator(Id rank, const ELoc& locatorType) const;
 
 private:

--- a/include/Estimation/KrigingAlgebraSimpleCase.hpp
+++ b/include/Estimation/KrigingAlgebraSimpleCase.hpp
@@ -9,14 +9,14 @@
 /******************************************************************************/
 #pragma once
 
+#include "Basic/OptCustom.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Db/RankHandler.hpp"
 #include "LinearOp/CholeskyDense.hpp"
-#include "gstlearn_export.hpp"
-#include "Basic/OptCustom.hpp"
-#include "Matrix/MatrixSymmetric.hpp"
-#include "Matrix/MatrixDense.hpp"
 #include "Matrix/AMatrix.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
+#include "gstlearn_export.hpp"
 #include <memory>
 
 namespace gstlrn
@@ -42,27 +42,28 @@ class RankHandler;
 class GSTLEARN_EXPORT KrigingAlgebraSimpleCase
 {
 public:
-  KrigingAlgebraSimpleCase(bool flagDual                        = false,
-                           const RankHandler* rankhandler       = nullptr,
-                           const VectorDouble* Z                = nullptr,
-                           const VectorDouble& Means            = VectorDouble(),
-                           Id flagchol                         = false,
-                           bool neighUnique                     = OptCustom::query("unique", 1));
+  KrigingAlgebraSimpleCase(bool flagDual                  = false,
+                           const RankHandler* rankhandler = nullptr,
+                           const VectorDouble* Z          = nullptr,
+                           const VectorDouble& Means      = VectorDouble(),
+                           Id flagchol                    = false,
+                           bool neighUnique               = OptCustom::query("unique", 1));
   KrigingAlgebraSimpleCase(KrigingAlgebraSimpleCase& r);
   KrigingAlgebraSimpleCase& operator=(const KrigingAlgebraSimpleCase& r) = delete;
   virtual ~KrigingAlgebraSimpleCase();
   Id prepare();
+
   void setDual(bool status);
   void setNeighUnique(bool nu = false) { _neighUnique = nu; }
   void resetNewData();
   void setZ(std::shared_ptr<VectorDouble>& Z);
   Id setData(const VectorDouble* Z          = nullptr,
-              const RankHandler* rankhandler = nullptr,
-              const VectorDouble& Means      = VectorDouble());
+             const RankHandler* rankhandler = nullptr,
+             const VectorDouble& Means      = VectorDouble());
   Id setLHS(const MatrixSymmetric* Sigma = nullptr,
-             const MatrixDense* X         = nullptr);
+            const MatrixDense* X         = nullptr);
   Id setRHS(MatrixDense* Sigma0 = nullptr,
-             MatrixDense* X0     = nullptr);
+            MatrixDense* X0     = nullptr);
   Id setVariance(const MatrixSymmetric* Sigma00 = nullptr);
 
   void printStatus() const;
@@ -72,7 +73,7 @@ public:
   void dumpAux();
 
   VectorDouble& getEstimation();
-  const VectorDouble &getStdv();
+  const VectorDouble& getStdv();
   double getVarianceZstar(Id i);
   VectorDouble getVarianceZstar();
   const MatrixSymmetric* getStdvMat();
@@ -94,8 +95,8 @@ public:
   MatrixDense* getX0() { return _X0.get(); }
   const VectorVectorInt* getSampleRanks() { return &_rankHandler->getSampleRanks(); }
   VectorInt* getSampleRanksByVariable(Id ivar) { return &_rankHandler->getSampleRanksByVariable(ivar); }
-  RankHandler* getRankHandler() { return _rankHandler.get();}
-  void setRankHandler(std::shared_ptr<RankHandler> &rkh){ _rankHandler = rkh;}
+  RankHandler* getRankHandler() { return _rankHandler.get(); }
+  void setRankHandler(std::shared_ptr<RankHandler>& rkh) { _rankHandler = rkh; }
   VectorInt* getNbgh() { return _nbgh.get(); }
   void setMeans(const VectorDouble& means);
 
@@ -174,10 +175,11 @@ private:
 
   bool _forbiddenWhenDual() const;
   void _resetAll();
+  static void _printInversionErrorMessage(const MatrixSymmetric& mat);
 
 private:
   // Quantities to be defined by the user
-  std::shared_ptr<VectorDouble> _Z;              // Data [flattened] (Dim: _neq)
+  std::shared_ptr<VectorDouble> _Z; // Data [flattened] (Dim: _neq)
   std::shared_ptr<RankHandler> _rankHandler;
   std::shared_ptr<VectorInt> _nbgh;
   std::shared_ptr<MatrixDense> _X;           // Drift at Data (Dim: _neq * _nbfl)
@@ -192,12 +194,12 @@ private:
   std::shared_ptr<CholeskyDense> _cholSigma;
   std::shared_ptr<MatrixDense> _XtInvSigma;    // X^t * Inv{Sigma} (Dim: _nbfl * _neq);
   std::shared_ptr<MatrixDense> _invSigmaX;     // Inv{Sigma} X (Dim: _neq * _nbfl);
-  std::shared_ptr<VectorDouble> _XtInvSigmaZ;        // X^t * Inv{Sigma} Z (Dim: _nbfl * _nvar);
+  std::shared_ptr<VectorDouble> _XtInvSigmaZ;  // X^t * Inv{Sigma} Z (Dim: _nbfl * _nvar);
   std::shared_ptr<MatrixSymmetric> _invSigmac; // Inv{X^t * Inv{Sigma} * X} (Dim: _nbfl * _nbfl)
-  std::shared_ptr<VectorDouble> _Beta;               // Drift coefficients (Dim: _nbfl)
+  std::shared_ptr<VectorDouble> _Beta;         // Drift coefficients (Dim: _nbfl)
   std::shared_ptr<MatrixDense> _LambdaSK;      // Weights for SK (Dim: _neq * _nrhs)
-                                                     // Following elements are defined for Dual programming
-  std::shared_ptr<VectorDouble> _bDual;              // Fake Covariance part in Dual (Dim: _neq)
+                                               // Following elements are defined for Dual programming
+  std::shared_ptr<VectorDouble> _bDual;        // Fake Covariance part in Dual (Dim: _neq)
   std::shared_ptr<VectorDouble> _invSigmaXBeta;
 
   VectorDouble _Zstar; // Estimated values (Dim: _nrhs)
@@ -209,10 +211,9 @@ private:
   MatrixSymmetric _VarZSK; // Estimator variance in SK (Dim: _nrhs * _nrhs)
   MatrixSymmetric _VarZUK; // Estimator variance in UK (Dim: _nrhs * _nrhs)
   MatrixSymmetric _Sigmac;
+
   // Following elements are defined for internal storage
-
   MatrixDense _Y0; // X0 - LambdaSK * X^t (Dim: _nrhs * _nbfl)
-
   MatrixDense _LambdaUKtSigma0;
   MatrixDense _MuUKtX0t;
   MatrixDense _invSigmaXMuUK;
@@ -235,4 +236,4 @@ private:
 
   VectorDouble _dummy;
 };
-}
+} // namespace gstlrn

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -5044,8 +5044,7 @@ bool Db::serializeH5(H5::Group& grp) const
 
   for (Id i = 0; i < ncol; ++i)
   {
-    // here we create H5::DataSet by hand to augment them with
-    // attributes
+    // Here we create H5::DataSet by hand to augment them with attributes
     auto data = dbG.createDataSet(names[i], H5::PredType::NATIVE_DOUBLE, ds);
     // Locators are semantically close to Db columns and H5::Attribute has a
     // nicer API than string H5::DataSets. Putting Locators inside Attribute

--- a/src/Db/PtrGeos.cpp
+++ b/src/Db/PtrGeos.cpp
@@ -11,16 +11,17 @@
 #include "Db/PtrGeos.hpp"
 #include "Basic/Message.hpp"
 #include "Basic/String.hpp"
+#include "Enum/ELoc.hpp"
 
-#include <sstream>
 #include <cstring>
+#include <sstream>
 
 namespace gstlrn
 {
 typedef struct
 {
   char SREF[LOCAL_SIZE];       /* Name of the Locator */
-  Id IREF;                    /* Unicity of the locator */
+  Id IREF;                     /* Unicity of the locator */
   char COMMENT[STRING_LENGTH]; /* Meaning */
 } Def_Locator;
 
@@ -149,8 +150,8 @@ Id getLocatorTypeFromName(const String& name_type)
   {
     if (*it != ELoc::UNKNOWN)
     {
-      auto i           = it.getValue();
-      auto lng         = static_cast<size_t>(strlen(DEF_LOCATOR[i].SREF));
+      auto i   = it.getValue();
+      auto lng = static_cast<size_t>(strlen(DEF_LOCATOR[i].SREF));
       if (name_type.compare(0, lng, DEF_LOCATOR[i].SREF) == 0) return i;
     }
     it.toNext();
@@ -171,8 +172,8 @@ Id locatorIdentify(String string, ELoc* ret_locatorType, Id* ret_locatorIndex, I
   *ret_locatorType  = ELoc::UNKNOWN;
   *ret_locatorIndex = -1;
   *ret_mult         = 1;
-  Id inum          = -1;
-  Id found         = -1;
+  Id inum           = -1;
+  Id found          = -1;
   bool mult         = 0;
 
   // Transform the input argument into lower case for comparison
@@ -184,8 +185,8 @@ Id locatorIdentify(String string, ELoc* ret_locatorType, Id* ret_locatorIndex, I
   {
     if (*it != ELoc::UNKNOWN)
     {
-      auto i           = it.getValue();
-      auto lng         = static_cast<size_t>(strlen(DEF_LOCATOR[i].SREF));
+      auto i   = it.getValue();
+      auto lng = static_cast<size_t>(strlen(DEF_LOCATOR[i].SREF));
       if (string_loc.compare(0, lng, DEF_LOCATOR[i].SREF) == 0) found = i;
     }
     it.toNext();
@@ -268,4 +269,4 @@ VectorInt getLocatorMultiples()
   }
   return mult;
 }
-}
+} // namespace gstlrn

--- a/src/Estimation/KrigingAlgebra.cpp
+++ b/src/Estimation/KrigingAlgebra.cpp
@@ -665,7 +665,7 @@ Id KrigingAlgebra::setBayes(const VectorDouble* PriorMeans,
   // Store the arguments (const pointers) into internal storage
   _PriorMeans = PriorMeans;
   _PriorCovs  = PriorCovs;
-  _flagBayes = true;
+  _flagBayes  = true;
 
   return 0;
 }
@@ -1168,7 +1168,7 @@ Id KrigingAlgebra::_patchRHSForXvalidUnique()
   MatrixSymmetric alpha;
   MatrixSymmetric::sample(alpha, _InvSigma, *_rankXvalidEqs);
   MatrixSymmetric InvAlpha = alpha;
-  InvAlpha.invert();
+  if (InvAlpha.invert()) return 1;
 
   // Calculate a1 term
   MatrixSymmetric omega(_nxvalid);
@@ -1208,7 +1208,7 @@ Id KrigingAlgebra::_patchRHSForXvalidUnique()
     MatrixSymmetric p3(_nbfl);
     p3.prodNormMatMatInPlace(&epsilon, &alpha, true);
     a2.linearCombination(1., &a2, -1., &p3);
-    a2.invert();
+    if (a2.invert()) return 1;
 
     // Compute omega
     MatrixSymmetric p4(_nxvalid);

--- a/src/Estimation/KrigingAlgebraSimpleCase.cpp
+++ b/src/Estimation/KrigingAlgebraSimpleCase.cpp
@@ -71,7 +71,6 @@ KrigingAlgebraSimpleCase::KrigingAlgebraSimpleCase(bool flagDual,
   , _flagCholesky(flagchol == -1 ? (flagDual || _neighUnique) : flagchol)
   , _dualHasChanged(true)
   , _invSigmaHasChanged(true)
-  , _XtInvSigmaHasChanged(true)
 {
   _Sigma0 = std::make_shared<MatrixDense>();
   _X0     = std::make_shared<MatrixDense>();
@@ -108,7 +107,7 @@ KrigingAlgebraSimpleCase::KrigingAlgebraSimpleCase(bool flagDual,
 KrigingAlgebraSimpleCase::KrigingAlgebraSimpleCase(KrigingAlgebraSimpleCase& r)
 {
 
-  // Quantities which doesn't evolve with the target in unique Neighborhood
+  // Quantities that do not evolve with the target in unique Neighborhood
 
   if (r._neighUnique)
     _copyPtrForUniqueNeigh(r);
@@ -730,7 +729,11 @@ Id KrigingAlgebraSimpleCase::_needInvSigma()
   else
   {
     _InvSigma->resize(_Sigma->getNRows(), _Sigma->getNCols());
-    _Sigma->invert2(*_InvSigma);
+    if (_Sigma->invert2(*_InvSigma))
+    {
+      _printInversionErrorMessage(*_Sigma);
+      return 1;
+    }
   }
   _invSigmaHasChanged = false;
   return 0;
@@ -951,8 +954,18 @@ Id KrigingAlgebraSimpleCase::_needSigmac()
     _Sigmac.prodMatMatInPlace(_XtInvSigma.get(), _X.get());
   // Compute the inverse matrix
   _invSigmac->resize(_nbfl, _nbfl);
-  if (_Sigmac.invert2(*_invSigmac)) return 1;
+  if (_Sigmac.invert2(*_invSigmac))
+  {
+    _printInversionErrorMessage(_Sigmac);
+    return 1;
+  }
   return 0;
+}
+
+void KrigingAlgebraSimpleCase::_printInversionErrorMessage(const MatrixSymmetric& mat) 
+{
+  messerr("Problem when inverting Kriging Matrix (NRows=%d x NCols=%d)",
+          mat.getNRows(), mat.getNCols());
 }
 
 Id KrigingAlgebraSimpleCase::_needBeta()
@@ -1049,9 +1062,9 @@ Id KrigingAlgebraSimpleCase::_needLambdaUK()
   if (!_LambdaUK.empty()) return 0;
   _LambdaUK.resize(_neq, _nrhs);
 
-  _needXtInvSigma();
-  _needLambdaSK();
-  _needMuUK();
+  if (_needXtInvSigma()) return 1;
+  if (_needLambdaSK()) return 1;
+  if (_needMuUK()) return 1;
 
   _invSigmaXMuUK.resize(_neq, _nrhs);
   if (_flagCholesky)

--- a/src/Estimation/KrigingSystemSimpleCase.cpp
+++ b/src/Estimation/KrigingSystemSimpleCase.cpp
@@ -448,6 +448,12 @@ Id KrigingSystemSimpleCase::estimate(Id iechout,
     neigh->select(iechout, *nbgh);
     if (nbgh->size() <= 0)
       return 0;
+    if (static_cast<Id>(nbgh->size()) < _getNbfl())
+    {
+      messerr("Not enough data (%d) to perform kriging (with %d Drift Functions) at target %d",
+              nbgh->size(), _getNbfl(), iechout + 1);
+      return 1;
+    }
     if (!_neigh->isUnchanged() || _neigh->getFlagContinuous() || OptDbg::force())
     {
       updateLHS(algebra, model, tabwork);

--- a/src/Matrix/MatrixDense.cpp
+++ b/src/Matrix/MatrixDense.cpp
@@ -192,15 +192,17 @@ void MatrixDense::_addProdVecMatInPlacePtr(constvect x, vect y, bool transpose) 
 
 Id MatrixDense::_invert()
 {
-  /// TODO : check beforehand if matrix is invertible ?
   eigenMat() = eigenMat().inverse();
+  if (!eigenMat().allFinite())
+    return 1;
   return 0;
 }
 
 Id MatrixDense::invert2(MatrixDense& res) const
 {
-  /// TODO : check beforehand if matrix is invertible ?
   res.eigenMat() = eigenMat().inverse();
+  if (!res.eigenMat().allFinite())
+    return 1;
   return 0;
 }
 

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -11,6 +11,12 @@
 #include "geoslib_define.h"
 
 #include "Basic/ASerializable.hpp"
+#include "Basic/OptDbg.hpp"
+#include "Db/Db.hpp"
+#include "Db/DbGrid.hpp"
+#include "Estimation/CalcKriging.hpp"
+#include "Model/Model.hpp"
+#include "Neigh/NeighMoving.hpp"
 
 using namespace gstlrn;
 
@@ -22,5 +28,20 @@ int main(int argc, char* argv[])
   StdoutRedirect sr(sfn.str(), argc, argv);
   ASerializable::setPrefixName("test_a_template-"); // Here set the test name
 
+  Db* dbin = Db::createFromNF("/home/drenard/Rtest/DR/Meryem/dbin.NF");
+  dbin->display();
+  DbGrid* dbout = DbGrid::createFromNF("/home/drenard/Rtest/DR/Meryem/dbout.NF");
+  dbout->display();
+  Model* model = Model::createFromNF("/home/drenard/Rtest/DR/Meryem/model.NF");
+  model->display();
+  NeighMoving* neigh = NeighMoving::createFromNF("/home/drenard/Rtest/DR/Meryem/neigh.NF");
+  neigh->display();
+
+  OptDbg::setReference(202);
+  (void)kriging(dbin, dbout, model, neigh);
+
+  delete dbout;
+  delete model;
+  delete neigh;
   return 0;
 }

--- a/tests/py/test_Benchmark_BRGM.py
+++ b/tests/py/test_Benchmark_BRGM.py
@@ -65,13 +65,14 @@ def case(optim=True, cholesky=False, nbthreads=1, flagStd=False):
         std = None
     return grid["*estim"], std
 
+
 estim, std = case(False, False, 1, True)
 
 nb_threads = 5
-estim1, _    = case(True, False, nb_threads, False)
-estim2, _    = case(True, True,  nb_threads, False)
+estim1, _ = case(True, False, nb_threads, False)
+estim2, _ = case(True, True, nb_threads, False)
 estim3, std3 = case(True, False, nb_threads, True)
-estim4, std4 = case(True, True,  nb_threads, True)
+estim4, std4 = case(True, True, nb_threads, True)
 
 print("Dual - Inversion - estimation", np.round(np.max(np.abs(estim - estim1)), 4))
 print("Dual - Cholesky - estimation", np.round(np.max(np.abs(estim - estim2)), 4))

--- a/tests/py/test_Benchmark_BRGM.py
+++ b/tests/py/test_Benchmark_BRGM.py
@@ -65,14 +65,13 @@ def case(optim=True, cholesky=False, nbthreads=1, flagStd=False):
         std = None
     return grid["*estim"], std
 
-
-estim, std = case(0, 0, 1, True)
+estim, std = case(False, False, 1, True)
 
 nb_threads = 5
-estim1, _ = case(1, 0, nb_threads, False)
-estim2, _ = case(1, 1, nb_threads, False)
-estim3, std3 = case(1, 0, nb_threads, True)
-estim4, std4 = case(1, 1, nb_threads, True)
+estim1, _    = case(True, False, nb_threads, False)
+estim2, _    = case(True, True,  nb_threads, False)
+estim3, std3 = case(True, False, nb_threads, True)
+estim4, std4 = case(True, True,  nb_threads, True)
 
 print("Dual - Inversion - estimation", np.round(np.max(np.abs(estim - estim1)), 4))
 print("Dual - Cholesky - estimation", np.round(np.max(np.abs(estim - estim2)), 4))


### PR DESCRIPTION
This branch has been created in order to face and solve the problem encountered by Meryem. The Kriging was producing lots of messages of 2 kinds: A zero-dimensioned array (not expected), a negative variance.

Several few improvements have been achieved here:
- the essential one is that we are now able, while using Eigen library, to check if the inversion of the Kriging matrix is feasible or not (this was the reason of the negative variances)
- a test has been added to forbid establishing the Kriging matrix as soon as the number of data is smaller than the number of drift functions
- the return code of the inversion is tested all the way through in the stack of steps used for Kriging

Therefore, in the current version, a message is produced to warn the user that, due to the choice of neighborhood, of Model (essentially the number of Drift conditions), Kriging cannot be performed. We should consider possibly suppressing the message (a similar message is simply not produced when the number of samples in the Neihborhood is zero).
