### PR TITLE
Correction bug calcul de covariance

### DIFF
--- a/src/Simulation/ASimuSpectral.cpp
+++ b/src/Simulation/ASimuSpectral.cpp
@@ -9,7 +9,6 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Simulation/ASimuSpectral.hpp"
-#include "Basic/AStringable.hpp"
 #include "Basic/Law.hpp"
 #include "Basic/NamingConvention.hpp"
 #include "Basic/VectorNumT.hpp"

--- a/src/Variogram/Vario.cpp
+++ b/src/Variogram/Vario.cpp
@@ -3134,6 +3134,7 @@ void Vario::_getStatistics(Db* db)
       ww = db->getWeight(iech);
       if (FFFF(ww) || ww < 0.) continue;
       z1 = _getIVAR(db, iech, ivar);
+      if (FFFF(z1)) continue;
       s1w += ww;
       s1z += z1;
     }

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -11,12 +11,6 @@
 #include "geoslib_define.h"
 
 #include "Basic/ASerializable.hpp"
-#include "Basic/OptDbg.hpp"
-#include "Db/Db.hpp"
-#include "Db/DbGrid.hpp"
-#include "Estimation/CalcKriging.hpp"
-#include "Model/Model.hpp"
-#include "Neigh/NeighMoving.hpp"
 
 using namespace gstlrn;
 
@@ -28,20 +22,5 @@ int main(int argc, char* argv[])
   StdoutRedirect sr(sfn.str(), argc, argv);
   ASerializable::setPrefixName("test_a_template-"); // Here set the test name
 
-  Db* dbin = Db::createFromNF("/home/drenard/Rtest/DR/Meryem/dbin.NF");
-  dbin->display();
-  DbGrid* dbout = DbGrid::createFromNF("/home/drenard/Rtest/DR/Meryem/dbout.NF");
-  dbout->display();
-  Model* model = Model::createFromNF("/home/drenard/Rtest/DR/Meryem/model.NF");
-  model->display();
-  NeighMoving* neigh = NeighMoving::createFromNF("/home/drenard/Rtest/DR/Meryem/neigh.NF");
-  neigh->display();
-
-  OptDbg::setReference(202);
-  (void)kriging(dbin, dbout, model, neigh);
-
-  delete dbout;
-  delete model;
-  delete neigh;
   return 0;
 }


### PR DESCRIPTION
Quick branch to correct the calculation of covariance (instead of variogram) on a dataset containing one or several TEST values. This problem was simply lying in the calculation of the global statistics, for getting the mean and variance used in the ergodic case: the TEST values were not excluded.