### PR TITLE
Fix MacOS architectures used for publishing R and python packages

### DIFF
--- a/.github/workflows/coverage-tests_r.yml
+++ b/.github/workflows/coverage-tests_r.yml
@@ -20,8 +20,7 @@ jobs:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
         # See the list here: https://github.com/actions/runner-images#available-images
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-26]
-        # macos15-intel not working with gstlearn packages (CRAN store issue?)
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-15-intel, macos-26]
         exclude:
           - os: ubuntu-22.04
             r_version: 4.2.3  # ggpubr install fails

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -40,11 +40,10 @@ jobs:
             {py: "3.13"},
             {py: "3.14"}
           ]
+        # Only one arm64 and one x86_64 Mac OS version are needed
         arch: [
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
             {ar: x86_64, os: macos-15-intel, pat: /usr/local},
-            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
+            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
           ]
 
     steps:
@@ -99,6 +98,12 @@ jobs:
         install_name_tool -change ${{matrix.arch.pat}}/opt/llvm/lib/libomp.dylib @loader_path/libomp.dylib gstlearn/_gstlearn.so
         # Note: wheel must be declared not pure (see setup.py)
         uv build --wheel
+        if [ "${{matrix.arch.os}}" == "macos-15-intel" ] && [ $(ls dist/*universal2.whl | wc -l) -gt 0 ]; then
+          # Fix wheel platform tag for x86_64 macOS
+          WHEEL_FILE=$(ls dist/*universal2.whl)
+          NEW_WHEEL_FILE=$(echo $WHEEL_FILE | sed 's/universal2/x86_64/')
+          mv $WHEEL_FILE $NEW_WHEEL_FILE
+        fi
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 
@@ -121,11 +126,10 @@ jobs:
             {py: "3.13"},
             {py: "3.14"}
           ]
+        # Only one arm64 and one x86_64 Mac OS version are needed
         arch: [
-            {ar: arm64,  os: macos-14},
-            {ar: arm64,  os: macos-15},
             {ar: x86_64, os: macos-15-intel},
-            {ar: arm64,  os: macos-26},
+            {ar: arm64,  os: macos-14},
           ]
 
     steps:

--- a/.github/workflows/publish_r_linux.yml
+++ b/.github/workflows/publish_r_linux.yml
@@ -128,10 +128,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      # Publish packages to our CRAN
       - env:
           CRAN_PATH: ${{needs.build.outputs.cran_path}}
-
-        # Publish packages to our CRAN
         uses: fabien-ors/cran-publish-action@v4
         with:
           host: ${{secrets.CG_HOST}}

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -37,11 +37,10 @@ jobs:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
+        # Only one arm64 and one x86_64 Mac OS version are needed
         arch: [
-            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
-            {ar: arm64,  os: macos-15, pat: /opt/homebrew},
             {ar: x86_64, os: macos-15-intel, pat: /usr/local},
-            {ar: arm64,  os: macos-26, pat: /opt/homebrew},
+            {ar: arm64,  os: macos-14, pat: /opt/homebrew},
          ]
 
     steps:
@@ -129,11 +128,10 @@ jobs:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.2]
+        # Only one arm64 and one x86_64 Mac OS version are needed
         arch: [
-            {ar: arm64,  os: macos-14},
-            {ar: arm64,  os: macos-15},
             {ar: x86_64, os: macos-15-intel},
-            {ar: arm64,  os: macos-26},
+            {ar: arm64,  os: macos-14},
          ]
 
     steps:
@@ -174,10 +172,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Publish packages to our CRAN
       - env:
           CRAN_PATH: ${{needs.build.outputs.cran_path}}
-
-        # Publish packages to our CRAN
         uses: fabien-ors/cran-publish-action@v4
         with:
           host: ${{secrets.CG_HOST}}

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -178,10 +178,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Publish packages to our CRAN
       - env:
           CRAN_PATH: ${{needs.build.outputs.cran_path}}
-
-        # Publish packages to our CRAN
         uses: fabien-ors/cran-publish-action@v4
         with:
           host: ${{secrets.CG_HOST}}


### PR DESCRIPTION
Only two MacOs architectures are needed for compiling and publishing python and R packages (arm64 and intel [x86_64])
Publish workflows have been simplified (and accelerated) using the oldest MacOS github runners available for each of these architectures. Coverage tests still check whether all MacOS github runners can install and use the delivered packages.