### PR TITLE
ShiftOpStencil optimization (multithreading)

### DIFF
--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -13,11 +13,14 @@
 #include "Basic/Grid.hpp"
 #include "Basic/Indirection.hpp"
 #include "Basic/VectorNumT.hpp"
+#include "Basic/OptCustom.hpp"
 #include "Covariances/CovAniso.hpp"
 #include "LinearOp/AShiftOp.hpp"
 #include "LinearOp/ShiftOpMatrix.hpp"
 #include "Mesh/MeshETurbo.hpp"
 #include "geoslib_define.h"
+
+#include <omp.h>
 
 namespace gstlrn
 {
@@ -87,10 +90,14 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
   Id size                     = static_cast<Id>(inv.size());
   const Indirection& indirect = _mesh->getGridIndirect();
 
+  auto nbthread = static_cast<I32>(OptCustom::query("ompthreads", 1));
+  omp_set_num_threads(nbthread);
+
   double total;
   if (!indirect.isDefined())
   {
     // Use the fast option when no selection is defined on the Grid
+#pragma omp parallel for private(total)
     for (Id ic = 0; ic < size; ic++)
     {
       total = 0.;
@@ -112,8 +119,13 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
     const Grid& grid = _mesh->getGrid();
     Id ndim          = _mesh->getNDim();
 
+#pragma omp parallel private(total)
+    {
     VectorInt center(ndim);
     VectorInt local(ndim);
+    // #pragma omp parallel for private(total, center, local) crashes, probably
+    // because center/local are not POD, so use a parallel block followed by for.
+#pragma omp for
     for (Id ic = 0; ic < size; ic++)
     {
       total = 0.;
@@ -134,6 +146,7 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
       }
       outv[ic] = total;
     }
+    } // omp parallel
   }
   return 0;
 }

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -93,14 +93,13 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
   auto nbthread = static_cast<I32>(OptCustom::query("ompthreads", 1));
   omp_set_num_threads(nbthread);
 
-  double total;
   if (!indirect.isDefined())
   {
     // Use the fast option when no selection is defined on the Grid
-#pragma omp parallel for private(total)
+#pragma omp parallel for
     for (Id ic = 0; ic < size; ic++)
     {
-      total = 0.;
+      double total = 0.;
       if (_isInside[ic])
       {
         for (Id iw = 0; iw < nw; iw++)
@@ -119,7 +118,7 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
     const Grid& grid = _mesh->getGrid();
     Id ndim          = _mesh->getNDim();
 
-#pragma omp parallel private(total)
+#pragma omp parallel
     {
     VectorInt center(ndim);
     VectorInt local(ndim);
@@ -128,7 +127,7 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
 #pragma omp for
     for (Id ic = 0; ic < size; ic++)
     {
-      total = 0.;
+      double total = 0.;
 
       // Check if the target point is not on the edge and not masked
       if (_isInside[ic])

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -118,13 +118,10 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
     const Grid& grid = _mesh->getGrid();
     Id ndim          = _mesh->getNDim();
 
-#pragma omp parallel
-    {
     VectorInt center(ndim);
     VectorInt local(ndim);
-    // #pragma omp parallel for private(total, center, local) crashes, probably
-    // because center/local are not POD, so use a parallel block followed by for.
-#pragma omp for
+
+#pragma omp parallel for firstprivate(center, local)
     for (Id ic = 0; ic < size; ic++)
     {
       double total = 0.;
@@ -145,7 +142,6 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
       }
       outv[ic] = total;
     }
-    } // omp parallel
   }
   return 0;
 }

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -99,8 +99,9 @@ Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
         for (Id iw = 0; iw < nw; iw++)
         {
           Id iabs      = ic + _absoluteShifts[iw];
-          double value = _isInside[iabs] ? inv[iabs] : 0.;
-          total += (*currentWeights)[iw] * value;
+          if (_isInside[iabs]) {
+            total += (*currentWeights)[iw] * inv[iabs];
+          }
         }
       }
       outv[ic] = total;


### PR DESCRIPTION
Two commits:
- one minor optimisation by avoiding using a variable and multiplying by it when it is equal to 0 (doesn't actually change anything on performances)
- use OpenMP parallelisation to compute the contribution of `ShiftOpStencil`

On my test data the results are still exactly identical, regardless of whether parallelisation is used or not.