### PR TITLE
Fix bug in MatrixSparse using a 32 bits index

### DIFF
--- a/include/LinearOp/ALinearOpEigenCG.hpp
+++ b/include/LinearOp/ALinearOpEigenCG.hpp
@@ -23,22 +23,22 @@
 #  include <iostream>
 #  include <unsupported/Eigen/IterativeSolvers>
 
-#  define DECLARE_EIGEN_TRAITS(TLinOP)                                                         \
-    namespace gstlrn                                                                           \
-    {                                                                                          \
-    class TLinOP;                                                                              \
-    }                                                                                          \
-    using Eigen::SparseMatrix;                                                                 \
-                                                                                               \
-    namespace Eigen                                                                            \
-    {                                                                                          \
-    namespace internal                                                                         \
-    {                                                                                          \
-    template<>                                                                                 \
-    struct traits<gstlrn::TLinOP>: public Eigen::internal::traits<Eigen::SparseMatrix<double>> \
-    {                                                                                          \
-    };                                                                                         \
-    }                                                                                          \
+#  define DECLARE_EIGEN_TRAITS(TLinOP)                                                                        \
+    namespace gstlrn                                                                                          \
+    {                                                                                                         \
+    class TLinOP;                                                                                             \
+    }                                                                                                         \
+    using Eigen::SparseMatrix;                                                                                \
+                                                                                                              \
+    namespace Eigen                                                                                           \
+    {                                                                                                         \
+    namespace internal                                                                                        \
+    {                                                                                                         \
+    template<>                                                                                                \
+    struct traits<gstlrn::TLinOP>: public Eigen::internal::traits<Eigen::SparseMatrix<double, 0, gstlrn::Id>> \
+    {                                                                                                         \
+    };                                                                                                        \
+    }                                                                                                         \
     }
 
 #  define DECLARE_EIGEN_PRODUCT(TLinOP)                                                                                             \

--- a/include/LinearOp/CholeskySparse.hpp
+++ b/include/LinearOp/CholeskySparse.hpp
@@ -34,7 +34,7 @@ DISABLE_WARNING_POP
 namespace gstlrn
 {
 class MatrixSparse;
-using Sp = Eigen::SparseMatrix<double>;
+using Sp = Eigen::SparseMatrix<double, 0, gstlrn::Id>;
 
 class GSTLEARN_EXPORT CholeskySparse: public ACholesky
 {

--- a/include/LinearOp/CholeskySparseInv.hpp
+++ b/include/LinearOp/CholeskySparseInv.hpp
@@ -21,7 +21,7 @@
 
 namespace gstlrn
 {
-typedef Eigen::SparseMatrix<double>::StorageIndex StorageIndex;
+typedef Eigen::SparseMatrix<double, 0, gstlrn::Id>::StorageIndex StorageIndex;
 
 template<typename SpMat>
 class MatchPattern

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -25,6 +25,9 @@ DISABLE_WARNING_UNUSED_BUT_SET_VARIABLE
 DISABLE_WARNING_DECLARATION_HIDE_GLOBAL
 #  include <Eigen/Sparse>
 DISABLE_WARNING_POP
+
+// Eigen::SparseMatrix<double> uses 'int' as StorageIndex
+typedef Eigen::SparseMatrix<double, 0, gstlrn::Id> EigenSparseMatrix; // (always stored Eigen::ColMajor)
 #endif
 
 namespace gstlrn
@@ -260,12 +263,12 @@ private:
 #ifndef SWIG
 
 public:
-  const Eigen::SparseMatrix<double>& eigenMat() const
+  const EigenSparseMatrix& eigenMat() const
   {
     return _eigenMatrix;
   }
 
-  Eigen::SparseMatrix<double>& eigenMat()
+  EigenSparseMatrix& eigenMat()
   {
     return _eigenMatrix;
   }
@@ -273,7 +276,7 @@ public:
 
 private:
 #ifndef SWIG
-  Eigen::SparseMatrix<double> _eigenMatrix; // Storage (always stored Eigen::ColMajor)
+  EigenSparseMatrix _eigenMatrix; // Storage
 #endif
   Id _nColMax;
 };
@@ -300,7 +303,7 @@ GSTLEARN_EXPORT MatrixSparse* prodNormDiagVec(const MatrixSparse* a,
 // Not exported method
 
 #ifndef SWIG
-GSTLEARN_EXPORT Eigen::SparseMatrix<double> AtMA(const Eigen::SparseMatrix<double>& A,
-                                                 const Eigen::SparseMatrix<double>& M);
+GSTLEARN_EXPORT EigenSparseMatrix AtMA(const EigenSparseMatrix& A,
+                                       const EigenSparseMatrix& M);
 #endif
 } // namespace gstlrn

--- a/include/Matrix/NF_Triplet.hpp
+++ b/include/Matrix/NF_Triplet.hpp
@@ -23,6 +23,7 @@ DISABLE_WARNING_DECLARATION_HIDE_GLOBAL
 DISABLE_WARNING_POP
 
 typedef Eigen::Triplet<double, gstlrn::Id> T;
+typedef Eigen::SparseMatrix<double, 0, gstlrn::Id> EigenSparseMatrix; // see MatrixSparse.hpp
 #endif
 
 namespace gstlrn
@@ -57,9 +58,9 @@ public:
   void appendInPlace(const NF_Triplet& T2);
 
 #ifndef SWIG
-  ::Eigen::SparseMatrix<double> buildEigenFromTriplet() const;
+  EigenSparseMatrix buildEigenFromTriplet() const;
 
-  static NF_Triplet createFromEigen(const Eigen::SparseMatrix<double>& mat, Id shiftRow = 0, Id shiftCol = 0);
+  static NF_Triplet createFromEigen(const EigenSparseMatrix& mat, Id shiftRow = 0, Id shiftCol = 0);
 #endif
 
 private:

--- a/src/Gibbs/GibbsMMulti.cpp
+++ b/src/Gibbs/GibbsMMulti.cpp
@@ -411,7 +411,7 @@ double GibbsMMulti::_getEstimate(Id ipgs,
 
   if (storeSparse)
   {
-    for (Eigen::SparseMatrix<double>::InnerIterator it(_matWgt->eigenMat(), icol); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(_matWgt->eigenMat(), icol); it; ++it)
     {
       _splitCol(it.row(), &jact, &jvar);
       jcase = getRank(ipgs, jvar);

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -130,7 +130,7 @@ void MatrixSparse::fillRandom(Id seed, double zeroPercent)
 
 void MatrixSparse::_transposeInPlace()
 {
-  Eigen::SparseMatrix<double> temp;
+  EigenSparseMatrix temp;
   temp = eigenMat().transpose();
   eigenMat().swap(temp);
 }
@@ -291,7 +291,7 @@ void MatrixSparse::multiplyRow(const VectorDouble& vec)
     return;
   }
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() *= vec[it.row()];
 }
 
@@ -304,7 +304,7 @@ void MatrixSparse::multiplyColumn(const VectorDouble& vec)
     return;
   }
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() *= vec[it.col()];
 }
 
@@ -317,7 +317,7 @@ void MatrixSparse::divideRow(const VectorDouble& vec)
     return;
   }
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() /= vec[it.row()];
 }
 
@@ -330,7 +330,7 @@ void MatrixSparse::divideColumn(const VectorDouble& vec)
     return;
   }
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() /= vec[it.col()];
 }
 
@@ -453,7 +453,7 @@ MatrixSparse* MatrixSparse::diagMat(MatrixSparse* A, Id oper_choice)
 
 bool MatrixSparse::_isElementPresent(Id irow, Id icol) const
 {
-  for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), icol); it; ++it)
+  for (EigenSparseMatrix::InnerIterator it(eigenMat(), icol); it; ++it)
   {
     if (it.row() == irow) return true;
   }
@@ -522,7 +522,7 @@ Id MatrixSparse::addVecInPlaceVD(const VectorDouble& x, VectorDouble& y) const
 void MatrixSparse::setConstant(double value)
 {
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() = value;
 }
 
@@ -542,7 +542,7 @@ void MatrixSparse::addScalar(double v)
 {
   if (isZero(v)) return;
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() += v;
 }
 
@@ -555,7 +555,7 @@ void MatrixSparse::addScalarDiag(double v)
   if (isZero(v)) return;
 
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
     {
       if (it.col() == it.row())
         it.valueRef() += v;
@@ -570,7 +570,7 @@ void MatrixSparse::prodScalar(double v)
 {
   if (isOne(v)) return;
   for (Id k = 0; k < eigenMat().outerSize(); ++k)
-    for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), k); it; ++it)
+    for (EigenSparseMatrix::InnerIterator it(eigenMat(), k); it; ++it)
       it.valueRef() *= v;
 }
 
@@ -863,9 +863,9 @@ Id MatrixSparse::_invert()
   if (!isSquare())
     my_throw("Invert method is restricted to Square matrices");
   auto n = getNCols();
-  Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> solver;
+  Eigen::SimplicialLLT<EigenSparseMatrix> solver;
   solver.compute(eigenMat());
-  Eigen::SparseMatrix<double> I(n, n);
+  EigenSparseMatrix I(n, n);
   I.setIdentity();
   eigenMat() = solver.solve(I);
 
@@ -879,7 +879,7 @@ Id MatrixSparse::_solve(const VectorDouble& b, VectorDouble& x) const
   if (static_cast<Id>(b.size()) != getNRows() || static_cast<Id>(x.size()) != getNRows())
     my_throw("b' and 'x' should have the same dimension as the Matrix");
 
-  Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> solver;
+  Eigen::SimplicialLLT<EigenSparseMatrix> solver;
   Eigen::Map<const Eigen::VectorXd> bm(b.data(), getNCols());
   Eigen::Map<Eigen::VectorXd> xm(x.data(), getNRows());
   xm = solver.compute(eigenMat()).solve(bm);
@@ -896,7 +896,7 @@ String MatrixSparse::toString(const AStringFormat* strfmt) const
 
 void MatrixSparse::_allocate(Id nrow, Id ncol, Id ncolmax)
 {
-  eigenMat() = Eigen::SparseMatrix<double>(nrow, ncol);
+  eigenMat() = EigenSparseMatrix(nrow, ncol);
   _setNCols(ncol);
   _setNRows(nrow);
 
@@ -915,9 +915,9 @@ void MatrixSparse::_allocate(Id nrow, Id ncol, Id ncolmax)
  */
 void MatrixSparse::_allocate()
 {
-  eigenMat() = Eigen::SparseMatrix<double>(getNRows(), getNCols());
+  eigenMat() = EigenSparseMatrix(getNRows(), getNCols());
   {
-    eigenMat() = Eigen::SparseMatrix<double>(getNRows(), getNCols());
+    eigenMat() = EigenSparseMatrix(getNRows(), getNCols());
 
     if (_nColMax > 0)
     {
@@ -991,7 +991,7 @@ Id MatrixSparse::_eigen_findColor(Id imesh,
 
   /* Checks the colors of the connected nodes */
 
-  for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), imesh); it; ++it)
+  for (EigenSparseMatrix::InnerIterator it(eigenMat(), imesh); it; ++it)
   {
     if (isZero(it.value())) continue;
     Id irow = it.row();
@@ -1173,7 +1173,7 @@ void MatrixSparse::gibbs(Id iech,
                          double* sk)
 {
   *yk = 0.;
-  for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), iech); it;
+  for (EigenSparseMatrix::InnerIterator it(eigenMat(), iech); it;
        ++it)
   {
     double coeff = it.valueRef();
@@ -1220,7 +1220,7 @@ MatrixSparse* MatrixSparse::getRowAsMatrixSparse(Id irow, double coeff) const
   // The input sparse matrix being symmetrical, we benefit from its
   // column-major storage (setting icol = irow)
   Id icol = irow;
-  for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), icol); it; ++it)
+  for (EigenSparseMatrix::InnerIterator it(eigenMat(), icol); it; ++it)
     res->eigenMat().coeffRef(0, it.row()) = coeff * it.value();
 
   return res;
@@ -1232,7 +1232,7 @@ MatrixSparse* MatrixSparse::getColumnAsMatrixSparse(Id icol, double coeff) const
   auto nrows = getNRows();
   auto* res  = new MatrixSparse(nrows, 1);
 
-  for (Eigen::SparseMatrix<double>::InnerIterator it(eigenMat(), icol); it; ++it)
+  for (EigenSparseMatrix::InnerIterator it(eigenMat(), icol); it; ++it)
     res->eigenMat().coeffRef(it.row(), 0) = coeff * it.value();
 
   return res;
@@ -1240,8 +1240,8 @@ MatrixSparse* MatrixSparse::getColumnAsMatrixSparse(Id icol, double coeff) const
 
 ///////////////Not exported //////////
 
-Eigen::SparseMatrix<double> AtMA(const Eigen::SparseMatrix<double>& A,
-                                 const Eigen::SparseMatrix<double>& M)
+EigenSparseMatrix AtMA(const EigenSparseMatrix& A,
+                       const EigenSparseMatrix& M)
 {
   return A.transpose() * M * A;
 }
@@ -1253,13 +1253,13 @@ Id MatrixSparse::forwardLU(const VectorDouble& b, VectorDouble& x, bool flagLowe
 
   if (!flagLower)
   {
-    const Eigen::SparseMatrix<double>& Lx = eigenMat().transpose();
-    xm                                    = Lx.triangularView<Eigen::Upper>().solve(bm);
+    const EigenSparseMatrix& Lx = eigenMat().transpose();
+    xm                          = Lx.triangularView<Eigen::Upper>().solve(bm);
   }
   else
   {
-    const Eigen::SparseMatrix<double>& Lx = eigenMat();
-    xm                                    = Lx.triangularView<Eigen::Lower>().solve(bm);
+    const EigenSparseMatrix& Lx = eigenMat();
+    xm                          = Lx.triangularView<Eigen::Lower>().solve(bm);
   }
   return 0;
 }

--- a/src/Matrix/NF_Triplet.cpp
+++ b/src/Matrix/NF_Triplet.cpp
@@ -63,22 +63,22 @@ void NF_Triplet::force(Id nrow, Id ncol)
     add(nrow - 1, ncol - 1, 0.);
 }
 
-Eigen::SparseMatrix<double> NF_Triplet::buildEigenFromTriplet() const
+EigenSparseMatrix NF_Triplet::buildEigenFromTriplet() const
 {
-  Eigen::SparseMatrix<double> mat(_nrowmax + 1, _ncolmax + 1);
+  EigenSparseMatrix mat(_nrowmax + 1, _ncolmax + 1);
   mat.setFromTriplets(_eigenT.begin(), _eigenT.end());
   //  mat.prune(EPSILON10);
   return mat;
 }
 
-NF_Triplet NF_Triplet::createFromEigen(const Eigen::SparseMatrix<double>& mat, Id shiftRow, Id shiftCol)
+NF_Triplet NF_Triplet::createFromEigen(const EigenSparseMatrix& mat, Id shiftRow, Id shiftCol)
 {
   NF_Triplet NF_T;
   std::vector<T> v;
   Id row_max = 0;
   Id col_max = 0;
   for (Id i = 0; i < mat.outerSize(); i++)
-    for (typename Eigen::SparseMatrix<double>::InnerIterator it(mat, i); it; ++it)
+    for (typename EigenSparseMatrix::InnerIterator it(mat, i); it; ++it)
     {
       Id irow = it.row() + shiftRow;
       Id icol = it.col() + shiftCol;


### PR DESCRIPTION
The code uses `Eigen::SparseMatrix<double>` which implicitly means the `StorageIndex` is an `int` (see `Eigen/src/SparseCore/SparseUtil.h`, line 52).

The fix is to specify the `StorageIndex` everywhere (this was already done e.g., in `NF_Triplet.hpp` when defining the `Eigen::Triplet`), for convenience there is a new `typedef EigenSparseMatrix` used in several places.