### PR TITLE
ASerializable: Set locale to support accents in Windows paths

### DIFF
--- a/src/Basic/ASerializable.cpp
+++ b/src/Basic/ASerializable.cpp
@@ -15,6 +15,7 @@
 #include "Basic/String.hpp"
 #include "Enum/EFormatNF.hpp"
 
+#include <clocale>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -22,8 +23,17 @@
 namespace gstlrn
 {
 String ASerializable::_myPrefixName = String();
+thread_local bool locale_set        = false;
 
-ASerializable::ASerializable()                                    = default;
+ASerializable::ASerializable()
+{
+  if (!locale_set)
+  {
+    // support utf8 characters in Windows files/folders
+    setlocale(LC_ALL, "en_US.utf8");
+    locale_set = true;
+  }
+}
 ASerializable::ASerializable(const ASerializable&)                = default;
 ASerializable& ASerializable::operator=(const ASerializable&)     = default;
 ASerializable::ASerializable(ASerializable&&) noexcept            = default;


### PR DESCRIPTION
On Windows, gstlearn currently cannot read or write files in a filesystem hierarchy using non-ASCII characters. This was detected by running `Mo-Option.py` inside a directory named with accented characters.

This PR fixes this issue by setting the locale in the `ASerializable` constructor, a class used to read & write files.

Pierre