### PR TITLE
Correction

### DIFF
--- a/doc/demo/python/Tuto_SPDE_Aniso.ipynb
+++ b/doc/demo/python/Tuto_SPDE_Aniso.ipynb
@@ -115,6 +115,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b02ed86d-1b96-4cef-8b0e-21980de2c6c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = gl.Model.createFromParam(\n",
+    "    gl.ECov.GAUSSIAN, range=200, space=gl.SpaceRN.create(1)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "31a38733",
    "metadata": {
     "scrolled": true

--- a/include/Simulation/SimuBoolean.hpp
+++ b/include/Simulation/SimuBoolean.hpp
@@ -14,10 +14,10 @@
 
 #include "geoslib_define.h"
 
+#include "Basic/AStringable.hpp"
+#include "Boolean/ModelBoolean.hpp"
 #include "Simulation/ACalcSimulation.hpp"
 #include "Simulation/SimuBooleanParam.hpp"
-#include "Boolean/ModelBoolean.hpp"
-#include "Basic/AStringable.hpp"
 
 namespace gstlrn
 {
@@ -40,26 +40,25 @@ class Db;
  * If the proportion is variable, it uses Proportion locator in output DbGrid
  */
 
-
 class GSTLEARN_EXPORT SimuBoolean: public ACalcSimulation, public AStringable
 {
 public:
   SimuBoolean(Id nbsimu = 0, Id seed = 4324324);
-  SimuBoolean(const SimuBoolean &r) = delete;
-  SimuBoolean& operator=(const SimuBoolean &r) = delete;
+  SimuBoolean(const SimuBoolean& r)            = delete;
+  SimuBoolean& operator=(const SimuBoolean& r) = delete;
   virtual ~SimuBoolean();
 
   /// Interface to AStringable
   String toString(const AStringFormat* strfmt = nullptr) const override;
 
-  Id simulate(Db *dbin,
-               DbGrid *dbout,
-               ModelBoolean* tokens,
-               const SimuBooleanParam& boolparam,
-               Id iptr_simu,
-               Id iptr_rank,
-               Id iptr_cover,
-               bool verbose = false);
+  Id simulate(Db* dbin,
+              DbGrid* dbout,
+              ModelBoolean* tokens,
+              const SimuBooleanParam& boolparam,
+              Id iptr_simu,
+              Id iptr_rank,
+              Id iptr_cover,
+              bool verbose = false);
 
   VectorDouble extractObjects() const;
 
@@ -72,20 +71,20 @@ private:
   Id _getObjectRank(Id mode, Id rank);
   Id _deleteObject(Id mode, Db* dbin);
   static Id _getAverageCount(const DbGrid* dbout,
-                              const ModelBoolean* tokens,
-                              const SimuBooleanParam& boolparam);
+                             const ModelBoolean* tokens,
+                             const SimuBooleanParam& boolparam);
   static Id _countConditioningPore(const Db* db);
   static Id _countConditioningGrain(const Db* db);
   Id _generatePrimary(Db* dbin,
-                       DbGrid* dbout,
-                       const ModelBoolean* tokens,
-                       const SimuBooleanParam& boolparam,
-                       bool verbose = false);
+                      DbGrid* dbout,
+                      const ModelBoolean* tokens,
+                      const SimuBooleanParam& boolparam,
+                      bool verbose = false);
   Id _generateSecondary(Db* dbin,
-                         DbGrid* dbout,
-                         const ModelBoolean* tokens,
-                         const SimuBooleanParam& boolparam,
-                         bool verbose = false);
+                        DbGrid* dbout,
+                        const ModelBoolean* tokens,
+                        const SimuBooleanParam& boolparam,
+                        bool verbose = false);
   void _projectToGrid(DbGrid* dbout,
                       const SimuBooleanParam& boolparam,
                       Id iptr_simu,
@@ -96,13 +95,13 @@ private:
   mutable Id _iptrCover;
 };
 
-GSTLEARN_EXPORT Id simbool(Db *dbin,
-                            DbGrid *dbout,
-                            ModelBoolean *tokens,
-                            const SimuBooleanParam& boolparam = SimuBooleanParam(),
-                            Id seed = 432431,
-                            bool flag_simu = true,
-                            bool flag_rank = true,
-                            bool verbose = false,
-                            const NamingConvention& namconv = NamingConvention("Boolean"));
-}
+GSTLEARN_EXPORT Id simbool(Db* dbin,
+                           DbGrid* dbout,
+                           ModelBoolean* tokens,
+                           const SimuBooleanParam& boolparam = SimuBooleanParam(),
+                           Id seed                           = 432431,
+                           bool flag_simu                    = true,
+                           bool flag_rank                    = true,
+                           bool verbose                      = false,
+                           const NamingConvention& namconv   = NamingConvention("Boolean"));
+} // namespace gstlrn

--- a/include/Transform/ATransform.hpp
+++ b/include/Transform/ATransform.hpp
@@ -10,13 +10,16 @@
 /******************************************************************************/
 #pragma once
 
+#include "gstlearn_export.hpp"
+
+#include "geoslib_define.h"
+
 #include "Basic/AStringable.hpp"
 #include "Basic/ICloneable.hpp"
 #include "Basic/ListParams.hpp"
 #include "Basic/VectorNumT.hpp"
 #include "Covariances/ACov.hpp"
-#include "geoslib_define.h"
-#include "gstlearn_export.hpp"
+
 namespace gstlrn
 {
 

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -146,11 +146,14 @@ Model* Model::createFromParam(const ECov& type,
   Id nvar = 1;
   if (!sills.empty()) nvar = sills.getNRows();
 
-  Id ndimRanges = (ranges.empty()) ? 0 : static_cast<Id>(ranges.size());
+  Id ndimRanges = 1; // By default, the argument 'range' gives the space dimension.
+  // If ranges is provided, its length provides an infirmation on the space dimension
+  if (!ranges.empty()) ndimRanges = static_cast<Id>(ranges.size());
 
   CovContext ctxt;
   if (space != nullptr)
   {
+    // Space is defined: check that its dimension is consistent with the one of 'ranges' if provided
     Id ndim = space->getNDim();
     if (ndimRanges != 1 && ndimRanges != ndim)
     {

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -133,6 +133,25 @@ Model* Model::createNugget(Id nvar, Id ndim, double sill)
   return model;
 }
 
+/**
+ * @brief Create a Model containing a single covariance defined from parameters.
+ *
+ * @param type Type of covariance (see ECov)
+ * @param range Range of the covariance (isotropic if 'ranges' is not defined).
+ * @param sill Sill of the covariance (used for monovariate case only)
+ * @param param A third parameter of the covariance (for example, the shape parameter for a Matern covariance)
+ * @param ranges Definition of the ranges in the anisotropic case (see remarks)
+ * @param sills Definition of the sill Matrix in the multivariate case (see remarks)
+ * @param angles Definition of the angles in the anisotropic case
+ * @param space Space definition (optional)
+ * @param flagRange When TRUE, 'range' and 'ranges' are interpreted as ranges, otherwise they are interpreted as scales
+ * @return Model*
+ *
+ * @remarks If 'ranges' is defined, its dimension gives an information on the space dimension.
+ * @remarks If 'space' is defined (which also provides an information on the space dimension), the consistency between the space dimension and the one of 'ranges' is checked.
+ * @remarks otherwise, the space dimension (defined by 'ranges') is maintained.
+ * @remarks If 'sills' is defined, its dimension gives an information on the number of variables.
+ */
 Model* Model::createFromParam(const ECov& type,
                               double range,
                               double sill,

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -146,12 +146,12 @@ Model* Model::createFromParam(const ECov& type,
   Id nvar = 1;
   if (!sills.empty()) nvar = sills.getNRows();
 
-  CovContext ctxt(nvar, space);
+  Id ndimRanges = (ranges.empty()) ? 0 : static_cast<Id>(ranges.size());
 
-  if (!ranges.empty())
+  CovContext ctxt;
+  if (space != nullptr)
   {
-    Id ndim       = static_cast<Id>(ctxt.getNDim());
-    Id ndimRanges = static_cast<Id>(ranges.size());
+    Id ndim = space->getNDim();
     if (ndimRanges != 1 && ndimRanges != ndim)
     {
       messerr("Incompatibility between:");
@@ -159,6 +159,11 @@ Model* Model::createFromParam(const ECov& type,
       messerr("Dimension of argument 'ranges' = %d", ndimRanges);
       return nullptr;
     }
+    ctxt = CovContext(nvar, space);
+  }
+  else
+  {
+    ctxt = CovContext(nvar, SpaceRN::create(ndimRanges));
   }
 
   auto* model = new Model(ctxt);

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -166,7 +166,7 @@ Model* Model::createFromParam(const ECov& type,
   }
   else
   {
-    if (ndimRanges > 0)
+    if (!ranges.empty())
       ctxt = CovContext(nvar, SpaceRN::create(ndimRanges));
     else
       ctxt = CovContext(nvar, space);

--- a/src/Model/Model.cpp
+++ b/src/Model/Model.cpp
@@ -163,7 +163,10 @@ Model* Model::createFromParam(const ECov& type,
   }
   else
   {
-    ctxt = CovContext(nvar, SpaceRN::create(ndimRanges));
+    if (ndimRanges > 0)
+      ctxt = CovContext(nvar, SpaceRN::create(ndimRanges));
+    else
+      ctxt = CovContext(nvar, space);
   }
 
   auto* model = new Model(ctxt);

--- a/src/Space/SpacePoint.cpp
+++ b/src/Space/SpacePoint.cpp
@@ -10,7 +10,6 @@
 /******************************************************************************/
 #include "Space/SpacePoint.hpp"
 #include "Basic/AException.hpp"
-#include "Basic/AStringable.hpp"
 #include "Space/ASpace.hpp"
 #include "Space/ASpaceObject.hpp"
 #include "geoslib_define.h"


### PR DESCRIPTION
When using a default space of Dimension 2. 
If you attempt to create a new model using createFromParam() function, you can specify some anisotropy by giving a vector of ranges. The dimension of this vector should give an information on the space dimension.
If this range-dimension is not equal to the default space dimension, a message was issued.

Instead, after this correction, the newly created model will have the space dimension provided by the length of the range vector. 
However, an error is still issued if the size of the range vector is not in accordance with the space argument that can also be provided as an argument to the same function.

Fix #858