### PR TITLE
ACov: Wrap _tabNoStat in std::unique_ptr

### DIFF
--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -34,6 +34,7 @@
 #include "geoslib_define.h"
 #include "gstlearn_export.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace gstlrn
@@ -523,7 +524,7 @@ private:
                                 const VectorVectorInt& index1,
                                 const VectorVectorInt& index2,
                                 const KrigOpt& krigopt = KrigOpt()) const;
-  virtual TabNoStat* _createNoStatTab();
+  virtual std::unique_ptr<TabNoStat> _createNoStatTab();
 
 protected:
   void _setNoStatDbIfNecessary(const Db* db);
@@ -578,6 +579,6 @@ protected:
   mutable SpacePoint _pAux;
   mutable SpacePoint* _pw1;
   mutable SpacePoint* _pw2;
-  TabNoStat* _tabNoStat;
+  std::unique_ptr<TabNoStat> _tabNoStat;
 };
 } // namespace gstlrn

--- a/include/Covariances/CorAniso.hpp
+++ b/include/Covariances/CorAniso.hpp
@@ -318,7 +318,7 @@ private:
 
   bool _isNoStat() const override;
   void _setContext(const CovContext& ctxt) override;
-  TabNoStat* _createNoStatTab() override;
+  std::unique_ptr<TabNoStat> _createNoStatTab() override;
   void _copyCovContext(const CovContext& ctxt) override;
 
   bool _isOptimEnabled() const override

--- a/include/Covariances/CorAniso.hpp
+++ b/include/Covariances/CorAniso.hpp
@@ -234,15 +234,15 @@ public:
   void makeTensorStationary(Id idim, Id jdim);
   void makeParamStationary();
 
-  TabNoStatCovAniso* getTabNoStatCovAniso() const { return static_cast<TabNoStatCovAniso*>(_tabNoStat); }
+  TabNoStatCovAniso& getTabNoStatCovAniso() const { return static_cast<TabNoStatCovAniso&>(*_tabNoStat); }
 
-  Id getNAngles() const { return getTabNoStatCovAniso()->getNAngles(); }
-  Id getNRanges() const { return getTabNoStatCovAniso()->getNRanges(); }
-  Id getNScales() const { return getTabNoStatCovAniso()->getNScales(); }
-  bool isNoStatForParam() const { return getTabNoStatCovAniso()->isParam(); }
-  bool isNoStatForTensor() const { return getTabNoStatCovAniso()->isDefinedForTensor(); }
-  bool isNoStatForAnisotropy() const { return getTabNoStatCovAniso()->isDefinedForAnisotropy(); }
-  bool isNoStatForRotation() const { return getTabNoStatCovAniso()->isDefinedForRotation(); }
+  Id getNAngles() const { return getTabNoStatCovAniso().getNAngles(); }
+  Id getNRanges() const { return getTabNoStatCovAniso().getNRanges(); }
+  Id getNScales() const { return getTabNoStatCovAniso().getNScales(); }
+  bool isNoStatForParam() const { return getTabNoStatCovAniso().isParam(); }
+  bool isNoStatForTensor() const { return getTabNoStatCovAniso().isDefinedForTensor(); }
+  bool isNoStatForAnisotropy() const { return getTabNoStatCovAniso().isDefinedForAnisotropy(); }
+  bool isNoStatForRotation() const { return getTabNoStatCovAniso().isDefinedForRotation(); }
 
   VectorDouble evalCovOnSphereVec(const VectorDouble& alpha,
                                   Id degree                  = 50,

--- a/include/Covariances/CovBase.hpp
+++ b/include/Covariances/CovBase.hpp
@@ -145,7 +145,7 @@ protected:
 
 private:
   void _makeStationary() override;
-  TabNoStat* _createNoStatTab() override;
+  std::unique_ptr<TabNoStat> _createNoStatTab() override;
 
   bool _isNoStat() const override;
   void _setContext(const CovContext& ctxt) override;

--- a/include/Covariances/CovBase.hpp
+++ b/include/Covariances/CovBase.hpp
@@ -78,7 +78,7 @@ public:
   void makeSillsStationary(bool silent = false);
   void makeSillNoStatFunctional(const AFunctional* func, Id ivar = 0, Id jvar = 0);
 
-  TabNoStatSills* getTabNoStatSills() const { return static_cast<TabNoStatSills*>(_tabNoStat); }
+  TabNoStatSills& getTabNoStatSills() const { return static_cast<TabNoStatSills&>(*_tabNoStat); }
 
   Id getNSills() const;
   bool isNoStatForVariance() const;

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -91,14 +91,13 @@ ACov& ACov::operator=(const ACov& r)
     _pAux                  = r._pAux;
     _pw1                   = r._pw1;
     _pw2                   = r._pw2;
-    _tabNoStat             = r._tabNoStat->clone();
+    _tabNoStat             = std::unique_ptr<TabNoStat>(r._tabNoStat->clone());
   }
   return *this;
 }
 
 ACov::~ACov()
 {
-  delete _tabNoStat;
 }
 
 double ACov::evalCov(const SpacePoint& p1,
@@ -215,8 +214,7 @@ void ACov::_optimizationPreProcess(Id mode, const std::vector<SpacePoint>& ps) c
 
 void ACov::createNoStatTab()
 {
-  delete _tabNoStat;
-  _tabNoStat = _createNoStatTab();
+  _tabNoStat = std::unique_ptr<TabNoStat>(_createNoStatTab());
 }
 
 void ACov::attachNoStatDb(const Db* db)
@@ -266,9 +264,9 @@ VectorDouble ACov::informCoords(const VectorVectorDouble& coords,
   return result;
 }
 
-TabNoStat* ACov::_createNoStatTab()
+std::unique_ptr<TabNoStat> ACov::_createNoStatTab()
 {
-  return new TabNoStat();
+  return std::make_unique<TabNoStat>();
 }
 
 bool ACov::_checkDims(Id idim, Id jdim) const

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -1214,7 +1214,7 @@ bool CorAniso::_isNoStat() const
 String CorAniso::toStringNoStat(const AStringFormat* strfmt, Id i) const
 {
   String sstr;
-  sstr = getTabNoStatCovAniso()->toStringInside(strfmt, i);
+  sstr = getTabNoStatCovAniso().toStringInside(strfmt, i);
   return sstr;
 }
 ///////////////////// Range ////////////////////////
@@ -1232,8 +1232,8 @@ void CorAniso::makeRangeNoStatFunctional(const AFunctional* func, Id idim)
 
 void CorAniso::makeRangeStationary(Id idim) const
 {
-  if (getTabNoStatCovAniso()->removeElem(EConsElem::RANGE, idim) == 0 &&
-      getTabNoStatCovAniso()->removeElem(EConsElem::SCALE, idim) == 0)
+  if (getTabNoStatCovAniso().removeElem(EConsElem::RANGE, idim) == 0 &&
+      getTabNoStatCovAniso().removeElem(EConsElem::SCALE, idim) == 0)
   {
     messerr("This parameter was already stationary!");
   }
@@ -1274,7 +1274,7 @@ void CorAniso::makeAngleNoStatFunctional(const AFunctional* func, Id idim)
 
 void CorAniso::makeAngleStationary(Id idim) const
 {
-  if (getTabNoStatCovAniso()->removeElem(EConsElem::ANGLE, idim) == 0)
+  if (getTabNoStatCovAniso().removeElem(EConsElem::ANGLE, idim) == 0)
   {
     messerr("This parameter was already stationary!");
   }
@@ -1298,7 +1298,7 @@ void CorAniso::makeTensorNoStatFunctional(const AFunctional* func, Id idim, Id j
 void CorAniso::makeTensorStationary(Id idim, Id jdim)
 {
   if (!_checkDims(idim, jdim)) return;
-  if (getTabNoStatCovAniso()->removeElem(EConsElem::TENSOR, idim, jdim) == 0)
+  if (getTabNoStatCovAniso().removeElem(EConsElem::TENSOR, idim, jdim) == 0)
   {
     messerr("This parameter was already stationary!");
   }
@@ -1321,7 +1321,7 @@ void CorAniso::makeParamNoStatFunctional(const AFunctional* func)
 void CorAniso::makeParamStationary()
 {
   if (!_checkParam()) return;
-  if (getTabNoStatCovAniso()->removeElem(EConsElem::PARAM) == 0)
+  if (getTabNoStatCovAniso().removeElem(EConsElem::PARAM) == 0)
   {
     messerr("This parameter was already stationary!");
   }
@@ -1381,25 +1381,25 @@ double CorAniso::getValue(const EConsElem& econs, Id iv1, Id iv2) const
 void CorAniso::informMeshByMeshForAnisotropy(const AMesh* amesh) const
 {
   for (const auto& e: _listaniso)
-    getTabNoStatCovAniso()->informMeshByMesh(amesh, e);
+    getTabNoStatCovAniso().informMeshByMesh(amesh, e);
 }
 
 void CorAniso::informMeshByApexForAnisotropy(const AMesh* amesh) const
 {
   for (const auto& e: _listaniso)
-    getTabNoStatCovAniso()->informMeshByApex(amesh, e);
+    getTabNoStatCovAniso().informMeshByApex(amesh, e);
 }
 
 void CorAniso::informDbInForAnisotropy(const Db* dbin) const
 {
   for (const auto& e: _listaniso)
-    getTabNoStatCovAniso()->informDbIn(dbin, e);
+    getTabNoStatCovAniso().informDbIn(dbin, e);
 }
 
 void CorAniso::informDbOutForAnisotropy(const Db* dbout) const
 {
   for (const auto& e: _listaniso)
-    getTabNoStatCovAniso()->informDbOut(dbout, e);
+    getTabNoStatCovAniso().informDbOut(dbout, e);
 }
 
 /**
@@ -1412,12 +1412,12 @@ void CorAniso::informDbOutForAnisotropy(const Db* dbout) const
 void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
 {
   // If no non-stationary parameter is defined, simply skip
-  if (!getTabNoStatCovAniso()->isNoStat()) return;
+  if (!getTabNoStatCovAniso().isNoStat()) return;
   double val1, val2;
 
   auto ndim = getNDim();
 
-  const auto& paramsnostat = getTabNoStatCovAniso()->getTable();
+  const auto& paramsnostat = getTabNoStatCovAniso().getTable();
   // Loop on the elements that can be updated one-by-one
 
   for (const auto& e: paramsnostat)
@@ -1456,9 +1456,9 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
     angle2 = angle1;
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::ANGLE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::ANGLE, idim))
       {
-        auto noStat = getTabNoStatCovAniso()->getElem(EConsElem::ANGLE, idim);
+        auto noStat = getTabNoStatCovAniso().getElem(EConsElem::ANGLE, idim);
         flagRotOne  = true;
         if (noStat->getValuesOnDb(icas1, iech1, &angle1[idim], icas2, iech2, &angle2[idim]))
           flagRotTwo = true;
@@ -1476,9 +1476,9 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
     scale2 = scale1;
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::SCALE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::SCALE, idim))
       {
-        auto noStat  = getTabNoStatCovAniso()->getElem(EConsElem::SCALE, idim);
+        auto noStat  = getTabNoStatCovAniso().getElem(EConsElem::SCALE, idim);
         flagScaleOne = true;
         if (noStat->getValuesOnDb(icas1, iech1, &scale1[idim], icas2, iech2, &scale2[idim]))
           flagScaleTwo = true;
@@ -1496,9 +1496,9 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
     range2 = range1;
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::RANGE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::RANGE, idim))
       {
-        auto noStat  = getTabNoStatCovAniso()->getElem(EConsElem::RANGE, idim);
+        auto noStat  = getTabNoStatCovAniso().getElem(EConsElem::RANGE, idim);
         flagRangeOne = true;
         if (noStat->getValuesOnDb(icas1, iech1, &range1[idim], icas2, iech2, &range2[idim]))
           flagRangeTwo = true;
@@ -1540,14 +1540,14 @@ void CorAniso::updateCovByPoints(Id icas1, Id iech1, Id icas2, Id iech2) const
 void CorAniso::updateCovByMesh(Id imesh, bool aniso) const
 {
   // If no non-stationary parameter is defined, simply skip
-  if (!getTabNoStatCovAniso()->isNoStat()) return;
+  if (!getTabNoStatCovAniso().isNoStat()) return;
 
   auto ndim = getNDim();
 
   // Loop on the elements that can be updated one-by-one
   if (!aniso)
   {
-    const auto paramsnostat = getTabNoStatCovAniso()->getTable();
+    const auto paramsnostat = getTabNoStatCovAniso().getTable();
     for (const auto& e: paramsnostat)
     {
       EConsElem type = e.first.getType();
@@ -1571,9 +1571,9 @@ void CorAniso::updateCovByMesh(Id imesh, bool aniso) const
 
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::ANGLE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::ANGLE, idim))
       {
-        auto noStat  = getTabNoStatCovAniso()->getElem(EConsElem::ANGLE, idim);
+        auto noStat  = getTabNoStatCovAniso().getElem(EConsElem::ANGLE, idim);
         angles[idim] = noStat->getValueOnMeshByMesh(imesh);
       }
     }
@@ -1585,9 +1585,9 @@ void CorAniso::updateCovByMesh(Id imesh, bool aniso) const
     scales = getScales();
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::SCALE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::SCALE, idim))
       {
-        auto noStat  = getTabNoStatCovAniso()->getElem(EConsElem::SCALE, idim);
+        auto noStat  = getTabNoStatCovAniso().getElem(EConsElem::SCALE, idim);
         scales[idim] = noStat->getValueOnMeshByMesh(imesh);
       }
     }
@@ -1599,9 +1599,9 @@ void CorAniso::updateCovByMesh(Id imesh, bool aniso) const
 
     for (Id idim = 0; idim < ndim; idim++)
     {
-      if (getTabNoStatCovAniso()->isElemDefined(EConsElem::RANGE, idim))
+      if (getTabNoStatCovAniso().isElemDefined(EConsElem::RANGE, idim))
       {
-        auto noStat  = getTabNoStatCovAniso()->getElem(EConsElem::RANGE, idim);
+        auto noStat  = getTabNoStatCovAniso().getElem(EConsElem::RANGE, idim);
         ranges[idim] = noStat->getValueOnMeshByMesh(imesh);
       }
     }
@@ -1614,9 +1614,9 @@ void CorAniso::updateCovByMesh(Id imesh, bool aniso) const
     for (Id idim = 0; idim < ndim; idim++)
     {
       for (Id jdim = 0; jdim < ndim; jdim++)
-        if (getTabNoStatCovAniso()->isElemDefined(EConsElem::TENSOR, idim, jdim))
+        if (getTabNoStatCovAniso().isElemDefined(EConsElem::TENSOR, idim, jdim))
         {
-          auto noStat = getTabNoStatCovAniso()->getElem(EConsElem::TENSOR, idim, jdim);
+          auto noStat = getTabNoStatCovAniso().getElem(EConsElem::TENSOR, idim, jdim);
         }
     }
   }

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -188,11 +188,11 @@ CorAniso::~CorAniso()
   delete _corfunc;
 }
 
-TabNoStat* CorAniso::_createNoStatTab()
+std::unique_ptr<TabNoStat> CorAniso::_createNoStatTab()
 {
-  _tabNoStat = new TabNoStatCovAniso();
-  return _tabNoStat;
+  return std::make_unique<TabNoStatCovAniso>();
 }
+
 void CorAniso::computeCorrec()
 {
   _corfunc->computeCorrec(getNDim());
@@ -867,7 +867,7 @@ void CorAniso::_initFromContext()
   _aniso.init(ndim);
   updateFromContext();
   setOptimEnabled(true);
-  _createNoStatTab();
+  createNoStatTab();
   _initParamInfo();
 }
 

--- a/src/Covariances/CovAniso.cpp
+++ b/src/Covariances/CovAniso.cpp
@@ -230,7 +230,7 @@ String CovAniso::toString(const AStringFormat* strfmt) const
   {
     sstr << toStrTitle(3, "List of Non-Stationary Parameters");
     sstr << _tabNoStat->toString(strfmt);
-    auto i = getTabNoStatSills()->getNSills();
+    auto i = getTabNoStatSills().getNSills();
     sstr << getCorAniso()->toStringNoStat(strfmt, i);
   }
   return sstr.str();

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -505,9 +505,9 @@ void CovBase::updateCovByMesh(Id imesh, bool aniso) const
   _cor->updateCovByMesh(imesh, aniso);
 }
 
-TabNoStat* CovBase::_createNoStatTab()
+std::unique_ptr<TabNoStat> CovBase::_createNoStatTab()
 {
-  return new TabNoStatSills();
+  return std::make_unique<TabNoStatSills>();
 }
 
 void CovBase::_makeStationary()

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -342,7 +342,7 @@ void CovBase::makeSillNoStatFunctional(const AFunctional* func, Id ivar, Id jvar
 
 void CovBase::makeSillsStationary(bool silent)
 {
-  if (getTabNoStatSills()->empty() && !silent)
+  if (getTabNoStatSills().empty() && !silent)
   {
     messerr("All the sills are already stationary!");
     return;
@@ -551,16 +551,14 @@ bool CovBase::_isNoStat() const
 
 Id CovBase::getNSills() const
 {
-  TabNoStatSills* tabnostat = getTabNoStatSills();
-  if (tabnostat == nullptr) return 0;
-  return tabnostat->getNSills();
+  TabNoStatSills& tabnostat = getTabNoStatSills();
+  return tabnostat.getNSills();
 }
 
 bool CovBase::isNoStatForVariance() const
 {
-  TabNoStatSills* tabnostat = getTabNoStatSills();
-  if (tabnostat == nullptr) return 0;
-  return tabnostat->isDefinedForVariance();
+  TabNoStatSills& tabnostat = getTabNoStatSills();
+  return tabnostat.isDefinedForVariance();
 }
 
 void CovBase::_multiplyCorDerivativesBySills(Id oldSize, std::vector<covmaptype>* gradFuncs)


### PR DESCRIPTION
This PR wraps the `_tabNoStat` pointer in `ACov` in `std::unique_ptr`. This way, the memory is automatically freed when the `ACov` instance is destroyed.

Also, `ACov` methods returning pointers to this member were modified to return references. This makes memory handling more explicit.

This PR should also solve the first memory issue in #818.

Pierre