### PR TITLE
ProjMulti: Use std::optional<reference> instead of pointer

### DIFF
--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -13,7 +13,7 @@
 #include "LinearOp/IProj.hpp"
 #include "gstlearn_export.hpp"
 
-#include <memory>
+#include <functional>
 
 namespace gstlrn
 {
@@ -33,11 +33,13 @@ protected:
 #endif
 
 public:
-  Id getNApex() const override { return (_projs.size() == 0 ? 0 : _projs.front()->getNApex()); }
-  Id getNPoint() const override { return (_projs.size() == 0 ? 0 : _projs.back()->getNPoint()); }
+  Id getNApex() const override { return (_projs.size() == 0 ? 0 : _projs.front().get().getNApex()); }
+  Id getNPoint() const override { return (_projs.size() == 0 ? 0 : _projs.back().get().getNPoint()); }
 
 private:
-  std::vector<std::unique_ptr<const IProj>> _projs;
+  using ProjVect = std::vector<std::reference_wrapper<const IProj>>;
+
+  ProjVect _projs;
   mutable VectorVectorDouble _works;
 };
 } // namespace gstlrn

--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -13,6 +13,9 @@
 #include "Basic/AStringable.hpp"
 #include "LinearOp/IProj.hpp"
 #include "gstlearn_export.hpp"
+
+#include <functional>
+#include <optional>
 #include <vector>
 
 namespace gstlrn
@@ -20,6 +23,8 @@ namespace gstlrn
 class GSTLEARN_EXPORT ProjMulti: public IProj, public AStringable
 {
 public:
+  using ProjVect = std::vector<std::vector<std::optional<std::reference_wrapper<const IProj>>>>;
+
   ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool silent = false);
 
   /// AStringable Interface
@@ -29,7 +34,7 @@ public:
   Id getNPoint() const override;
   Id getNVariable() const { return _nvariable; }
   Id getNLatent() const { return _nlatent; }
-  virtual ~ProjMulti();
+  ~ProjMulti() override = default;
   bool empty() const { return _projs.empty(); }
 
 #ifndef SWIG
@@ -40,9 +45,8 @@ protected:
 #endif
 
 private:
-  bool _checkArg(const std::vector<std::vector<const IProj*>>& projs) const;
+  bool _checkArg(const ProjVect& projs) const;
   void _init();
-  virtual void _clear() {};
 
 protected:
   Id findFirstNoNullOnRow(Id j) const;
@@ -51,7 +55,7 @@ protected:
   const VectorInt& getNApexs() const { return _apexNumbers; }
 
 protected:
-  std::vector<std::vector<const IProj*>> _projs; // NOT TO BE DELETED
+  ProjVect _projs;
 
 private:
   Id _pointNumber;

--- a/include/LinearOp/ProjMultiMatrix.hpp
+++ b/include/LinearOp/ProjMultiMatrix.hpp
@@ -10,23 +10,29 @@
 /******************************************************************************/
 #pragma once
 
+#include "LinearOp/ProjMatrix.hpp"
 #include "LinearOp/ProjMulti.hpp"
 #include "Matrix/MatrixSparse.hpp"
 
 namespace gstlrn
 {
-class ProjMatrix;
 class AMesh;
 class Db;
 class VectorMeshes;
 
 class GSTLEARN_EXPORT ProjMultiMatrix: public ProjMulti
 {
+  using ProjsStore = std::vector<std::vector<std::optional<ProjMatrix>>>;
+
 public:
   ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*>>& proj,
-                  bool toClean = false,
-                  bool silent  = false);
-  virtual ~ProjMultiMatrix();
+                  bool silent = false);
+#ifndef SWIG
+  ProjMultiMatrix(ProjsStore&& proj,
+                  bool silent = false);
+#endif // SWIG
+
+  ~ProjMultiMatrix() override = default;
   static std::vector<std::vector<const ProjMatrix*>> create(std::vector<const ProjMatrix*>& vectproj,
                                                             Id nvariable);
   static ProjMultiMatrix* createFromDbAndMeshes(const Db* db,
@@ -40,15 +46,14 @@ public:
 #ifndef SWIG
 
 protected:
+  void init();
+
   Id _addPoint2mesh(const constvect inv, vect outv) const override;
   Id _addMesh2point(const constvect inv, vect outv) const override;
+  ProjsStore _projsStore;
 #endif
 
 private:
   MatrixSparse _Proj;
-  void _clear() override;
-
-private:
-  bool _toClean;
 };
 } // namespace gstlrn

--- a/src/LinearOp/ProjComposition.cpp
+++ b/src/LinearOp/ProjComposition.cpp
@@ -12,7 +12,8 @@
 
 namespace gstlrn
 {
-ProjComposition::ProjComposition(std::vector<const IProj*> projs) : IProj()
+ProjComposition::ProjComposition(std::vector<const IProj*> projs)
+  : IProj()
 {
   // Nothing to do except checking compatibility. Incompatible sizes are a
   // developer bug and return codes of other functions are never really
@@ -23,9 +24,9 @@ ProjComposition::ProjComposition(std::vector<const IProj*> projs) : IProj()
   if (projs.size() == 0) return;
 
   // Check compatibility and allocate work arrays. Use raw pointers to make
-  // iterating easier then if everything is OK convert to std::unique_ptr<>.
-  _works.resize(projs.size()-1);
-  size_t idx = 0;
+  // iterating easier.
+  _works.resize(projs.size() - 1);
+  size_t idx      = 0;
   const IProj* p1 = projs[idx++];
   while (idx < projs.size())
   {
@@ -33,59 +34,59 @@ ProjComposition::ProjComposition(std::vector<const IProj*> projs) : IProj()
     const IProj* p2 = projs[idx];
     if (p1->getNPoint() != p2->getNApex())
     {
-      // Abort. Delete everything first.
-      for (auto p : projs) delete p;
+      // Abort.
       return;
     }
-    _works[idx-1].resize(p1->getNPoint());
+    _works[idx - 1].resize(p1->getNPoint());
     p1 = p2;
     idx++;
   }
-  for (auto p : projs) _projs.push_back(std::unique_ptr<const IProj>(p));
+  for (const auto* p: projs) _projs.emplace_back(*p);
 }
 
 Id ProjComposition::_addPoint2mesh(const constvect in, vect out) const
 {
   if (_projs.size() == 0) return -1;
-  if (_projs.size() == 1) return _projs[0]->addPoint2mesh(in, out);
+  if (_projs.size() == 1) return _projs[0].get().addPoint2mesh(in, out);
 
   // Call point2mesh() to initialise temporary results to 0, but use
   // addPoint2Mesh() at the end to preserve what's already in 'out'.
-  size_t idx = _projs.size()-1;
+  size_t idx = _projs.size() - 1;
 
   // Unroll a bit the loop because first/last use different in/out arrays.
   // This also means size == 1 is a special case (treated above).
-  Id ret = _projs[idx]->point2mesh(in, _works[idx-1]);
+  Id ret = _projs[idx].get().point2mesh(in, _works[idx - 1]);
   if (ret != 0) return ret;
   idx--;
 
   while (idx > 0)
   {
-    ret = _projs[idx]->point2mesh(_works[idx], _works[idx-1]);
+    ret = _projs[idx].get().point2mesh(_works[idx], _works[idx - 1]);
     if (ret != 0) return ret;
     idx--;
   }
 
-  return _projs[idx]->addPoint2mesh(_works[0], out);
+  return _projs[idx].get().addPoint2mesh(_works[0], out);
 }
 
-Id ProjComposition::_addMesh2point(const constvect in, vect out) const {
+Id ProjComposition::_addMesh2point(const constvect in, vect out) const
+{
   if (_projs.size() == 0) return -1;
-  if (_projs.size() == 1) return _projs[0]->addMesh2point(in, out);
+  if (_projs.size() == 1) return _projs[0].get().addMesh2point(in, out);
 
   size_t idx = 0;
 
-  Id ret = _projs[0]->mesh2point(in, _works[0]);
+  Id ret = _projs[0].get().mesh2point(in, _works[0]);
   if (ret != 0) return ret;
   idx++;
 
   while (idx < _projs.size() - 1)
   {
-    ret = _projs[idx]->mesh2point(_works[idx-1], _works[idx]);
+    ret = _projs[idx].get().mesh2point(_works[idx - 1], _works[idx]);
     if (ret != 0) return ret;
     idx++;
   }
 
-  return _projs[idx]->addMesh2point(_works[idx-1], out);
+  return _projs[idx].get().addMesh2point(_works[idx - 1], out);
 }
-}
+} // namespace gstlrn

--- a/src/LinearOp/ProjMulti.cpp
+++ b/src/LinearOp/ProjMulti.cpp
@@ -21,7 +21,7 @@ Id ProjMulti::findFirstNoNullOnRow(Id j) const
 {
   Id i = 0;
 
-  while (i < static_cast<Id>(_projs[j].size()) && _projs[j][i] == nullptr)
+  while (i < static_cast<Id>(_projs[j].size()) && !_projs[j][i])
   {
     i++;
   }
@@ -36,7 +36,7 @@ Id ProjMulti::findFirstNoNullOnRow(Id j) const
 Id ProjMulti::findFirstNoNullOnCol(Id j) const
 {
   Id i = 0;
-  while (i < static_cast<Id>(_projs.size()) && _projs[i][j] == nullptr)
+  while (i < static_cast<Id>(_projs.size()) && !_projs[i][j])
   {
     i++;
   }
@@ -48,7 +48,7 @@ Id ProjMulti::findFirstNoNullOnCol(Id j) const
   return i;
 }
 
-bool ProjMulti::_checkArg(const std::vector<std::vector<const IProj*>>& projs) const
+bool ProjMulti::_checkArg(const ProjVect& projs) const
 {
   if (projs.empty())
   {
@@ -82,16 +82,16 @@ bool ProjMulti::_checkArg(const std::vector<std::vector<const IProj*>>& projs) c
     if (fcol == -1)
       return true;
 
-    auto npoints = projs[i][fcol]->getNPoint();
+    auto npoints = projs[i][fcol]->get().getNPoint();
     for (Id j = fcol + 1; j < nlatent; j++)
     {
-      if (projs[i][j] != nullptr)
+      if (projs[i][j])
       {
-        if (projs[i][j]->getNPoint() != npoints)
+        if (projs[i][j]->get().getNPoint() != npoints)
         {
           messerr("Inconsistency between the IProj Point Numbers.");
           messerr("Element [%d,%d] should have Point Number = %d  instead of %d.",
-                  i, j, npoints, projs[i][j]->getNPoint());
+                  i, j, npoints, projs[i][j]->get().getNPoint());
           return true;
         }
       }
@@ -104,16 +104,16 @@ bool ProjMulti::_checkArg(const std::vector<std::vector<const IProj*>>& projs) c
     if (frow == -1)
       return true;
 
-    auto nvertex = projs[frow][j]->getNApex();
+    auto nvertex = projs[frow][j]->get().getNApex();
     for (Id i = frow + 1; i < nvariable; i++)
     {
-      if (projs[i][j] != nullptr)
+      if (projs[i][j])
       {
-        if (projs[i][j]->getNApex() != nvertex)
+        if (projs[i][j]->get().getNApex() != nvertex)
         {
           messerr("Inconsistency between the IProj Apex Numbers.");
           messerr("Element [%d,%d] should have Apex Number = %d  instead of %d.",
-                  i, j, nvertex, projs[i][j]->getNApex());
+                  i, j, nvertex, projs[i][j]->get().getNApex());
           return true;
         }
       }
@@ -130,7 +130,7 @@ void ProjMulti::_init()
   for (Id i = 0; i < _nvariable; i++)
   {
     Id fcol      = findFirstNoNullOnRow(i);
-    auto npoints = _projs[i][fcol]->getNPoint();
+    auto npoints = _projs[i][fcol]->get().getNPoint();
     _pointNumbers.push_back(npoints);
     _pointNumber += npoints;
   }
@@ -138,19 +138,31 @@ void ProjMulti::_init()
   for (Id j = 0; j < _nlatent; j++)
   {
     Id frow      = findFirstNoNullOnCol(j);
-    auto nvertex = _projs[frow][j]->getNApex();
+    auto nvertex = _projs[frow][j]->get().getNApex();
     _apexNumbers.push_back(nvertex);
     _apexNumber += nvertex;
   }
 }
 
-ProjMulti::~ProjMulti()
+static ProjMulti::ProjVect convert(const std::vector<std::vector<const IProj*>>& projs)
 {
-  _clear();
+  ProjMulti::ProjVect res(projs.size());
+  for (size_t i = 0; i < projs.size(); ++i)
+  {
+    res[i].resize(projs[i].size());
+    for (size_t j = 0; j < projs[i].size(); j++)
+    {
+      if (projs[i][j] != nullptr)
+      {
+        res[i][j] = *projs[i][j];
+      }
+    }
+  }
+  return res;
 }
 
 ProjMulti::ProjMulti(const std::vector<std::vector<const IProj*>>& projs, bool silent)
-  : _projs(projs)
+  : _projs(convert(projs))
   , _pointNumber(0)
   , _apexNumber(0)
   , _nlatent(0)
@@ -182,11 +194,11 @@ Id ProjMulti::_addPoint2mesh(const constvect inv, vect outv) const
     std::fill(_workmesh.begin(), _workmesh.end(), 0.);
     for (Id j = 0; j < _nvariable; j++)
     {
-      if (_projs[j][i] != nullptr)
+      if (_projs[j][i])
       {
         constvect view(inv.data() + iad, _pointNumbers[j]);
         wms = vect(_workmesh);
-        _projs[j][i]->addPoint2mesh(view, wms);
+        _projs[j][i]->get().addPoint2mesh(view, wms);
       }
       iad += _pointNumbers[j];
     }
@@ -210,11 +222,11 @@ Id ProjMulti::_addMesh2point(const constvect inv, vect outv) const
     std::fill(_work.begin(), _work.end(), 0.);
     for (Id j = 0; j < _nlatent; j++)
     {
-      if (_projs[i][j] != nullptr)
+      if (_projs[i][j])
       {
         constvect view(inv.data() + iad, _apexNumbers[j]);
         ws = vect(_work);
-        _projs[i][j]->addMesh2point(view, ws);
+        _projs[i][j]->get().addMesh2point(view, ws);
       }
       iad += _apexNumbers[j];
     }
@@ -253,11 +265,11 @@ String ProjMulti::toString(const AStringFormat* /*strfmt*/) const
     for (Id icol = 0; icol < _nlatent; icol++)
     {
       sstr << "- Row (" << irow + 1 << ") - Col (" << icol + 1 << ") : ";
-      const IProj* proj = _projs[irow][icol];
-      if (proj == nullptr)
+      const auto& proj = _projs[irow][icol];
+      if (!proj)
         sstr << "empty";
       else
-        sstr << " Mesh (" << getNPoint() << " - " << proj->getNApex() << ")";
+        sstr << " Mesh (" << getNPoint() << " - " << proj->get().getNApex() << ")";
       sstr << std::endl;
     }
   }

--- a/src/LinearOp/ProjMultiMatrix.cpp
+++ b/src/LinearOp/ProjMultiMatrix.cpp
@@ -8,10 +8,9 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+
 #include "LinearOp/ProjMultiMatrix.hpp"
-#include "Basic/AStringable.hpp"
 #include "Db/Db.hpp"
-#include "LinearOp/IProj.hpp"
 #include "LinearOp/ProjMatrix.hpp"
 #include "LinearOp/ProjMulti.hpp"
 #include "Matrix/MatrixSparse.hpp"
@@ -19,19 +18,29 @@
 
 namespace gstlrn
 {
-static std::vector<std::vector<const IProj*>> castToBase(const std::vector<std::vector<const ProjMatrix*>>& vec)
+
+template<typename T>
+static std::vector<std::vector<const IProj*>> castToBase(const std::vector<std::vector<T>>& vec)
 {
   std::vector<std::vector<const IProj*>> casted(vec.size());
   Id iv = 0;
   for (const auto& e: vec)
   {
-    std::vector<const IProj*> temp(e.size());
+    auto& dst = casted[iv++];
+    dst.resize(e.size());
     Id ie = 0;
     for (const auto& f: e)
     {
-      temp[ie++] = static_cast<const IProj*>(f);
+      if (!f)
+      {
+        dst[ie++] = {};
+        continue;
+      }
+      if constexpr (std::is_same<T, const ProjMatrix*>::value)
+        dst[ie++] = f;
+      else if constexpr (std::is_same<T, std::optional<ProjMatrix>>::value)
+        dst[ie++] = &f.value();
     }
-    casted[iv++] = temp;
   }
   return casted;
 }
@@ -68,7 +77,7 @@ ProjMultiMatrix* ProjMultiMatrix::createFromDbAndMeshes(const Db* db,
     messerr("nvar should be > 0");
     return nullptr;
   }
-  Id nmeshes = static_cast<Id>(meshes.size());
+  Id nmeshes = meshes.size();
   if (nmeshes == 0)
   {
     messerr("You have to provide at least one mesh");
@@ -87,43 +96,23 @@ ProjMultiMatrix* ProjMultiMatrix::createFromDbAndMeshes(const Db* db,
     return nullptr;
   }
 
-  std::vector<std::vector<const ProjMatrix*>> stocker;
+  ProjsStore stocker(nvar);
 
-  Id nmesh       = static_cast<Id>(meshes.size());
-  bool flagIsVar = checkOnZVariable && db->hasLocator(ELoc::Z);
+  const auto nmesh = meshes.size();
+  bool flagIsVar   = checkOnZVariable && db->hasLocator(ELoc::Z);
   for (Id ivar = 0; ivar < nvar; ivar++)
   {
-    stocker.push_back(std::vector<const ProjMatrix*>());
     for (Id imesh = 0; imesh < nmesh; imesh++)
       for (Id jvar = 0; jvar < nvar; jvar++)
       {
         Id kvar = (flagIsVar) ? jvar : -1;
         if (ivar != jvar)
-          stocker[ivar].push_back(nullptr);
+          stocker[ivar].emplace_back();
         else
-          stocker[ivar].push_back(new ProjMatrix(db, meshes(imesh), kvar, verbose));
+          stocker[ivar].emplace_back(ProjMatrix(db, meshes(imesh), kvar, verbose));
       }
   }
-  return new ProjMultiMatrix(stocker, true);
-}
-
-void ProjMultiMatrix::_clear()
-{
-  if (!_toClean || _projs.empty()) return;
-
-  for (auto& e: _projs)
-  {
-    for (auto& f: e)
-    {
-      delete const_cast<IProj*>(f);
-      f = nullptr;
-    }
-    e.clear();
-  }
-  _projs.clear();
-}
-ProjMultiMatrix::~ProjMultiMatrix()
-{
+  return new ProjMultiMatrix(std::move(stocker));
 }
 
 std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<const ProjMatrix*>& vectproj,
@@ -136,7 +125,7 @@ std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<
   {
     if (vectproj[i] == nullptr)
     {
-      messerr("Projmatrix shouldn't be nullptr.");
+      messerr("ProjMatrix shouldn't be nullptr.");
       return result;
     }
   }
@@ -159,7 +148,7 @@ std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<
     std::vector<const ProjMatrix*> e(nlatent * nvariable, nullptr);
     for (Id j = 0; j < nlatent; j++)
     {
-      e[j * nvariable + i] = vectproj[j];
+      e[(j * nvariable) + i] = vectproj[j];
     }
     result[i] = e;
   }
@@ -167,11 +156,23 @@ std::vector<std::vector<const ProjMatrix*>> ProjMultiMatrix::create(std::vector<
 }
 
 ProjMultiMatrix::ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*>>& proj,
-                                 bool toClean,
                                  bool silent)
   : ProjMulti(castToBase(proj), silent)
   , _Proj(MatrixSparse(0, 0))
-  , _toClean(toClean)
+{
+  this->init();
+}
+
+ProjMultiMatrix::ProjMultiMatrix(ProjsStore&& proj,
+                                 bool silent)
+  : ProjMulti(castToBase(proj), silent)
+  , _projsStore(std::move(proj))
+  , _Proj(MatrixSparse(0, 0))
+{
+  this->init();
+}
+
+void ProjMultiMatrix::init()
 {
   if (ProjMulti::empty()) return;
   const VectorInt& pointNumbers = getNPoints();
@@ -182,9 +183,9 @@ ProjMultiMatrix::ProjMultiMatrix(const std::vector<std::vector<const ProjMatrix*
     MatrixSparse currentrow;
     for (Id j = 0; j < getNLatent(); j++)
     {
-      if (_projs[i][j] != nullptr)
+      if (_projs[i][j])
       {
-        MatrixSparse::glueInPlace(&currentrow, const_cast<MatrixSparse*>(static_cast<const MatrixSparse*>(proj[i][j])), 0, 1);
+        MatrixSparse::glueInPlace(&currentrow, &static_cast<const ProjMatrix&>(_projs[i][j].value().get()), 0, 1);
       }
       else
       {

--- a/tests/py/output/test_ProjMatrixMulti.ref
+++ b/tests/py/output/test_ProjMatrixMulti.ref
@@ -6,7 +6,7 @@ I. Creation of the vector<vector<Projmatrix*>> from a vector<ProjMatrix*>
 ---------------------------------------------------------------------
 Test1: with a nullptr element:
 --------
-Projmatrix shouldn't be nullptr.
+ProjMatrix shouldn't be nullptr.
 ---------------------
 Test2: with different Point Numbers:
 --------

--- a/tests/py/output/test_ProjMatrixMulti_clang.ref
+++ b/tests/py/output/test_ProjMatrixMulti_clang.ref
@@ -6,7 +6,7 @@ I. Creation of the vector<vector<Projmatrix*>> from a vector<ProjMatrix*>
 ---------------------------------------------------------------------
 Test1: with a nullptr element:
 --------
-Projmatrix shouldn't be nullptr.
+ProjMatrix shouldn't be nullptr.
 ---------------------
 Test2: with different Point Numbers:
 --------


### PR DESCRIPTION
This PR reworks the `_projs` member of the `ProjMulti` class to make sure memory is externally managed. To do so, naked pointers have been replaced with references wrapped in `std::optional` (because the naked pointers were allowed to be `nullptr`).

Work has been done to adapt `ProjMultiMatrix` to this change. In particular, since

- the `ProjMultiMatrix::createFromDbAndMeshes` method did transfer the ownership to the `IProj` variables to the `ProjMulti` instance in the `_projs` variable
- while the `ProjMultiMatrix`  constructor kept the ownership of `_projs` outside the instance.

To account for these two behaviors, a new member variable in `ProjMultiMatrix` named `_projsStore` owns the memory of the `IProj`s when called from `createFromDbAndMeshes`. It is empty when the main constructor is used.

This should solve the second memory leak of #818 (the typo fix contained in this PR has also been transferred here).

Pierre