### PR TITLE
Remove unused getAllIsSpatialTemporal function in AKernel

### DIFF
--- a/include/Covariances/AKernel.hpp
+++ b/include/Covariances/AKernel.hpp
@@ -151,7 +151,6 @@ private:
 };
 
 GSTLEARN_EXPORT VectorInt getAllMaxDimension();
-GSTLEARN_EXPORT VectorBool getAllIsSpatialTemporal();
 GSTLEARN_EXPORT VectorString getAllFormula();
 
 } // namespace gstlrn

--- a/src/Covariances/AKernel.cpp
+++ b/src/Covariances/AKernel.cpp
@@ -395,12 +395,6 @@ VectorInt getAllMaxDimension()
   return maxdims;
 }
 
-VectorBool getAllIsSpatialTemporal()
-{
-  messerrNotImplemented(String(), "getAllIsSpatialTemporal");
-  return VectorBool();
-}
-
 GSTLEARN_EXPORT VectorString getAllFormula()
 {
   AKernel* kernel = nullptr;


### PR DESCRIPTION
This should definitely fix #804 by removing unused function: getAllIsSpatialTemporal