### PR TITLE
Fix instructions for installing gstlearn under R

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -35,7 +35,7 @@ install.packages("gstlearn",repos="https://soft.mines-paristech.fr/cran")
 For installing a prerelease version:
 
 ```
-install.package("gstlearn", repos="https://soft.mines-paristech.fr/cran/prerelease")
+install.packages("gstlearn", repos="https://soft.mines-paristech.fr/cran/prerelease")
 ```
 
 Note: With slow Internet connection, you may need to increase the default timeout (60s) (gstlearn package is around 17Mo!)


### PR DESCRIPTION
Replace install.package instruction by install.packages in R README.