### PR TITLE
SPDE on 1D, inform anistropies on meshes/vertices, and bug fix

### DIFF
--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -458,6 +458,9 @@ public:
     return TEST;
   }
   void makeStationary();
+  virtual void setFlagAnisoOnMesh(bool flagAnisoOnMesh) { _flagAnisoOnMesh = flagAnisoOnMesh; }
+  inline bool getFlagAnisoOnMesh() const { return _flagAnisoOnMesh; }
+  Id makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db = nullptr, const String& namecol = String());
   virtual Id makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func = nullptr, const Db* db = nullptr, const String& namecol = String());
   void createNoStatTab();
   void informMeshByMesh(const AMesh* amesh) const;
@@ -525,6 +528,7 @@ private:
                                 const VectorVectorInt& index2,
                                 const KrigOpt& krigopt = KrigOpt()) const;
   virtual std::unique_ptr<TabNoStat> _createNoStatTab();
+  Id _makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func = nullptr, const Db* db = nullptr, const String& namecol = String());
 
 protected:
   void _setNoStatDbIfNecessary(const Db* db);
@@ -580,5 +584,6 @@ protected:
   mutable SpacePoint* _pw1;
   mutable SpacePoint* _pw2;
   std::unique_ptr<TabNoStat> _tabNoStat;
+  bool _flagAnisoOnMesh;
 };
 } // namespace gstlrn

--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -458,7 +458,7 @@ public:
     return TEST;
   }
   void makeStationary();
-  virtual void setFlagAnisoOnMesh(bool flagAnisoOnMesh) { _flagAnisoOnMesh = flagAnisoOnMesh; }
+  void setFlagAnisoOnMesh(bool flagAnisoOnMesh) { _flagAnisoOnMesh = flagAnisoOnMesh; }
   inline bool getFlagAnisoOnMesh() const { return _flagAnisoOnMesh; }
   Id makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db = nullptr, const String& namecol = String());
   virtual Id makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func = nullptr, const Db* db = nullptr, const String& namecol = String());

--- a/include/Covariances/ACov.hpp
+++ b/include/Covariances/ACov.hpp
@@ -458,9 +458,6 @@ public:
     return TEST;
   }
   void makeStationary();
-  void setFlagAnisoOnMesh(bool flagAnisoOnMesh) { _flagAnisoOnMesh = flagAnisoOnMesh; }
-  inline bool getFlagAnisoOnMesh() const { return _flagAnisoOnMesh; }
-  Id makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db = nullptr, const String& namecol = String());
   virtual Id makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func = nullptr, const Db* db = nullptr, const String& namecol = String());
   void createNoStatTab();
   void informMeshByMesh(const AMesh* amesh) const;
@@ -584,6 +581,5 @@ protected:
   mutable SpacePoint* _pw1;
   mutable SpacePoint* _pw2;
   std::unique_ptr<TabNoStat> _tabNoStat;
-  bool _flagAnisoOnMesh;
 };
 } // namespace gstlrn

--- a/include/Covariances/ANoStat.hpp
+++ b/include/Covariances/ANoStat.hpp
@@ -33,8 +33,8 @@ public:
   double getValueOnMeshByApex(Id iapex) const;
   double getValueOnMesh(Id iapex, bool center = false) const;
   void informField(const VectorVectorDouble& coords, VectorDouble& tab, bool verbose = false);
-  void informMeshByMesh(const AMesh* amesh, bool verbose = false);
-  void informMeshByApex(const AMesh* amesh, bool verbose = false);
+  virtual void informMeshByMesh(const AMesh* amesh, bool verbose = false);
+  virtual void informMeshByApex(const AMesh* amesh, bool verbose = false);
   void informDbIn(const Db* dbin, bool verbose = false);
   void informDbOout(const Db* dbout, bool verbose = false);
 

--- a/include/Covariances/CorAniso.hpp
+++ b/include/Covariances/CorAniso.hpp
@@ -215,6 +215,12 @@ public:
   }
   double normalizeOnSphere(Id n = 50) const;
 
+  
+  void setFlagAnisoOnMesh(bool flagAnisoOnMesh) { _flagAnisoOnMesh = flagAnisoOnMesh; }
+  inline bool getFlagAnisoOnMesh() const { return _flagAnisoOnMesh; }
+  Id makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db = nullptr, const String& namecol = String());
+  Id makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func = nullptr, const Db* db = nullptr, const String& namecol = String()) override;
+
   //////////////////////// New NoStat methods //////////////////////////
 
   void makeRangeNoStatDb(const String& namecol, Id idim = 0, const Db* db = nullptr);
@@ -351,6 +357,7 @@ private:
 
   bool _optimNoAniso;   // All ranges should be equal
   bool _optimLockIso2d; // Range U and V should be equal
+  bool _flagAnisoOnMesh;
   mutable std::vector<MatrixSquare> _dRot;
   const std::array<EConsElem, 4> _listaniso = {EConsElem::RANGE,
                                                EConsElem::SCALE,

--- a/include/Covariances/CovAniso.hpp
+++ b/include/Covariances/CovAniso.hpp
@@ -120,6 +120,7 @@ public:
                                           bool flagRange             = true);
 
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, setFlagAnisoOnMesh)
+  FORWARD_METHOD_NON_CONST(getCorAnisoModify, getFlagAnisoOnMesh)
 
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, setParam)
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, computeMarkovCoeffs)

--- a/include/Covariances/CovAniso.hpp
+++ b/include/Covariances/CovAniso.hpp
@@ -119,6 +119,8 @@ public:
                                           const VectorDouble& angles = VectorDouble(),
                                           bool flagRange             = true);
 
+  FORWARD_METHOD_NON_CONST(getCorAnisoModify, setFlagAnisoOnMesh)
+
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, setParam)
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, computeMarkovCoeffs)
   FORWARD_METHOD_NON_CONST(getCorAnisoModify, setRangeIsotropic)

--- a/include/Covariances/NoStatOnMesh.hpp
+++ b/include/Covariances/NoStatOnMesh.hpp
@@ -10,34 +10,26 @@
 /******************************************************************************/
 #pragma once
 
-#include "Covariances/ANoStat.hpp"
+#include "Covariances/NoStatArray.hpp"
 #include "gstlearn_export.hpp"
-#include <memory>
-
-class Db;
 
 namespace gstlrn
 {
-class GSTLEARN_EXPORT NoStatArray: public ANoStat
+class GSTLEARN_EXPORT NoStatOnMesh: public NoStatArray
 {
 public:
-  NoStatArray() {};
-  NoStatArray(std::shared_ptr<const Db> dbref, const String& colname);
-  NoStatArray(const NoStatArray& m)            = delete;
-  NoStatArray& operator=(const NoStatArray& m) = delete;
-  virtual ~NoStatArray() {};
-  String toString(const AStringFormat* strfmt = nullptr) const override;
+  NoStatOnMesh() {};
+  NoStatOnMesh(std::shared_ptr<const Db> dbref, const String& colname);
 
-  const String& getColName() const { return _colName; }
-  const std::shared_ptr<const Db>& getDbNoStat() const { return _dbNoStat; }
+  NoStatOnMesh(const NoStatOnMesh& m)            = delete;
+  NoStatOnMesh& operator=(const NoStatOnMesh& m) = delete;
+
+  void informMeshByMesh(const AMesh* amesh, bool verbose = false) override;
+  void informMeshByApex(const AMesh* amesh, bool verbose = false) override;
+
+  virtual ~NoStatOnMesh() {};
 
 private:
-  void _informField(const VectorVectorDouble& coords,
-                    VectorDouble& tab,
-                    bool verbose = false) override;
-
-protected:
-  std::shared_ptr<const Db> _dbNoStat;
-  const String _colName;
+  void _informFieldByMesh(const AMesh* amesh, VectorDouble& tab, bool onMeshes);
 };
 } // namespace gstlrn

--- a/include/LinearOp/PrecisionOpMatrix.hpp
+++ b/include/LinearOp/PrecisionOpMatrix.hpp
@@ -66,6 +66,7 @@ public:
 #endif
   const MatrixSparse* getQ() const { return _Q.get(); }
   const MatrixSparse* getS() const;
+  const VectorDouble& getTildeC() const;
 
 private:
   void _buildQ();

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -21,8 +21,8 @@
 #include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Covariances/NoStatArray.hpp"
-#include "Covariances/NoStatOnMesh.hpp"
 #include "Covariances/NoStatFunctional.hpp"
+#include "Covariances/NoStatOnMesh.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
 #include "Enum/ECalcMember.hpp"
@@ -57,7 +57,6 @@ ACov::ACov(const CovContext& ctxt)
   , _p2A(ctxt.getSpace())
   , _pAux(ctxt.getSpace())
   , _tabNoStat(nullptr)
-  , _flagAnisoOnMesh(false)
 {
   createNoStatTab();
 }
@@ -75,7 +74,6 @@ ACov::ACov(const ACov& r)
   , _pw1(r._pw1)
   , _pw2(r._pw2)
   , _tabNoStat(r._tabNoStat == nullptr ? nullptr : r._tabNoStat->clone())
-  , _flagAnisoOnMesh(r._flagAnisoOnMesh)
 {
 }
 
@@ -95,7 +93,6 @@ ACov& ACov::operator=(const ACov& r)
     _pw1                   = r._pw1;
     _pw2                   = r._pw2;
     _tabNoStat             = std::unique_ptr<TabNoStat>(r._tabNoStat->clone());
-    _flagAnisoOnMesh       = r._flagAnisoOnMesh;
   }
   return *this;
 }
@@ -2020,20 +2017,8 @@ void ACov::_makeStationary()
 {
 }
 
-Id ACov::makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db, const String& namecol)
-{
-  std::shared_ptr<ANoStat> ns;
-  if (!checkAndManageNoStatDb(db, namecol)) return 1;
-
-  ns = std::shared_ptr<ANoStat>(new NoStatOnMesh(_tabNoStat->getDbNoStatRef(), namecol));
-
-  return _tabNoStat->addElem(ns, econs, iv1, iv2);
-}
-
 Id ACov::makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func, const Db* db, const String& namecol)
 {
-  if (_flagAnisoOnMesh && db != nullptr) return makeElemNoStatOnMesh(econs, iv1, iv2, db, namecol);
-
   return _makeElemNoStat(econs, iv1, iv2, func, db, namecol);
 }
 

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -21,6 +21,7 @@
 #include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovContext.hpp"
 #include "Covariances/NoStatArray.hpp"
+#include "Covariances/NoStatOnMesh.hpp"
 #include "Covariances/NoStatFunctional.hpp"
 #include "Db/Db.hpp"
 #include "Db/DbGrid.hpp"
@@ -56,6 +57,7 @@ ACov::ACov(const CovContext& ctxt)
   , _p2A(ctxt.getSpace())
   , _pAux(ctxt.getSpace())
   , _tabNoStat(nullptr)
+  , _flagAnisoOnMesh(false)
 {
   createNoStatTab();
 }
@@ -73,6 +75,7 @@ ACov::ACov(const ACov& r)
   , _pw1(r._pw1)
   , _pw2(r._pw2)
   , _tabNoStat(r._tabNoStat == nullptr ? nullptr : r._tabNoStat->clone())
+  , _flagAnisoOnMesh(r._flagAnisoOnMesh)
 {
 }
 
@@ -92,6 +95,7 @@ ACov& ACov::operator=(const ACov& r)
     _pw1                   = r._pw1;
     _pw2                   = r._pw2;
     _tabNoStat             = std::unique_ptr<TabNoStat>(r._tabNoStat->clone());
+    _flagAnisoOnMesh       = r._flagAnisoOnMesh;
   }
   return *this;
 }
@@ -2016,7 +2020,24 @@ void ACov::_makeStationary()
 {
 }
 
+Id ACov::makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db, const String& namecol)
+{
+  std::shared_ptr<ANoStat> ns;
+  if (!checkAndManageNoStatDb(db, namecol)) return 1;
+
+  ns = std::shared_ptr<ANoStat>(new NoStatOnMesh(_tabNoStat->getDbNoStatRef(), namecol));
+
+  return _tabNoStat->addElem(ns, econs, iv1, iv2);
+}
+
 Id ACov::makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func, const Db* db, const String& namecol)
+{
+  if (_flagAnisoOnMesh && db != nullptr) return makeElemNoStatOnMesh(econs, iv1, iv2, db, namecol);
+
+  return _makeElemNoStat(econs, iv1, iv2, func, db, namecol);
+}
+
+Id ACov::_makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func, const Db* db, const String& namecol)
 {
   std::shared_ptr<ANoStat> ns;
   if (func == nullptr)

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -25,6 +25,7 @@
 #include "Covariances/ACov.hpp"
 #include "Covariances/CovCalcMode.hpp"
 #include "Covariances/CovFactory.hpp"
+#include "Covariances/NoStatOnMesh.hpp"
 #include "Covariances/TabNoStatCovAniso.hpp"
 #include "Db/Db.hpp"
 #include "Enum/EConsElem.hpp"
@@ -112,6 +113,7 @@ CorAniso::CorAniso(const CovContext& ctxt, const ECov& type)
   , _noStatFactor(1.)
   , _optimNoAniso(false)
   , _optimLockIso2d(false)
+  , _flagAnisoOnMesh(false)
 {
   initFromContext();
 }
@@ -124,6 +126,7 @@ CorAniso::CorAniso(const CovContext& ctxt, const String& symbol)
   , _noStatFactor(1.)
   , _optimNoAniso(false)
   , _optimLockIso2d(false)
+  , _flagAnisoOnMesh(false)
 {
   ECov covtype = CovFactory::identifyCovariance(symbol, ctxt);
   _corfunc     = CovFactory::createCovFunc(covtype, ctxt);
@@ -142,6 +145,7 @@ CorAniso::CorAniso(
   , _noStatFactor(1.)
   , _optimNoAniso(false)
   , _optimLockIso2d(false)
+  , _flagAnisoOnMesh(false)
 {
   initFromContext();
 
@@ -164,6 +168,7 @@ CorAniso::CorAniso(const CorAniso& r)
   , _noStatFactor(r._noStatFactor)
   , _optimNoAniso(r._optimNoAniso)
   , _optimLockIso2d(r._optimLockIso2d)
+  , _flagAnisoOnMesh(r._flagAnisoOnMesh)
 {
 }
 
@@ -172,13 +177,14 @@ CorAniso& CorAniso::operator=(const CorAniso& r)
   if (this != &r)
   {
     ACov::operator=(r);
-    _corfunc        = CovFactory::duplicateCovFunc(*r._corfunc);
-    _scales         = r._scales;
-    _angles         = r._angles;
-    _aniso          = r._aniso;
-    _noStatFactor   = r._noStatFactor;
-    _optimNoAniso   = r._optimNoAniso;
-    _optimLockIso2d = r._optimLockIso2d;
+    _corfunc         = CovFactory::duplicateCovFunc(*r._corfunc);
+    _scales          = r._scales;
+    _angles          = r._angles;
+    _aniso           = r._aniso;
+    _noStatFactor    = r._noStatFactor;
+    _optimNoAniso    = r._optimNoAniso;
+    _optimLockIso2d  = r._optimLockIso2d;
+    _flagAnisoOnMesh = r._flagAnisoOnMesh;
   }
   return *this;
 }
@@ -1282,6 +1288,24 @@ String CorAniso::toStringNoStat(const AStringFormat* strfmt, Id i) const
   sstr = getTabNoStatCovAniso().toStringInside(strfmt, i);
   return sstr;
 }
+
+Id CorAniso::makeElemNoStatOnMesh(const EConsElem& econs, Id iv1, Id iv2, const Db* db, const String& namecol)
+{
+  std::shared_ptr<ANoStat> ns;
+  if (!checkAndManageNoStatDb(db, namecol)) return 1;
+
+  ns = std::shared_ptr<ANoStat>(new NoStatOnMesh(_tabNoStat->getDbNoStatRef(), namecol));
+
+  return _tabNoStat->addElem(ns, econs, iv1, iv2);
+}
+
+Id CorAniso::makeElemNoStat(const EConsElem& econs, Id iv1, Id iv2, const AFunctional* func, const Db* db, const String& namecol)
+{
+  if (_flagAnisoOnMesh) return makeElemNoStatOnMesh(econs, iv1, iv2, db, namecol);
+
+  return ACov::makeElemNoStat(econs, iv1, iv2, func, db, namecol);
+}
+
 ///////////////////// Range ////////////////////////
 void CorAniso::makeRangeNoStatDb(const String& namecol, Id idim, const Db* db)
 {

--- a/src/Covariances/NoStatOnMesh.cpp
+++ b/src/Covariances/NoStatOnMesh.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#include "Covariances/NoStatOnMesh.hpp"
+#include "Basic/VectorHelper.hpp"
+#include "Db/Db.hpp"
+#include "geoslib_define.h"
+
+namespace gstlrn
+{
+NoStatOnMesh::NoStatOnMesh(std::shared_ptr<const Db> dbref,
+                           const String& colname)
+  : NoStatArray(dbref, colname)
+{
+}
+
+void NoStatOnMesh::informMeshByMesh(const AMesh* amesh, bool verbose)
+{
+  DECLARE_UNUSED(verbose);
+  _informFieldByMesh(amesh, _tabmesh, true);
+}
+
+void NoStatOnMesh::informMeshByApex(const AMesh* amesh, bool verbose)
+{
+  DECLARE_UNUSED(verbose);
+  _informFieldByMesh(amesh, _tabvertices, false);
+}
+
+void NoStatOnMesh::_informFieldByMesh(const AMesh* amesh, VectorDouble& tab, bool onMeshes)
+{
+  Id iatt = _dbNoStat->getUID(_colName);
+  if (iatt < 0)
+  {
+    messerr("The Non-stationary attribute  is not defined in _dbNoStat anymore");
+    return;
+  }
+
+  /* Loop on the point samples */
+
+  Id nech = onMeshes ? amesh->getNMeshes() : amesh->getNApices();
+
+  tab.resize(nech);
+
+  for (Id iech = 0; iech < nech; iech++)
+  {
+    tab[iech] = _dbNoStat->getArray(iech, iatt);
+  }
+}
+
+} // namespace gstlrn

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -44,6 +44,11 @@ const MatrixSparse* PrecisionOpMatrix::getS() const
   return dynamic_cast<const ShiftOpMatrix*>(getShiftOp())->getS();
 }
 
+const VectorDouble& PrecisionOpMatrix::getTildeC() const
+{
+  return dynamic_cast<const ShiftOpMatrix*>(getShiftOp())->getTildeC();
+}
+
 PrecisionOpMatrix::~PrecisionOpMatrix()
 {
   delete _chol;

--- a/src/LinearOp/ShiftOpMatrix.cpp
+++ b/src/LinearOp/ShiftOpMatrix.cpp
@@ -892,6 +892,13 @@ Id ShiftOpMatrix::_buildS(const AMesh* amesh, double tol)
     _S->addValue(ip0, ip0, S);
   }
 
+  // Workaround for 1d
+  if (ndim == 1)
+  {
+    _TildeC.multiplyCst(3.);
+    _S->prodScalar(2.);
+  }
+
   // Ending S construction
 
   _S->prodNormDiagVecInPlace(_TildeC, -3);

--- a/src/Mesh/AMesh.cpp
+++ b/src/Mesh/AMesh.cpp
@@ -539,14 +539,15 @@ Id AMesh::getMeshAndInPlaceWeightsFromCoordinates(const VectorDouble& coords, Ve
   VectorDouble distances;
 
   /* Loop on the elligible meshes */
-  Id nb_neigh = 5;
+  Id nb_neigh = MIN(5, getNMeshes());;
   (void)ball.queryOneInPlace(coords, nb_neigh, neighs, distances);
   Id found = _findBarycenter(coords, units, nb_neigh, neighs, weights);
 
   // If search has failed with a small number of neighbors, try with a larger one
   if (found < 0)
   {
-    nb_neigh = 50;
+    nb_neigh = MIN(50, getNMeshes());
+
     (void)ball.queryOneInPlace(coords, nb_neigh, neighs, distances);
     found = _findBarycenter(coords, units, nb_neigh, neighs, weights);
   }

--- a/src/all_sources.cmake
+++ b/src/all_sources.cmake
@@ -106,6 +106,7 @@ set(SRC
   Covariances/CovProportional.cpp
   Covariances/ANoStat.cpp
   Covariances/NoStatArray.cpp
+  Covariances/NoStatOnMesh.cpp
   Covariances/NoStatFunctional.cpp
   Covariances/CovGradientGeneric.cpp
   Covariances/CovGradientAnalytic.cpp

--- a/swig/swig_exp.i
+++ b/swig/swig_exp.i
@@ -260,6 +260,7 @@
 %include Covariances/TabNoStatSills.hpp
 %include Covariances/ANoStat.hpp
 %include Covariances/NoStatArray.hpp
+%include Covariances/NoStatOnMesh.hpp
 %include Covariances/NoStatFunctional.hpp
 %include Covariances/ACov.hpp
 %include Covariances/CovBase.hpp

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -217,6 +217,7 @@
   #include "Covariances/TabNoStatSills.hpp"
   #include "Covariances/ANoStat.hpp"
   #include "Covariances/NoStatArray.hpp"
+  #include "Covariances/NoStatOnMesh.hpp"
   #include "Covariances/NoStatFunctional.hpp"
   #include "Covariances/ACov.hpp"
   #include "Covariances/CovBase.hpp"


### PR DESCRIPTION
+ Add a workaround for SPDE to work in 1D
+ Add a flag to ACov/CovAniso to inform local anistropies directly on meshes/vertices
+ Expose TildeC vector

--
+ Fix in getMeshAndInPlaceWeightsFromCoordinates(), for Ball Tree search, when the number of meshes is lower than the number of defined neighbors