### PR TITLE
Add explanation when no internet is detected

### DIFF
--- a/r/modules/document.R
+++ b/r/modules/document.R
@@ -114,7 +114,7 @@ locateFile <- function (filename, where='references', directory=NULL, verbose=FA
   # Test on the web
   if (!internetAvailable())
   {
-    print(paste("Error: Cannot access to", filename, "(no Internet)!"))
+    print(paste("Error: Cannot access to", filename, "(no Internet - 'lares' package is required)!"))
     return(NULL)
   }
   


### PR DESCRIPTION
Executing loadData function (either in R or python) could fail if:
- the requested data file is not located in sub-directories (add verbose=True) - AND -
- an Internet connection is not detected (all tutorial data files are located on our website gstlearn.org)

To test if an Internet connection is available, we use:
- 'requests' package in Python
- 'lares' package in R

When loadData fails, the "No Internet" error message is now completed by a sentence about those required packages.