### PR TITLE
Target Python Stable ABI to produce wheels compatible with more Python versions

### DIFF
--- a/.github/actions/compress_and_upload_nonreg_artifacts/action.yml
+++ b/.github/actions/compress_and_upload_nonreg_artifacts/action.yml
@@ -23,13 +23,13 @@ runs:
         mv ${{ inputs.os-name }}-neutral.tar.gz $GITHUB_WORKSPACE/
 
     - name: Publish output logs as artefact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.os-name }}-nonreg-logs
         path: ${{ inputs.build-dir }}/tests/${{ inputs.os-name }}-logs.tar.gz
 
     - name: Publish output neutral files as artefact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.os-name }}-neutral-files
         path: ${{ github.workspace }}/${{ inputs.os-name }}-neutral.tar.gz

--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Publish output logs as artefact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: demos-courses-python-logs
         path: ${{env.BUILD_DIR}}/tests/demos-courses-python-logs.tar.gz

--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Publish output logs as artefact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: demos-courses-r-logs
         path: ${{env.BUILD_DIR}}/tests/demos-courses-r-logs.tar.gz

--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -94,4 +94,3 @@ jobs:
       uses: ./.github/actions/compress_and_upload_nonreg_artifacts
       with:
         os-name: macos
-

--- a/.github/workflows/publish_courses.yml
+++ b/.github/workflows/publish_courses.yml
@@ -110,7 +110,7 @@ jobs:
         echo "COURSES_FOLDER=${{env.BUILD_DIR}}/courses" >> "$GITHUB_ENV"
         echo "PROJECT_FULL_VERSION=${PROJECT_FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         # This will become the folder name in the server
         name: courses

--- a/.github/workflows/publish_data.yml
+++ b/.github/workflows/publish_data.yml
@@ -42,7 +42,7 @@ jobs:
         PROJECT_FULL_VERSION=$(cmake --build ${{env.BUILD_DIR}} --target print_version | grep PROJECT_FULL_VERSION | cut -d "=" -f2 | xargs)
         echo "PROJECT_FULL_VERSION=${PROJECT_FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         # This will become the folder name in the server
         name: data

--- a/.github/workflows/publish_demos.yml
+++ b/.github/workflows/publish_demos.yml
@@ -110,7 +110,7 @@ jobs:
         echo "DEMO_FOLDER=${{env.BUILD_DIR}}/demo" >> "$GITHUB_ENV"
         echo "PROJECT_FULL_VERSION=${PROJECT_FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         # This will become the folder name in the server
         name: demos

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -59,12 +59,12 @@ jobs:
         python3 -m grip r/README.md --export r/R_README.html
         echo "R_README_FILE=$(ls r/R_README.html)" >> "$GITHUB_ENV"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: bib-file-${{env.PROJECT_VERSION}}
         path: ${{env.BIB_FILE}}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: r-readme-${{env.PROJECT_VERSION}}
         path: ${{env.R_README_FILE}}

--- a/.github/workflows/publish_doxygen.yml
+++ b/.github/workflows/publish_doxygen.yml
@@ -63,7 +63,7 @@ jobs:
         echo "HTML_FOLDER=${{env.BUILD_DIR}}/doxygen/html" >> "$GITHUB_ENV"
         echo "PROJECT_FULL_VERSION=${PROJECT_FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         # This will become the folder name in the server
         name: doxygen

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -133,7 +133,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: macos-python-package-${{matrix.arch.os}}
 

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -105,7 +105,7 @@ jobs:
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.CMAKE_BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all versions
       with:
         name: macos-python-package-${{matrix.arch.os}}

--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -35,10 +35,6 @@ jobs:
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
             {py: "3.10"},
-            {py: "3.11"},
-            {py: "3.12"},
-            {py: "3.13"},
-            {py: "3.14"}
           ]
         # Only one arm64 and one x86_64 Mac OS version are needed
         arch: [
@@ -98,6 +94,8 @@ jobs:
         install_name_tool -change ${{matrix.arch.pat}}/opt/llvm/lib/libomp.dylib @loader_path/libomp.dylib gstlearn/_gstlearn.so
         # Note: wheel must be declared not pure (see setup.py)
         uv build --wheel
+        uvx wheel tags --python-tag=cp310 --abi-tag=abi3 dist/*.whl
+        rm dist/*cp310-cp310*.whl
         if [ "${{matrix.arch.os}}" == "macos-15-intel" ] && [ $(ls dist/*universal2.whl | wc -l) -gt 0 ]; then
           # Fix wheel platform tag for x86_64 macOS
           WHEEL_FILE=$(ls dist/*universal2.whl)
@@ -110,7 +108,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       # Use specific artifact identifier for publishing all versions
       with:
-        name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
+        name: macos-python-package-${{matrix.arch.os}}
         path: ${{env.MY_PKG}}
 
   test:
@@ -137,7 +135,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: macos-python-package-${{matrix.arch.os}}-${{matrix.python.py}}
+        name: macos-python-package-${{matrix.arch.os}}
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v6
@@ -171,5 +169,4 @@ jobs:
     # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
-        name: macos-python-package-*
-
+        name: macos-python-package

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -36,12 +36,7 @@ jobs:
         # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            "cp39-cp39",
             "cp310-cp310",
-            "cp311-cp311",
-            "cp312-cp312",
-            "cp313-cp313",
-            "cp314-cp314"
           ]
         image: [
            manylinux_2_28_x86_64
@@ -114,14 +109,16 @@ jobs:
       run : |
         cd ${{ env.BUILD_DIR }}/python/${{ env.CMAKE_BUILD_TYPE }}
         # Note: wheel must be declared not pure (see setup.py)
-        uv build --wheel -C="--build-option=--plat-name=${{ matrix.image }}"
+        uv build --wheel
+        uvx wheel tags --python-tag=cp310 --abi-tag=abi3 --platform-tag=${{ matrix.image }} dist/*.whl
+        rm dist/*${{ matrix.python }}*.whl
         cd ../../..
         echo "MY_PKG=$(ls ${{ env.BUILD_DIR }}/python/${{ env.CMAKE_BUILD_TYPE }}/dist/*)" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v4
       # Use specific artifact identifier for publishing all versions
       with:
-        name: linux-python-package-${{ matrix.image }}-${{ matrix.python }}
+        name: linux-python-package-${{ matrix.image }}
         path: ${{env.MY_PKG}}
 
   test:
@@ -134,7 +131,6 @@ jobs:
         # Python version
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
-            "cp39-cp39",
             "cp310-cp310",
             "cp311-cp311",
             "cp312-cp312",
@@ -150,7 +146,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: linux-python-package-${{ matrix.image }}-${{ matrix.python }}
+        name: linux-python-package-${{ matrix.image }}
 
     - name: Register the python version
       run: |
@@ -188,5 +184,4 @@ jobs:
     # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
-        name: linux-python-package-*
-
+        name: linux-python-package

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -115,7 +115,7 @@ jobs:
         cd ../../..
         echo "MY_PKG=$(ls ${{ env.BUILD_DIR }}/python/${{ env.CMAKE_BUILD_TYPE }}/dist/*)" >> "$GITHUB_ENV"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all versions
       with:
         name: linux-python-package-${{ matrix.image }}

--- a/.github/workflows/publish_python_manylinux.yml
+++ b/.github/workflows/publish_python_manylinux.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: linux-python-package-${{ matrix.image }}
 

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: windows-python-package-${{matrix.arch.ar}}
 

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -42,17 +42,16 @@ jobs:
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},
-            {pl: win32,     ar: x86, of: Win32} # TODO : Win32 to be removed ?
           ]
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Python Version
-      uses: actions/setup-python@v5
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v6
       with:
-        python-version: ${{matrix.python.py}}
-        architecture: ${{matrix.arch.ar}}
+        python-version: ${{ matrix.python.py }}
+        activate-environment: true
 
     - name: Install dependencies
       run: |
@@ -65,14 +64,8 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: ${{ matrix.arch.ar }}-windows
 
     - name: Install Python dependencies
-      # Force specific old version for Numpy
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy
-        python -m pip install build
-        python -m pip install wheel
-        python -m pip install twine
-        python -m pip install uv
+        uv pip install numpy
 
     - name: Install Doxygen under windows
       uses: fabien-ors/install-doxygen-windows-action@v1
@@ -110,8 +103,8 @@ jobs:
       run : |
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python -m build --wheel
-        python -m wheel tags --python-tag=cp310 --abi-tag=abi3 --platform-tag=${{ matrix.arch.pl }} "$(ls dist\*.whl)"
+        uv build --wheel
+        uvx wheel tags --python-tag=cp310 --abi-tag=abi3 --platform-tag=${{ matrix.arch.pl }} "$(ls dist\*.whl)"
         rm dist\*cp310-cp310*.whl
         cd ..\..\..
         $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*.whl" -File
@@ -138,7 +131,6 @@ jobs:
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},
-            # GitHub's VM don't run on x86
           ]
 
     steps:

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -39,10 +39,6 @@ jobs:
         python: [
           # Double quote for version is needed otherwise 3.10 => 3.1
             {py: "3.10"},
-            {py: "3.11"},
-            {py: "3.12"},
-            {py: "3.13"},
-            {py: "3.14"}
           ]
         arch: [
             {pl: win_amd64, ar: x64, of: x64},
@@ -74,6 +70,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install numpy
         python -m pip install build
+        python -m pip install wheel
         python -m pip install twine
         python -m pip install uv
 
@@ -113,15 +110,17 @@ jobs:
       run : |
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python -m build --wheel -C="--build-option=--plat-name=${{matrix.arch.pl}}"
+        python -m build --wheel
+        python -m wheel tags --python-tag=cp310 --abi-tag=abi3 --platform-tag=${{ matrix.arch.pl }} "$(ls dist\*.whl)"
+        rm dist\*cp310-cp310*.whl
         cd ..\..\..
-        $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*" -File
+        $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*.whl" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
     - uses: actions/upload-artifact@v4
       # Use specific artifact identifier for publishing all versions
       with:
-        name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
+        name: windows-python-package-${{matrix.arch.ar}}
         path: ${{env.MY_PKG}}
 
   test:
@@ -147,7 +146,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: windows-python-package-${{matrix.arch.ar}}-${{matrix.python.py}}
+        name: windows-python-package-${{matrix.arch.ar}}
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v6
@@ -181,5 +180,4 @@ jobs:
     # Delete the artifacts (for freeing storage space under github)
     - uses: geekyeggo/delete-artifact@v5
       with:
-        name: windows-python-package-*
-
+        name: windows-python-package

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -110,7 +110,7 @@ jobs:
         $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*.whl" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all versions
       with:
         name: windows-python-package-${{matrix.arch.ar}}

--- a/.github/workflows/publish_r_linux.yml
+++ b/.github/workflows/publish_r_linux.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: linux-r-package
 

--- a/.github/workflows/publish_r_linux.yml
+++ b/.github/workflows/publish_r_linux.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         cat ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/create_doc.out
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: linux-r-package
         path: ${{env.MY_PKG}}

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}
 

--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -115,7 +115,7 @@ jobs:
       run: |
         cat ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/create_doc.out
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all versions
       with:
         name: macos-r-package-${{matrix.arch.os}}-${{matrix.r_version}}

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -125,7 +125,7 @@ jobs:
       run: |
         cat ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/create_doc.out
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all R versions
       with:
         name: windows-r-package-${{matrix.r_version}}

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -142,7 +142,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         name: windows-r-package-${{matrix.r_version}}
 

--- a/.github/workflows/publish_references.yml
+++ b/.github/workflows/publish_references.yml
@@ -42,7 +42,7 @@ jobs:
         PROJECT_FULL_VERSION=$(cmake --build ${{env.BUILD_DIR}} --target print_version | grep PROJECT_FULL_VERSION | cut -d "=" -f2 | xargs)
         echo "PROJECT_FULL_VERSION=${PROJECT_FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         # This will become the folder name in the server
         name: references

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,7 +11,7 @@ set(PYTHON_PACKAGE_NAME ${PROJECT_NAME})
 
 # Look for Python3
 #set(CMAKE_FIND_DEBUG_MODE TRUE)
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module NumPy)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.SABIModule NumPy)
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
   Python3_NumPy_VERSION_MATCH ${Python3_NumPy_VERSION})
 set(Python3_NumPy_VERSION_MAJOR ${CMAKE_MATCH_1})
@@ -169,7 +169,7 @@ if (MSVC OR APPLE)
   # Link to python's libraries (needed for MSVC and MacOS)
   # Prefer using Python3::Module (which works for MacOS) in place of ${Python3_LIBRARIES}
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17664
-  target_link_libraries(python_build PRIVATE Python3::Module)
+  target_link_libraries(python_build PRIVATE Python3::SABIModule)
 endif()
 
 if (CLANG)

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -8,6 +8,12 @@
 /* License: BSD 3-clause                                                      */
 /*                                                                            */
 /******************************************************************************/
+
+%begin %{
+// use the Python Stable ABI to target several Python versions at once
+#define Py_LIMITED_API 0x030A0000 // Python 3.10 and up
+%}
+
 // Keep sync with PYTHON_PACKAGE_NAME in CMakeLists.txt
 %module(directors="1") gstlearn // TODO : configure this using CMake configure_file
 
@@ -414,7 +420,7 @@
     // Reading the storage format
     PyObject* format_obj = PyObject_GetAttrString(obj, "format");
     if (!format_obj) return SWIG_TypeError; 
-    const char* format_str = PyUnicode_AsUTF8(format_obj);
+    const char* format_str = PyUnicode_AsUTF8AndSize(format_obj, nullptr);
     if (!format_str) return SWIG_TypeError;
 
     // Recover 'data' information
@@ -813,7 +819,7 @@ namespace gstlrn
 
   PyObject *col;
   while ((col = PyIter_Next(iter))) {
-      const char *colname = PyUnicode_AsUTF8(col);
+      const char *colname = PyUnicode_AsUTF8AndSize(col, nullptr);
       PyObject *series = PyObject_GetItem($input, col);
       PyObject *values = PyObject_GetAttrString(series, "values");
 

--- a/tools/scripts/toString.py
+++ b/tools/scripts/toString.py
@@ -130,6 +130,7 @@ if __name__ == "__main__":
     with open(output_txt_file, "w", encoding="utf-8") as file:
         excluded = [
             "AStringable",
+            "ATransformWithAutoDiff",
             "PrecisionOpMulti",
             "PrecisionOpMultiMatrix",
             "MatrixSparse",


### PR DESCRIPTION
This PR uses the Python Limited API / Stable ABI (https://docs.python.org/3/c-api/stable.html#stable-application-binary-interface) to generate Python packages compatible with several Python versions at once.

Only one CPython function explicitly called in SWIG typemaps has been changed to its corresponding function in the Python Limited API: `PyUnicode_AsUTF8` became `PyUnicode_AsUTF8AndSize`, which is compatible with Python 3.10 and onwards.

The `publish_python` workflows have been updated to produce only one wheel per platform. This wheel should be compatible with Python 3.10 and more recent versions. Wheel tags have been updated. Test jobs still use several Python versions since they are a lot faster.

~~The same has been done for R packages. Since building them on older R versions seem to work on latest R, the number of building jobs has been reduced to only one R, the `4.2.3`.~~

Corresponding publish workflow: https://github.com/pierre-guillou/gstlearn/actions/runs/22306793706

In addition,

- `actions/upload-artifact` has been upgraded from `v4` to `v6`
- `actions/download-artifact` has been upgraded from `v4` to `v7`
- building the Matrix R dependency is not needed anymore (maybe related to https://github.com/gstlearn/gstlearn/commit/35f18576d05b19a242e196fc1ad06e8cf4fbcfe7)
- `uv` is used in the `publish_python_windows` job
- the `x86` Windows platform for Python has been removed.

Overall, this should reduce a lot the time spend in the `publish` workflow, since we are now under the 5 jobs limitation for the macOS jobs (at least for the `build` jobs).

Pierre