### PR TITLE
Stick to scikit.sparse 0.4.16

### DIFF
--- a/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_python_ubuntu-latest.yml
@@ -60,7 +60,7 @@ jobs:
         uv pip install pandas
         uv pip install scipy
         uv pip install dash
-        uv pip install scikit-sparse
+        uv pip install scikit-sparse==0.4.16
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
The 0.5.0 version of scikit.sparse brings a new behavior for sparse matrix inversion.
Tuto_SPDE.ipynb and Tuto_SpatioTemp.ipynb were failing.
While waiting a diagnosis and a fix, we stick to the previous version.