### PR TITLE
Avoid `omp_set_num_threads`

### DIFF
--- a/include/Matrix/AMatrix.hpp
+++ b/include/Matrix/AMatrix.hpp
@@ -309,9 +309,6 @@ private:
 };
 
 /* Shortcut functions for C style aficionados */
-GSTLEARN_EXPORT I32 getMultiThread();
-GSTLEARN_EXPORT void setMultiThread(I32 nthreads);
-GSTLEARN_EXPORT bool isMultiThread();
 GSTLEARN_EXPORT bool getFlagMatrixCheck();
 GSTLEARN_EXPORT void setFlagMatrixCheck(bool flag);
 } // namespace gstlrn

--- a/src/Estimation/CalcKrigingSimpleCase.cpp
+++ b/src/Estimation/CalcKrigingSimpleCase.cpp
@@ -145,7 +145,6 @@ bool CalcKrigingSimpleCase::_run()
   bool use_parallel = !getModelGeneric()->isNoStat();
   Id nech_out       = getDbout()->getNSample();
   auto nbthread     = static_cast<I32>(OptCustom::query("ompthreads", 1)); // TODO : would like to use more threads
-  omp_set_num_threads(nbthread);
 
   SpacePoint pin(getModelGeneric()->getSpace());
   SpacePoint pout(getModelGeneric()->getSpace());
@@ -157,7 +156,7 @@ bool CalcKrigingSimpleCase::_run()
   const double* selcol = getDbout()->getColumnPtr(ELoc::SEL, 0);
   bool hassel = getDbout()->hasLocator(ELoc::SEL);
 #pragma omp threadprivate(neigh)
-#pragma omp parallel for firstprivate(pin, pout, tabwork, algebra, model) schedule(guided) if (use_parallel)
+#pragma omp parallel for firstprivate(pin, pout, tabwork, algebra, model) schedule(guided) num_threads(nbthread) if (use_parallel)
   for (Id iech_out = 0; iech_out < nech_out; iech_out++)
   {
     if (hassel && !selcol[iech_out]) continue; // Skip non-selected targets
@@ -181,7 +180,7 @@ bool CalcKrigingSimpleCase::_run()
     if (_iechSingleTarget >= 0) _storeResultsForExport(ksys, algebra, iech_out);
   }
 
-#pragma omp parallel
+#pragma omp parallel num_threads(nbthread) if (use_parallel)
   {
     delete neigh;
     neigh = nullptr;

--- a/src/LinearOp/MultiGridSPDE.cpp
+++ b/src/LinearOp/MultiGridSPDE.cpp
@@ -114,7 +114,6 @@ ProjMatrix MultiGridSPDE::buildProlongator(const DbGrid* dbfine, const DbGrid* d
 
   NF_Triplet triplet;
   std::vector<NF_Triplet> privateTriplets(nbthread);
-  omp_set_num_threads(nbthread);
 
   mesh_c.buildAdjacencyMatrix();
   _cova->optimizationPreProcessForData(dbcoarse);
@@ -125,7 +124,7 @@ ProjMatrix MultiGridSPDE::buildProlongator(const DbGrid* dbfine, const DbGrid* d
   VectorDouble lambdas;
   VectorInt all_parents;
 #pragma omp threadprivate(rkh)
-#pragma omp parallel for firstprivate(indices_p1, lambdas, all_parents, ones, pin, pout, tabwork, cova, C, c0, weights, s1) schedule(guided)
+#pragma omp parallel for firstprivate(indices_p1, lambdas, all_parents, ones, pin, pout, tabwork, cova, C, c0, weights, s1) schedule(guided) num_threads(nbthread)
   for (Id i = 0; i < dbfine->getNSample(); i++)
   {
     indices_p1.clear();
@@ -198,7 +197,7 @@ ProjMatrix MultiGridSPDE::buildProlongator(const DbGrid* dbfine, const DbGrid* d
         privateTriplets[tid].add(i, all_parents[j], weights[j]);
   }
 
-#pragma omp parallel
+#pragma omp parallel num_threads(nbthread)
   {
 
     delete rkh;

--- a/src/Matrix/AMatrix.cpp
+++ b/src/Matrix/AMatrix.cpp
@@ -24,7 +24,6 @@
 namespace gstlrn
 {
 
-static I32 _globalMultiThread = 0;
 static bool _flagMatrixCheck  = false;
 
 AMatrix::AMatrix(Id nrow, Id ncol)
@@ -1308,21 +1307,6 @@ void AMatrix::linearCombination(double val1,
       if (mat3 != nullptr) value += val3 * mat3->getValue(irow, icol);
       setValue(irow, icol, value);
     }
-}
-
-void setMultiThread(I32 nthreads)
-{
-  if (nthreads > 0) _globalMultiThread = nthreads;
-}
-
-I32 getMultiThread()
-{
-  return _globalMultiThread;
-}
-
-bool isMultiThread()
-{
-  return _globalMultiThread > 0;
 }
 
 void setFlagMatrixCheck(bool flagMatrixCheck)

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -12,6 +12,7 @@
 #include "Basic/AException.hpp"
 #include "Basic/AStringable.hpp"
 #include "Basic/Law.hpp"
+#include "Basic/OptCustom.hpp"
 #include "Basic/Utilities.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Basic/WarningMacro.hpp"
@@ -928,7 +929,8 @@ void MatrixSparse::_allocate()
     {
       eigenMat().reserve(Eigen::VectorXi::Constant(getNCols(), static_cast<I32>(_nColMax)));
     }
-    if (isMultiThread()) omp_set_num_threads(getMultiThread());
+    const auto nbthread = static_cast<I32>(OptCustom::query("ompthreads", 1));
+    Eigen::setNbThreads(nbthread);
   }
 }
 

--- a/tests/cpp/test_Matrix.cpp
+++ b/tests/cpp/test_Matrix.cpp
@@ -12,6 +12,7 @@
 #include "Basic/Law.hpp"
 #include "Basic/Message.hpp"
 #include "Basic/OptCst.hpp"
+#include "Basic/OptCustom.hpp"
 #include "Basic/VectorHelper.hpp"
 #include "Enum/ECst.hpp"
 #include "LinearOp/CholeskyDense.hpp"
@@ -66,7 +67,7 @@ int main(int argc, char* argv[])
   std::stringstream sfn;
   sfn << gslBaseName(__FILE__) << ".out";
   StdoutRedirect sr(sfn.str(), argc, argv);
-  setMultiThread(8);
+  OptCustom::define("ompthreads", 8);
 
   OptCst::define(ECst::NTCOL, -1);
   OptCst::define(ECst::NTROW, -1);


### PR DESCRIPTION
This PR removes the calls to `omp_set_num_threads`, which have a persistent effect, to use instead the `num_threads` clause of the `#pragma omp parallel` directive.

The most complex case is in `MatrixSparse.cpp`. Here, the `omp_set_num_threads` has been replaced with `Eigen::setNbThreads` (which I assume was the original intention). A few `MultiThreaded` free functions in `AMatrix` have been consequently removed (I think the correct way now is to use `OptCustom`).

Fix #881.

Pierre