### PR TITLE
New format rules and pre commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,52 +1,66 @@
----
-# This requires a version of clang-format above 19
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
+# This requires a version of clang-format above 21
+AlignAfterOpenBracket: true
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
 AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: AcrossComments
+AlignConsecutiveMacros: None
 AlignEscapedNewlines: Right
-AlignTrailingComments: true
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: false
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
-#AlwaysBreakAfterReturnType: None
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakTemplateDeclarations: 'Yes'
-AlignOperands: AlignAfterOperator
-BinPackArguments: true
+BinPackArguments: false
 BinPackParameters: false
+BitFieldColonSpacing: After
 BraceWrapping:
   AfterControlStatement: Always
-BreakBeforeBinaryOperators: None
-BreakAfterReturnType: None
+BreakAfterReturnType: Automatic
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Allman
 BreakConstructorInitializers: BeforeComma
+BreakTemplateDeclarations: 'Yes'
+ColumnLimit: 80
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
-ColumnLimit: 0 # To prevent automatic line breaking
 DerivePointerAlignment: false
 EmptyLineBeforeAccessModifier: Always
+EnumTrailingComma: Remove
+FixNamespaceComments: true
+IncludeBlocks: Preserve
 IndentCaseLabels: true
+IndentPPDirectives: None
 IndentWidth: 2
-IndentPPDirectives: AfterHash
-NamespaceIndentation: None
-PackConstructorInitializers: Never
-PenaltyReturnTypeOnItsOwnLine: 10  # Strongly discourages breaking return type
-PenaltyBreakBeforeFirstCallParameter: 100  # Keeps function name & first parameter together
+IndentWrappedFunctionNames: true
+LineEnding: LF
+NamespaceIndentation: All
 PPIndentWidth: 2
+PackConstructorInitializers: Never
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyReturnTypeOnItsOwnLine: 10
 PointerAlignment: Left
+QualifierAlignment: Left
 ReferenceAlignment: Left
-ReflowComments: true
-SortIncludes: true
+ReflowComments: IndentOnly
+RemoveEmptyLinesInUnwrappedLines: true
+RemoveParentheses: MultipleParentheses
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 0
+SortIncludes:
+  Enabled: true
+SortUsingDeclarations: Lexicographic
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: true
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeInheritanceColon: false
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SpaceBeforeRangeBasedForLoopColon: false
@@ -59,5 +73,5 @@ SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
 SpacesInSquareBrackets: false
+Standard: c++20
 UseTab: Never
-...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-added-large-files
+  - repo: 'https://github.com/astral-sh/ruff-pre-commit'
+    rev: 'v0.15.2'
+    hooks:
+      # Run the formatter.
+      - id: ruff-format
+  - repo: 'https://github.com/pre-commit/mirrors-clang-format'
+    rev: 'v22.1.1'
+    hooks:
+      - id: clang-format
+exclude: |
+    (?x)^(
+        doc/data|
+        doc/licenses|
+        .*\.ref$|
+        .*\.dat$|
+        .*\.out$|
+        .*\.asciidoc$
+    )

--- a/include/API/Style.hpp
+++ b/include/API/Style.hpp
@@ -16,188 +16,196 @@
 
 namespace gstlrn
 {
-/**
- * \brief
- * The Style class contains all the recommended styles considerations.
- * It has no special functionalities.<br/>
- * This is only a template class that developers can mimic.
- *
- * This class includes **coding rules** and **doxygen documentation** examples.
- *
- * Since doxygen 1.8.0, Markdown support is available in doxygen comments
- * ([see here](https://www.doxygen.nl/manual/markdown.html)).<br/>
- *
- * Look at *gstlearn* [READMEs](https://github.com/gstlearn/gstlearn)
- * for a quick overview of Markdown syntax.
- *
- * ## Main class features
- *
- * This class demonstrates:
- * - How to use doxygen for documenting the class:
- *    - this global class description
- *    - the private member attributes documentation
- *    - all methods and arguments documentation (at least public ones)
- * - Some mandatory coding rules (see below):
- *    - constructors
- *    - pro active usage of `const`
- *    - error handling with exceptions,
- *    - etc...
- * - How to use some *gstlearn* global features such has:
- *    - Enumerations (see AEnum) - TODO
- *    - `DECLARE_UNUSED` macro (need including geoslib_define.h)
- *    - ...to be expanded
- * - When functions should not be used anymore by developpers, use
- *   GSTLEARN_DEPRECATED in body of function definition (see Db::getNSampleActive())
- * - When functions are kept in order to be refactored later, put TODO FUTURE_REFACTOR as a comment
- * - Some coding constraints due to the [customized] SWIG for R version:
- *    - limit the use of function overriding
- *    - do not use namespace or static variables in default argument values
- *    - do not comment the argument name when it is unused (use
- *      `DECLARE_UNUSED`)
- *    - do not use following argument names: 'in', '_*'
- *    - always inherit from pure virtual classes in last position (ex:
- *      ICloneable)
- *
- * ## C++ naming convention
- *
- * Here are some rules about naming C++ types, functions, variables and symbols:
- * - Only usual abbreviations are accepted (ie: min, max, idx, temp, ...)
- * - Constants (macro): all in capitals with underscore (MAX_LENGTH)
- * - Enums: idem
- * - Class or structure names: upper camel case (ie: SparseMatrix, Database)
- * - Aliases (typedef): idem
- * - Class' methods: lower camel case (ie: loadData, getArmonicMean, isEmpty)
- * - Class' attributes (variables): idem
- * - Anything which is 'private' or 'protected' in a class starts with underscore (ie: _myMember)
- * - Local variables: lower case separated by underscore (i.e.: temp_value,
- *   color_idx)
- * - Methods visibility;
- *     Method _func() is internal to the class (private or protected)
- *     Method func_() is not exported via SWIG (using ifndef SWIG)
- * - Use of "InPlace" suffix:
- *     It is used in methods that modify either a member of this class or a
- *     returned argument. Important remark. The member or agument must have been
- *     correctly dimensioned beforehand; no test will be performed (in order to
- *     speed up the processing).
- *
- * ## C++ coding rules
- *
- * Here are some coding rules (good practices) for C++ developers:
- * - Do not use `goto`
- * - Use `break` only in `switch` cases
- * - Limit the number of global variables
- * - Use `const` every where
- * - Do not use old C-style (use C++ STL)
- * - Do not use `using namespace`
- * - Make the includes list as small as possible in C++ header (use forward
- *   declaration)
- * - Expose only what is necessary (all is private by default)
- *
- * More good practices available
- *   [here](www.possibility.com/Cpp/CppCodingStandard.html)
- *
- * Important note: All C++ coding rules are configured in the .clang-format
- *                 file. located in the root folder. Developers can use the
- *                 "Clang format" VS code extension to benefit from the
- *                 automatic formating feature
- *
- * ## Class' constructors/destructors
- *
- * Here are some rules regarding constructors and destructors:
- * - Always add a default constructor (no arguments or arguments with default
- *   values)
- * - Always add a copy constructor (with some exceptions - see Calc* classes)
- * - Always add an assignment operator (with some exceptions - see Calc*
- *   classes)
- * - Always add a virtual destructor
- *
- * ## Documenting Methods
- *
- * Main principles for documenting class methods are the following:
- * - Add one-line comment before each public prototype in the C++ header
- * - Add a doxygen section above each method definition in the C++ body
- * - All this except for trivial methods\tooltip{getters, setters and inline
- *   functions}, constructors and destructors
- * - Define pointer for ENUM. Example to point to EMorpho Enum:  \link
- *   EMorpho.hpp EMorpho \endlink
- */
-class GSTLEARN_EXPORT Style
-{
-public:
-  Style();                          // No need for one-line documentation in the header
-  Style(const Style& r);            // idem
-  Style& operator=(const Style& r); // idem
-  virtual ~Style();                 // idem
-
-  // Example of a method with a standard documentation (do not use doxygen
-  // here - all the documentation is in the body file!)
-  static Id documentedStandard(Id myArg);
-  // Example of a method with a documentation having a Latex formula (do not use
-  // doxygen here!)
-  static Id documentedWithFormula(Id myArg);
-  // Example of a method where argument is not used (do not use doxygen here!)
-  static Id unusedArgument(Id a);
-
-  // Special static function (global) with a default argument (do not use
-  // doxygen here!)
-  static void myFunction(Id myArgInt, double myArgDoubleDef = 2.);
-
   /**
-   * \defgroup Getters Style: Defining the Style
+   * \brief
+   * The Style class contains all the recommended styles considerations.
+   * It has no special functionalities.<br/>
+   * This is only a template class that developers can mimic.
    *
-   **/
-
-  /** @addtogroup Getters_0 Accessors to private members value
-   * \ingroup Getters
+   * This class includes **coding rules** and **doxygen documentation** examples.
    *
-   * This is the demonstration that you can write a unique doxygen documentation
-   * for a group of functions. This is useful when all functions handle
-   * the same functionality and differ only by their name or arguments.
+   * Since doxygen 1.8.0, Markdown support is available in doxygen comments
+   * ([see here](https://www.doxygen.nl/manual/markdown.html)).<br/>
    *
-   * This is also a way to isolate the documentation for trivial functions and
-   * make the doxygen page of the class shorter.
-   *  @{
+   * Look at *gstlearn* [READMEs](https://github.com/gstlearn/gstlearn)
+   * for a quick overview of Markdown syntax.
+   *
+   * ## Main class features
+   *
+   * This class demonstrates:
+   * - How to use doxygen for documenting the class:
+   *    - this global class description
+   *    - the private member attributes documentation
+   *    - all methods and arguments documentation (at least public ones)
+   * - Some mandatory coding rules (see below):
+   *    - constructors
+   *    - pro active usage of `const`
+   *    - error handling with exceptions,
+   *    - etc...
+   * - How to use some *gstlearn* global features such has:
+   *    - Enumerations (see AEnum) - TODO
+   *    - `DECLARE_UNUSED` macro (need including geoslib_define.h)
+   *    - ...to be expanded
+   * - When functions should not be used anymore by developpers, use
+   *   GSTLEARN_DEPRECATED in body of function definition (see Db::getNSampleActive())
+   * - When functions are kept in order to be refactored later, put TODO FUTURE_REFACTOR as a comment
+   * - Some coding constraints due to the [customized] SWIG for R version:
+   *    - limit the use of function overriding
+   *    - do not use namespace or static variables in default argument values
+   *    - do not comment the argument name when it is unused (use
+   *      `DECLARE_UNUSED`)
+   *    - do not use following argument names: 'in', '_*'
+   *    - always inherit from pure virtual classes in last position (ex:
+   *      ICloneable)
+   *
+   * ## C++ naming convention
+   *
+   * Here are some rules about naming C++ types, functions, variables and symbols:
+   * - Only usual abbreviations are accepted (ie: min, max, idx, temp, ...)
+   * - Constants (macro): all in capitals with underscore (MAX_LENGTH)
+   * - Enums: idem
+   * - Class or structure names: upper camel case (ie: SparseMatrix, Database)
+   * - Aliases (typedef): idem
+   * - Class' methods: lower camel case (ie: loadData, getArmonicMean, isEmpty)
+   * - Class' attributes (variables): idem
+   * - Anything which is 'private' or 'protected' in a class starts with underscore (ie: _myMember)
+   * - Local variables: lower case separated by underscore (i.e.: temp_value,
+   *   color_idx)
+   * - Methods visibility;
+   *     Method _func() is internal to the class (private or protected)
+   *     Method func_() is not exported via SWIG (using ifndef SWIG)
+   * - Use of "InPlace" suffix:
+   *     It is used in methods that modify either a member of this class or a
+   *     returned argument. Important remark. The member or agument must have been
+   *     correctly dimensioned beforehand; no test will be performed (in order to
+   *     speed up the processing).
+   *
+   * ## C++ coding rules
+   *
+   * Here are some coding rules (good practices) for C++ developers:
+   * - Do not use `goto`
+   * - Use `break` only in `switch` cases
+   * - Limit the number of global variables
+   * - Use `const` every where
+   * - Do not use old C-style (use C++ STL)
+   * - Do not use `using namespace`
+   * - Make the includes list as small as possible in C++ header (use forward
+   *   declaration)
+   * - Expose only what is necessary (all is private by default)
+   *
+   * More good practices available
+   *   [here](www.possibility.com/Cpp/CppCodingStandard.html)
+   *
+   * Important note: All C++ coding rules are configured in the .clang-format
+   *                 file. located in the root folder. Developers can use the
+   *                 "Clang format" VS code extension to benefit from the
+   *                 automatic formating feature
+   *
+   * ## Class' constructors/destructors
+   *
+   * Here are some rules regarding constructors and destructors:
+   * - Always add a default constructor (no arguments or arguments with default
+   *   values)
+   * - Always add a copy constructor (with some exceptions - see Calc* classes)
+   * - Always add an assignment operator (with some exceptions - see Calc*
+   *   classes)
+   * - Always add a virtual destructor
+   *
+   * ## Documenting Methods
+   *
+   * Main principles for documenting class methods are the following:
+   * - Add one-line comment before each public prototype in the C++ header
+   * - Add a doxygen section above each method definition in the C++ body
+   * - All this except for trivial methods\tooltip{getters, setters and inline
+   *   functions}, constructors and destructors
+   * - Define pointer for ENUM. Example to point to EMorpho Enum:  \link
+   *   EMorpho.hpp EMorpho \endlink
    */
-  inline double getArgDouble() const { return _argDouble; }
-  inline Id getArgInt() const { return _argInt; }
-  inline const VectorDouble& getArgVectorDouble() const
+  class GSTLEARN_EXPORT Style
   {
-    return _argVectorDouble;
-  }
-  inline const VectorInt& getArgVectorInt() const { return _argVectorInt; }
-  /**@}*/
+  public:
+    Style(); // No need for one-line documentation in the header
+    Style(const Style& r); // idem
+    Style& operator=(const Style& r); // idem
+    virtual ~Style(); // idem
 
-  /** @addtogroup Getters_1 Function that update private members value
-   * \ingroup Getters
-   *
-   * Usually, a class should not have these kind of simple accessors (setters).
-   * Otherwise, defining member attributes as *private* makes no sense.
-   *
-   * Mutators\tooltip{non `const` methods that change the state of a class} are
-   * usually non trivial and must be defined in the C++ body files.
-   * @{
-   */
-  inline void setArgDouble(double argDouble) { _argDouble = argDouble; }
-  inline void setArgInt(Id argInt) { _argInt = argInt; }
-  inline void setArgVectorDouble(const VectorDouble& argVectorDouble)
-  {
-    _argVectorDouble = argVectorDouble;
-  }
-  inline void setArgVectorInt(const VectorInt& argVectorInt)
-  {
-    _argVectorInt = argVectorInt;
-  }
-  /**@}*/
+    // Example of a method with a standard documentation (do not use doxygen
+    // here - all the documentation is in the body file!)
+    static Id documentedStandard(Id myArg);
+    // Example of a method with a documentation having a Latex formula (do not use
+    // doxygen here!)
+    static Id documentedWithFormula(Id myArg);
+    // Example of a method where argument is not used (do not use doxygen here!)
+    static Id unusedArgument(Id a);
 
-private:
-  // Example of a private method
-  static Id _increment(Id arg, bool verbose = false);
+    // Special static function (global) with a default argument (do not use
+    // doxygen here!)
+    static void myFunction(Id myArgInt, double myArgDoubleDef = 2.);
 
-private:
-  // Use same line documentation for private members
-  Id _argInt;                   //!< Private attribute of type `Id`
-  double _argDouble;             //!< Private attribute of type `double`
-  VectorInt _argVectorInt;       //!< Private attribute of type `VectorInt`
-  VectorDouble _argVectorDouble; //!< Private attribute of type `VectorDouble`
-};
-}
+    /**
+     * \defgroup Getters Style: Defining the Style
+     *
+     **/
+
+    /** @addtogroup Getters_0 Accessors to private members value
+     * \ingroup Getters
+     *
+     * This is the demonstration that you can write a unique doxygen documentation
+     * for a group of functions. This is useful when all functions handle
+     * the same functionality and differ only by their name or arguments.
+     *
+     * This is also a way to isolate the documentation for trivial functions and
+     * make the doxygen page of the class shorter.
+     *  @{
+     */
+    inline double getArgDouble() const { return _argDouble; }
+
+    inline Id getArgInt() const { return _argInt; }
+
+    inline const VectorDouble& getArgVectorDouble() const
+    {
+      return _argVectorDouble;
+    }
+
+    inline const VectorInt& getArgVectorInt() const { return _argVectorInt; }
+
+    /**@}*/
+
+    /** @addtogroup Getters_1 Function that update private members value
+     * \ingroup Getters
+     *
+     * Usually, a class should not have these kind of simple accessors (setters).
+     * Otherwise, defining member attributes as *private* makes no sense.
+     *
+     * Mutators\tooltip{non `const` methods that change the state of a class} are
+     * usually non trivial and must be defined in the C++ body files.
+     * @{
+     */
+    inline void setArgDouble(double argDouble) { _argDouble = argDouble; }
+
+    inline void setArgInt(Id argInt) { _argInt = argInt; }
+
+    inline void setArgVectorDouble(const VectorDouble& argVectorDouble)
+    {
+      _argVectorDouble = argVectorDouble;
+    }
+
+    inline void setArgVectorInt(const VectorInt& argVectorInt)
+    {
+      _argVectorInt = argVectorInt;
+    }
+
+    /**@}*/
+
+  private:
+    // Example of a private method
+    static Id _increment(Id arg, bool verbose = false);
+
+  private:
+    // Use same line documentation for private members
+    Id _argInt; //!< Private attribute of type `Id`
+    double _argDouble; //!< Private attribute of type `double`
+    VectorInt _argVectorInt; //!< Private attribute of type `VectorInt`
+    VectorDouble _argVectorDouble; //!< Private attribute of type `VectorDouble`
+  };
+} // namespace gstlrn


### PR DESCRIPTION
This PR:
- updates the C++ code formatting rules (clang-format) according to our workshop on 2026 March 20th
- shows the result of applying these rules on Style.hpp file
- add a pre-commit configuration file which permits to perform locally some tasks automatically before each commit :
     - remove trailing whitespace
     - makes sure files end in a newline and only a newline
     - check yaml syntax (in github workflow and Rmd headers notably)
     - prevent from adding large files in the repo
     - format the python code with ruff => no more fail of the CI due to `ruff format --check` ^_^
     - format the C++ code with clang-format

**Install and configure pre-commit:**
To enable the pre-commit to be executed on your local computer, you must:
- In your _gstlearn_ 'uv' environnement, install pre-commit package:
     `uv pip install pre-commit`
- In a new terminal, in the root folder of the _gstlearn_ repo, configure the pre-commit:
     `pre-commit install`

In a close future:
- pre-commit rules will be checked in the CI (already the case for ruff format)
- the whole code will be reformated (to be done when DevOps have no local running modifications)