### PR TITLE
Suite matrix

### DIFF
--- a/include/Matrix/AMatrix.hpp
+++ b/include/Matrix/AMatrix.hpp
@@ -23,7 +23,68 @@ namespace gstlrn
 {
 class NF_Triplet;
 class EOperator;
+class MatrixSparse;
+class MatrixDense;
+class MatrixSquare;
+class MatrixSymmetric;
 
+template<class T>
+struct is_dense_matrix: std::false_type
+{
+};
+template<class T>
+struct is_sparse_matrix: std::false_type
+{
+};
+template<class T>
+struct is_square_matrix: std::false_type
+{
+};
+template<class T>
+struct is_symmetric_matrix: std::false_type
+{
+};
+
+// Spécialisations
+template<>
+struct is_dense_matrix<MatrixDense>: std::true_type
+{
+};
+template<>
+struct is_dense_matrix<MatrixSquare>: std::true_type
+{
+};
+template<>
+struct is_dense_matrix<MatrixSymmetric>: std::true_type
+{
+};
+template<>
+struct is_sparse_matrix<MatrixSparse>: std::true_type
+{
+};
+template<>
+struct is_square_matrix<MatrixSquare>: std::true_type
+{
+};
+template<>
+struct is_square_matrix<MatrixSymmetric>: std::true_type
+{
+};
+template<>
+struct is_symmetric_matrix<MatrixSymmetric>: std::true_type
+{
+};
+
+// Helper variables
+
+template<class T>
+inline constexpr bool is_dense_matrix_v = is_dense_matrix<T>::value;
+template<class T>
+inline constexpr bool is_sparse_matrix_v = is_sparse_matrix<T>::value;
+template<class T>
+inline constexpr bool is_square_v = is_square_matrix<T>::value;
+template<class T>
+inline constexpr bool is_symmetric_v = is_symmetric_matrix<T>::value;
 /**
  * This class is the root of the Matrix organization in gstlearn
  * A matrix is a 2-D organization: it is characterized by its number of rows
@@ -97,10 +158,41 @@ public:
   /*! Set all the values of the Matrix at once */
   virtual void fill(double value) = 0;
 
-  ////////////////////////
-  // Template functions //
-  ////////////////////////
-#ifndef SWIG
+  template<class MA, class MB, class MC>
+  static void prodMatMatInPlace(MA& A, const MB& B, const MC& C, bool transposeB = false, bool transposeC = false)
+  {
+    // Vérification générale : tous doivent être Dense ou Sparse
+    static_assert(
+      (is_dense_matrix_v<MA> || is_sparse_matrix_v<MA>) &&
+        (is_dense_matrix_v<MB> || is_sparse_matrix_v<MB>) &&
+        (is_dense_matrix_v<MC> || is_sparse_matrix_v<MC>),
+      "prodMatMatInPlace: All arguments must be Dense or Sparse matrices");
+
+    Id nrow;
+    Id ncol;
+
+    if (!_areCompatible(B.getNRows(), B.getNCols(), transposeB,
+                        C.getNRows(), C.getNCols(), transposeC,
+                        nrow, ncol))
+      return;
+
+    if (A.getNRows() != nrow || A.getNCols() != ncol)
+    {
+      A.resize(nrow, ncol);
+    }
+
+    if constexpr (is_sparse_matrix_v<MA>)
+    {
+      A._productGeneral(A, B, C, transposeB, transposeC);
+    }
+    else
+    {
+      static_assert(is_dense_matrix_v<MA> && is_dense_matrix_v<MB> && is_dense_matrix_v<MC>,
+                    "Dense product requires Dense-like matrices (MD/MSQ/MSYM)");
+      A._productGeneral(A, B, C, transposeB, transposeC);
+    }
+  }
+
   /**
    * @brief Return 'other' + 'cst'
    *
@@ -413,6 +505,35 @@ public:
   }
 
   /**
+   * @brief Operate: 'res' = 'res' * 'other1'
+   *
+   * @tparam T
+   * @param res Output matrix
+   * @param other2 First matrix
+   * @param transpose2 True if 'other2' must be transposed
+   */
+  template<typename T>
+  static void productInPlace(T& res,
+                             const T& other2,
+                             bool transpose2 = false)
+  {
+    static_assert(std::is_base_of_v<AMatrix, T>,
+                  "Invalid type for Matrix product (template method). "
+                  "Only MatrixDense and MatrixSparse are allowed");
+    Id nrow;
+    Id ncol;
+    if (!_areCompatible(res.getNRows(), res.getNCols(), false,
+                        other2.getNRows(), other2.getNCols(), transpose2,
+                        nrow, ncol)) return;
+
+    if (res.getNRows() != nrow || res.getNCols() != ncol)
+    {
+      res.resize(nrow, ncol);
+    }
+    res._productGeneral(res, res, other2, false, transpose2);
+  }
+
+  /**
    * @brief Return: 'other' * 'vec'
    *
    * @tparam T
@@ -716,7 +837,6 @@ public:
   virtual void resetFromVD(Id nrows, Id ncols, const VectorDouble& tab, bool byCol = true);
   virtual void resetFromVVD(const VectorVectorDouble& tab, bool byCol = true);
 
-#endif
   ////// End of templates
 
   /*! Transpose the matrix in place*/
@@ -743,8 +863,6 @@ public:
 
   /*! Perform x %*% 'this' %*% y */
   double prodVecMatVec(const VectorDouble& x, const VectorDouble& y) const;
-  /*! Perform 'this' = 'y' %*% 'this' or 'this' %*% 'y' */
-  void prodMat(const AMatrix* matY, bool transposeY = false);
 
   /*! Extract the contents of the matrix */
   virtual NF_Triplet getMatrixToTriplet(Id shiftRow = 0, Id shiftCol = 0) const;

--- a/include/Matrix/MatrixDense.hpp
+++ b/include/Matrix/MatrixDense.hpp
@@ -238,7 +238,6 @@ protected:
   double _getValueByRank(Id rank) const override;
   double& _getValueRef(Id irow, Id icol) override;
 
-
 private:
   void _recopy(const MatrixDense& r);
   bool _needToReset(Id nrows, Id ncols) override;

--- a/include/Matrix/MatrixFactory.hpp
+++ b/include/Matrix/MatrixFactory.hpp
@@ -33,7 +33,6 @@ public:
                        const AMatrix* y,
                        bool transposeX = false,
                        bool transposeY = false);
-  static MatrixSquare* createMatrixSquare(const MatrixSquare* x, Id nrow);
   static AMatrix* createReduce(const AMatrix* x,
                                const VectorInt& selRows = VectorInt(),
                                const VectorInt& selCols = VectorInt(),
@@ -64,7 +63,6 @@ public:
  ** \remarks: To be called as follows:
  **      MatrixSparse* mat = MatrixFactory::prodMatMat<MatrixSparse>(x, y);
  **
- ** TODO : Why 2 methods for MatrixFactory::prodMatMat ?
  *****************************************************************************/
 template<typename T>
 T* MatrixFactory::prodMatMat(const AMatrix* x,

--- a/include/Matrix/MatrixSparse.hpp
+++ b/include/Matrix/MatrixSparse.hpp
@@ -33,10 +33,7 @@ typedef Eigen::SparseMatrix<double, 0, gstlrn::Id> EigenSparseMatrix; // (always
 namespace gstlrn
 {
 class EOperator;
-} // namespace gstlrn
 
-namespace gstlrn
-{
 class MatrixDense;
 /**
  * Sparse Matrix
@@ -61,9 +58,6 @@ public:
 
   /// Cloneable interface
   IMPLEMENT_CLONING(MatrixSparse)
-
-  //// Interface to AStringable
-  String toString(const AStringFormat* strfmt = nullptr) const override;
 
   /// Interface for ALinearOp
 

--- a/src/API/Potential.cpp
+++ b/src/API/Potential.cpp
@@ -1379,8 +1379,7 @@ Id Potential::_extdriftEstablish(DbGrid* dbout)
   if (a.invert()) return 1;
 
   MatrixDense b = _extdriftBuildRHS();
-
-  a.prodMatMatInPlace(&b, &_wgtExt);
+  AMatrix::prodMatMatInPlace(a, b, _wgtExt);
 
   return 0;
 }
@@ -2603,7 +2602,7 @@ Id Potential::simulate(DbGrid* dbout,
 
   // Establish the simulated error vector and get the dual form
   _fillDualSimulation(nbsimu, zvals);
-  lhs.prodMatMatInPlace(&zvals, &zduals);
+  AMatrix::prodMatMatInPlace(lhs, zvals, zduals);
   if (OptDbg::isReferenceDefined() || OptDbg::query(EDbg::KRIGING))
     printMatrix(zduals.getValues(), nbsimu, _nequa, "\n[Simu-Err] *%* [A]-1", 0, 1);
 

--- a/src/Anamorphosis/AnamDiscreteDD.cpp
+++ b/src/Anamorphosis/AnamDiscreteDD.cpp
@@ -324,7 +324,9 @@ MatrixDense AnamDiscreteDD::factors_maf(bool verbose)
       double prop = getDDStatProp(icut);
       tab.setValue(iclass, icut, ((bval - cval) - prop) / sqrt(prop * (1. - prop)));
     }
-  getPcaZ2Fs().prodMatMatInPlace(&tab, &maf);
+  MatrixSquare res;
+  AMatrix::prodMatMatInPlace(res, tab, maf);
+  setPcaZ2F(res);
 
   /* Verbose option */
 

--- a/src/Anamorphosis/PPMT.cpp
+++ b/src/Anamorphosis/PPMT.cpp
@@ -428,7 +428,8 @@ Id PPMT::fitFromMatrix(AMatrix* Y, Id niter, bool verbose)
     // Sphering
     if (verbose) message("- Sphering\n");
     _initSphering = sphering(Y);
-    Y->prodMat(_initSphering);
+    auto* Yd      = dynamic_cast<MatrixDense*>(Y);
+    AMatrix::prodMatMatInPlace(*Yd, *Yd, *_initSphering);
   }
 
   // Loop on the iterations
@@ -513,7 +514,7 @@ Id PPMT::rawToGaussian(Db* db,
   if (_flagPreprocessing)
   {
     _initGaussianizeForward(&Y);
-    Y.prodMat(_initSphering);
+    AMatrix::prodMatMatInPlace(Y, Y, *_initSphering);
   }
 
   // Loop on the iterations
@@ -570,8 +571,9 @@ Id PPMT::gaussianToRaw(Db* db,
   // Post-processing
   if (_flagPreprocessing)
   {
-    AMatrix* backSphering = _initSphering->transpose();
-    Y.prodMat(backSphering);
+    AMatrix* backSphering   = _initSphering->transpose();
+    auto* backSpheringDense = dynamic_cast<MatrixDense*>(backSphering);
+    AMatrix::prodMatMatInPlace(Y, Y, *backSpheringDense);
 
     _initGaussianizeBackward(&Y);
   }

--- a/src/Core/krige.cpp
+++ b/src/Core/krige.cpp
@@ -2983,7 +2983,7 @@ static Id st_sampling_krige_data(Db* db,
 
     eigvec->prodByDiagInPlace(3, eigval);
     auto* spart = dynamic_cast<MatrixDense*>(MatrixFactory::createGlue(sq, &v, true, false));
-    spart->prodMatMatInPlace(spart, eigvec);
+    AMatrix::prodMatMatInPlace(*spart, *spart, *eigvec);
     delete eigvec;
 
     if (beta > 0.)

--- a/src/Core/seismic.cpp
+++ b/src/Core/seismic.cpp
@@ -2697,7 +2697,7 @@ static Id st_estimate_wgt(ST_Seismic_Neigh* ngh,
   /* Calculate the kriging weights */
 
   lhs.invert();
-  lhs.prodMatMatInPlace(&rhs, &wgt);
+  AMatrix::prodMatMatInPlace(lhs, rhs, wgt);
 
   if (OptDbg::query(EDbg::KRIGING))
     st_wgt_print(ngh, NVAR, nech, nred, flag.data(), wgt.getValues().data());

--- a/src/Core/spde.cpp
+++ b/src/Core/spde.cpp
@@ -1975,10 +1975,10 @@ static MatrixSparse* st_spde_fill_S(AMesh* amesh, Model* model, const double* un
           matw.setValue(idim, icorn, matu.getValue(idim, icorn));
 
       /*! Perform 'this' = 'x' * 'y' */
-      mat1.prodMatMatInPlace(&matw, &Calcul.hh, true, false);
+      AMatrix::prodMatMatInPlace(mat1, matw, Calcul.hh);
       if (flag_nostat)
         AMatrix::productInPlace(matv, matw, Calcul.vv, true);
-      mat.prodMatMatInPlace(&mat1, &matw);
+      AMatrix::prodMatMatInPlace(mat, mat1, matw);
 
       for (Id j0 = 0; j0 < ncorner; j0++)
         for (Id j1 = 0; j1 < ncorner; j1++)
@@ -2159,15 +2159,17 @@ static MatrixSparse* st_extract_Q1_hetero(Id row_var,
                                           Id* ncols)
 {
   Id error;
-  MatrixSparse *Q, *Brow, *Bcol, *B1, *Bt, *Qn;
+  MatrixSparse *Q, *Brow, *Bcol, *Bt;
   SPDE_SS_Environ* SS;
 
   /* Initializations */
 
   error = 1;
-  Q = Brow = Bcol = B1 = Bt = Qn = nullptr;
-  SS                             = MATGRF(SPDE_CURRENT_IGRF);
-  SPDE_Matelem& Matelem1         = spde_get_current_matelem(0);
+  MatrixSparse B1;
+  MatrixSparse Qn;
+  Q = Brow = Bcol = Bt   = nullptr;
+  SS                     = MATGRF(SPDE_CURRENT_IGRF);
+  SPDE_Matelem& Matelem1 = spde_get_current_matelem(0);
 
   /* Identify the operating matrices */
 
@@ -2177,14 +2179,12 @@ static MatrixSparse* st_extract_Q1_hetero(Id row_var,
   if (Bcol == nullptr) goto label_end;
   Bt = Bcol->transpose();
   if (Bt == nullptr) goto label_end;
-  B1 = MatrixFactory::prodMatMat<MatrixSparse>(Brow, Matelem1.QC->Q);
-  if (B1 == nullptr) goto label_end;
-  Qn = MatrixFactory::prodMatMat<MatrixSparse>(B1, Bt);
-  if (Qn == nullptr) goto label_end;
+  AMatrix::prodMatMatInPlace(B1, *Brow, *Matelem1.QC->Q);
+  AMatrix::prodMatMatInPlace(Qn, B1, *Bt);
 
   /* Multiply by the corresponding sill */
 
-  Q = MatrixSparse::addMatMat(Qn, Qn, st_get_isill(0, row_var, col_var), 0.);
+  Q = MatrixSparse::addMatMat(&Qn, &Qn, st_get_isill(0, row_var, col_var), 0.);
   if (Q == nullptr) goto label_end;
 
   /* Set the error return code */
@@ -2194,9 +2194,7 @@ static MatrixSparse* st_extract_Q1_hetero(Id row_var,
   *ncols = (col_oper == 1) ? SS->ndata1[col_var] : SS->ntarget1[col_var];
 
 label_end:
-  delete B1;
   delete Bt;
-  delete Qn;
   if (error) delete Q;
   return (Q);
 }
@@ -2363,7 +2361,7 @@ static MatrixSparse* st_spde_build_Q(MatrixSparse* S,
   {
     AMatrix::linearCombinationInPlace(*Q, 0., 1., *Q, blin[iterm], *Bi);
     if (iterm < nblin - 1)
-      Bi->prodMat(S);
+      AMatrix::prodMatMatInPlace(*Bi, *Bi, *S);
   }
   delete Bi;
 
@@ -4760,15 +4758,16 @@ label_end:
  *****************************************************************************/
 static QChol* st_derive_Qc(double s2, QChol* Qc, SPDE_Matelem& Matelem)
 {
-  MatrixSparse *Bt, *B2, *Q, *B;
+  MatrixSparse *Bt, *Q, *B;
   Id error;
 
   // Initializations
 
   error = 1;
-  Bt = B2 = nullptr;
-  Q       = Matelem.QC->Q;
-  B       = Matelem.Aproj;
+  Bt    = nullptr;
+  Q     = Matelem.QC->Q;
+  B     = Matelem.Aproj;
+  MatrixSparse B2;
 
   // Clean the previous Qc (if it exists)
 
@@ -4780,12 +4779,11 @@ static QChol* st_derive_Qc(double s2, QChol* Qc, SPDE_Matelem& Matelem)
           s2);
   Bt = B->transpose();
   if (Bt == nullptr) goto label_end;
-  B2 = MatrixFactory::prodMatMat<MatrixSparse>(Bt, B);
-  if (B2 == nullptr) goto label_end;
+  AMatrix::prodMatMatInPlace(B2, *Bt, *B);
 
   Qc = st_qchol_manage(1, NULL);
   if (Qc == nullptr) goto label_end;
-  Qc->Q = MatrixSparse::addMatMat(Q, B2, s2, 1.);
+  Qc->Q = MatrixSparse::addMatMat(Q, &B2, s2, 1.);
   if (Qc->Q == nullptr) goto label_end;
 
   // Perform the Cholesky transform
@@ -4797,7 +4795,6 @@ static QChol* st_derive_Qc(double s2, QChol* Qc, SPDE_Matelem& Matelem)
 label_end:
   message("Done\n");
   delete Bt;
-  delete B2;
   if (error) Qc = st_qchol_manage(-1, Qc);
   return (Qc);
 }

--- a/src/Core/variopgs.cpp
+++ b/src/Core/variopgs.cpp
@@ -2524,7 +2524,7 @@ static double st_rkl(Id maxpts,
   vec[0]            = x;
   vec[1]            = y;
   VectorDouble mean = AMatrix::product(temp, vec);
-  double v1 = law_df_bigaussian(vec, cste, corr1);
+  double v1         = law_df_bigaussian(vec, cste, corr1);
   mvndst2n(lower.data(), upper.data(), mean.data(), covar.getValues().data(),
            maxpts, abseps, releps, &error, &v2, &inform);
   return (v1 * v2);
@@ -2563,14 +2563,14 @@ static double st_ikl(Id maxpts,
   index[1] = index2;
 
   // Build submatrices
-  VectorDouble low       = VH::reduce(lower, index);
-  VectorDouble upp       = VH::reduce(upper, index);
-  MatrixSymmetric* corr1 = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, true, true));
-  MatrixSymmetric* corrc = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, false, true));
-  MatrixSymmetric* corr2 = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, false, false));
+  VectorDouble low = VH::reduce(lower, index);
+  VectorDouble upp = VH::reduce(upper, index);
+  auto* corr1      = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, true, true));
+  auto* corrc      = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, false, true));
+  auto* corr2      = dynamic_cast<MatrixSymmetric*>(MatrixFactory::createReduce(&correl, index, index, false, false));
   MatrixSymmetric inv_corr1(*corr1);
   if (inv_corr1.invert()) messageAbort("st_ikl #1");
-  MatrixSquare* temp = dynamic_cast<MatrixSquare*>(MatrixFactory::prodMatMat(corrc, &inv_corr1));
+  auto* temp = dynamic_cast<MatrixSquare*>(MatrixFactory::prodMatMat(corrc, &inv_corr1));
 
   // Derive covar
   MatrixSquare covar(2);
@@ -2737,8 +2737,8 @@ static double st_d2_dkldkj(Id index1,
   if (invcorr1.invert()) messageAbort("st_d2_dkldkj #2");
 
   VectorDouble temp = AMatrix::product(invcorr1, crosscor);
-  double covar   = invcorr1.normVec(crosscor);
-  double sdcovar = sqrt(corr2 - covar);
+  double covar      = invcorr1.normVec(crosscor);
+  double sdcovar    = sqrt(corr2 - covar);
 
   VectorDouble lowi = VH::reduceOne(lower, index2);
   VectorDouble uppi = VH::reduceOne(upper, index2);

--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -411,7 +411,7 @@ MatrixDense CorAniso::simulateSpectralOmega(Id nb) const
   MatrixDense omega  = _corfunc->simulateSpectralOmega(nb);
   const auto& tensor = getAniso().getTensorInverse();
   // omega = omega * tensor;
-  omega.prodMat(&tensor);
+  AMatrix::prodMatMatInPlace(omega, omega, tensor);
   return omega;
 }
 

--- a/src/Covariances/CorGaussianMixture.cpp
+++ b/src/Covariances/CorGaussianMixture.cpp
@@ -246,7 +246,7 @@ SpectrumOnRN* CorGaussianMixture::simulateOnRN(Id ns) const
     double xi = 0.0;
     if (_corRef->getType() == ECov::MATERN)
     {
-      xi = 1 / law_gamma(nu0, (kappa0 * kappa0 / 4));
+      xi = 1 / law_gamma(nu0, kappa0 * kappa0 / 4);
     }
     else if (_corRef->getType() == ECov::CAUCHY)
     {
@@ -299,7 +299,7 @@ SpectrumOnRN* CorGaussianMixture::simulateOnRN(Id ns) const
 
   // apply the geometrical anisotropy
   const auto& tensor = _corRef->getAniso().getTensorInverse();
-  omega.prodMat(&tensor);
+  AMatrix::prodMatMatInPlace(omega, omega, tensor);
 
   // simulation of the random phase
   VectorDouble phi(ns);

--- a/src/Covariances/CovBase.cpp
+++ b/src/Covariances/CovBase.cpp
@@ -736,7 +736,7 @@ void CovBase::updateCov()
   }
 
   if (nvaroptim > 0)
-    _sillCur.prodMatMatInPlace(&_cholSills, &_cholSills, false, true);
+    AMatrix::prodMatMatInPlace(_sillCur, _cholSills, _cholSills, false, true);
 }
 
 #ifdef HDF5

--- a/src/Estimation/ALikelihood.cpp
+++ b/src/Estimation/ALikelihood.cpp
@@ -180,7 +180,7 @@ double ALikelihood::computeLogLikelihood(bool flagPrint, bool verbose)
 
     // Calculate XtCm1X = Xt * Cm1 * X
     _XtCm1X.resize(_X.getNCols(), _X.getNCols());
-    _XtCm1X.prodMatMatInPlace(&_X, &_Cm1X, true, false);
+    AMatrix::prodMatMatInPlace(_XtCm1X, _X, _Cm1X, true, false);
 
     // Construct ZtCm1X = Zt * Cm1 * X and perform its Cholesky decomposition
     // workaround to create a shared_ptr which is not deleted at the end of the scope

--- a/src/Estimation/KrigingAlgebra.cpp
+++ b/src/Estimation/KrigingAlgebra.cpp
@@ -861,18 +861,18 @@ Id KrigingAlgebra::_patchColCokVarianceZstar(MatrixSymmetric* varZK)
   L0tCL0.prodNormMatMatInPlace(&_Lambda0, &_Sigma00pp, true);
 
   MatrixDense p2(_nrhs, _neq);
-  p2.prodMatMatInPlace(&_Lambda0, &_Sigma0p, true, true);
+  AMatrix::prodMatMatInPlace(p2, _Lambda0, _Sigma0p, true, true);
   MatrixSymmetric L0tCLK(_nrhs);
 
   if (_flagSK)
   {
     if (_needLambdaSK()) return 1;
-    L0tCLK.prodMatMatInPlace(&p2, &_LambdaSK);
+    AMatrix::prodMatMatInPlace(L0tCLK, p2, _LambdaSK);
   }
   else
   {
     if (_needLambdaUK()) return 1;
-    L0tCLK.prodMatMatInPlace(&p2, &_LambdaUK);
+    AMatrix::prodMatMatInPlace(L0tCLK, p2, _LambdaUK);
   }
 
   AMatrix::linearCombinationInPlace(*varZK, 0., 1., *varZK, -1., L0tCLK, 1., L0tCL0);
@@ -885,7 +885,7 @@ Id KrigingAlgebra::_needVarZSK()
   if (_needSigma0()) return 1;
   if (_needLambdaSK()) return 1;
   _VarZSK.resize(_nrhs, _nrhs);
-  _VarZSK.prodMatMatInPlace(&_LambdaSK, _Sigma0, true, false);
+  AMatrix::prodMatMatInPlace(_VarZSK, _LambdaSK, *_Sigma0, true, false);
 
   if (_ncck > 0)
   {
@@ -927,16 +927,16 @@ Id KrigingAlgebra::_needStdv()
     if (_needMuUK()) return 1;
     _Stdv = *_Sigma00;
     MatrixSymmetric p1(_nrhs, _nrhs);
-    p1.prodMatMatInPlace(&_LambdaUK, _Sigma0, true);
+    AMatrix::prodMatMatInPlace(p1, _LambdaUK, *_Sigma0, true);
     MatrixSymmetric p2(_nrhs, _nrhs);
-    p2.prodMatMatInPlace(&_MuUK, _X0, true, true);
+    AMatrix::prodMatMatInPlace(p2, _MuUK, *_X0, true, true);
     AMatrix::linearCombinationInPlace(_Stdv, 0., 1., _Stdv, -1., p1, 1, p2);
 
     if (_ncck > 0)
     {
       if (_needSigma00p()) return 1;
       MatrixSymmetric p3(_nrhs);
-      p3.prodMatMatInPlace(&_Sigma00p, &_Lambda0, true);
+      AMatrix::prodMatMatInPlace(p3, _Sigma00p, _Lambda0, true);
       AMatrix::linearCombinationInPlace(_Stdv, 0., 1., _Stdv, -1., p3);
     }
   }
@@ -1002,7 +1002,7 @@ Id KrigingAlgebra::_needXtInvSigma()
   if (_needInvSigma()) return 1;
 
   _XtInvSigma.resize(_nbfl, _neq);
-  _XtInvSigma.prodMatMatInPlace(_X, &_InvSigma, true, false);
+  AMatrix::prodMatMatInPlace(_XtInvSigma, *_X, _InvSigma, true, false);
   return 0;
 }
 
@@ -1013,7 +1013,7 @@ Id KrigingAlgebra::_needSigmac()
   if (_needXtInvSigma()) return 1;
 
   _Sigmac.resize(_nbfl, _nbfl);
-  _Sigmac.prodMatMatInPlace(&_XtInvSigma, _X);
+  AMatrix::prodMatMatInPlace(_Sigmac, _XtInvSigma, *_X);
 
   // Bayesian case
   if (_flagBayes)
@@ -1093,7 +1093,7 @@ Id KrigingAlgebra::_needY0()
   if (_needInvSigmaSigma0()) return 1;
 
   MatrixDense LambdaSKtX(_nrhs, _nbfl);
-  LambdaSKtX.prodMatMatInPlace(&_InvSigmaSigma0, _X, true, false);
+  AMatrix::prodMatMatInPlace(LambdaSKtX, _InvSigmaSigma0, *_X, true, false);
 
   _Y0.resize(_nrhs, _nbfl);
   AMatrix::linearCombinationInPlace(_Y0, 0., 1., *_X0, -1., LambdaSKtX);
@@ -1108,7 +1108,7 @@ Id KrigingAlgebra::_needY0p()
   if (_needXtInvSigma()) return 1;
 
   _Y0p.resize(_ncck, _nbfl);
-  _Y0p.prodMatMatInPlace(&_Sigma0p, &_XtInvSigma, true, true);
+  AMatrix::prodMatMatInPlace(_Y0p, _Sigma0p, _XtInvSigma, true, true);
   AMatrix::linearCombinationInPlace(_Y0p, 0., 1., _X0p, -1., _Y0p);
   return 0;
 }
@@ -1128,14 +1128,14 @@ Id KrigingAlgebra::_needMuUK()
     if (_needLambda0()) return 1;
 
     MatrixDense LtY(_nrhs, _nbfl);
-    LtY.prodMatMatInPlace(&_Lambda0, &_Y0p, true);
+    AMatrix::prodMatMatInPlace(LtY, _Lambda0, _Y0p, true);
     AMatrix::linearCombinationInPlace(LtY, 0., 1., _Y0, -1., LtY);
 
-    _MuUK.prodMatMatInPlace(&_Sigmac, &LtY, false, true);
+    AMatrix::prodMatMatInPlace(_MuUK, _Sigmac, LtY, false, true);
   }
   else
   {
-    _MuUK.prodMatMatInPlace(&_Sigmac, &_Y0, false, true);
+    AMatrix::prodMatMatInPlace(_MuUK, _Sigmac, _Y0, false, true);
   }
   return 0;
 }
@@ -1146,7 +1146,7 @@ Id KrigingAlgebra::_needInvSigmaSigma0()
   if (_needSigma0()) return 1;
   if (_needInvSigma()) return 1;
   _InvSigmaSigma0.resize(_neq, _nrhs);
-  _InvSigmaSigma0.prodMatMatInPlace(&_InvSigma, _Sigma0);
+  AMatrix::prodMatMatInPlace(_InvSigmaSigma0, _InvSigma, *_Sigma0);
   return 0;
 }
 
@@ -1193,10 +1193,10 @@ Id KrigingAlgebra::_patchRHSForXvalidUnique()
     MatrixDense::sample(X, *_X, *_rankXvalidEqs, VectorInt(), true);
 
     // Compute epsilon (up to its sign); inv(alpha) * beta
-    AMatrix* p1 = MatrixFactory::prodMatMat(&InvAlpha, &beta);
+    MatrixDense p1;
+    AMatrix::prodMatMatInPlace(p1, InvAlpha, beta);
     MatrixDense epsilon(_nxvalid, _nbfl);
-    epsilon.prodMatMatInPlace(p1, &X);
-    delete p1;
+    AMatrix::prodMatMatInPlace(epsilon, p1, X);
 
     // Compute a3 (transpose)
     MatrixDense a3(_nxvalid, _nbfl);
@@ -1284,10 +1284,10 @@ Id KrigingAlgebra::_needLambdaSK()
     if (_needLambda0()) return 1;
 
     MatrixDense S(_neq, _nrhs);
-    S.prodMatMatInPlace(&_Sigma0p, &_Lambda0);
+    AMatrix::prodMatMatInPlace(S, _Sigma0p, _Lambda0);
     AMatrix::linearCombinationInPlace(S, 0., 1., *_Sigma0, -1., S);
     _LambdaSK.resize(_neq, _nrhs);
-    _LambdaSK.prodMatMatInPlace(&_InvSigma, &S);
+    AMatrix::prodMatMatInPlace(_LambdaSK, _InvSigma, S);
   }
   else
   {
@@ -1307,8 +1307,7 @@ Id KrigingAlgebra::_needLambdaUK()
   if (_needMuUK()) return 1;
 
   MatrixDense p1(_neq, _nrhs);
-  p1.prodMatMatInPlace(&_XtInvSigma, &_MuUK, true, false);
-  // MatrixRectangular::sum(_LambdaSK, &p1, _LambdaUK);
+  AMatrix::prodMatMatInPlace(p1, _XtInvSigma, _MuUK, true, false);
   AMatrix::linearCombinationInPlace(_LambdaUK, 0., 1., _LambdaSK, 1., p1);
 
   return 0;
@@ -1327,7 +1326,7 @@ Id KrigingAlgebra::_needDual()
     if (_needXtInvSigma()) return 1;
 
     VectorDouble wp = AMatrix::product(_XtInvSigma, *_Z, false);
-    _cDual = AMatrix::product(_Sigmac, wp, false);
+    _cDual          = AMatrix::product(_Sigmac, wp, false);
 
     VectorDouble p1 = AMatrix::product(_XtInvSigma, _cDual, true);
     VH::linearCombinationInPlace(1., _bDual, -1., p1, _bDual);
@@ -1460,26 +1459,26 @@ Id KrigingAlgebra::_needLambda0()
   }
 
   MatrixDense Sigma0ptInvSigma(_ncck, _neq);
-  Sigma0ptInvSigma.prodMatMatInPlace(&_Sigma0p, &_InvSigma, true);
+  AMatrix::prodMatMatInPlace(Sigma0ptInvSigma, _Sigma0p, _InvSigma, true);
 
   // Determine the Bottom part of the ratio
   MatrixSymmetric bot = _Sigma00pp;
 
   MatrixSymmetric bot1(_ncck);
-  bot1.prodMatMatInPlace(&Sigma0ptInvSigma, &_Sigma0p);
+  AMatrix::prodMatMatInPlace(bot1, Sigma0ptInvSigma, _Sigma0p);
 
   MatrixDense Y0pSigmac;
   if (_nbfl > 0)
   {
     Y0pSigmac = MatrixDense(_ncck, _nbfl);
-    Y0pSigmac.prodMatMatInPlace(&_Y0p, &_Sigmac);
+    AMatrix::prodMatMatInPlace(Y0pSigmac, _Y0p, _Sigmac);
   }
 
   MatrixSymmetric bot2;
   if (_nbfl > 0)
   {
     bot2 = MatrixSymmetric(_ncck);
-    bot2.prodMatMatInPlace(&Y0pSigmac, &_Y0p, false, true);
+    AMatrix::prodMatMatInPlace(bot2, Y0pSigmac, _Y0p, false, true);
   }
   AMatrix::linearCombinationInPlace(bot, 0., 1., bot, -1., bot1, (_nbfl > 0) ? 1. : 0., bot2);
 
@@ -1489,18 +1488,18 @@ Id KrigingAlgebra::_needLambda0()
   MatrixDense top = _Sigma00p;
 
   MatrixDense top1(_ncck, _nrhs);
-  top1.prodMatMatInPlace(&Sigma0ptInvSigma, _Sigma0);
+  AMatrix::prodMatMatInPlace(top1, Sigma0ptInvSigma, *_Sigma0);
 
   MatrixDense top2;
   if (_nbfl > 0)
   {
     top2 = MatrixDense(_ncck, _nrhs);
-    top2.prodMatMatInPlace(&Y0pSigmac, &_Y0, false, true);
+    AMatrix::prodMatMatInPlace(top2, Y0pSigmac, _Y0, false, true);
   }
   AMatrix::linearCombinationInPlace(top, 0., 1., top, -1., top1, (_nbfl > 0) ? 1. : 0., top2);
 
   _Lambda0.resize(_ncck, _nrhs);
-  _Lambda0.prodMatMatInPlace(&bot, &top);
+  AMatrix::prodMatMatInPlace(_Lambda0, bot, top);
 
   return 0;
 }

--- a/src/Estimation/KrigingAlgebraSimpleCase.cpp
+++ b/src/Estimation/KrigingAlgebraSimpleCase.cpp
@@ -830,7 +830,7 @@ Id KrigingAlgebraSimpleCase::_needVarZSK()
   if (!_VarZSK.empty()) return 0;
   if (_needLambdaSK()) return 1;
   _VarZSK.resize(_nrhs, _nrhs);
-  _VarZSK.prodMatMatInPlace(_LambdaSK.get(), _Sigma0.get(), true, false);
+  AMatrix::prodMatMatInPlace(_VarZSK, *_LambdaSK, *_Sigma0, true, false);
   return 0;
 }
 
@@ -861,9 +861,9 @@ Id KrigingAlgebraSimpleCase::_needStdv()
 
     _Stdv.resize(_nrhs, _nrhs);
     _LambdaUKtSigma0.resize(_nrhs, _nrhs);
-    _LambdaUKtSigma0.prodMatMatInPlace(&_LambdaUK, _Sigma0.get(), true);
+    AMatrix::prodMatMatInPlace(_LambdaUKtSigma0, _LambdaUK, *_Sigma0, true);
     _MuUKtX0t.resize(_nrhs, _nrhs);
-    _MuUKtX0t.prodMatMatInPlace(&_MuUK, _X0.get(), true, true);
+    AMatrix::prodMatMatInPlace(_MuUKtX0t, _MuUK, *_X0, true, true);
     AMatrix::linearCombinationInPlace(_Stdv, 0., 1., *_Sigma00, -1., _LambdaUKtSigma0, +1., _MuUKtX0t);
   }
 
@@ -937,7 +937,7 @@ Id KrigingAlgebraSimpleCase::_needXtInvSigma()
   else
   {
     _XtInvSigma->resize(_nbfl, _neq);
-    _XtInvSigma->prodMatMatInPlace(_X.get(), _InvSigma.get(), true, false);
+    AMatrix::prodMatMatInPlace(*_XtInvSigma, *_X, *_InvSigma, true, false);
   }
   _XtInvSigmaHasChanged = false;
   return 0;
@@ -949,9 +949,9 @@ Id KrigingAlgebraSimpleCase::_needSigmac()
   if (_needXtInvSigma()) return 1;
   _Sigmac.resize(_nbfl, _nbfl);
   if (_flagCholesky)
-    _Sigmac.prodMatMatInPlace(_invSigmaX.get(), _X.get(), true);
+    AMatrix::prodMatMatInPlace(_Sigmac, *_invSigmaX, *_X, true);
   else
-    _Sigmac.prodMatMatInPlace(_XtInvSigma.get(), _X.get());
+    AMatrix::prodMatMatInPlace(_Sigmac, *_XtInvSigma, *_X);
   // Compute the inverse matrix
   _invSigmac->resize(_nbfl, _nbfl);
   if (_Sigmac.invert2(*_invSigmac))
@@ -990,10 +990,9 @@ Id KrigingAlgebraSimpleCase::_needMuUK()
   _LambdaSKtX.resize(_nrhs, _nbfl);
   _Y0.resize(_nrhs, _nbfl);
 
-  _LambdaSKtX.prodMatMatInPlace(_LambdaSK.get(), _X.get(), true, false);
+  AMatrix::prodMatMatInPlace(_LambdaSKtX, *_LambdaSK, *_X, true, false);
   AMatrix::linearCombinationInPlace(_Y0, 0., 1., *_X0, -1., _LambdaSKtX);
-
-  _MuUK.prodMatMatInPlace(_invSigmac.get(), &_Y0, false, true);
+  AMatrix::prodMatMatInPlace(_MuUK, *_invSigmac, _Y0, false, true);
   return 0;
 }
 
@@ -1067,10 +1066,11 @@ Id KrigingAlgebraSimpleCase::_needLambdaUK()
   if (_needMuUK()) return 1;
 
   _invSigmaXMuUK.resize(_neq, _nrhs);
+
   if (_flagCholesky)
-    _invSigmaXMuUK.prodMatMatInPlace(_invSigmaX.get(), &_MuUK);
+    AMatrix::prodMatMatInPlace(_invSigmaXMuUK, *_invSigmaX, _MuUK);
   else
-    _invSigmaXMuUK.prodMatMatInPlace(_XtInvSigma.get(), &_MuUK, true);
+    AMatrix::prodMatMatInPlace(_invSigmaXMuUK, *_XtInvSigma, _MuUK, true);
 
   MatrixDense::sum(_LambdaSK.get(), &_invSigmaXMuUK, &_LambdaUK);
 

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -316,7 +316,7 @@ MatrixSparse* PrecisionOpMatrix::_build_Q()
   for (Id iterm = 1; iterm < nblin; iterm++)
   {
     AMatrix::linearCombinationInPlace(*Q, 0., 1., *Q, blin[iterm], *Bi);
-    if (iterm < nblin - 1) Bi->prodMat(S);
+    if (iterm < nblin - 1) AMatrix::prodMatMatInPlace(*Bi, *Bi, *S);
   }
   delete Bi;
 

--- a/src/LinearOp/ShiftOpMatrix.cpp
+++ b/src/LinearOp/ShiftOpMatrix.cpp
@@ -608,7 +608,7 @@ double ShiftOpMatrix::_computeGradLogDetHH(const AMesh* amesh,
     }
 
     work.normMatrix(rotmat, temp);
-    work2.prodMatMatInPlace(&work, &invHH);
+    AMatrix::prodMatMatInPlace(work2, work, invHH);
     double result = work2.trace();
     return result;
   }

--- a/src/MLayers/MLayers.cpp
+++ b/src/MLayers/MLayers.cpp
@@ -1585,10 +1585,9 @@ Id MLayers::_calculateDriftBayes(bool verbose,
   invS.invert();
 
   /* Auxiliary calculations */
-  ffc.prodMatMatInPlace(&fftab, acov);
-  invH.prodMatMatInPlace(&ffc, &fftab, false, true);
+  AMatrix::prodMatMatInPlace(ffc, fftab, *acov);
+  AMatrix::prodMatMatInPlace(invH, ffc, fftab, false, true);
   AMatrix::productInPlace(fm1z, ffc, zval);
-  // AMatrix::prodXXX(fm1z, ffc, zval); // TODO: a verifier
 
   /* Calculate the Posterior Variance-Covariance matrix */
   for (Id ipar = 0; ipar < _npar; ipar++)
@@ -1619,8 +1618,8 @@ Id MLayers::_calculateDriftBayes(bool verbose,
 
   /* Auxiliary arrays prepared for estimation */
 
-  a0.prodMatMatInPlace(&fftab, &post_vars, true);
-  ss.prodMatMatInPlace(acov, &fftab, false, true);
+  AMatrix::prodMatMatInPlace(a0, fftab, post_vars, true);
+  AMatrix::prodMatMatInPlace(ss, *acov, fftab, false, true);
   for (Id ipar = 0; ipar < _npar; ipar++)
     for (Id jpar = 0; jpar < _npar; jpar++)
       invS.setValue(ipar, jpar, post_vars.getValue(ipar, jpar));

--- a/src/Matrix/AMatrix.cpp
+++ b/src/Matrix/AMatrix.cpp
@@ -310,7 +310,7 @@ void AMatrix::transposeInPlace()
 AMatrix* AMatrix::transpose() const
 {
   auto* mat = dynamic_cast<AMatrix*>(clone());
-  mat->transposeInPlace();
+  mat->_transposeInPlace();
   return mat;
 }
 
@@ -1158,11 +1158,6 @@ void AMatrix::makePositiveColumn()
   }
 }
 
-void AMatrix::prodMat(const AMatrix* matY, bool transposeY)
-{
-  prodMatMatInPlace(this, matY, false, transposeY);
-}
-
 void setFlagMatrixCheck(bool flagMatrixCheck)
 {
   _flagMatrixCheck = flagMatrixCheck;
@@ -1209,4 +1204,5 @@ bool AMatrix::_isEqualVect(const constvect& a, const constvect& b, double eps)
   }
   return true;
 }
+
 } // namespace gstlrn

--- a/src/Matrix/MatrixDense.cpp
+++ b/src/Matrix/MatrixDense.cpp
@@ -257,6 +257,13 @@ void MatrixDense::_productGeneral(MatrixDense& res,
                                   bool transpose1,
                                   bool transpose2)
 {
+  if (&res == &other1 || &res == &other2)
+  {
+    MatrixDense temp(res.getNRows(), res.getNCols());
+    _productGeneral(temp, other1, other2, transpose1, transpose2);
+    res = temp;
+    return;
+  }
   if (transpose1)
   {
     if (transpose2)

--- a/src/Matrix/MatrixFactory.cpp
+++ b/src/Matrix/MatrixFactory.cpp
@@ -101,35 +101,6 @@ AMatrix* MatrixFactory::prodMatMat(const AMatrix* x,
   return res;
 }
 
-/****************************************************************************/
-/*!
- **  Create a Matrix similar to the input one with a given row number
- **
- ** \return Pointer to the newly created AMatrix matrix
- **
- ** \param[in]  x          First AMatrix matrix
- ** \param[in]  nrow       Number of rows
- **
- *****************************************************************************/
-MatrixSquare* MatrixFactory::createMatrixSquare(const MatrixSquare* x,
-                                                Id nrow)
-{
-  /// TODO : use typeinfo
-  const auto* mxsg     = dynamic_cast<const MatrixSquare*>(x);
-  const auto* mxsym = dynamic_cast<const MatrixSymmetric*>(x);
-
-  MatrixSquare* res = nullptr;
-  if (mxsg != nullptr)
-  {
-    res = new MatrixSquare(nrow);
-  }
-  else if (mxsym != nullptr)
-  {
-    res = new MatrixSymmetric(nrow);
-  }
-  return res;
-}
-
 /**
  * Create a submatrix from an input matrix
  * by specifying the list of rows and columns to be extracted or excluded
@@ -183,9 +154,9 @@ AMatrix* MatrixFactory::createReduce(const AMatrix* x,
   bool flagSame = (localSelRows == localSelCols);
 
   /// TODO : use typeinfo
-  AMatrix* res                 = nullptr;
-  const auto* mxrg      = dynamic_cast<const MatrixDense*>(x);
-  const auto* mxsg     = dynamic_cast<const MatrixSquare*>(x);
+  AMatrix* res      = nullptr;
+  const auto* mxrg  = dynamic_cast<const MatrixDense*>(x);
+  const auto* mxsg  = dynamic_cast<const MatrixSquare*>(x);
   const auto* mxsym = dynamic_cast<const MatrixSymmetric*>(x);
 
   if (mxsym != nullptr)

--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -22,7 +22,6 @@
 
 #include <Eigen/src/Core/Map.h>
 #include <Eigen/src/Core/Matrix.h>
-#include <iostream>
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_COND_EXPR_CONSTANT
@@ -892,13 +891,6 @@ Id MatrixSparse::_solve(const VectorDouble& b, VectorDouble& x) const
   xm = solver.compute(eigenMat()).solve(bm);
 
   return 0;
-}
-
-String MatrixSparse::toString(const AStringFormat* strfmt) const
-{
-  std::stringstream sstr;
-  sstr << AMatrix::toString(strfmt) << std::endl;
-  return sstr.str();
 }
 
 void MatrixSparse::_allocate(Id nrow, Id ncol, Id ncolmax)

--- a/src/Matrix/MatrixSymmetric.cpp
+++ b/src/Matrix/MatrixSymmetric.cpp
@@ -882,8 +882,8 @@ Id MatrixSymmetric::squareRootInPlace(MatrixSymmetric& tabout)
     eigval[i] = sqrt(eigval[i]);
   MatrixSymmetric D(nrow);
   D.setDiagonal(eigval);
-  tabout.prodMatMatInPlace(&eigvec, &D, false, false);
-  tabout.prodMatMatInPlace(&tabout, &eigvec, false, true);
+  AMatrix::prodMatMatInPlace(tabout, eigvec, D, false, false);
+  AMatrix::prodMatMatInPlace(tabout, tabout, eigvec, false, true);
   return 0;
 }
 
@@ -927,7 +927,7 @@ MatrixSymmetric* MatrixSymmetric::createRandomDefinitePositive(Id neq, Id seed)
   MatrixSymmetric local(neq);
   local.fillRandom(0, seed);
   auto* mat = new MatrixSymmetric(neq);
-  mat->prodMatMatInPlace(&local, &local, true);
+  AMatrix::prodMatMatInPlace(*mat, local, local, true);
   return mat;
 }
 

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -165,7 +165,7 @@ double ClassicalPolynomial::evalOpByRank(MatrixSparse* S, Id rank) const
   MatrixSparse* outv = nullptr;
   for (Id j = degree - 2; j >= 0; j--)
   {
-    if (j != degree - 2) work->prodMatMatInPlace(S, outv);
+    if (j != degree - 2) AMatrix::prodMatMatInPlace(*work, *S, *outv);
     if (j == 0) break;
     delete outv;
     outv = work->clone();

--- a/src/Stats/PCA.cpp
+++ b/src/Stats/PCA.cpp
@@ -866,7 +866,7 @@ VectorDouble PCA::mafOfIndex() const
   }
 
   MatrixDense local(nclass, ncut);
-  local.prodMatMatInPlace(&i_norm_val, &_Z2F);
+  AMatrix::prodMatMatInPlace(local, i_norm_val, _Z2F);
   VectorDouble maf_index = VH::concatenate(VH::initVDouble(nclass, 1.), local.getValues());
 
   return maf_index;

--- a/src/Variogram/Vario.cpp
+++ b/src/Variogram/Vario.cpp
@@ -4697,7 +4697,7 @@ Id Vario::_driftEstimateCoefficients(Db* db)
 
   /* Pre-process the vector X %*% (t(X) %*% X)-1 */
 
-  _DRFXA.prodMatMatInPlace(&_DRFTAB, &matdrf);
+  AMatrix::prodMatMatInPlace(_DRFXA, _DRFTAB, matdrf);
 
   return 0;
 }

--- a/swig/swig_inc.i
+++ b/swig/swig_inc.i
@@ -1115,6 +1115,17 @@ namespace gstlrn {
   {
     AMatrix::productInPlace(y, x, *$self, transpose, true);
   }
+  void AMatrix::prodMat(const MatrixDense* matY, bool transposeY)
+  {
+    AMatrix::prodMatMatInPlace(*self, *self, *matY, false, transposeY);
+  }
+  void AMatrix::prodMatMatInPlace(const MatrixDense* x,
+                                  const MatrixDense* y,
+                                  bool transposeX = false,
+                                  bool transposeY = false)
+  {
+    AMatrix::prodMatMatInPlace(*self, *x, *y, transposeX, transposeY);
+  }
 }
 
 %extend gstlrn::MatrixSparse {
@@ -1146,6 +1157,17 @@ namespace gstlrn {
   void prodVecMatInPlace(const VectorDouble& x, VectorDouble& y, bool transpose = false) const
   {
     AMatrix::productInPlace(y, x, *$self, transpose, true);
+  }
+  void AMatrix::prodMat(const MatrixSparse* matY, bool transposeY)
+  {
+    AMatrix::prodMatMatInPlace(*self, *self, *matY, false, transposeY);
+  }
+  void AMatrix::prodMatMatInPlace(const MatrixSparse* x,
+                                  const MatrixSparse* y,
+                                  bool transposeX = false,
+                                  bool transposeY = false)
+  {
+    AMatrix::prodMatMatInPlace(*self, *x, *y, transposeX, transposeY);
   }
 }
 

--- a/tests/cpp/bench_Tools.cpp
+++ b/tests/cpp/bench_Tools.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
   timer.reset();
   for (Id itime = 0; itime < ntimes; itime++)
   {
-    res.prodMatMatInPlace(&mata, &matb);
+    AMatrix::prodMatMatInPlace(res, mata, matb);
     result = res(0, 0);
   }
   timer.displayIntervalMilliseconds("with algebra", 1700);

--- a/tests/cpp/output/test_Matrix.ref
+++ b/tests/cpp/output/test_Matrix.ref
@@ -1004,3 +1004,309 @@ Eigen Vectors
       [  4,]      0.004      0.237      0.005     -0.008      0.732      0.108      0.629
       [  5,]      0.839      0.016     -0.543      0.000     -0.004     -0.001     -0.003
       [  6,]      0.544     -0.031      0.839      0.000      0.001      0.000      0.000
+Initial Sparse Matrix MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -1.090
+      [  1,]          .     -0.898          .
+      [  2,]      1.298          .          .
+      [  3,]      0.090          .     -1.064
+
+Initial Sparse Matrix MS2
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -0.527
+      [  1,]      1.715      0.392          .
+      [  2,]      0.784          .      0.837
+      [  3,]      0.957     -0.873     -0.905
+
+Initial Dense Matrix M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -1.090
+      [  1,]      0.000     -0.898      0.000
+      [  2,]      1.298      0.000      0.000
+      [  3,]      0.090      0.000     -1.064
+Initial Dense Matrix M2
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -0.527
+      [  1,]      1.715      0.392      0.000
+      [  2,]      0.784      0.000      0.837
+      [  3,]      0.957     -0.873     -0.905
+
+Testing free functions
+======================
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+AMatrix::add(M1, M1, 10.) -> M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+AMatrix::add(MS1, MS1, 10.) -> MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+AMatrix::add(M2, M1, M2) -> M2
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -1.617
+      [  1,]      1.715     -0.506      0.000
+      [  2,]      2.082      0.000      0.837
+      [  3,]      1.047     -0.873     -1.969
+AMatrix::add(MS2, MS1, MS2) -> MS2
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -1.617
+      [  1,]      1.715     -0.506          .
+      [  2,]      2.082          .      0.837
+      [  3,]      1.047     -0.873     -1.969
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+AMatrix::prod(M2, M1, 1.2) -> M2
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -1.308
+      [  1,]      0.000     -1.078      0.000
+      [  2,]      1.558      0.000      0.000
+      [  3,]      0.108      0.000     -1.277
+AMatrix::prod(MS2, MS1, 1.2) -> MS2
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -1.308
+      [  1,]          .     -1.078          .
+      [  2,]      1.558          .          .
+      [  3,]      0.108          .     -1.277
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+AMatrix::prodHadamard(M2, M1, M2) -> M2
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000      0.574
+      [  1,]      0.000     -0.352      0.000
+      [  2,]      1.018      0.000      0.000
+      [  3,]      0.086      0.000      0.962
+AMatrix::prodHadamard(MS2, MS1, MS2) -> S2
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .      0.574
+      [  1,]          .     -0.352          .
+      [  2,]      1.018          .          .
+      [  3,]      0.086          .      0.962
+
+
+Testing member functions
+========================
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1.addCst(10.) -> M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+MS1.addCst(10.) -> MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1add = M1.addCst(10.) -> M1add
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+MS1add = MS1.addCst(10.) -> MS1add
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1.prodCstInPlace(2.) -> M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -2.180
+      [  1,]      0.000     -1.797      0.000
+      [  2,]      2.596      0.000      0.000
+      [  3,]      0.179      0.000     -2.128
+MS1.prodCstInPlace(2.) -> MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -2.180
+      [  1,]          .     -1.797          .
+      [  2,]      2.596          .          .
+      [  3,]      0.179          .     -2.128
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1prod = M1.prodCst(2.) -> M1prod
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      0.000      0.000     -2.180
+      [  1,]      0.000     -1.797      0.000
+      [  2,]      2.596      0.000      0.000
+      [  3,]      0.179      0.000     -2.128
+MS1prod = MS1.prodCst(2.) -> MS1prod
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]          .          .     -2.180
+      [  1,]          .     -1.797          .
+      [  2,]      2.596          .          .
+      [  3,]      0.179          .     -2.128
+
+
+Testing the operators
+=====================
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1 += 10. -> M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+MS1 += 10. -> MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1 -= 10. -> M1
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]    -10.000    -10.000    -11.090
+      [  1,]    -10.000    -10.898    -10.000
+      [  2,]     -8.702    -10.000    -10.000
+      [  3,]     -9.910    -10.000    -11.064
+MS1 -= 10. -> MS1
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]    -10.000    -10.000    -11.090
+      [  1,]    -10.000    -10.898    -10.000
+      [  2,]     -8.702    -10.000    -10.000
+      [  3,]     -9.910    -10.000    -11.064
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1addOp = M1 + 10. -> M1addOp
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+MS1addOp = MS1 + 10. -> MS1addOp
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     10.000     10.000      8.910
+      [  1,]     10.000      9.102     10.000
+      [  2,]     11.298     10.000     10.000
+      [  3,]     10.090     10.000      8.936
+
+Matrices M1, M2, MS1 and MS2 are reset to initial values
+M1subtractOp = M1 - 10. -> M1subtractOp
+- Number of rows    = 4
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]    -10.000    -10.000    -11.090
+      [  1,]    -10.000    -10.898    -10.000
+      [  2,]     -8.702    -10.000    -10.000
+      [  3,]     -9.910    -10.000    -11.064
+MS1subtractOp = MS1 - 10. -> MS1subtractOp
+- Number of rows    = 4
+- Number of columns = 3
+- Sparse Format
+                 [,  0]     [,  1]     [,  2]
+      [  0,]    -10.000    -10.000    -11.090
+      [  1,]    -10.000    -10.898    -10.000
+      [  2,]     -8.702    -10.000    -10.000
+      [  3,]     -9.910    -10.000    -11.064
+
+
+Testing child classes
+=====================
+Initial Square Matrix MSq1
+- Number of rows    = 3
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     -1.569      0.958     -0.898
+      [  1,]     -0.875      1.041      0.090
+      [  2,]     -0.106      0.603      0.651
+Initial Square Matrix MSq2
+- Number of rows    = 3
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     -1.274      1.006      0.239
+      [  1,]      0.583      0.784     -0.019
+      [  2,]      0.898      0.828     -1.688
+Matrices MSq1 and MSq2 are reset to initial values
+addInPlace(MSq2, MSq1, 10.) -> MSq2
+- Number of rows    = 3
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]      8.431     10.958      9.102
+      [  1,]      9.125     11.041     10.090
+      [  2,]      9.894     10.603     10.651
+Matrices MSq1 and MSq2 are reset to initial values
+addInPlace(MSq2, MSq1, MSq2) -> MSq2
+- Number of rows    = 3
+- Number of columns = 3
+                 [,  0]     [,  1]     [,  2]
+      [  0,]     -2.843      1.964     -0.659
+      [  1,]     -0.292      1.826      0.071
+      [  2,]      0.792      1.431     -1.037

--- a/tests/cpp/test_Matrix.cpp
+++ b/tests/cpp/test_Matrix.cpp
@@ -57,6 +57,58 @@ void reset_to_initial_contents(AMatrix* M,
   MSP->setValues(M->getValues());
 }
 
+void reset(MatrixDense& M1,
+           MatrixDense& M2,
+           MatrixSparse& MS1,
+           MatrixSparse& MS2,
+           bool verbose = false)
+{
+  MS1.fillRandom(0.3, 31366);
+  MS2.fillRandom(0.3, 424672);
+  MatrixDense* Mt1 = MatrixSparse::createFromSparse(MS1);
+  MatrixDense* Mt2 = MatrixSparse::createFromSparse(MS2);
+  M1               = *Mt1;
+  M2               = *Mt2;
+  delete Mt1;
+  delete Mt2;
+
+  if (verbose)
+  {
+    message("Initial Sparse Matrix MS1\n");
+    MS1.display();
+    message("Initial Sparse Matrix MS2\n");
+    MS2.display();
+    message("Initial Dense Matrix M1\n");
+    M1.display();
+    message("Initial Dense Matrix M2\n");
+    M2.display();
+  }
+  else
+  {
+    message("Matrices M1, M2, MS1 and MS2 are reset to initial values\n");
+  }
+}
+
+void resetSquare(MatrixSquare& MSq1,
+                 MatrixSquare& MSq2,
+                 bool verbose = false)
+{
+  MSq1.fillRandom(0., 31366);
+  MSq2.fillRandom(0., 424672);
+
+  if (verbose)
+  {
+    message("Initial Square Matrix MSq1\n");
+    MSq1.display();
+    message("Initial Square Matrix MSq2\n");
+    MSq2.display();
+  }
+  else
+  {
+    message("Matrices MSq1 and MSq2 are reset to initial values\n");
+  }
+}
+
 /****************************************************************************/
 /*!
 ** Main program for testing the new classes of matrix algebra
@@ -95,7 +147,7 @@ int main(int argc, char* argv[])
   matd.setValues({1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   matd.display();
   AMatrix* pmat = &matd;
-  MatrixDense* matd2(dynamic_cast<MatrixDense*>(pmat->clone())); // dynamic_cast cannot be avoided here
+  auto* matd2(dynamic_cast<MatrixDense*>(pmat->clone())); // dynamic_cast cannot be avoided here
   matd2->display();
 
   VectorDouble V1, V2, V3, Vref;
@@ -133,7 +185,6 @@ int main(int argc, char* argv[])
   // The symmetric matrix is obtained as M = t(MR) %*% MR
   AMatrix* MRt = MR.transpose();
   MRt->display();
-  //  AMatrix* M = prodMatMatInPlace(MRt, &MR);
   AMatrix* M = MatrixFactory::prodMatMat(MRt, &MR);
   message("Matrix M (should be symmetric). Checking = %d\n", static_cast<Id>(M->isSymmetric()));
   M->display();
@@ -402,7 +453,7 @@ int main(int argc, char* argv[])
 
   message("Making the product of the matrix by itself\n");
   MatrixSquare MSG2(MSG);
-  MSG.prodMatMatInPlace(&MSG2, &MSG2);
+  AMatrix::prodMatMatInPlace(MSG, MSG2, MSG2);
   MSG.display();
 
   message("Clearing matrix and Setting Diagonal to a vector (sequence from 1 to %d)\n", ncol);
@@ -484,7 +535,7 @@ int main(int argc, char* argv[])
 
   message("Making the product of the matrix by itself\n");
   MatrixSparse MSP2(*MSP);
-  MSP->prodMatMatInPlace(&MSP2, &MSP2);
+  AMatrix::prodMatMatInPlace(*MSP, MSP2, MSP2);
   MSP->display();
 
   message("Clearing matrix and Setting Diagonal to a vector (sequence from 1 to %d)\n", ncol);
@@ -528,7 +579,7 @@ int main(int argc, char* argv[])
   tu.display();
 
   MatrixSquare res(neq);
-  res.prodMatMatInPlace(&tl, &tu);
+  AMatrix::prodMatMatInPlace(res, tl, tu);
   message("\nChecking the product\n");
   res.display();
   message("compared to Initial\n");
@@ -728,5 +779,185 @@ int main(int argc, char* argv[])
 
   // Free the pointers
   delete M;
+
+  ///////////////////////////
+  // Testing new functions //
+  ///////////////////////////
+
+  // Creating two matrix sparse and derive the equivalent MatrixDense
+  // so that comparative calculations can be run on the two types of matrix.
+  MatrixSparse MS1(4, 3);
+  MatrixSparse MS2(4, 3);
+  MatrixDense M1;
+  MatrixDense M2;
+  reset(M1, M2, MS1, MS2, true);
+
+  ////////////////////////////////
+  // Testing the free functions //
+  ////////////////////////////////
+  mestitle(0, "Testing free functions");
+
+  // Adding a Constant
+  reset(M1, M2, MS1, MS2, false);
+
+  AMatrix::addInPlace(M1, M1, 10.);
+  message("AMatrix::add(M1, M1, 10.) -> M1\n");
+  M1.display();
+
+  AMatrix::addInPlace(MS1, MS1, 10.);
+  message("AMatrix::add(MS1, MS1, 10.) -> MS1\n");
+  MS1.display();
+
+  // Adding two matrices
+  reset(M1, M2, MS1, MS2, false);
+
+  AMatrix::addInPlace(M2, M1, M2);
+  message("AMatrix::add(M2, M1, M2) -> M2\n");
+  M2.display();
+
+  AMatrix::addInPlace(MS2, MS1, MS2);
+  message("AMatrix::add(MS2, MS1, MS2) -> MS2\n");
+  MS2.display();
+
+  // Product of a matrix by a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  AMatrix::productInPlace(M2, M1, 1.2);
+  message("AMatrix::prod(M2, M1, 1.2) -> M2\n");
+  M2.display();
+
+  AMatrix::productInPlace(MS2, MS1, 1.2);
+  message("AMatrix::prod(MS2, MS1, 1.2) -> MS2\n");
+  MS2.display();
+
+  // Hadamard Product of two matrices
+  reset(M1, M2, MS1, MS2, false);
+
+  AMatrix::prodHadamardInPlace(M2, M1, M2);
+  message("AMatrix::prodHadamard(M2, M1, M2) -> M2\n");
+  M2.display();
+
+  AMatrix::prodHadamardInPlace(MS2, MS1, MS2);
+  message("AMatrix::prodHadamard(MS2, MS1, MS2) -> S2\n");
+  MS2.display();
+
+  //////////////////////////////////
+  // Testing the member functions //
+  //////////////////////////////////
+  mestitle(0, "Testing member functions");
+
+  // Adding a Constant
+  reset(M1, M2, MS1, MS2, false);
+
+  M1.addCst(10.);
+  message("M1.addCst(10.) -> M1\n");
+  M1.display();
+
+  MS1.addCst(10.);
+  message("MS1.addCst(10.) -> MS1\n");
+  MS1.display();
+
+  // Adding a Constant and allocating a new class
+  reset(M1, M2, MS1, MS2, false);
+
+  auto M1add = M1.addCst(10.);
+  message("M1add = M1.addCst(10.) -> M1add\n");
+  M1add.display();
+
+  auto MS1add = MS1.addCst(10.);
+  message("MS1add = MS1.addCst(10.) -> MS1add\n");
+  MS1add.display();
+
+  // Product of a matrix by a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  M1.prodCst(2.);
+  message("M1.prodCstInPlace(2.) -> M1\n");
+  M1.display();
+
+  MS1.prodCst(2.);
+  message("MS1.prodCstInPlace(2.) -> MS1\n");
+  MS1.display();
+
+  // Product of a matrix by a constant and allocating a new class
+  reset(M1, M2, MS1, MS2, false);
+
+  auto M1prod = M1.prodCst(2.);
+  message("M1prod = M1.prodCst(2.) -> M1prod\n");
+  M1prod.display();
+
+  auto MS1prod = MS1.prodCst(2.);
+  message("MS1prod = MS1.prodCst(2.) -> MS1prod\n");
+  MS1prod.display();
+
+  ///////////////////////////
+  // Testing the operators //
+  ///////////////////////////
+  mestitle(0, "Testing the operators");
+
+  // Operator += with a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  M1 += 10.;
+  message("M1 += 10. -> M1\n");
+  M1.display();
+
+  MS1 += 10.;
+  message("MS1 += 10. -> MS1\n");
+  MS1.display();
+
+  // Operator -= with a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  M1 -= 10.;
+  message("M1 -= 10. -> M1\n");
+  M1.display();
+
+  MS1 -= 10.;
+  message("MS1 -= 10. -> MS1\n");
+  MS1.display();
+
+  // Operator + with a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  auto M1addOp = M1 + 10.;
+  message("M1addOp = M1 + 10. -> M1addOp\n");
+  M1addOp.display();
+
+  auto MS1addOp = MS1 + 10.;
+  message("MS1addOp = MS1 + 10. -> MS1addOp\n");
+  MS1addOp.display();
+
+  // Operator + with a constant
+  reset(M1, M2, MS1, MS2, false);
+
+  auto M1subtractOp = M1 - 10.;
+  message("M1subtractOp = M1 - 10. -> M1subtractOp\n");
+  M1subtractOp.display();
+
+  auto MS1subtractOp = MS1 - 10.;
+  message("MS1subtractOp = MS1 - 10. -> MS1subtractOp\n");
+  MS1subtractOp.display();
+
+  ///////////////////////////
+  // Testing child classes //
+  ///////////////////////////
+  mestitle(0, "Testing child classes");
+  MatrixSquare MSq1(3);
+  MatrixSquare MSq2(3);
+  resetSquare(MSq1, MSq2, true);
+
+  // Adding a constant
+  resetSquare(MSq1, MSq2, false);
+  AMatrix::addInPlace(MSq2, MSq1, 10.);
+  message("addInPlace(MSq2, MSq1, 10.) -> MSq2\n");
+  MSq2.display();
+
+  // Adding a constant
+  resetSquare(MSq1, MSq2, false);
+  AMatrix::addInPlace(MSq2, MSq1, MSq2);
+  message("addInPlace(MSq2, MSq1, MSq2) -> MSq2\n");
+  MSq2.display();
+
   return (0);
 }

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -9,9 +9,11 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Basic/ASerializable.hpp"
-#include "LinearOp/PrecisionOpMatrix.hpp"
-#include "Mesh/MeshETurbo.hpp"
-#include "Model/Model.hpp"
+#include "Matrix/AMatrix.hpp"
+#include "Matrix/MatrixDense.hpp"
+#include "Matrix/MatrixFactory.hpp"
+#include "Matrix/MatrixSquare.hpp"
+#include "Matrix/MatrixSymmetric.hpp"
 #include "geoslib_define.h"
 
 using namespace gstlrn;
@@ -23,15 +25,11 @@ int main(int argc, char* argv[])
   sfn << gslBaseName(__FILE__) << ".out";
   StdoutRedirect sr(sfn.str(), argc, argv);
   ASerializable::setPrefixName("test_a_template-"); // Here set the test name
-  Id nx = 350;
 
-  auto mesh   = MeshETurbo({nx, nx}, {}, {}, {}, false);
-  auto range  = nx / 2.;
-  auto sill   = 1.;
-  auto param  = 1.;
-  auto* model = Model::createFromParam(ECov::MATERN, range, sill, param);
-  message("Number of apices = %d\n", mesh.getNApices());
+  auto M1    = MatrixSquare(7, 7);
+  auto M2    = MatrixSymmetric(7, 7);
+  AMatrix* M = MatrixFactory::prodMatMat(&M1, &M2);
+  M->printConcreteClassName();
 
-  auto QOpCs = PrecisionOpMatrix(&mesh, model->getCovAniso(0));
   return 0;
 }

--- a/tests/py/test_MatrixSimulable.py
+++ b/tests/py/test_MatrixSimulable.py
@@ -8,8 +8,7 @@ np.random.seed(12334)
 # %%
 A = gl.MatrixSparse(4, 4)
 A.fillRandom()
-A.prodMat(A.transpose())
-
+gl.AMatrix.prodMatMatInPlace(A, A, A, False, True)
 Apython = A.toTL().todense()
 AChol = np.linalg.cholesky(Apython)
 x = np.random.normal(size=4)


### PR DESCRIPTION
Je publie cette version (non finie) des manipulations de matrices... essentiellement le produit de deux matrices, du type:
A = B * C
Pour 'instant, on n'invoque pas l'utilisation de symboles... On se contente de reflechir aux methodes

Je suis devant le probleme suivant:
0) on ne veut plus utiliser les pointeurs... ce qui ecarte le recours au polymorphisme!!! (pour eviter les codes un peu lourds retournant des pointeurs en AMatrix*, qu'il faut dynamic_caster avant utilisation et ne pas oublier de detruire a la fin!
Je pense qu'il y a consensus sur ce point.

1) on arrive (je pense) au consensus qu'on ne veut pas de methode de classe du genre:
             A.prod(B, C)
2) on prefere des methodes "static" comme:
            A = prod(B, C)
 voire en place comme:
           prod(A, B, C)
Le probleme est essentiellement souleve par l'ecriture du genre:
          A = prod(B, C)
ou il faut deviner le type de sortie.

C'est simple dans la branche MatrixSparse, mais plus complique dans la branche MatrixDense  (et ses filles MatrixSquare  et MatrixSymmetric): comment coder elegamment l'intelligence.

On peut illustrer ce pb plus simplement avec la methode transpose().
- Pour elle, on envisage plutot une methode de classe plutot qu'une static.
- cette methode ne modifie pas le type de matrice (pas besoin d'intelligence).
 Mais on voudrait permettre les codes suivants (ou MS represente une matrice Square et MY une matrice symmetrique):

Avec type sortie "auto":
auto res = MY.transpose()  alors res sera MatrixSymetric
auto res = MS.transpose() alors res sera MatrixSquare

Mais aussi avec type de sortie impose par l'utilisateur
MatrixSymetric res = MY.transpose() (ne devrait pas poser de pobleme)
MatrixSquare res = MS.transpose() (ne devrait pas poser de probleme)
MatrixSquare res = MY.transpose(): ce cas n'est pas naturel mais reste envisageable (peut etre).

Enfin, j'ai commencer a remplacer les anciens prodMatMat() par mypro() ou myprodInPlace() qui sont les versions modernes des produits. Je me suis arrete en cours
Pas encore touche a ProdNorm (At*B*A ou A*B*At).... mais ne devrait pas etre complique lorsque prodMatMat sera resolu.

Le dernier choix (et de taille) serait de savoir si la hierarchie MatrixDense -> MatrixSquare -> MatrixSymmetric est utile???
- Elle permet de ne "montrer" que les methodes necessaires (pourvu qu'on continue l'effort du cote de MatrixSparse) 
- Elle est probablement la cause de toute la complexite mentionnee ci-dessus
- Elle necessiterait que le caracter (carre ou symetrique) soit desormais un membre de la classe AMatrix et que l'utilisation d'un argument specifiquement carre ou symmetrique passe par le test prealable de cette caracteristique.

J'ai pushe cette version (temporaire mais utilisable) pour permettre de reflechir un peu avtn de terminer cette refactorisation.
