### PR TITLE
Correcting the instability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ test_*.NF
 test_*.out
 test_*-Data
 test_*-Grid
+test_a_template.cpp
 .ruff_cache

--- a/doc/details/derivatives.tex
+++ b/doc/details/derivatives.tex
@@ -20,7 +20,7 @@ with:
 
 We define the rotated coordinate \( \tilde{h} = R h \), so:
 \[
-r(h)^2 = \tilde{h}^\top \Lambda \tilde{h}
+{r(h)}^2 = \tilde{h}^\top \Lambda \tilde{h}
 \]
 
 \section*{2D Case}
@@ -62,7 +62,7 @@ Let \( d = 3 \), and \( R \in SO(3) \) be a rotation matrix parameterized by Eul
 
 \subsection*{Derivative with respect to scale \( s_i \)}
 
-Same as in 2D:
+Same as in 2D\@:
 \[
 \frac{\partial k(h)}{\partial s_i} = - \frac{C'(r)}{r} \cdot \frac{\tilde{h}_i^2}{s_i^3}
 \]
@@ -114,7 +114,7 @@ We want to maximize the log-likelihood function:
 
 Let's denote
 
-\[\hat\beta(\theta) = (X'Q_\theta X)^{-1}X'Q_\theta y\]
+\[\hat\beta(\theta) = {(X'Q_\theta X)}^{-1}X'Q_\theta y\]
 We can easily show that  \[\hat\beta(\theta) = \arg\max_\beta \ell(\theta,\beta)\]
 
 So we can define the profiled log-likelihood as:
@@ -130,12 +130,12 @@ Let's denote \( \hat y(\theta) = X\hat\beta(\theta) \).
 
 The derivative of the profiled log-likelihood with respect to \(\theta\) is given by:
 \[\frac{\partial p\ell(\theta)}{\partial \theta} = \frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta}\right) 
- -  \hat r(\theta)^\top Q_\theta \frac{\partial \hat r(\theta)}{\partial \theta}
- -  \frac{1}{2}\hat r(\theta)^\top  \frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) \]     
+ -  \hat {r(\theta)}^\top Q_\theta \frac{\partial \hat r(\theta)}{\partial \theta}
+ -  \frac{1}{2}\hat {r(\theta)}^\top  \frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) \]     
  
  Now let's compute the derivatives of \(\hat r(\theta)\):
 
-\[\hat r(\theta) = y - X\hat\beta(\theta) = y - X(X'Q_\theta X)^{-1}X'Q_\theta y\]
+\[\hat r(\theta) = y - X\hat\beta(\theta) = y - X{(X'Q_\theta X)}^{-1}X'Q_\theta y\]
 The derivative of \(\hat r(\theta)\) with respect to \(\theta\) is:
 
 \begin{align}
@@ -145,21 +145,21 @@ The derivative of \(\hat r(\theta)\) with respect to \(\theta\) is:
 with 
 
 \begin{align}
-  \frac{\partial \hat \beta(\theta)}{\partial \theta} &= -(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta}X (X'Q_\theta X)^{-1} X'Q_\theta y + (X'Q_\theta X)^{-1}X' \frac{\partial Q_\theta}{\partial \theta}y\\
-&=(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)
+  \frac{\partial \hat \beta(\theta)}{\partial \theta} &= -{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta}X {(X'Q_\theta X)}^{-1} X'Q_\theta y + {(X'Q_\theta X)}^{-1}X' \frac{\partial Q_\theta}{\partial \theta}y\\
+&={(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)
 \end{align}
 
 So 
 
-\[\frac{\partial \hat r(\theta)}{\partial \theta} = -X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\]
+\[\frac{\partial \hat r(\theta)}{\partial \theta} = -X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\]
 And we can compute
 
 \begin{align*}
-  \hat r(\theta)^\top Q_\theta \frac{\partial \hat r(\theta)}{\partial \theta} &= - \hat r(\theta)^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
-&= - (y-\hat y(\theta))^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
-&= - y^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)+ \hat y(\theta)^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
-&= - y^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) + y^\top Q_\theta X(X'Q_\theta X)^{-1}X' Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
-&=  - y^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)+ y^\top Q_\theta X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
+  \hat {r(\theta)}^\top Q_\theta \frac{\partial \hat r(\theta)}{\partial \theta} &= - \hat {r(\theta)}^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
+&= - {(y-\hat y(\theta))}^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
+&= - y^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)+ \hat {y(\theta)}^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
+&= - y^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) + y^\top Q_\theta X{(X'Q_\theta X)}^{-1}X' Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
+&=  - y^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)+ y^\top Q_\theta X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta} \hat r(\theta)\\
 &= 0
 \end{align*}
 
@@ -167,7 +167,7 @@ And we can compute
 
 Finally, we can rewrite the derivative of the profiled log-likelihood as:
 \[\frac{\partial p\ell(\theta)}{\partial \theta} = \frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta}\right) 
- -  \frac{1}{2}\hat r(\theta)^\top  \frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) \]
+ -  \frac{1}{2}\hat {r(\theta)}^\top  \frac{\partial Q_\theta}{\partial \theta} \hat r(\theta) \]
 
 
  For the second derivative, we have:
@@ -175,25 +175,25 @@ Finally, we can rewrite the derivative of the profiled log-likelihood as:
  \begin{align*}
 \frac{\partial^2 p\ell}{\partial \theta_i\partial\theta_j}(\theta) &= -\frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_i} Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_j}\right) +
 \frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j}\right)-  
-\frac{1}{2}\hat r(\theta)^\top  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} \hat r(\theta)\\
-&-\hat r(\theta)^\top\frac{\partial Q_\theta}{\partial \theta_i} \frac{\partial\hat r(\theta)}{\partial \theta_j}\\
+\frac{1}{2}\hat {r(\theta)}^\top  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} \hat r(\theta)\\
+&-\hat {r(\theta)}^\top\frac{\partial Q_\theta}{\partial \theta_i} \frac{\partial\hat r(\theta)}{\partial \theta_j}\\
 &= -\frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_i} Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_j}\right) +
 \frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j}\right)-  
-\frac{1}{2}\hat r(\theta)^\top  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} \hat r(\theta)\\
-&+\hat r(\theta)^\top\frac{\partial Q_\theta}{\partial \theta_i}X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j} \hat r(\theta)\\
+\frac{1}{2}\hat {r(\theta)}^\top  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} \hat r(\theta)\\
+&+\hat {r(\theta)}^\top\frac{\partial Q_\theta}{\partial \theta_i}X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j} \hat r(\theta)\\
  \end{align*}
 
-We can deduce the terms of the "Fisher information matrix" by taking the expectation of the second derivative of the profiled log-likelihood:
+We can deduce the terms of the \textbf{Fisher information matrix} by taking the expectation of the second derivative of the profiled log-likelihood:
 
 \begin{align*}
   E\left[\frac{\partial^2 p\ell}{\partial \theta_i\partial\theta_j}(\theta)\right] &=-\frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_i} Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_j}\right) +
   \frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j}\right)-  
-  \frac{1}{2}\mathrm{tr}\left(  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} E\left[\hat r(\theta)\hat r(\theta)^\top\right]\right)\\
-  &+\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}E\left[ \hat r(\theta)\hat r(\theta)^\top\right]\right)\\
+  \frac{1}{2}\mathrm{tr}\left(  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} E\left[\hat r(\theta)\hat {r(\theta)}^\top\right]\right)\\
+  &+\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}E\left[ \hat r(\theta)\hat {r(\theta)}^\top\right]\right)\\
   &=-\frac{1}{2} \mathrm{tr}\left(Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_i} Q_\theta^{-1} \frac{\partial Q_\theta}{\partial \theta_j}\right) +  
-  \frac{1}{2}\mathrm{tr}\left(  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} X(X'Q_\theta X)^{-1}X'\right)\\
-  &+\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}Q_\theta^{-1}\right)\\
-  &-\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X(X'Q_\theta X)^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}X(X'Q_\theta X)^{-1}X'\right)\\
+  \frac{1}{2}\mathrm{tr}\left(  \frac{\partial^2 Q_\theta}{\partial \theta_i\partial\theta_j} X{(X'Q_\theta X)}^{-1}X'\right)\\
+  &+\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}Q_\theta^{-1}\right)\\
+  &-\mathrm{tr}\left( \frac{\partial Q_\theta}{\partial \theta_i}X{(X'Q_\theta X)}^{-1}X'\frac{\partial Q_\theta}{\partial \theta_j}X{(X'Q_\theta X)}^{-1}X'\right)\\
 \end{align*}
 
 \end{document}

--- a/src/Core/model_auto.cpp
+++ b/src/Core/model_auto.cpp
@@ -526,9 +526,7 @@ label_end:
  ** \param[out] npadir_ret Total number of lags for all directions
  **
  *****************************************************************************/
-static Id st_get_vario_dimension(Vario* vario,
-                                 Id* nbexp_ret,
-                                 Id* npadir_ret)
+static Id st_get_vario_dimension(Vario* vario, Id* nbexp_ret, Id* npadir_ret)
 {
   Id nbexp  = 0;
   Id npadir = 0;

--- a/src/Variogram/Vario.cpp
+++ b/src/Variogram/Vario.cpp
@@ -1817,7 +1817,7 @@ Id Vario::getNext(Id ivar, Id jvar, Id idir, Id shift) const
   VectorDouble sw;
   auto nlag = getNLag(idir);
   Id count;
-  if (getFlagAsym()) return ITEST;
+  // if (getFlagAsym()) return ITEST; // This test does not seem usefull for the only type of call (from model_auto)
   auto iad = getDirSize(idir) - 1;
   count    = 0;
   for (Id ilag = 0; ilag < nlag && count < shift; ilag++)


### PR DESCRIPTION
This bug was linked to an instability generated by the function Vario::getNext().
This function was not properly answering in the case of call for an Asymetric covariance. And this happened ONLY in the case of fitting using Covariance (as for PGS for example).
The result was unpredictable as it returned ITEST which was used next as an address.

In the mean time, the function test_a_template has been added to the list of IGNORED files to enable manipulating un-cleaned versions of this file.

Ultimately (and with no link) , the MD file Derivative.tex was cleaned out of latex_syntax_checker problems.