### PR TITLE
Update clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# This requires a version of clang-format above 21
+# This requires a version of clang-format above 22
 AlignAfterOpenBracket: true
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments: None
@@ -16,12 +16,13 @@ AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakTemplateDeclarations: 'Yes'
-BinPackArguments: false
-BinPackParameters: false
+BinPackArguments: true
+BinPackParameters: OnePerLine
 BitFieldColonSpacing: After
 BraceWrapping:
   AfterControlStatement: Always
 BreakAfterReturnType: Automatic
+BreakAfterOpenBracketFunction: true
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Allman
 BreakConstructorInitializers: BeforeComma


### PR DESCRIPTION
This PR updates the `.clang-format` file with the following changes:
- `BinPackArguments` set to `true`: function calls are allowed to have several arguments on the same line
- `BinPackParameters` set to `AlwaysOnePerLine` instead of `false` (this should have the same behavior): in function declarations & definitions, keep one parameter per line
- `BreakAfterOpenBracketFunction` set to `true`: in function declarations, definitions & calls, force a line break if parameters/arguments are too long. This last option is clang-format >= 22.

`Style.hpp` has been updated accordingly.

Pierre