### PR TITLE
GitHub Actions: Fix nonreg-macos brew install error

### DIFF
--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -42,7 +42,7 @@ jobs:
         brew install eigen
         brew install nlopt
         brew install hdf5
-        brew install gdal  # for terra
+        brew install gdal || true  # for terra
         echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
     - name: Setup Python


### PR DESCRIPTION
Ignore `brew install` error when install `gdal`.
