### PR TITLE
Remove doxygen warnings on MultiGridSolver

### DIFF
--- a/include/LinearOp/MultiGridSolver.hpp
+++ b/include/LinearOp/MultiGridSolver.hpp
@@ -25,8 +25,6 @@
 #include <memory>
 #include <vector>
 
-#pragma once
-
 namespace gstlrn
 {
 


### PR DESCRIPTION
Remove one "pragma once" in MultiGridSolver.hpp (recent doxygen version doesn't like it).
Thank you @pierre-guillou for your eagle eye!