### PR TITLE
Use new files-publish-action v7 version (more efficient)

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -61,12 +61,12 @@ jobs:
 
     - uses: actions/upload-artifact@v6
       with:
-        name: bib-file-${{env.PROJECT_VERSION}}
+        name: bib-file-${{env.PROJECT_FULL_VERSION}}
         path: ${{env.BIB_FILE}}
 
     - uses: actions/upload-artifact@v6
       with:
-        name: r-readme-${{env.PROJECT_VERSION}}
+        name: r-readme-${{env.PROJECT_FULL_VERSION}}
         path: ${{env.R_README_FILE}}
 
   call-data:
@@ -146,20 +146,20 @@ jobs:
 
       - env:
           PROJECT_FULL_VERSION: ${{needs.get-version.outputs.project_full_version}}
-        uses: fabien-ors/files-publish-action@v3
+        uses: fabien-ors/files-publish-action@v7
         with:
           host: ${{ secrets.CG_HOST }}
           username: ${{ secrets.CG_USR }}
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{env.PROJECT_FULL_VERSION}}"
-          pattern: "*.bib"
+          pattern: "bib-file*"
 
       - env:
           PROJECT_FULL_VERSION: ${{needs.get-version.outputs.project_full_version}}
-        uses: fabien-ors/files-publish-action@v3
+        uses: fabien-ors/files-publish-action@v7
         with:
           host: ${{ secrets.CG_HOST }}
           username: ${{ secrets.CG_USR }}
           password: ${{ secrets.CG_PWD }}
           dest-path: "/var/www/html/gstlearn/${{env.PROJECT_FULL_VERSION}}"
-          pattern: "R_README.html"
+          pattern: "r-readme*"


### PR DESCRIPTION
This PR modifies publish_doc workflow in order to uses the new version of files-publish-action (v7) which only downloads required artifacts (more efficient). It also renames the artifact names for bib-file and r-readme using the correct project version.