### PR TITLE
Replace assert in clone() with static_assert

### DIFF
--- a/include/Basic/ICloneable.hpp
+++ b/include/Basic/ICloneable.hpp
@@ -51,7 +51,8 @@ public:                                                                        \
     static_assert(                                                             \
       !std::is_abstract<Class>::value,                                         \
       "Class cannot be cloned as it is abstract");                             \
-    assert(typeid(*this) == typeid(Class));                                    \
+    static_assert(                                                             \
+      std::is_base_of_v<Class, std::remove_cvref_t<decltype(*this)>>);         \
     return (new Class(*this));                                                 \
   }
 } // namespace gstlrn


### PR DESCRIPTION
The assert is a runtime check that is removed in Release mode. On the contrary, static_assert is checked at compile-time, independently of the build type.

The assert has been triggered in `InvNuggetOp::cloneInvNuggetMatrix()` because `typeid(Derived) != typeid(Base)`. The static_assert fixes this issue as well.