### PR TITLE
MatrixSparse: Fix Eigen assert in Debug mode

### DIFF
--- a/src/Matrix/MatrixSparse.cpp
+++ b/src/Matrix/MatrixSparse.cpp
@@ -1472,11 +1472,13 @@ namespace gstlrn
     Eigen::Map<const Eigen::VectorXd> vecm(vec.data(), vec.size());
     if (transpose)
     {
-      res.eigenMat() = a.eigenMat().transpose() * vecm * a.eigenMat();
+      res.eigenMat() =
+        a.eigenMat().transpose() * vecm.asDiagonal() * a.eigenMat();
     }
     else
     {
-      res.eigenMat() = a.eigenMat() * vecm * a.eigenMat().transpose();
+      res.eigenMat() =
+        a.eigenMat() * vecm.asDiagonal() * a.eigenMat().transpose();
     }
   }
 


### PR DESCRIPTION
The `MatrixSparse::_prodnormGeneral` method is using a matrix-vector-matrix multiplication that hits an assert in Eigen when gstlearn is built in Debug mode.

The assert message is `lhs.cols() == rhs.rows() && "invalid matrix product" && "if you wanted a coeff-wise or a dot product use the respective explicit functions"`. See `test_Vecchia` for instance.

This PR fixes the issue by converting the inner vector to a diagonal matrix, which already occurs in `MatrixSparse::prodNormMatVecInPlace`.

Pierre