### PR TITLE
Fix out-of-bounds in CorAniso

### DIFF
--- a/src/Covariances/CorAniso.cpp
+++ b/src/Covariances/CorAniso.cpp
@@ -1888,7 +1888,9 @@ namespace gstlrn
       {
         if (getNDim() > 2 || idim < 1)
         {
-          _aniso.setRotationAngle(idim, _angles[idim].getValue());
+          double angleLocal =
+            (_angles.size() > 0) ? _angles[idim].getValue() : 0.;
+          _aniso.setRotationAngle(idim, angleLocal);
         }
         _aniso.setRadiusDir(idim, exp(_scales[idim].getValue()));
       }


### PR DESCRIPTION
If the internal member _angles has not been defined, we can use the default value of each one of its element, e.g. "zero".
This has been corrected.
Fix #903