### PR TITLE
Add missing GSTLEARN_EXPORT

### DIFF
--- a/include/Basic/PolyLine2D.hpp
+++ b/include/Basic/PolyLine2D.hpp
@@ -118,7 +118,7 @@ namespace gstlrn
     friend class Faults;
   };
 
-  double distanceBetweenPolylines(
+  GSTLEARN_EXPORT double distanceBetweenPolylines(
     const PolyLine2D& poly1,
     const PolyLine2D& poly2,
     const PolyPoint2D& pldist1,


### PR DESCRIPTION
Has caused an `undefined symbol` error at run-time when importing the Python package.

Pierre