### PR TITLE
Stick to fs 2.0.1 R package

### DIFF
--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -52,6 +52,7 @@ jobs:
 
     - name: Install R dependencies
       run: |
+        Rscript -e "install.packages ('https://cran.r-project.org/src/contrib/Archive/fs/fs_2.0.1.tar.gz')"
         Rscript -e "install.packages (c('ggpubr', 'ggplot2', 'ggnewscale', 'vctrs', 'lares', 'rgl', 'Matrix', 'FNN', 'tidyr', 'geigen', 'callr', 'knitr', 'readxl', 'tictoc'))"
 
     - name: Install the customized SWIG from source


### PR DESCRIPTION
This PR fixes de R demos non-reg.
New version of 'fs' package (2.1.0) needs new dependencies (uv.h) not available on github runner.
We prefer to stick to the previous version (2.0.1) while waiting to diagnose the issue.