### PR TITLE
Fix Rmd CI due to rgl package and missing libGLU.so

### DIFF
--- a/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
+++ b/.github/workflows/nonreg-demos-courses_r_ubuntu-latest.yml
@@ -43,6 +43,7 @@ jobs:
           libeigen3-dev \
           libnlopt-dev \
           libpng-dev \
+          libglu1-mesa-dev \
           pandoc
 
     - name: Setup R Version


### PR DESCRIPTION
Graphics3D and Spectral_Sphere demo were crashing due to a missing shared library on the runner: libGLU.so (which is now requred by the 'rgl' package)
By installing libglu1-mesa-dev beforehand, the issue disappears