### PR TITLE
Correct the issue 917 for N. Bez by modifying CovCalcMode class

### DIFF
--- a/include/Covariances/CovCalcMode.hpp
+++ b/include/Covariances/CovCalcMode.hpp
@@ -18,6 +18,13 @@
 
 namespace gstlrn
 {
+  /**
+   * @brief This class contains the information about the mode of covariance calculation, such as:
+   * - whether to calculate variogram instead of covariance,
+   * - whether to calculate unitary covariance (without sill, needed in Goulard's method),
+   * - whether to calculate sill for coregionalization envelop,
+   * - the higher variogram order (0 for standard variogram).
+   */
   class GSTLEARN_EXPORT CovCalcMode: public AStringable
   {
   public:
@@ -42,6 +49,8 @@ namespace gstlrn
 
     bool getUnitary() const { return _unitary; }
 
+    bool getEnvelop() const { return _envelop; }
+
     Id getOrderVario() const { return _orderVario; }
 
     void setAsVario(bool asVario) { _asVario = asVario; }
@@ -50,12 +59,15 @@ namespace gstlrn
 
     void setUnitary(bool unitary) { _unitary = unitary; }
 
+    void setEnvelop(bool envelop) { _envelop = envelop; }
+
     void setOrderVario(Id orderVario) { _orderVario = orderVario; }
 
   private:
     ECalcMember _member; /*! LHS (default), RHS or VAR(IANCE) */
     bool _asVario; /*! True to calculate variogram instead of covariance */
     bool _unitary; /*! True to calculate covariance without sill (in Goulard) */
+    bool _envelop; /*! True to calculate sill for coregionalization envelop */
     Id _orderVario; /*! Higher Variogram Order (0: standard) */
   };
 } // namespace gstlrn

--- a/src/Covariances/ACov.cpp
+++ b/src/Covariances/ACov.cpp
@@ -2487,13 +2487,12 @@ namespace gstlrn
     {
       (void)GH::rotationGetDirectionDefault(ndim, codir);
     }
-    Id nh = static_cast<Id>(hh.size());
-    VectorDouble gg(nh);
-    VectorDouble g1 = sample(hh, codir, ivar, ivar, mode);
-    VectorDouble g2 = sample(hh, codir, jvar, jvar, mode);
-
-    for (Id i = 0; i < nh; i++) gg[i] = isign * sqrt(ABS(g1[i] * g2[i]));
-
+    CovCalcMode modeLoc =
+      (mode != nullptr) ? *mode : CovCalcMode(ECalcMember::LHS);
+    modeLoc.setEnvelop(true);
+    VectorDouble gg = sample(hh, codir, ivar, jvar, &modeLoc);
+    if (isign < 0)
+      for (Id i = 0, n = gg.size(); i < n; i++) gg[i] = -gg[i];
     return gg;
   }
 

--- a/src/Covariances/CovAniso.cpp
+++ b/src/Covariances/CovAniso.cpp
@@ -115,7 +115,12 @@ namespace gstlrn
   double
     CovAniso::_getSillValue(Id ivar, Id jvar, const CovCalcMode* mode) const
   {
-    if (mode != nullptr && mode->getUnitary()) return 1.;
+    if (mode != nullptr)
+    {
+      if (mode->getUnitary()) return 1;
+      if (mode->getEnvelop())
+        return sqrt(getSill(ivar, ivar) * getSill(jvar, jvar));
+    }
     return getSill(ivar, jvar);
   }
 

--- a/src/Covariances/CovCalcMode.cpp
+++ b/src/Covariances/CovCalcMode.cpp
@@ -22,6 +22,7 @@ namespace gstlrn
     , _member(member)
     , _asVario(asVario)
     , _unitary(unitary)
+    , _envelop(false)
     , _orderVario(orderVario)
   {
   }
@@ -31,6 +32,7 @@ namespace gstlrn
     , _member(r._member)
     , _asVario(r._asVario)
     , _unitary(r._unitary)
+    , _envelop(r._envelop)
     , _orderVario(r._orderVario)
   {
   }
@@ -43,6 +45,7 @@ namespace gstlrn
       _member = r._member;
       _asVario = r._asVario;
       _unitary = r._unitary;
+      _envelop = r._envelop;
       _orderVario = r._orderVario;
     }
     return *this;

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -9,7 +9,6 @@
 /*                                                                            */
 /******************************************************************************/
 #include "Basic/ASerializable.hpp"
-#include "Variogram/Vario.hpp"
 #include "geoslib_define.h"
 
 using namespace gstlrn;
@@ -22,13 +21,5 @@ int main(int argc, char* argv[])
   StdoutRedirect sr(sfn.str(), argc, argv);
   ASerializable::setPrefixName("test_a_template-"); // Here set the test name
 
-  String filename = "/home/drenard/TEST_gstlearn/test_SimGaussian-Vario_TB";
-  auto filetype = ASerializable::getFileIdentity(filename);
-  auto* vario = Vario::createFromNF(filename, false);
-  if (!vario)
-  {
-    std::cerr << "Error creating Vario from file: " << filename << std::endl;
-    return 1;
-  }
   return 0;
 }


### PR DESCRIPTION
The calculation of the coregionalization envelop has been corrected. It was used only in:
- the method envelop()
- the graphic representation of a multivariate model

Fix #917 