### PR TITLE
Add dependency for gdal under MacOS

### DIFF
--- a/.github/workflows/nonreg-tests_macos-latest.yml
+++ b/.github/workflows/nonreg-tests_macos-latest.yml
@@ -42,6 +42,7 @@ jobs:
         brew install eigen
         brew install nlopt
         brew install hdf5
+        brew install python-tk # for gdal
         brew install gdal || true  # for terra
         echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
This PR fixes the non-reg tests under MacOS.

The R package 'terra' needs gdal library. gdal was not correctly installed due to a missing new dependency (python-tk)

This has been added in "Setup dependenciues" job.