### PR TITLE
Use last version of customized swig for R

### DIFF
--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -48,7 +48,7 @@ jobs:
         pacman -Sy --noconfirm mingw-w64-x86_64-hdf5
 
     - name: Install the customized SWIG from source
-      uses: fabien-ors/install-swig-windows-action@v2
+      uses: fabien-ors/install-swig-windows-action@v3
       with:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Visual Studio 17 2022"

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -82,7 +82,7 @@ jobs:
         doxygen-version: ${{env.DOXYGEN_VERSION}}
 
     - name: Install the customized SWIG from source
-      uses: fabien-ors/install-swig-windows-action@v2
+      uses: fabien-ors/install-swig-windows-action@v3
       with:
         swig-root: ${{env.SWIG_ROOT}}
         generator: "Visual Studio 17 2022"


### PR DESCRIPTION
Since the customized SWIG has been updated to the last version (SWIG 4.5.0), the github action for installing SWIG must be updated.