### PR TITLE
Fix compilation with VS 2017 / boost::span

### DIFF
--- a/include/Basic/ICloneable.hpp
+++ b/include/Basic/ICloneable.hpp
@@ -42,7 +42,7 @@ namespace gstlrn
   };
 
 // std::remove_cvref_t not defined in C++17, however std::decay_t provides a
-// close-enough equivalent since this is not used here with functions or arrays, see:
+// close-enough equivalent since this is not used here with functions or arrays
 // https://devblogs.microsoft.com/cppblog/cpp17-20-features-and-fixes-in-vs-2019/
 #ifdef USE_BOOST_SPAN
 #define REMOVE_CVREF_T std::decay_t

--- a/include/Basic/ICloneable.hpp
+++ b/include/Basic/ICloneable.hpp
@@ -41,6 +41,15 @@ namespace gstlrn
 #endif
   };
 
+// std::remove_cvref_t not defined in C++17, however std::decay_t provides a
+// close-enough equivalent since this is not used here with functions or arrays, see:
+// https://devblogs.microsoft.com/cppblog/cpp17-20-features-and-fixes-in-vs-2019/
+#ifdef USE_BOOST_SPAN
+#define REMOVE_CVREF_T std::decay_t
+#else
+#define REMOVE_CVREF_T std::remove_cvref_t
+#endif
+
 // Thanks to here (macro way):
 // https://alfps.wordpress.com/2010/06/12/cppx-3-ways-to-mix-in-a-generic-cloning-implementation/
 #define IMPLEMENT_CLONING(Class)                                               \
@@ -52,7 +61,7 @@ public:                                                                        \
       !std::is_abstract<Class>::value,                                         \
       "Class cannot be cloned as it is abstract");                             \
     static_assert(                                                             \
-      std::is_base_of_v<Class, std::remove_cvref_t<decltype(*this)>>);         \
+      std::is_base_of_v<Class, REMOVE_CVREF_T<decltype(*this)>>);              \
     return (new Class(*this));                                                 \
   }
 } // namespace gstlrn

--- a/include/Basic/ICloneable.hpp
+++ b/include/Basic/ICloneable.hpp
@@ -60,8 +60,7 @@ public:                                                                        \
     static_assert(                                                             \
       !std::is_abstract<Class>::value,                                         \
       "Class cannot be cloned as it is abstract");                             \
-    static_assert(                                                             \
-      std::is_base_of_v<Class, REMOVE_CVREF_T<decltype(*this)>>);              \
+    static_assert(std::is_base_of_v<Class, REMOVE_CVREF_T<decltype(*this)>>);  \
     return (new Class(*this));                                                 \
   }
 } // namespace gstlrn

--- a/include/LinearOp/IPrecisionOp.hpp
+++ b/include/LinearOp/IPrecisionOp.hpp
@@ -52,10 +52,11 @@ namespace gstlrn
 #endif
   };
 
-  // For some reason VS2017 crashes at runtime when a derived class calls this constructor
-  // if = default is in the class declaration, but works if it's inline here (which makes
-  // the constructor "user-provided" and may cause the difference?). This is a bug,
-  // most likely due to a mix of dllexport, default keyword and virtual (base) classes?
+  // For some reason VS2017 crashes at runtime when a derived class calls this
+  // constructor if = default is in the class declaration, but works if it's
+  // inline here (which makes the constructor "user-provided" and may cause the
+  // difference?). This is a bug, most likely due to a mix of dllexport, default
+  // keyword and virtual (base) classes?
   inline IPrecisionOp::IPrecisionOp() = default;
 
 } // namespace gstlrn

--- a/include/LinearOp/IPrecisionOp.hpp
+++ b/include/LinearOp/IPrecisionOp.hpp
@@ -20,7 +20,7 @@ namespace gstlrn
   class GSTLEARN_EXPORT IPrecisionOp: virtual public ASimulable
   {
   public:
-    IPrecisionOp() = default;
+    IPrecisionOp(); // default but see below
     IPrecisionOp(const IPrecisionOp&) = default;
 
     IPrecisionOp(IPrecisionOp&& m) noexcept
@@ -51,5 +51,11 @@ namespace gstlrn
     virtual std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const = 0;
 #endif
   };
+
+  // For some reason VS2017 crashes at runtime when a derived class calls this constructor
+  // if = default is in the class declaration, but works if it's inline here (which makes
+  // the constructor "user-provided" and may cause the difference?). This is a bug,
+  // most likely due to a mix of dllexport, default keyword and virtual (base) classes?
+  inline IPrecisionOp::IPrecisionOp() = default;
 
 } // namespace gstlrn

--- a/include/LinearOp/MultiGridSolver.hpp
+++ b/include/LinearOp/MultiGridSolver.hpp
@@ -42,7 +42,7 @@ namespace gstlrn
     MultiGridSolver(const MultiGridSolver& other) = delete;
     MultiGridSolver(MultiGridSolver&& other) noexcept = default;
     MultiGridSolver& operator=(const MultiGridSolver& other) = delete;
-    MultiGridSolver& operator=(MultiGridSolver&& other) noexcept = default;
+    MultiGridSolver& operator=(MultiGridSolver&& other) /*noexcept*/ = default;
     virtual ~MultiGridSolver() = default;
 
     MultiGridSolver& compute(const ALinearOp& /*default*/) { return *this; }

--- a/src/Simulation/BooleanObject.cpp
+++ b/src/Simulation/BooleanObject.cpp
@@ -83,9 +83,9 @@ namespace gstlrn
     else
       sstr << "Object with unknown mode = " << _mode << std::endl;
     sstr << "- Type        = " << _token.getType().getDescr() << std::endl;
-    constvect center_ndim(_center.begin(), _center.begin() + _ndim);
+    constvect center_ndim(_center.data(), _center.data() + _ndim);
     sstr << "- Center      = " << toStrVectorVec(String(), center_ndim);
-    constvect extension_ndim(_extension.begin(), _extension.begin() + _ndim);
+    constvect extension_ndim(_extension.data(), _extension.data() + _ndim);
     sstr << "- Extension   = " << toStrVectorVec(String(), extension_ndim);
     sstr << "- Orientation = " << _orientation << std::endl;
 


### PR DESCRIPTION
* boost::span doesn't have constructors from iterators, so use a constructor from pointer instead.
* std::remove_cvref is C++20 only, for C++17 we can use std::decay. This isn't strictly equivalent however for our use-case this is the same.
* For some reason VS refuses to use the move assignment of MultiGridSolver (in SPDEOp::SPDEOp) when it is marked noexcept (and it tries to use the copy assignment which is deleted so we get an error, which is good here!). I don't think that noexcept is very important in this declaration so I've commented it out.
* There is a crash in IPrecisionOp default functions, see comment in code. I am uneasy with this crash, and the fix, because I don't understand either of them, and I can't find a reference to any VS2017 bug that would explain it. I also wasn't able to extract a simplified minimal example that crashes. This means that issue could happen anywhere else as I can't give a rule of when it does...