### PR TITLE
Reduce memory usage for SPDE

### DIFF
--- a/include/LinearOp/PrecisionOp.hpp
+++ b/include/LinearOp/PrecisionOp.hpp
@@ -132,6 +132,7 @@ namespace gstlrn
     APolynomial* getPoly(const EPowerPT& power);
 
 #ifndef SWIG
+
   protected:
     Id
       _addEvalPoly(const EPowerPT& power, const constvect inv, vect outv) const;

--- a/include/LinearOp/PrecisionOp.hpp
+++ b/include/LinearOp/PrecisionOp.hpp
@@ -165,9 +165,6 @@ namespace gstlrn
   protected:
     mutable VectorDouble _work;
     mutable VectorDouble _work2;
-    mutable VectorDouble _work3;
-    mutable VectorDouble _work4;
-    mutable VectorDouble _work5;
     mutable VectorVectorDouble _workPoly;
 #endif
   };

--- a/include/LinearOp/PrecisionOp.hpp
+++ b/include/LinearOp/PrecisionOp.hpp
@@ -129,10 +129,10 @@ namespace gstlrn
     double computeLogDet(Id nMC = 1) const override;
     virtual VectorDouble extractDiag() const;
 
-  protected:
     APolynomial* getPoly(const EPowerPT& power);
 
 #ifndef SWIG
+  protected:
     Id
       _addEvalPoly(const EPowerPT& power, const constvect inv, vect outv) const;
     Id _addToDest(const constvect inv, vect outv) const override;

--- a/include/LinearOp/PrecisionOpMatrix.hpp
+++ b/include/LinearOp/PrecisionOpMatrix.hpp
@@ -90,6 +90,9 @@ namespace gstlrn
   private:
     std::shared_ptr<MatrixSparse> _Q;
     mutable CholeskySparse* _chol;
+    mutable VectorDouble _work3;
+    mutable VectorDouble _work4;
+    mutable VectorDouble _work5;
   };
 
 } // namespace gstlrn

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -58,7 +58,7 @@ namespace gstlrn
     double computeLogDet(Id nMC = 1) const override;
     std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const override;
 
-	PrecisionOp* getPrecision(Id idx);
+    PrecisionOp* getPrecision(Id idx);
 
   protected:
 #ifndef SWIG

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -58,6 +58,8 @@ namespace gstlrn
     double computeLogDet(Id nMC = 1) const override;
     std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const override;
 
+	PrecisionOp* getPrecision(Id idx);
+
   protected:
 #ifndef SWIG
     Id _addToDest(const constvect vecin, vect vecout) const override;

--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -43,10 +43,13 @@ namespace gstlrn
       return (_projs.size() == 0 ? 0 : _projs.back().get().getNPoint());
     }
 
+#ifndef SWIG
+
     Id setWorkArrays(vect work1, vect work2 = {});
 
   protected:
     Id initWorkArrays(vect& work1, vect& work2) const;
+#endif
 
   private:
     using ProjVect = std::vector<std::reference_wrapper<const IProj>>;

--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -53,6 +53,6 @@ namespace gstlrn
 
     ProjVect _projs;
     mutable VectorDouble _w1, _w2; // local work arrays
-    mutable vect _work1, _work2;   // shared work arrays
+    mutable vect _work1, _work2; // shared work arrays
   };
 } // namespace gstlrn

--- a/include/LinearOp/ProjComposition.hpp
+++ b/include/LinearOp/ProjComposition.hpp
@@ -43,10 +43,16 @@ namespace gstlrn
       return (_projs.size() == 0 ? 0 : _projs.back().get().getNPoint());
     }
 
+    Id setWorkArrays(vect work1, vect work2 = {});
+
+  protected:
+    Id initWorkArrays(vect& work1, vect& work2) const;
+
   private:
     using ProjVect = std::vector<std::reference_wrapper<const IProj>>;
 
     ProjVect _projs;
-    mutable VectorVectorDouble _works;
+    mutable VectorDouble _w1, _w2; // local work arrays
+    mutable vect _work1, _work2;   // shared work arrays
   };
 } // namespace gstlrn

--- a/include/LinearOp/ProjMulti.hpp
+++ b/include/LinearOp/ProjMulti.hpp
@@ -74,7 +74,5 @@ namespace gstlrn
     VectorInt _pointNumbers;
     VectorInt _apexNumbers;
     bool _silent;
-    mutable VectorDouble _work;
-    mutable VectorDouble _workmesh;
   };
 } // namespace gstlrn

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -154,6 +154,7 @@ namespace gstlrn
 
   protected:
     void _prepare(bool w1 = true, bool w2 = true) const;
+
   private:
     void _addADinvAt(const constvect inv, vect outv) const;
 

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -152,8 +152,9 @@ namespace gstlrn
     Id _buildRhs(const constvect inv) const;
 #endif
 
-  private:
+  protected:
     void _prepare(bool w1 = true, bool w2 = true) const;
+  private:
     void _addADinvAt(const constvect inv, vect outv) const;
 
   protected:
@@ -166,8 +167,6 @@ namespace gstlrn
     APreconditioner* _precond;
     bool _verbose;
 
-  private:
-    Id _ndat;
     mutable VectorDouble _workdat1;
     mutable VectorDouble _workdat2;
     mutable VectorDouble _workdat3;
@@ -177,6 +176,9 @@ namespace gstlrn
     mutable VectorDouble _rhs;
     mutable VectorDouble _workmesh;
     mutable VectorDouble _workGibbsData;
+
+  private:
+    Id _ndat;
   };
 
   /****************************************************************************/

--- a/include/Polynomials/ClassicalPolynomial.hpp
+++ b/include/Polynomials/ClassicalPolynomial.hpp
@@ -77,7 +77,7 @@ namespace gstlrn
 
   private:
     mutable VectorDouble _w1, _w2; // local work arrays
-    mutable vect _work1, _work2;   // shared work arrays
+    mutable vect _work1, _work2; // shared work arrays
 #endif
   };
 } // namespace gstlrn

--- a/include/Polynomials/ClassicalPolynomial.hpp
+++ b/include/Polynomials/ClassicalPolynomial.hpp
@@ -70,14 +70,14 @@ namespace gstlrn
 
     void _addEvalOp(const ALinearOp* Op, const constvect inv, vect outv)
       const override;
+    Id setWorkArrays(vect work1, vect work2);
 
-#endif
-
-#ifndef SWIG
+  protected:
+    Id initWorkArrays(vect& work1, vect& work2, size_t size) const;
 
   private:
-    mutable VectorDouble _work;
-    mutable VectorDouble _work2;
+    mutable VectorDouble _w1, _w2; // local work arrays
+    mutable vect _work1, _work2;   // shared work arrays
 #endif
   };
 } // namespace gstlrn

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -360,14 +360,14 @@ namespace gstlrn
     const EPowerPT& power) const
   {
     constvect in = inv;
-    if (_work.size() == 0) _work.resize(getSize());
     if (_work2.size() == 0) _work2.resize(getSize());
-    vect worksp(_work);
     vect worksp2(_work2);
     // Pre-processing
 
     if (power == EPowerPT::ONE || power == EPowerPT::MINUSONE)
     {
+      if (_work.size() == 0) _work.resize(getSize());
+      vect worksp(_work);
       _shiftOp->prodLambda(inv, worksp, power);
       in = worksp;
     }

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -428,7 +428,7 @@ namespace gstlrn
         }
       }
 
-      if (_work5.size() == 0) _work5.resize(getSize());
+      if (_work.size() == 0) _work.resize(getSize());
 
       // TODO use clone is probably better...
       if (a == nullptr)
@@ -437,7 +437,7 @@ namespace gstlrn
         return 1;
       }
       static_cast<ClassicalPolynomial*>(_polynomials[power].get())
-        ->evalOpTraining(a->getS(), invs, _workPoly, _work5);
+        ->evalOpTraining(a->getS(), invs, _workPoly, _work);
 
       for (Id i = 0; i < static_cast<Id>(inv.size()); i++)
       {
@@ -454,12 +454,12 @@ namespace gstlrn
 
   void PrecisionOp::evalInverse(const constvect vecin, VectorDouble& vecout)
   {
-    if (_work.size() != vecin.size()) _work.resize(vecin.size());
+    if (_work2.size() != vecin.size()) _work2.resize(vecin.size());
     vect vecouts(vecout);
     _shiftOp->prodLambda(vecin, vecouts, EPowerPT::MINUSONE);
-    vect works(_work);
-    _evalPoly(EPowerPT::MINUSONE, vecout, works);
-    _shiftOp->prodLambda(works, vecouts, EPowerPT::MINUSONE);
+    vect works2(_work2);
+    _evalPoly(EPowerPT::MINUSONE, vecout, works2);
+    _shiftOp->prodLambda(works2, vecouts, EPowerPT::MINUSONE);
   }
 
   VectorDouble PrecisionOp::computeCov(Id imesh)

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -389,7 +389,7 @@ namespace gstlrn
     vect outv,
     const EPowerPT& power) const
   {
-    const constvect* inPtr = &inv;
+    constvect in = inv;
     if (_work.size() == 0) _work.resize(getSize());
     if (_work2.size() == 0) _work2.resize(getSize());
     vect worksp(_work);
@@ -399,12 +399,12 @@ namespace gstlrn
     if (power == EPowerPT::ONE || power == EPowerPT::MINUSONE)
     {
       _shiftOp->prodLambda(inv, worksp, power);
-      inPtr = reinterpret_cast<constvect*>(&worksp);
+      in = worksp;
     }
 
     // Polynomial evaluation
 
-    if (_evalPoly(power, *inPtr, worksp2) != 0)
+    if (_evalPoly(power, in, worksp2) != 0)
       my_throw(
         "Computation in 'eval' interrupted due to problem in '_evalPoly'");
 

--- a/src/LinearOp/PrecisionOp.cpp
+++ b/src/LinearOp/PrecisionOp.cpp
@@ -39,9 +39,6 @@ namespace gstlrn
     , _training(false)
     , _destroyShiftOp(false)
     , _userPoly(false)
-    , _work()
-    , _work2()
-    , _work3()
   {
   }
 
@@ -57,16 +54,7 @@ namespace gstlrn
     , _training(false)
     , _destroyShiftOp(false)
     , _userPoly(false)
-    , _work()
-    , _work2()
-    , _work3()
   {
-    if (_shiftOp != nullptr)
-    {
-      _work.resize(_shiftOp->getSize());
-      _work2.resize(_shiftOp->getSize());
-      _work3.resize(_shiftOp->getSize());
-    }
   }
 
   PrecisionOp::PrecisionOp(
@@ -82,9 +70,6 @@ namespace gstlrn
     , _training(false)
     , _destroyShiftOp(true)
     , _userPoly(false)
-    , _work()
-    , _work2()
-    , _work3()
   {
     const auto* meshTurbo = dynamic_cast<const MeshETurbo*>(mesh);
 
@@ -105,9 +90,6 @@ namespace gstlrn
     {
       _shiftOp->normalizeLambdaBySills(mesh);
     }
-    _work.resize(_shiftOp->getSize());
-    _work2.resize(_shiftOp->getSize());
-    _work3.resize(_shiftOp->getSize());
   }
 
   PrecisionOp::PrecisionOp(const PrecisionOp& pmat)
@@ -119,9 +101,6 @@ namespace gstlrn
     , _training(false)
     , _destroyShiftOp(pmat._destroyShiftOp)
     , _userPoly(false)
-    , _work(pmat._work)
-    , _work2(pmat._work2)
-    , _work3(pmat._work3)
   {
     if (_destroyShiftOp)
       _shiftOp = dynamic_cast<AShiftOp*>(pmat._shiftOp->clone());
@@ -143,9 +122,6 @@ namespace gstlrn
       _training = pmat._training;
       _destroyShiftOp = pmat._destroyShiftOp;
       _userPoly = pmat._userPoly;
-      _work = pmat._work;
-      _work2 = pmat._work2;
-      _work3 = pmat._work3;
 
       if (_destroyShiftOp)
       {
@@ -173,9 +149,6 @@ namespace gstlrn
     , _training(pmat._training)
     , _destroyShiftOp(pmat._destroyShiftOp)
     , _userPoly(pmat._userPoly)
-    , _work(std::move(pmat._work))
-    , _work2(std::move(pmat._work2))
-    , _work3(std::move(pmat._work3))
   {
     pmat._shiftOp = nullptr;
     pmat._cova = nullptr;
@@ -194,9 +167,6 @@ namespace gstlrn
       _training = pmat._training;
       _destroyShiftOp = pmat._destroyShiftOp;
       _userPoly = pmat._userPoly;
-      _work = std::move(pmat._work);
-      _work2 = std::move(pmat._work2);
-      _work3 = std::move(pmat._work3);
 
       pmat._shiftOp = nullptr;
       pmat._cova = nullptr;

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -239,7 +239,7 @@ namespace gstlrn
     const EPowerPT& power)
   {
     DECLARE_UNUSED(iapex, igparam)
-    if (_work.size() == 0) _work3.resize(getSize());
+    if (_work.size() == 0) _work.resize(getSize());
     if (_work5.size() == 0) _work5.resize(getSize());
 
     vect ws(_work);

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -137,13 +137,13 @@ namespace gstlrn
     vect result,
     const EPowerPT& power)
   {
-    if (_work2.size() == 0) _work2.resize(getSize());
     if (_work3.size() == 0) _work3.resize(getSize());
     if (_work4.size() == 0) _work4.resize(getSize());
+    if (_work5.size() == 0) _work5.resize(getSize());
 
-    vect w2s(_work2);
     vect w3s(_work3);
     vect w4s(_work4);
+    vect w5s(_work5);
     setTraining(false);
     evalPower(Y, w3s, power);
     setTraining(true);
@@ -173,10 +173,10 @@ namespace gstlrn
             (Y[iapex] * _work4[iapex] + X[iapex] * _work3[iapex]) * temp / val;
         }
 
-        evalDerivOptim(w2s, iapex, igparam, power);
+        evalDerivOptim(w5s, iapex, igparam, power);
         for (Id i = 0; i < getSize(); i++)
         {
-          result[iadress] += _work2[i] * Y[i];
+          result[iadress] += _work5[i] * Y[i];
         }
       }
     }
@@ -240,10 +240,10 @@ namespace gstlrn
   {
     DECLARE_UNUSED(iapex, igparam)
     if (_work.size() == 0) _work.resize(getSize());
-    if (_work5.size() == 0) _work5.resize(getSize());
+    if (_work2.size() == 0) _work2.resize(getSize());
 
     vect ws(_work);
-    vect w5s(_work5);
+    vect w2s(_work2);
     if (power == EPowerPT::MINUSONE)
       my_throw("'evalDeriv' is not yet implemented for 'POPT_MINUSONE'");
     if (power == EPowerPT::MINUSHALF)
@@ -252,7 +252,7 @@ namespace gstlrn
       my_throw("'evalDeriv' is not yet implemented for 'POPT_LOG'");
 
     // ((ClassicalPolynomial*) getPoly(power))->evalDerivOpOptim(getShiftOp(), ws,
-    //                                                           w5s, outv,
+    //                                                           w2s, outv,
     //                                                           _workPoly, iapex,
     //                                                           igparam);
 

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -239,11 +239,11 @@ namespace gstlrn
     const EPowerPT& power)
   {
     DECLARE_UNUSED(iapex, igparam)
-    //if (_work.size() == 0) _work.resize(getSize());
-    //if (_work2.size() == 0) _work2.resize(getSize());
+    // if (_work.size() == 0) _work.resize(getSize());
+    // if (_work2.size() == 0) _work2.resize(getSize());
 
-    //vect ws(_work);
-    //vect w2s(_work2);
+    // vect ws(_work);
+    // vect w2s(_work2);
     if (power == EPowerPT::MINUSONE)
       my_throw("'evalDeriv' is not yet implemented for 'POPT_MINUSONE'");
     if (power == EPowerPT::MINUSHALF)

--- a/src/LinearOp/PrecisionOpMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMatrix.cpp
@@ -239,11 +239,11 @@ namespace gstlrn
     const EPowerPT& power)
   {
     DECLARE_UNUSED(iapex, igparam)
-    if (_work.size() == 0) _work.resize(getSize());
-    if (_work2.size() == 0) _work2.resize(getSize());
+    //if (_work.size() == 0) _work.resize(getSize());
+    //if (_work2.size() == 0) _work2.resize(getSize());
 
-    vect ws(_work);
-    vect w2s(_work2);
+    //vect ws(_work);
+    //vect w2s(_work2);
     if (power == EPowerPT::MINUSONE)
       my_throw("'evalDeriv' is not yet implemented for 'POPT_MINUSONE'");
     if (power == EPowerPT::MINUSHALF)

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -439,7 +439,7 @@ namespace gstlrn
     {
       messerr(
         "computeLogDet is not implemented for multivariate case in the "
-        "matrix-free version\n");
+        "matrix-free version");
       return TEST;
     }
     double result = 0.;
@@ -454,6 +454,9 @@ namespace gstlrn
   {
     if (idx < 0 || idx > _getNCov())
     {
+      messerr(
+        "The index passed to getPrecision() must be between 0 and %d\n",
+        _getNCov()-1);
       return nullptr;
     }
     return _pops[idx];

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -450,12 +450,13 @@ namespace gstlrn
     return result;
   }
 
-  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx) {
+  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx)
+  {
     if (idx < 0 || idx > _getNCov())
     {
       return nullptr;
     }
     return _pops[idx];
   }
-  
+
 } // namespace gstlrn

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -456,7 +456,7 @@ namespace gstlrn
     {
       messerr(
         "The index passed to getPrecision() must be between 0 and %d\n",
-        _getNCov()-1);
+        _getNCov() - 1);
       return nullptr;
     }
     return _pops[idx];

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -449,4 +449,13 @@ namespace gstlrn
     }
     return result;
   }
+
+  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx) {
+    if (idx < 0 || idx > _getNCov())
+    {
+      return nullptr;
+    }
+    return _pops[idx];
+  }
+  
 } // namespace gstlrn

--- a/src/LinearOp/ProjComposition.cpp
+++ b/src/LinearOp/ProjComposition.cpp
@@ -24,7 +24,7 @@ namespace gstlrn
     if (projs.size() == 0) return;
 
     // Check compatibility. Use raw pointers to make iterating easier.
-    size_t idx      = 0;
+    size_t idx = 0;
     const IProj* p1 = projs[idx++];
     while (idx < projs.size())
     {
@@ -41,7 +41,8 @@ namespace gstlrn
     for (const auto* p: projs) _projs.emplace_back(*p);
   }
 
-  Id ProjComposition::setWorkArrays(vect work1, vect work2) {
+  Id ProjComposition::setWorkArrays(vect work1, vect work2)
+  {
     // Set work arrays (typically a space reused by other operators to save
     // memory). This function just checks that they are large enough.
 
@@ -57,14 +58,17 @@ namespace gstlrn
       max_size = std::max(max_size, (size_t)_projs[i].get().getNPoint());
     }
 
-    if (work1.size() < max_size || (_projs.size() > 2 && work2.size() < max_size)) return -1;
+    if (work1.size() < max_size
+        || (_projs.size() > 2 && work2.size() < max_size))
+      return -1;
 
     _work1 = work1;
     _work2 = work2;
     return 0;
   }
 
-  Id ProjComposition::initWorkArrays(vect& work1, vect& work2) const {
+  Id ProjComposition::initWorkArrays(vect& work1, vect& work2) const
+  {
     if (_projs.size() < 2) return 0; // no work array needed
 
     size_t max_size = 0;

--- a/src/LinearOp/ProjComposition.cpp
+++ b/src/LinearOp/ProjComposition.cpp
@@ -23,10 +23,8 @@ namespace gstlrn
     // element is weird but why not (but it's just handled normally below)?
     if (projs.size() == 0) return;
 
-    // Check compatibility and allocate work arrays. Use raw pointers to make
-    // iterating easier.
-    _works.resize(projs.size() - 1);
-    size_t idx = 0;
+    // Check compatibility. Use raw pointers to make iterating easier.
+    size_t idx      = 0;
     const IProj* p1 = projs[idx++];
     while (idx < projs.size())
     {
@@ -37,11 +35,69 @@ namespace gstlrn
         // Abort.
         return;
       }
-      _works[idx - 1].resize(p1->getNPoint());
       p1 = p2;
       idx++;
     }
     for (const auto* p: projs) _projs.emplace_back(*p);
+  }
+
+  Id ProjComposition::setWorkArrays(vect work1, vect work2) {
+    // Set work arrays (typically a space reused by other operators to save
+    // memory). This function just checks that they are large enough.
+
+    if (_projs.size() < 2) return 0; // no work array needed
+
+    // Max of all intermediate sizes. One of the two must be that size, the
+    // other (if needed) could be smaller but the proper size depends on how all
+    // operators are chained (it might not be the second largest size!). Usually
+    // both sizes will not be too different anyway so use same for both.
+    size_t max_size = 0;
+    for (size_t i = 0; i < _projs.size() - 1; ++i)
+    {
+      max_size = std::max(max_size, (size_t)_projs[i].get().getNPoint());
+    }
+
+    if (work1.size() < max_size || (_projs.size() > 2 && work2.size() < max_size)) return -1;
+
+    _work1 = work1;
+    _work2 = work2;
+    return 0;
+  }
+
+  Id ProjComposition::initWorkArrays(vect& work1, vect& work2) const {
+    if (_projs.size() < 2) return 0; // no work array needed
+
+    size_t max_size = 0;
+    for (size_t i = 0; i < _projs.size() - 1; ++i)
+    {
+      max_size = std::max(max_size, (size_t)_projs[i].get().getNPoint());
+    }
+
+    if (_work1.size() > 0)
+    {
+      if (_work1.size() < max_size) return -1;
+      work1 = _work1;
+    }
+    else
+    {
+      if (_w1.size() < max_size) _w1.resize(max_size);
+      work1 = _w1;
+    }
+
+    if (_projs.size() == 2) return 0;
+
+    if (_work2.size() > 0)
+    {
+      if (_work2.size() < max_size) return -1;
+      work2 = _work2;
+    }
+    else
+    {
+      if (_w2.size() < max_size) _w2.resize(max_size);
+      work2 = _w2;
+    }
+
+    return 0;
   }
 
   Id ProjComposition::_addPoint2mesh(const constvect in, vect out) const
@@ -49,24 +105,30 @@ namespace gstlrn
     if (_projs.size() == 0) return -1;
     if (_projs.size() == 1) return _projs[0].get().addPoint2mesh(in, out);
 
+    vect work1, work2;
+    Id ret = initWorkArrays(work1, work2);
+    if (ret != 0) return ret;
+
     // Call point2mesh() to initialise temporary results to 0, but use
     // addPoint2Mesh() at the end to preserve what's already in 'out'.
     size_t idx = _projs.size() - 1;
 
     // Unroll a bit the loop because first/last use different in/out arrays.
     // This also means size == 1 is a special case (treated above).
-    Id ret = _projs[idx].get().point2mesh(in, _works[idx - 1]);
+    ret = _projs[idx].get().point2mesh(in, work1);
     if (ret != 0) return ret;
     idx--;
 
+    vect win = work1, wout = work2;
     while (idx > 0)
     {
-      ret = _projs[idx].get().point2mesh(_works[idx], _works[idx - 1]);
+      ret = _projs[idx].get().point2mesh(win, wout);
       if (ret != 0) return ret;
       idx--;
+      std::swap(win, wout);
     }
 
-    return _projs[idx].get().addPoint2mesh(_works[0], out);
+    return _projs[idx].get().addPoint2mesh(win, out);
   }
 
   Id ProjComposition::_addMesh2point(const constvect in, vect out) const
@@ -74,19 +136,24 @@ namespace gstlrn
     if (_projs.size() == 0) return -1;
     if (_projs.size() == 1) return _projs[0].get().addMesh2point(in, out);
 
-    size_t idx = 0;
+    vect work1, work2;
+    Id ret = initWorkArrays(work1, work2);
+    if (ret != 0) return ret;
 
-    Id ret = _projs[0].get().mesh2point(in, _works[0]);
+    size_t idx = 0;
+    ret = _projs[idx].get().mesh2point(in, work1);
     if (ret != 0) return ret;
     idx++;
 
+    vect win = work1, wout = work2;
     while (idx < _projs.size() - 1)
     {
-      ret = _projs[idx].get().mesh2point(_works[idx - 1], _works[idx]);
+      ret = _projs[idx].get().mesh2point(win, wout);
       if (ret != 0) return ret;
       idx++;
+      std::swap(win, wout);
     }
 
-    return _projs[idx].get().addMesh2point(_works[idx - 1], out);
+    return _projs[idx].get().addMesh2point(win, out);
   }
 } // namespace gstlrn

--- a/src/LinearOp/ProjMulti.cpp
+++ b/src/LinearOp/ProjMulti.cpp
@@ -188,27 +188,20 @@ namespace gstlrn
 
   Id ProjMulti::_addPoint2mesh(const constvect inv, vect outv) const
   {
-    vect wms;
     Id iadvar = 0;
     for (Id i = 0; i < _nlatent; i++)
     {
       Id iad = 0;
-      Id nvertex = _apexNumbers[i];
-      _workmesh.resize(nvertex);
-      std::fill(_workmesh.begin(), _workmesh.end(), 0.);
+      vect outs(outv.data() + iadvar, _apexNumbers[i]);
       for (Id j = 0; j < _nvariable; j++)
       {
         if (_projs[j][i])
         {
           constvect view(inv.data() + iad, _pointNumbers[j]);
-          wms = vect(_workmesh);
-          _projs[j][i]->get().addPoint2mesh(view, wms);
+          _projs[j][i]->get().addPoint2mesh(view, outs);
         }
         iad += _pointNumbers[j];
       }
-
-      vect outs(outv.data() + iadvar, _workmesh.size());
-      VectorHelper::addInPlace(wms, outs);
       iadvar += _apexNumbers[i];
     }
     return 0;
@@ -216,26 +209,20 @@ namespace gstlrn
 
   Id ProjMulti::_addMesh2point(const constvect inv, vect outv) const
   {
-    vect ws;
     Id iadvar = 0;
     for (Id i = 0; i < _nvariable; i++)
     {
       Id iad = 0;
-      Id npoint = _pointNumbers[i];
-      _work.resize(npoint);
-      std::fill(_work.begin(), _work.end(), 0.);
+      vect outs(outv.data() + iadvar, _pointNumbers[i]);
       for (Id j = 0; j < _nlatent; j++)
       {
         if (_projs[i][j])
         {
           constvect view(inv.data() + iad, _apexNumbers[j]);
-          ws = vect(_work);
-          _projs[i][j]->get().addMesh2point(view, ws);
+          _projs[i][j]->get().addMesh2point(view, outs);
         }
         iad += _apexNumbers[j];
       }
-      vect outs(outv.data() + iadvar, _work.size());
-      VectorHelper::addInPlace(ws, outs);
       iadvar += _pointNumbers[i];
     }
     return 0;

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -44,7 +44,6 @@ namespace gstlrn
     if (_invNoise == nullptr) return;
     if (_QKriging == nullptr) return;
     _ndat = _projInKriging->getNPoint();
-    _prepare(true, true);
   }
 
   ASPDEOp::~ASPDEOp()
@@ -92,8 +91,6 @@ namespace gstlrn
 
   Id ASPDEOp::_addToDest(const constvect inv, vect outv) const
   {
-    _prepare();
-
     Id status = _QKriging->addToDest(
       inv, outv); // TODO: find why outv is set to zero in multistructure case
     if (status) return status;
@@ -103,6 +100,8 @@ namespace gstlrn
 
   void ASPDEOp::_addProjOp(const constvect inv, vect out) const
   {
+    _prepare();
+
     vect w1s(_workdat1);
     vect w2s(_workdat2);
     _projInKriging->mesh2point(inv, w1s);
@@ -469,6 +468,8 @@ namespace gstlrn
 
   Id ASPDEOp::_buildRhs(const constvect inv) const
   {
+    _prepare(true, false);
+
     _rhs.resize(getSize());
     vect w1(_workdat1);
     _invNoise->evalDirect(inv, w1);
@@ -478,11 +479,12 @@ namespace gstlrn
 
   void ASPDEOp::evalInvCov(const constvect inv, vect result) const
   {
+    _prepare(false, true);
+
     // InvNoise - InvNoise * Proj' * (Q + Proj * InvNoise * Proj')^-1 * Proj * InvNoise
 
     _rhs.resize(getSize());
     _workmesh.resize(getSize());
-    _workdat2.resize(_getNDat());
     _workdat3.resize(_getNDat());
 
     _invNoise->evalDirect(inv, result);
@@ -498,12 +500,13 @@ namespace gstlrn
     const MatrixDense& driftMat,
     bool verbose) const
   {
+    _prepare(true, false);
+
     Id xsize = (driftMat.getNCols());
     VectorDouble XtInvSigmaZ(xsize);
     MatrixSymmetric XtInvSigmaX(xsize);
     VectorDouble result(xsize);
 
-    _workdat1.resize(_getNDat());
     vect w1s(_workdat1);
     for (Id i = 0; i < xsize; i++)
     {

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -120,7 +120,6 @@ namespace gstlrn
     // Resize if necessary
     _workdat3.resize(_getNDat());
     _workdat4.resize(_getNDat());
-    _workmesh.resize(getSizeSimu());
     _workNoiseMesh.resize(getSizeSimu());
     _workNoiseData.resize(_getNDat());
 
@@ -200,7 +199,6 @@ namespace gstlrn
   void ASPDEOp::_simNonCond(vect outv) const
   {
     // Resize if necessary
-    _workmesh.resize(getSizeSimu());
     _workNoiseMesh.resize(getSizeSimu());
 
     // Non conditional simulation on mesh

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -83,6 +83,45 @@ namespace gstlrn
     }
   }
 
+  Id ClassicalPolynomial::setWorkArrays(vect work1, vect work2) {
+    // Set work arrays (typically a space reused by other operators to save
+    // memory). The size can't be checked here (the required size is only
+    // known when calling one of the eval functions), so it is up to the
+    // caller to ensure they are always large-enough!
+
+    if (work1.empty() || work2.empty()) return -1;
+
+    _work1 = work1;
+    _work2 = work2;
+    return 0;
+  }
+
+  Id ClassicalPolynomial::initWorkArrays(vect& work1, vect& work2, size_t size) const {
+    if (_work1.size() > 0)
+    {
+      if (_work1.size() < size) return -1;
+      work1 = vect(_work1.data(), size);
+    }
+    else
+    {
+      if (_w1.size() < size) _w1.resize(size);
+      work1 = vect(_w1.data(), size);
+    }
+
+    if (_work2.size() > 0)
+    {
+      if (_work2.size() < size) return -1;
+      work2 = vect(_work2.data(), size);
+    }
+    else
+    {
+      if (_w2.size() < size) _w2.resize(size);
+      work2 = vect(_w2.data(), size);
+    }
+
+    return 0;
+  }
+
   void ClassicalPolynomial::_addEvalOp(
     const ALinearOp* Op,
     const constvect inv,
@@ -91,18 +130,7 @@ namespace gstlrn
     Id n = static_cast<Id>(inv.size());
 
     vect swap1, swap2;
-
-    if (static_cast<Id>(_work.size()) != n)
-    {
-      _work.resize(n);
-    }
-    if (static_cast<Id>(_work2.size()) != n)
-    {
-      _work2.resize(n);
-    }
-
-    swap1 = vect(_work);
-    swap2 = vect(_work2);
+    if (initWorkArrays(swap1, swap2, n) != 0) return;
 
     for (Id i = 0; i < n; i++)
     {

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -83,7 +83,8 @@ namespace gstlrn
     }
   }
 
-  Id ClassicalPolynomial::setWorkArrays(vect work1, vect work2) {
+  Id ClassicalPolynomial::setWorkArrays(vect work1, vect work2)
+  {
     // Set work arrays (typically a space reused by other operators to save
     // memory). The size can't be checked here (the required size is only
     // known when calling one of the eval functions), so it is up to the
@@ -96,7 +97,9 @@ namespace gstlrn
     return 0;
   }
 
-  Id ClassicalPolynomial::initWorkArrays(vect& work1, vect& work2, size_t size) const {
+  Id ClassicalPolynomial::initWorkArrays(vect& work1, vect& work2, size_t size)
+    const
+  {
     if (_work1.size() > 0)
     {
       if (_work1.size() < size) return -1;

--- a/src/Polynomials/ClassicalPolynomial.cpp
+++ b/src/Polynomials/ClassicalPolynomial.cpp
@@ -90,7 +90,7 @@ namespace gstlrn
   {
     Id n = static_cast<Id>(inv.size());
 
-    vect swap1, swap2, swap3;
+    vect swap1, swap2;
 
     if (static_cast<Id>(_work.size()) != n)
     {
@@ -108,6 +108,7 @@ namespace gstlrn
     {
       outv[i] += _coeffs[0] * inv[i];
     }
+    if (_coeffs.size() == 1) return;
 
     Op->evalDirect(inv, swap1);
 
@@ -121,9 +122,7 @@ namespace gstlrn
       if (j < static_cast<Id>(_coeffs.size()) - 1)
       {
         Op->evalDirect(swap1, swap2);
-        swap3 = swap1;
-        swap1 = swap2;
-        swap2 = swap3;
+        std::swap(swap1, swap2);
       }
     }
   }


### PR DESCRIPTION
A lot of classes uses internal work arrays to store intermediate values (for example when computing `out += A*B*in`, an intermediate array is needed to compute `B*in` before adding to `out`). When working on large data they can start to add up... a lot!

This PR tries to reduce memory usage in two ways:
- In some cases, some work arrays were allocated but not used (usually when they are needed in another function of the same class). Sometimes two different work arrays were used in two different functions when the same one could be reused. In some other cases a minor rearranging of the code can avoid using work arrays entirely.
- In two cases (`ProjComposition` and `ClassicalPolynomial`) I have implemented a pair of methods that allow the caller to specify the work arrays to be used, rather than allocating them locally within the class (this is entirely optional). When the caller knows exactly how these class are going to be used, and thus when each work array is going to be used, this allows sharing the same work array(s) between several instances of these classes, or reusing the work arrays for something else.

Changes related to the first point should not be too contentious. For the second point, this is slightly contorted and exposes some of the internals of classes in a way that isn't very nice (and puts some responsibility on the caller to ensure the work arrays are used properly!), but I think it works. It is entirely optional so I think it should be OK (just ignore those function when memory usage is not an issue).