### PR TITLE
Fix hash table collisions for some multi-variable non-stationary covariances.

### DIFF
--- a/include/Covariances/ParamId.hpp
+++ b/include/Covariances/ParamId.hpp
@@ -17,6 +17,8 @@
 #include "Basic/AStringable.hpp"
 #include "Basic/ICloneable.hpp"
 
+#include <boost/container_hash/hash.hpp>
+
 namespace gstlrn
 {
   /**
@@ -75,11 +77,13 @@ namespace gstlrn
   {
     std::size_t operator()(const ParamId& p) const
     {
-      std::size_t hash_a = std::hash<Id>()(p.getType().toEnum());
-      std::size_t hash_b = std::hash<Id>()(p.getIV1());
-      std::size_t hash_c = std::hash<Id>()(p.getIV2());
-      // Combinaison des hachages avec une méthode simple (exemple: XOR et décalage)
-      return hash_a ^ (hash_b << 1) ^ (hash_c << 2);
+      // To ensure a robust hash (see comment in TabNoStat.hpp),
+      // use boost::hash_combine() rather than rolling out our own.
+      std::size_t hash = 0;
+      boost::hash_combine(hash, p.getType().toEnum());
+      boost::hash_combine(hash, p.getIV1());
+      boost::hash_combine(hash, p.getIV2());
+      return hash;
     }
   };
 

--- a/include/Covariances/TabNoStat.hpp
+++ b/include/Covariances/TabNoStat.hpp
@@ -20,13 +20,38 @@
 #include "Enum/EConsElem.hpp"
 #include "geoslib_define.h"
 #include <memory>
+
+#ifdef USE_BOOST_SPAN
+// Hash containers use user-specified hash operators (e.g., ParamIdHash) that
+// return a 64 bits hash. This is internally folded into a bucket index which
+// depends on the current container size. With VS2017 (and maybe other
+// versions), this is done internally by std::_Hash::_Hashval() in xhash by
+// masking (&) with the size. This can cause some hash collisions, because in
+// effect this amounts to only looking at the lowest-order bits of the full
+// hash (those that match the size).
+//
+// boost::unordered_map implements a smarter folding strategy that uses all
+// bits, to avoid this.
+//
+// gcc does not seem to have this problem, even though the folding of the hash
+// is apparently also done by default with a modulo (which is the same), see
+// the _Mod_range_hashing struct in hashtable_policy.h?
+#include <boost/unordered_map.hpp>
+#else
 #include <unordered_map>
+#endif
 
 namespace gstlrn
 {
+#ifdef USE_BOOST_SPAN
+  typedef boost::
+    unordered_map<ParamId, std::shared_ptr<ANoStat>, ParamIdHash, ParamIdEqual>
+      mapNoStat;
+#else
   typedef std::
     unordered_map<ParamId, std::shared_ptr<ANoStat>, ParamIdHash, ParamIdEqual>
       mapNoStat;
+#endif
 
   class GSTLEARN_EXPORT TabNoStat: public AStringable,
                                    public ICloneable,


### PR DESCRIPTION
This is an issue that I have only reproduced on Windows (VS2017), however I cannot be confident that it could not also happen on Linux, given what I can see of the code of the C++ standard library. So maybe the fix should be extended to all platforms?

In a nutshell, the issue is that internally the hash function used in `ParamId` is not robust enough, combined with another weakness of VS2017 implementation of the standard library, leading to some hash collisions. Replacing all this by `boost` seems to fix the issue.

In all its gory details:

I am trying to set some non-stationary covariance parameters in my `Model`, with a code like:
```C++
model->getCovAniso(0)->makeSillNoStatFunctional(..., 0, 0);
model->getCovAniso(0)->makeSillNoStatFunctional(..., 0, 1);
model->getCovAniso(0)->makeSillNoStatFunctional(..., 1, 0);
model->getCovAniso(0)->makeSillNoStatFunctional(..., 1, 1);

if (nb_vars == 3) {
	model->getCovAniso(0)->makeSillNoStatFunctional(..., 0, 2);
	model->getCovAniso(0)->makeSillNoStatFunctional(..., 2, 0);
	model->getCovAniso(0)->makeSillNoStatFunctional(..., 1, 2);
	model->getCovAniso(0)->makeSillNoStatFunctional(..., 2, 1);
	model->getCovAniso(0)->makeSillNoStatFunctional(..., 2, 2);
}
```

When I have only 2 variables (`nb_vars == 2`) this works correctly, however when I add a third variable, some of the calls in the second block trigger an error message `"Warning, this non stationarity was already specified. It has been replaced with the new specifications."` (then some furter Bad Things happen, but that's not the point).

This is because in ` TabNoStat::addElem()`, the check of whether this element is already assigned with:
`Id res = static_cast<Id>(_items.count(param));`
returns 1, whereas it should return 0!

Ultimately, I ended up digging into the hash function `ParamIdHash` in ParamId.hpp, then followed into the stdlib's code for how this hash is used. In VS2017's implementation, this goes through the `xhash` file and specifically `std::_Hash::_Hashval()` which does:
``C++
size_type _Hashval(const key_type& _Keyval) const
		{	// return hash value, masked to current table size
		return (_Traitsobj(_Keyval) & _Mask);
		}
``
(`_Mask` here is indeed the current table size, or rather the power of 2 above it minus 1)

The purpose of this function is to fold the 64 bits hash provided by the hash function into a bucket index, depending on the size of the hash table.

Checking out the values used in the hash algorithm, I end up with these two cases:
`ParamId 1: elem = SILL (4), iv1 = 1, iv2 = 0`
`hash(elem) = 3232700585171816769`
`hash(iv1) = 9929646806074584996`
`hash(iv2) = 12161962213042174405`
`final hash = 11266139947194657053`

`ParamId 2: elem = SILL (4), iv1 = 1, iv2 = 2`
`hash(elem) = 3232700585171816769`
`hash(iv1) = 9929646806074584996`
`hash(iv2) = 16626593026977353223 `
`final hash = 11939226570740987413`

In my case, at that point in the code `_Mask == 7` (there are only 5 elements when I'm adding the last one). This is a binary mask of `0111`.

In binary:
`ParamId 1: 1001 1100 0101 1001 0101 1110 1001 0111 0110 0110 0110 0000 0010 1001 0001 1101`
`ParamId 2: 1010 0101 1011 0000 1010 0111 0100 1111 0011 0001 1110 1011 1111 0110 0001 0101`

Masking with `0111` keeps only the 3 lowest bits i.e., `0101` in both cases. Therefore both keys `(SILL, 1, 0)` and `(SILL, 1, 2)` have the same hash, and this causes the code to then fail.

I did not found a lot of documentation on this, however if I understand correctly, to get a proper hash function, we thus need two things:
- The hash function itself should randomly affect all bits of the output hash (and not just some of them). See e.g., https://stackoverflow.com/questions/35985960/c-why-is-boosthash-combine-the-best-way-to-combine-hash-values which recommends using `boost::hash_combine()` to ensure this is done properly. This isn't really the issue here, the hash implementation in `ParamIdHash` is already trying to mix up things, but I think it's best to use a more robust hash function in all cases, so I have changed it to use `boost::hash_combine()`.
- The hash class should also affect all bits when it folds the key back into the range of possible buckets. VS2017's implementation is clearly faulty here, the only hint to this problem that I found is in this old article (archive only!): https://web.archive.org/web/20181119104554/http://www.crashedtestdummy.com/?p=54 The workaround here is also to use `boost` (specifically, `boost::unordered_map` instead of `std::unordered_map`).

In this PR, the second part is only done for Windows (when `USE_BOOST_SPAN` is defined), because I did not manage to reproduce the issue on Linux/gcc. However, when I tried to look into gcc's headers file, I ended up in `hashtable_policy.h` which defines a `struct _Mod_range_hashing` that does this folding and uses modulo, which should have the same issues as the bitwise-`&` used by MSVC (it only affects the lowest bits of the hash).

Therefore I believe the issue can also happen on Linux/gcc, and I just was lucky to not hit it. So maybe we should use `boost::unordered_map` in all cases, not just on Windows?

(for `boost` itself, the implementation of the hashing functions is in `hash.hpp` and `hash_mix.hpp` and both use complicated mixing schemes explicitly designed to achieve, well, a proper mixing, so I am more confident in these ones being correct)