### PR TITLE
Upgrade non-reg to Visual Studio 18 2026 (python)

### DIFF
--- a/.github/workflows/nonreg-tests_windows-latest-msvc.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-msvc.yml
@@ -45,12 +45,12 @@ jobs:
     - name: Build & install nlopt static libraries
       uses: ./.github/actions/nlopt_static_windows
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 18 2026"
 
     - name: Build & install HDF5 static libraries
       uses: ./.github/actions/hdf5_static_windows
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 18 2026"
 
     - name: Setup Python
       uses: ./.github/actions/setup_python

--- a/.github/workflows/nonreg-tests_windows-latest-rtools.yml
+++ b/.github/workflows/nonreg-tests_windows-latest-rtools.yml
@@ -34,6 +34,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Install the customized SWIG from source
+      uses: fabien-ors/install-swig-windows-action@v3
+      with:
+        swig-root: ${{env.SWIG_ROOT}}
+        generator: "Visual Studio 18 2026"
+
     - name: Setup R
       uses: ./.github/actions/setup_r
       with:
@@ -46,12 +52,6 @@ jobs:
         pacman -Sy --noconfirm mingw-w64-x86_64-eigen3
         pacman -Sy --noconfirm mingw-w64-x86_64-nlopt
         pacman -Sy --noconfirm mingw-w64-x86_64-hdf5
-
-    - name: Install the customized SWIG from source
-      uses: fabien-ors/install-swig-windows-action@v3
-      with:
-        swig-root: ${{env.SWIG_ROOT}}
-        generator: "Visual Studio 17 2022"
 
     - name: Configure build directory
       run: |


### PR DESCRIPTION
Since windows-latest uses now VS 2026, non-reg python workflow generator has been updated.
The non-reg R workflow has been stuck to windows-2022 because we don't succeed in compiling SWIG under VS2026 yet.