### PR TITLE
Fix compilation error on Windows/VS2017.

### DIFF
--- a/include/Core/Colors.hpp
+++ b/include/Core/Colors.hpp
@@ -183,8 +183,8 @@ namespace gstlrn
 
     for (size_t i = 0; i < a.size(); i++)
     {
-      if (std::tolower(static_cast<unsigned char>(a[i]))
-          != std::tolower(static_cast<unsigned char>(b[i])))
+      if (::tolower(static_cast<unsigned char>(a[i]))
+          != ::tolower(static_cast<unsigned char>(b[i])))
         return false;
     }
     return true;


### PR DESCRIPTION
Not sure whether the issue is Windows or VS2017.

We had the same issue a long time ago and weirdly in `FileLAS.cpp` we still manage to use `std::tolower()` so this might just be a missing `#include`? In any case, the alternative (`::tolower()`) is already used in a few places so that should be fine.