### PR TITLE
add checkout step to html checker workflow

### DIFF
--- a/.github/workflows/publish_check_html.yml
+++ b/.github/workflows/publish_check_html.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Add missing actions/checkout@v6 step to clone the repository onto the runner.