### PR TITLE
Improving variogram cloud

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.12.0
 ==============
-- In db_vcloud: allow varioparam being defaulted and modify argument order (lagmax is now third)
+- vcloudFromDb: (new name for db_vcloud), allows varioparam being defaulted and modify argument order (lagmax is now third)
+- vcloudCalculate() is now called vcloudFromParam()
 
 Release 1.11.1
 ==============

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ This file contains the logs between consecutive releases
 
 Release 1.12.0
 ==============
-
+- In db_vcloud: allow varioparam being defaulted and modify argument order (lagmax is now third)
 
 Release 1.11.1
 ==============

--- a/doc/courses/python/04_Variography.ipynb
+++ b/doc/courses/python/04_Variography.ipynb
@@ -131,7 +131,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "id": "4adc1da2",
       "metadata": {},
       "outputs": [
@@ -167,7 +167,7 @@
       ],
       "source": [
         "varioParamOmni = gl.VarioParam.createOmniDirection(100)\n",
-        "grid_cloud = gl.db_vcloud(dat, varioParamOmni)\n",
+        "grid_cloud = gl.vcloudFromDb(dat, varioParamOmni)\n",
         "grid_cloud.display()"
       ]
     },

--- a/doc/courses/r/04_Variography.Rmd
+++ b/doc/courses/r/04_Variography.Rmd
@@ -51,7 +51,7 @@ cat(loadDoc("Variogram_Cloud.md"), sep="\n")
 
 ```{r Variogram_Cloud}
 varioParamOmni = VarioParam_createOmniDirection(nlag = 100)
-grid.cloud = db_vcloud(dat, varioParamOmni)
+grid.cloud = vcloudFromDb(dat, varioParamOmni)
 grid.cloud$display()
 ```
 

--- a/doc/demo/python/Tuto_2D.ipynb
+++ b/doc/demo/python/Tuto_2D.ipynb
@@ -173,7 +173,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "dbcloud = gl.db_vcloud(mydb, myVarioParamOmni)"
+        "dbcloud = gl.vcloudFromDb(mydb, myVarioParamOmni)"
       ]
     },
     {

--- a/doc/demo/r/Tuto_2D.Rmd
+++ b/doc/demo/r/Tuto_2D.Rmd
@@ -93,7 +93,7 @@ myVarioParamOmni$addDir(mydir)
 We use the variogram definition in order to calculate the variogram cloud.
 
 ```{r}
-dbcloud = db_vcloud(db=mydb, varioparam=myVarioParamOmni)
+dbcloud = vcloudFromDb(db=mydb, varioparam=myVarioParamOmni)
 ```
 
 We recall that the Variogram cloud is calculated by filling an underlying grid where each cell is painted according to the number of pairs at the given distance and given variability. Representing the variogram cloud.

--- a/include/LithoRule/RuleProp.hpp
+++ b/include/LithoRule/RuleProp.hpp
@@ -81,7 +81,7 @@ namespace gstlrn
     std::vector<Rule> fit(
       Db* db,
       const VarioParam* varioparam,
-      Id ngrfmax,
+      Id ngrfmax = 1,
       bool use_discrete = false,
       bool verbose = false);
     Id gaussToCategory(

--- a/include/Variogram/VCloud.hpp
+++ b/include/Variogram/VCloud.hpp
@@ -101,9 +101,9 @@ namespace gstlrn
   GSTLEARN_EXPORT DbGrid* db_vcloud(
     Db* db,
     const VarioParam* varioparam = nullptr,
+    double lagmax = TEST,
     const ECalcVario& calculType = ECalcVario::fromKey("VARIOGRAM"),
     bool flag_ergodic = true,
-    double lagmax = TEST,
     double varmax = TEST,
     Id lagnb = 100,
     Id varnb = 100,

--- a/include/Variogram/VCloud.hpp
+++ b/include/Variogram/VCloud.hpp
@@ -91,14 +91,7 @@ namespace gstlrn
     Id _IPTR;
   };
 
-  GSTLEARN_EXPORT DbGrid* vcloudGrid(
-    const Db* db,
-    double lagmax = TEST,
-    double varmax = TEST,
-    Id lagnb = 100,
-    Id varnb = 100);
-
-  GSTLEARN_EXPORT DbGrid* db_vcloud(
+  GSTLEARN_EXPORT DbGrid* vcloudFromDb(
     Db* db,
     const VarioParam* varioparam = nullptr,
     double lagmax = TEST,
@@ -109,7 +102,7 @@ namespace gstlrn
     Id varnb = 100,
     const NamingConvention& namconv = NamingConvention("Cloud"));
 
-  GSTLEARN_EXPORT DbGrid* vcloudCalculate(
+  GSTLEARN_EXPORT DbGrid* vcloudFromParam(
     Db* db,
     const ECalcVario& calculType = ECalcVario::fromKey("VARIOGRAM"),
     bool flag_ergodic = true,

--- a/include/Variogram/VCloud.hpp
+++ b/include/Variogram/VCloud.hpp
@@ -100,7 +100,7 @@ namespace gstlrn
 
   GSTLEARN_EXPORT DbGrid* db_vcloud(
     Db* db,
-    const VarioParam* varioparam,
+    const VarioParam* varioparam = nullptr,
     const ECalcVario& calculType = ECalcVario::fromKey("VARIOGRAM"),
     bool flag_ergodic = true,
     double lagmax = TEST,

--- a/src/Variogram/VCloud.cpp
+++ b/src/Variogram/VCloud.cpp
@@ -318,9 +318,9 @@ namespace gstlrn
    **
    ** \param[in]  db           Db descriptor
    ** \param[in]  varioparam   VarioParam structure
+   ** \param[in]  lagmax       Maximum distance
    ** \param[in]  calculType   Calculation type
    ** \param[in]  flag_ergodic Ergodic flag
-   ** \param[in]  lagmax       Maximum distance
    ** \param[in]  varmax       Maximum Variance value (see remarks)
    ** \param[in]  lagnb        Number of discretization steps along distance axis
    ** \param[in]  varnb        Number of discretization steps along variance axis
@@ -335,9 +335,9 @@ namespace gstlrn
   DbGrid* db_vcloud(
     Db* db,
     const VarioParam* varioparam,
+    double lagmax,
     const ECalcVario& calculType,
     bool flag_ergodic,
-    double lagmax,
     double varmax,
     Id lagnb,
     Id varnb,
@@ -448,7 +448,7 @@ namespace gstlrn
       varioparam = VarioParam::createOmniDirection(nlag, dlag, toldis);
 
     auto* dbgrid = db_vcloud(
-      db, varioparam, calculType, flag_ergodic, TEST, TEST, lagnb, varnb);
+      db, varioparam, TEST, calculType, flag_ergodic, TEST, lagnb, varnb);
 
     return dbgrid;
   }

--- a/src/Variogram/VCloud.cpp
+++ b/src/Variogram/VCloud.cpp
@@ -158,8 +158,7 @@ namespace gstlrn
   {
     if (db == nullptr) return (1);
 
-    /* Preliminary checks */
-
+    // Preliminary checks
     if (db->getNDim() != _varioparam->getNDim())
     {
       messerr("Inconsistent parameters:");
@@ -174,8 +173,7 @@ namespace gstlrn
       return (1);
     }
 
-    /* Allocate new variables */
-
+    // Allocate new variables
     setCalcul(calculType);
     setErgodic(flag_ergodic);
     if (getFlagAsym())
@@ -187,8 +185,7 @@ namespace gstlrn
     Id iptr = _dbcloud->addColumnsByConstant(ndir, 0.);
     if (iptr < 0) return (1);
 
-    /* Loop on the directions to evaluate */
-
+    // Loop on the directions
     for (Id idir = 0; idir < ndir; idir++)
     {
       _IPTR = iptr + idir;
@@ -197,7 +194,6 @@ namespace gstlrn
     }
 
     // Naming of the newly created variables
-
     namconv.setNamesAndLocators(
       db, VectorString(), ELoc::Z, -1, _dbcloud, iptr, String(), ndir, false);
 
@@ -243,8 +239,7 @@ namespace gstlrn
     Id nech = db->getNSample();
     Id nvar = db->getNLoc(ELoc::Z);
 
-    /* Loop on the first point */
-
+    // Loop on the first point
     for (Id iech = 0; iech < nech - 1; iech++)
     {
       if (hasSel && !db->isActive(iech)) continue;
@@ -259,6 +254,7 @@ namespace gstlrn
         // Reject the point as soon as one BiTargetChecker is not correct
         if (!vario->keepPair(idir, T1, T2, &dist)) continue;
 
+        // Add the contribution of the pair to the Variogram Cloud
         (this->*_evaluate)(db, nvar, iech, jech, idir, 0, dist, false);
       }
     }
@@ -350,6 +346,18 @@ namespace gstlrn
     // Create a grid as a support for the variogram cloud calculations
 
     DbGrid* dbgrid = vcloudGrid(db, lagmax, varmax, lagnb, varnb);
+
+    // Create an omnidirectional varioparam (if not provided)
+
+    if (varioparam == nullptr)
+    {
+      auto lagmax_local = lagmax;
+      if (FFFF(lagmax_local)) lagmax_local = db->getExtensionDiagonal();
+      // Evaluate the lag so that the maximum distance fit 'lagmax'
+      // (given the tolerance on distance which is defaulted to 0.5)
+      auto dlag = lagmax_local / 1.5;
+      varioparam = VarioParam::createOmniDirection(1, dlag, 0.5);
+    }
 
     // Initialize the variogram cloud structure
 

--- a/src/Variogram/VCloud.cpp
+++ b/src/Variogram/VCloud.cpp
@@ -288,28 +288,6 @@ namespace gstlrn
     return _dbcloud->indiceToRank(indg);
   }
 
-  DbGrid*
-    vcloudGrid(const Db* db, double lagmax, double varmax, Id lagnb, Id varnb)
-  {
-    if (FFFF(lagmax)) lagmax = db->getExtensionDiagonal();
-    if (FFFF(varmax))
-      varmax = 3. * db->getVariance(db->getNameByLocator(ELoc::Z));
-
-    // Create a grid as a support for the variogram cloud calculations
-
-    VectorInt nx(2);
-    nx[0] = lagnb;
-    nx[1] = varnb;
-    VectorDouble dx(2);
-    dx[0] = lagmax / static_cast<double>(lagnb);
-    dx[1] = varmax / static_cast<double>(varnb);
-    VectorDouble x0(2);
-    x0[0] = 0.;
-    x0[1] = 0.;
-    DbGrid* dbgrid = DbGrid::create(nx, dx, x0);
-    return dbgrid;
-  }
-
   /****************************************************************************/
   /*!
    **  Evaluate the experimental variogram cloud
@@ -332,7 +310,7 @@ namespace gstlrn
    ** variance of the first variable (Z_locator)
    **
    *****************************************************************************/
-  DbGrid* db_vcloud(
+  DbGrid* vcloudFromDb(
     Db* db,
     const VarioParam* varioparam,
     double lagmax,
@@ -345,7 +323,20 @@ namespace gstlrn
   {
     // Create a grid as a support for the variogram cloud calculations
 
-    DbGrid* dbgrid = vcloudGrid(db, lagmax, varmax, lagnb, varnb);
+    if (FFFF(lagmax)) lagmax = db->getExtensionDiagonal();
+    if (FFFF(varmax))
+      varmax = 3. * db->getVariance(db->getNameByLocator(ELoc::Z));
+
+    VectorInt nx(2);
+    nx[0] = lagnb;
+    nx[1] = varnb;
+    VectorDouble dx(2);
+    dx[0] = lagmax / static_cast<double>(lagnb);
+    dx[1] = varmax / static_cast<double>(varnb);
+    VectorDouble x0(2);
+    x0[0] = 0.;
+    x0[1] = 0.;
+    DbGrid* dbgrid = DbGrid::create(nx, dx, x0);
 
     // Create an omnidirectional varioparam (if not provided)
 
@@ -425,7 +416,7 @@ namespace gstlrn
     return sstr.str();
   }
 
-  DbGrid* vcloudCalculate(
+  DbGrid* vcloudFromParam(
     Db* db,
     const ECalcVario& calculType,
     bool flag_ergodic,
@@ -447,7 +438,7 @@ namespace gstlrn
     else
       varioparam = VarioParam::createOmniDirection(nlag, dlag, toldis);
 
-    auto* dbgrid = db_vcloud(
+    auto* dbgrid = vcloudFromDb(
       db, varioparam, TEST, calculType, flag_ergodic, TEST, lagnb, varnb);
 
     return dbgrid;

--- a/tests/cpp/test_a_template.cpp
+++ b/tests/cpp/test_a_template.cpp
@@ -20,4 +20,6 @@ int main(int argc, char* argv[])
   sfn << gslBaseName(__FILE__) << ".out";
   StdoutRedirect sr(sfn.str(), argc, argv);
   ASerializable::setPrefixName("test_a_template-"); // Here set the test name
+
+  return 0;
 }


### PR DESCRIPTION
This branch partly answers to the Issue #871.

1) The function db_vcloud ()is now renamed vcloudFromDb().
The order of its arguments has been modified to allow 'lagmax' is higher order
The argument 'varioparam' is now optional: when not present, the omnidirectional 'varioparam' is created internally

2) The method vcloud_calculate() is now called vcloudFromParam()

3) The method vcloudGrid() (which was used only locally to dimension the output grid) has been deleted.