### PR TITLE
Revisiting Bench option in Variogram calculation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ This file contains the logs between consecutive releases
 
 Release 1.12.0
 ==============
-
+- In Variogram calculation with Bench criterion, BenchDir has been added
+- Bench and Cylrad criteria are now saved in Neutral Files (H5 format only)
 
 Release 1.11.1
 ==============

--- a/include/Basic/SerializeHDF5.hpp
+++ b/include/Basic/SerializeHDF5.hpp
@@ -163,6 +163,24 @@ namespace gstlrn
       return file;
     }
 
+    inline bool existsH5Item(
+      const H5::H5Object& grp,
+      const String& name,
+      bool verbose = false)
+    {
+      const auto grp_name = grp.getObjName();
+
+      if (!grp.attrExists(name))
+      {
+        if (verbose)
+          messerr(
+            "Could not read value '%s' in group '%s': attribute does not exist",
+            name.c_str(), grp_name.data());
+        return false;
+      }
+      return true;
+    }
+
     /**
      * @brief Read a HDF5 DataSet into a generic VectorT
      *

--- a/include/Geometry/BiTargetCheckGeometry.hpp
+++ b/include/Geometry/BiTargetCheckGeometry.hpp
@@ -25,7 +25,8 @@ namespace gstlrn
       double tolang = 90.,
       double bench = 0.,
       double cylrad = 0.,
-      bool flagasym = false);
+      bool flagasym = false,
+      const VectorDouble& benchdir = VectorDouble());
     BiTargetCheckGeometry(const BiTargetCheckGeometry& r);
     BiTargetCheckGeometry& operator=(const BiTargetCheckGeometry& r);
     virtual ~BiTargetCheckGeometry();
@@ -44,7 +45,8 @@ namespace gstlrn
       double tolang = 90.,
       double bench = 0.,
       double cylrad = 0.,
-      bool flagasym = false);
+      bool flagasym = false,
+      const VectorDouble& benchdir = VectorDouble());
 
     double getDist() const { return _dist; }
 
@@ -55,6 +57,7 @@ namespace gstlrn
     double _bench;
     double _cylrad;
     bool _flagAsym;
+    VectorDouble _benchDir;
 
     mutable VectorDouble _delta;
     mutable double _psmin;

--- a/include/Variogram/DirParam.hpp
+++ b/include/Variogram/DirParam.hpp
@@ -38,7 +38,7 @@ namespace gstlrn
    * given in degrees.
    * - the distance between the two points (measured along the axis perpendicular to the direction)
    * must be smaller than a maximum cylinder distance (**cylrad**).
-   * - the distance between the two points (measured along the highest space dimension) must be smaller than a bench height (**bench**)
+   * - the distance between the two points (measured along the direction provided by **benchDir** [defaulted to the *vertical*]) must be smaller than a bench height (**bench**)
    * - the difference between the code values (locator ELoc::CODE) defined at both samples must be either smaller or larger
    * than the tolerance on the code (**tolcode**).
    * - the two saples must share the same data (ELoc::DATE)
@@ -62,6 +62,7 @@ namespace gstlrn
       const VectorDouble& breaks = VectorDouble(),
       const VectorDouble& codir = VectorDouble(),
       double angle2D = TEST,
+      const VectorDouble& benchdir = VectorDouble(),
       const ASpaceSharedPtr& space = ASpaceSharedPtr());
     DirParam(
       const DbGrid* dbgrid,
@@ -85,6 +86,7 @@ namespace gstlrn
       const VectorDouble& breaks = VectorDouble(),
       const VectorDouble& codir = VectorDouble(),
       double angle2D = TEST,
+      const VectorDouble& benchdir = VectorDouble(),
       const ASpaceSharedPtr& space = ASpaceSharedPtr());
     static DirParam* createOmniDirection(
       Id nlag = 10,
@@ -96,6 +98,7 @@ namespace gstlrn
       double cylrad = TEST,
       double tolcode = 0.,
       const VectorDouble& breaks = VectorDouble(),
+      const VectorDouble& benchdir = VectorDouble(),
       const ASpaceSharedPtr& space = ASpaceSharedPtr());
     static DirParam* createFromGrid(
       const DbGrid* dbgrid,
@@ -129,6 +132,8 @@ namespace gstlrn
     bool isConsistent(const ASpace* space) const override;
 
     double getBench() const { return _bench; }
+
+    const VectorDouble& getBenchDir() const { return _benchDir; }
 
     const VectorDouble& getBreaks() const { return _breaks; }
 
@@ -179,6 +184,8 @@ namespace gstlrn
 
     void setBench(double bench) { _bench = bench; }
 
+    void setBenchDir(const VectorDouble& benchdir) { _benchDir = benchdir; }
+
     void setCylRad(double cylrad) { _cylRad = cylrad; }
 
     void setTolDist(double toldist) { _tolDist = toldist; }
@@ -216,5 +223,6 @@ namespace gstlrn
     VectorDouble _breaks;
     VectorDouble _codir;
     VectorInt _grincr;
+    VectorDouble _benchDir;
   };
 } // namespace gstlrn

--- a/include/Variogram/Vario.hpp
+++ b/include/Variogram/Vario.hpp
@@ -619,5 +619,6 @@ namespace gstlrn
     double toldis = 0.5,
     double tolang = TEST,
     double bench = TEST,
-    double cylrad = TEST);
+    double cylrad = TEST,
+    const VectorDouble& benchdir = VectorDouble());
 } // namespace gstlrn

--- a/include/Variogram/VarioParam.hpp
+++ b/include/Variogram/VarioParam.hpp
@@ -72,6 +72,7 @@ namespace gstlrn
       const VectorDouble& breaks = VectorDouble(),
       double scale = 0.,
       const VectorDouble& dates = VectorDouble(),
+      const VectorDouble& benchdir = VectorDouble(),
       const ASpaceSharedPtr& space = ASpaceSharedPtr());
     static VarioParam* createMultiple(
       Id ndir,

--- a/src/Geometry/BiTargetCheckGeometry.cpp
+++ b/src/Geometry/BiTargetCheckGeometry.cpp
@@ -21,7 +21,8 @@ namespace gstlrn
     double tolang,
     double bench,
     double cylrad,
-    bool flagasym);
+    bool flagasym,
+    const VectorDouble& benchdir);
 
   BiTargetCheckGeometry::BiTargetCheckGeometry(
     Id ndim,
@@ -29,7 +30,8 @@ namespace gstlrn
     double tolang,
     double bench,
     double cylrad,
-    bool flagasym)
+    bool flagasym,
+    const VectorDouble& benchdir)
     : ABiTargetCheck()
     , _ndim(ndim)
     , _codir(codir)
@@ -37,6 +39,7 @@ namespace gstlrn
     , _bench(bench)
     , _cylrad(cylrad)
     , _flagAsym(flagasym)
+    , _benchDir(benchdir)
     , _psmin(0.)
     , _dist(0.)
   {
@@ -51,6 +54,7 @@ namespace gstlrn
     , _bench(r._bench)
     , _cylrad(r._cylrad)
     , _flagAsym(r._flagAsym)
+    , _benchDir(r._benchDir)
     , _psmin(r._psmin)
     , _dist(r._dist)
   {
@@ -68,6 +72,7 @@ namespace gstlrn
       _bench = r._bench;
       _cylrad = r._cylrad;
       _flagAsym = r._flagAsym;
+      _benchDir = r._benchDir;
       _psmin = r._psmin;
       _dist = r._dist;
     }
@@ -82,10 +87,11 @@ namespace gstlrn
     double tolang,
     double bench,
     double cylrad,
-    bool flagasym)
+    bool flagasym,
+    const VectorDouble& benchdir)
   {
     return new BiTargetCheckGeometry(
-      ndim, codir, tolang, bench, cylrad, flagasym);
+      ndim, codir, tolang, bench, cylrad, flagasym, benchdir);
   }
 
   String BiTargetCheckGeometry::toString(const AStringFormat* /*strfmt*/) const
@@ -95,7 +101,11 @@ namespace gstlrn
     sstr << "- Direction" << toStrVector(String(), _codir) << std::endl;
     sstr << "- Tolerance angular" << _tolAng << std::endl;
     if (!FFFF(_bench) && _bench > 0.)
+    {
       sstr << "Bench (%lf)" << _bench << std::endl;
+      sstr << "Bench Direction" << toStrVector(String(), _benchDir)
+           << std::endl;
+    }
     if (!FFFF(_cylrad) && _cylrad > 0.)
       sstr << "Cylinder check (%lf)" << _cylrad << std::endl;
 
@@ -141,7 +151,7 @@ namespace gstlrn
     // Check for vertical slicing test
     if (!FFFF(_bench) && _bench > 0.)
     {
-      double dvect = ABS(_delta[_ndim - 1]);
+      double dvect = ABS(_delta.innerProduct(_benchDir));
       if (dvect > _bench) return false;
     }
 

--- a/src/Variogram/DirParam.cpp
+++ b/src/Variogram/DirParam.cpp
@@ -32,6 +32,7 @@ namespace gstlrn
     const VectorDouble& breaks,
     const VectorDouble& codir,
     double angle2D,
+    const VectorDouble& benchdir,
     const ASpaceSharedPtr& space)
     : ASpaceObject(space)
     , _nLag(nlag)
@@ -46,6 +47,7 @@ namespace gstlrn
     , _breaks(breaks)
     , _codir(codir)
     , _grincr()
+    , _benchDir(benchdir)
   {
     _completeDefinition(angle2D);
   }
@@ -68,6 +70,7 @@ namespace gstlrn
     , _breaks()
     , _codir()
     , _grincr(grincr)
+    , _benchDir()
   {
     auto ndim = getDefaultSpaceDimension();
     if (space != nullptr) ndim = static_cast<Id>(space->getNDim());
@@ -93,6 +96,7 @@ namespace gstlrn
     , _breaks(r._breaks)
     , _codir(r._codir)
     , _grincr(r._grincr)
+    , _benchDir(r._benchDir)
   {
   }
 
@@ -113,6 +117,7 @@ namespace gstlrn
       _breaks = r._breaks;
       _codir = r._codir;
       _grincr = r._grincr;
+      _benchDir = r._benchDir;
     }
     return *this;
   }
@@ -132,11 +137,12 @@ namespace gstlrn
     const VectorDouble& breaks,
     const VectorDouble& codir,
     double angle2D,
+    const VectorDouble& benchdir,
     const ASpaceSharedPtr& space)
   {
     return new DirParam(
       nlag, dlag, toldis, tolang, opt_code, idate, bench, cylrad, tolcode,
-      breaks, codir, angle2D, space);
+      breaks, codir, angle2D, benchdir, space);
   }
 
   DirParam* DirParam::createOmniDirection(
@@ -149,11 +155,12 @@ namespace gstlrn
     double cylrad,
     double tolcode,
     const VectorDouble& breaks,
+    const VectorDouble& benchdir,
     const ASpaceSharedPtr& space)
   {
     return new DirParam(
       nlag, dlag, toldis, 90.1, opt_code, idate, bench, cylrad, tolcode, breaks,
-      VectorDouble(), TEST, space);
+      VectorDouble(), TEST, benchdir, space);
   }
 
   DirParam* DirParam::createFromGrid(
@@ -203,6 +210,17 @@ namespace gstlrn
 
     // Capping the tolerance on angles
     if (_tolAngle > 90.) _tolAngle = 90.;
+
+    // Constructing 'benchDir' if not provided. Otherwise normalize the vector
+    if (_benchDir.empty())
+    {
+      _benchDir.resize(ndim, 0.);
+      _benchDir[ndim - 1] = 1.;
+    }
+    else
+    {
+      _benchDir.normalizeInPlace();
+    }
   }
 
   void DirParam::setTolAngle(double tolang)
@@ -288,7 +306,11 @@ namespace gstlrn
            << " (degrees)" << std::endl;
 
     if (!FFFF(_bench) && _bench > 0.)
+    {
       sstr << "Slice bench                 = " << toStr(_bench) << std::endl;
+      sstr << toStrVector("Bench Direction             = ", _benchDir);
+    }
+
     if (!FFFF(_cylRad) && _cylRad > 0.)
       sstr << "Slice radius                = " << toStr(_cylRad) << std::endl;
 
@@ -316,7 +338,6 @@ namespace gstlrn
     {
 
       // Case of a variogram defined on a Grid db
-
       sstr << toStrVector("Grid Direction coefficients = ", _grincr);
     }
 
@@ -353,7 +374,7 @@ namespace gstlrn
       double tolang = 90. / static_cast<double>(ndir);
       DirParam dirparam = DirParam(
         nlag, dlag, toldis, tolang, 0, 0, TEST, TEST, 0., VectorDouble(), codir,
-        TEST, space);
+        TEST, VectorDouble(), space);
       dirs.push_back(dirparam);
     }
     return dirs;
@@ -386,7 +407,7 @@ namespace gstlrn
       (void)GH::rotationGetDirection2D(anglesloc, codir);
       DirParam dirparam = DirParam(
         nlag, dlag, toldis, tolang, 0, 0, TEST, TEST, 0., VectorDouble(), codir,
-        TEST, space);
+        TEST, VectorDouble(), space);
       dirs.push_back(dirparam);
     }
     return dirs;
@@ -419,7 +440,7 @@ namespace gstlrn
       codir[idim] = 1;
       DirParam* dirparam = DirParam::create(
         nlag, dlag, 0.5, 0., 0, 0, TEST, TEST, 0., VectorDouble(), codir, TEST,
-        space);
+        VectorDouble(), space);
       dirs.push_back(*dirparam);
       delete dirparam;
     }

--- a/src/Variogram/Vario.cpp
+++ b/src/Variogram/Vario.cpp
@@ -286,7 +286,8 @@ namespace gstlrn
       {
         BiTargetCheckGeometry* bipts = BiTargetCheckGeometry::create(
           _db->getNDim(), dirparam.getCodirs(), dirparam.getTolAngle(),
-          dirparam.getBench(), dirparam.getCylRad(), getFlagAsym());
+          dirparam.getBench(), dirparam.getCylRad(), getFlagAsym(),
+          dirparam.getBenchDir());
         _addBiTargetCheck(bipts);
         _biPtsPerDirection++;
       }
@@ -2125,7 +2126,7 @@ namespace gstlrn
       auto space = SpaceRN::create(ndim);
       DirParam dirparam = DirParam(
         nlag, dlag, toldis, tolang, opt_code, 0, TEST, TEST, tolcode,
-        VectorDouble(), codir, TEST, space);
+        VectorDouble(), codir, TEST, VectorDouble(), space);
       if (isDefinedForGrid) dirparam.setGrincr(grincr);
       _varioparam.addDir(dirparam);
 
@@ -5472,16 +5473,33 @@ namespace gstlrn
       double tolcode = 0.;
       double dlag = 0.;
       double toldist = 0.;
+      double bench = 0.;
       double tolang = 0.;
+      double cylrad = 0.;
       bool flagGrid = false;
       VectorInt grincr;
       VectorDouble codir;
+      VectorDouble benchdir;
 
       ret = ret && SerializeHDF5::readValue(*dirG, "NLag", nlag);
       ret = ret && SerializeHDF5::readValue(*dirG, "Code", optionCode);
       ret = ret && SerializeHDF5::readValue(*dirG, "TolCode", tolcode);
       ret = ret && SerializeHDF5::readValue(*dirG, "Lag", dlag);
       ret = ret && SerializeHDF5::readValue(*dirG, "TolDist", toldist);
+
+      // The parameters 'cylrad', 'bench' and 'benchdir' are optional (to cope with old version of the class)
+      if (SerializeHDF5::existsH5Item(*dirG, "CylRad", false))
+      {
+        ret = ret && SerializeHDF5::readValue(*dirG, "CylRad", cylrad);
+      }
+      if (SerializeHDF5::existsH5Item(*dirG, "Bench", false))
+      {
+        ret = ret && SerializeHDF5::readValue(*dirG, "Bench", bench);
+      }
+      if (SerializeHDF5::existsH5Item(*dirG, "BenchDir", false))
+      {
+        ret = ret && SerializeHDF5::readVec(*dirG, "BenchDir", benchdir);
+      }
       ret = ret && SerializeHDF5::readValue(*dirG, "GridDef", flagGrid);
 
       if (!flagGrid)
@@ -5496,8 +5514,8 @@ namespace gstlrn
 
       auto space = SpaceRN::create(ndim);
       DirParam dirparam = DirParam(
-        nlag, dlag, toldist, tolang, optionCode, 0, TEST, TEST, tolcode,
-        VectorDouble(), codir, TEST, space);
+        nlag, dlag, toldist, tolang, optionCode, 0, bench, cylrad, tolcode,
+        VectorDouble(), codir, TEST, benchdir, space);
       if (flagGrid) dirparam.setGrincr(grincr);
 
       _varioparam.addDir(dirparam);
@@ -5545,8 +5563,7 @@ namespace gstlrn
          && SerializeHDF5::writeVec(
               varioG, "Variances", getVarMatrix().getValues());
 
-    /* Loop on the directions */
-
+    // Loop on the directions
     auto dirsG = varioG.createGroup("Directions");
     for (Id idir = 0; ret && idir < getNDir(); idir++)
     {
@@ -5562,6 +5579,12 @@ namespace gstlrn
       ret = ret && SerializeHDF5::writeValue(dirG, "Lag", dirparam.getDPas());
       ret = ret
          && SerializeHDF5::writeValue(dirG, "TolDist", dirparam.getTolDist());
+      ret =
+        ret && SerializeHDF5::writeValue(dirG, "CylRad", dirparam.getCylRad());
+      ret =
+        ret && SerializeHDF5::writeValue(dirG, "Bench", dirparam.getBench());
+      ret = ret
+         && SerializeHDF5::writeVec(dirG, "BenchDir", dirparam.getBenchDir());
       ret = ret
          && SerializeHDF5::writeValue(
               dirG, "GridDef", dirparam.isDefinedForGrid());
@@ -5648,7 +5671,7 @@ namespace gstlrn
     else
       varioparam = VarioParam::createOmniDirection(
         nlag, dlag, toldis, 0, 0, TEST, TEST, 0., VectorDouble(), 0.,
-        VectorDouble(), space);
+        VectorDouble(), VectorDouble(), space);
 
     auto* vario = new Vario(*varioparam);
     if (vario->compute(
@@ -5726,7 +5749,8 @@ namespace gstlrn
     double toldis,
     double tolang,
     double bench,
-    double cylrad)
+    double cylrad,
+    const VectorDouble& benchdir)
   {
 
     auto space = SpaceRN::create(db->getNDim());
@@ -5736,7 +5760,7 @@ namespace gstlrn
     double tolcode = 0.;
     auto dirparam = DirParam(
       nlag, dlag, toldis, tolang, opt_code, 0, bench, cylrad, tolcode,
-      VectorDouble(), codir, TEST, space);
+      VectorDouble(), codir, TEST, benchdir, space);
     auto* varioparam = new VarioParam();
     varioparam->addDir(dirparam);
 

--- a/src/Variogram/VarioParam.cpp
+++ b/src/Variogram/VarioParam.cpp
@@ -124,6 +124,7 @@ namespace gstlrn
    * @param breaks Definition of the irregular intervals
    * @param scale Scaling factor
    * @param dates Range of dates
+   * @param benchdir Direction of the bench (if any)
    * @param space Pointer to the space definition
    * @return
    */
@@ -139,11 +140,12 @@ namespace gstlrn
     const VectorDouble& breaks,
     double scale,
     const VectorDouble& dates,
+    const VectorDouble& benchdir,
     const ASpaceSharedPtr& space)
   {
     DirParam* dir = DirParam::createOmniDirection(
       nlag, dlag, toldis, opt_code, idate, bench, cylrad, tolcode, breaks,
-      space);
+      benchdir, space);
     auto* varioparam = new VarioParam(scale, dates);
     varioparam->addDir(*dir);
     delete dir;
@@ -237,7 +239,7 @@ namespace gstlrn
     {
       DirParam dirparam(
         nlag, dlag, toldis, tolang, 0, 0, TEST, TEST, 0., VectorDouble(),
-        VectorDouble(), TEST, space);
+        VectorDouble(), TEST, VectorDouble(), space);
 
       VectorDouble codir(ndim, 0.);
       codir[idim] = 1.;

--- a/tests/ipynb/output/Tuto_Vario3D.asciidoc
+++ b/tests/ipynb/output/Tuto_Vario3D.asciidoc
@@ -40,29 +40,29 @@ Number of direction(s)      = 1
 Space dimension             = 3
 Variable(s)                 = [value]
 
-Variance-Covariance Matrix     0.083
+Variance-Covariance Matrix      0.083
 
 Direction #1
 ------------
 Number of lags              = 10
-Direction coefficients      =      1.000     0.000     0.000
-Direction angles (degrees)  =      0.000     0.000     0.000
-Tolerance on direction      =     90.000 (degrees)
-Calculation lag             =      0.100
-Tolerance on distance       =     50.000 (Percent of the lag value)
+Direction coefficients      =       1.000      0.000      0.000
+Direction angles (degrees)  =       0.000      0.000      0.000
+Tolerance on direction      =      90.000 (degrees)
+Calculation lag             =       0.100
+Tolerance on distance       =      50.000 (Percent of the lag value)
 
 For variable 1
-      Rank    Npairs  Distance     Value
-         0    73.000     0.029     0.074
-         1   383.000     0.096     0.088
-         2   309.000     0.200     0.072
-         3   956.000     0.307     0.079
-         4   844.000     0.410     0.080
-         5  1783.000     0.501     0.082
-         6  1361.000     0.599     0.084
-         7  1516.000     0.700     0.082
-         8  1401.000     0.795     0.088
-         9   871.000     0.894     0.087----
+       Rank     Npairs   Distance      Value
+          0     73.000      0.029      0.074
+          1    383.000      0.096      0.088
+          2    309.000      0.200      0.072
+          3    956.000      0.307      0.079
+          4    844.000      0.410      0.080
+          5   1783.000      0.501      0.082
+          6   1361.000      0.599      0.084
+          7   1516.000      0.700      0.082
+          8   1401.000      0.795      0.088
+          9    871.000      0.894      0.087----
 
 
 #NO_DIFF#XXX
@@ -80,52 +80,53 @@ Number of direction(s)      = 2
 Space dimension             = 3
 Variable(s)                 = [value]
 
-Variance-Covariance Matrix     0.083
+Variance-Covariance Matrix      0.083
 
 Direction #1
 ------------
 Number of lags              = 10
-Direction coefficients      =      1.000     0.000     0.000
-Direction angles (degrees)  =      0.000     0.000     0.000
-Tolerance on direction      =     90.000 (degrees)
-Slice bench                 =      1.000
-Calculation lag             =      0.100
-Tolerance on distance       =     50.000 (Percent of the lag value)
+Direction coefficients      =       1.000      0.000      0.000
+Direction angles (degrees)  =       0.000      0.000      0.000
+Tolerance on direction      =      90.000 (degrees)
+Slice bench                 =       1.000
+Bench Direction             =       0.000      0.000      1.000
+Calculation lag             =       0.100
+Tolerance on distance       =      50.000 (Percent of the lag value)
 
 For variable 1
-      Rank    Npairs  Distance     Value
-         0    73.000     0.029     0.074
-         1   383.000     0.096     0.088
-         2   309.000     0.200     0.072
-         3   956.000     0.307     0.079
-         4   844.000     0.410     0.080
-         5  1783.000     0.501     0.082
-         6  1361.000     0.599     0.084
-         7  1516.000     0.700     0.082
-         8  1401.000     0.795     0.088
-         9   871.000     0.894     0.087
+       Rank     Npairs   Distance      Value
+          0     73.000      0.029      0.074
+          1    383.000      0.096      0.088
+          2    309.000      0.200      0.072
+          3    956.000      0.307      0.079
+          4    844.000      0.410      0.080
+          5   1783.000      0.501      0.082
+          6   1361.000      0.599      0.084
+          7   1516.000      0.700      0.082
+          8   1401.000      0.795      0.088
+          9    871.000      0.894      0.087
 
 Direction #2
 ------------
 Number of lags              = 10
-Direction coefficients      =      0.000     0.000     1.000
-Direction angles (degrees)  =      0.000     0.000    90.000
-Tolerance on direction      =      0.001 (degrees)
-Calculation lag             =      0.100
-Tolerance on distance       =     50.000 (Percent of the lag value)
+Direction coefficients      =       0.000      0.000      1.000
+Direction angles (degrees)  =       0.000      0.000     90.000
+Tolerance on direction      =       0.001 (degrees)
+Calculation lag             =       0.100
+Tolerance on distance       =      50.000 (Percent of the lag value)
 
 For variable 1
-      Rank    Npairs  Distance     Value
-         0    20.000     0.022     0.094
-         1   210.000     0.098     0.088
-         2   140.000     0.195     0.071
-         3   180.000     0.298     0.083
-         4   150.000     0.411     0.080
-         5   100.000     0.512     0.090
-         6    80.000     0.603     0.077
-         7    60.000     0.695     0.084
-         8    70.000     0.801     0.096
-         9    30.000     0.905     0.097----
+       Rank     Npairs   Distance      Value
+          0     20.000      0.022      0.094
+          1    210.000      0.098      0.088
+          2    140.000      0.195      0.071
+          3    180.000      0.298      0.083
+          4    150.000      0.411      0.080
+          5    100.000      0.512      0.090
+          6     80.000      0.603      0.077
+          7     60.000      0.695      0.084
+          8     70.000      0.801      0.096
+          9     30.000      0.905      0.097----
 
 
 #NO_DIFF#XXX


### PR DESCRIPTION
This branch revisit the Bench option used for Variogram calculation.
Initially the bench criterion was the following:
- considering the vector VEC between the Target and an eligible Data
- considering the width of the bench option (BENCH)
- considering the space dimension NDIM
The Datum was rejected if VEC[NDIM-1] > BENCH.
Clearly the criterion was applied on the last coordinate (vertical in 3D).

The demand was to generalize this criterion by defining in addition a vector for considering the bench criterion: BENCHDIR. This is vector provided by the user: 
- if it is provided, it is normalized internally (to speed up further calculations)
- if is is not defined, it is generated as the unit vector with a 1 in its NDIM-1 component (to be compliant with the previous implementation of the bench option).

Now the algorithm becomes:
ABS(BENCHDIR * VEC) > BENCH
(where "*" stands for the scalar product.

So doing, I also discovered that two elements were not saved/restored in Neutral Files: CYLRAD and BENCH.
They have been added.  The READING has been enhanced in order to remain compatible with the old files (where the two arguments were missing).

Fix #870.