### PR TITLE
Refactor ShiftOpStencil / PrecisionOp / PrecisionOpMulti

### DIFF
--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -62,7 +62,7 @@ namespace gstlrn
     double computeLogDet(Id nMC = 1) const override;
     std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const override;
 
-    PrecisionOp* getPrecision(Id idx);
+    PrecisionOp* getPrecision(Id idx) const;
 
   protected:
 #ifndef SWIG

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -62,6 +62,7 @@ namespace gstlrn
     double computeLogDet(Id nMC = 1) const override;
     std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const override;
 
+    Id getNCov() const;
     PrecisionOp* getPrecision(Id idx) const;
 
   protected:
@@ -72,7 +73,6 @@ namespace gstlrn
 
     void buildQop(bool stencil = false);
     Id size(Id imesh) const;
-    Id _getNCov() const;
 
     Id _getCovInd(Id i) const { return _covList[i]; }
 

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -46,6 +46,10 @@ namespace gstlrn
       const VectorMeshes& meshes = VectorMeshes(),
       bool stencil = false,
       bool buildOp = true);
+    PrecisionOpMulti(
+      std::vector<PrecisionOp*> pops,
+      Model* model,
+      const VectorMeshes& meshes);
     PrecisionOpMulti(const PrecisionOpMulti& m) = delete;
     PrecisionOpMulti& operator=(const PrecisionOpMulti& m) = delete;
     virtual ~PrecisionOpMulti();
@@ -112,6 +116,7 @@ namespace gstlrn
     VectorInt _nmeshList;
     bool _allStat;
     bool _ready;
+    bool _destroyPrecisionOp;
 
     mutable VectorVectorDouble _works;
     mutable VectorDouble _workTot;

--- a/include/LinearOp/PrecisionOpMulti.hpp
+++ b/include/LinearOp/PrecisionOpMulti.hpp
@@ -52,7 +52,7 @@ namespace gstlrn
       const VectorMeshes& meshes);
     PrecisionOpMulti(const PrecisionOpMulti& m) = delete;
     PrecisionOpMulti& operator=(const PrecisionOpMulti& m) = delete;
-    virtual ~PrecisionOpMulti();
+    virtual ~PrecisionOpMulti() = default;
 
     /// AStringable Interface
     String toString(const AStringFormat* strfmt = nullptr) const override;
@@ -63,7 +63,7 @@ namespace gstlrn
     std::pair<double, double> rangeEigenVal(Id ndiscr = 100) const override;
 
     Id getNCov() const;
-    PrecisionOp* getPrecision(Id idx) const;
+    PrecisionOp& getPrecision(Id idx) const;
 
   protected:
 #ifndef SWIG
@@ -92,11 +92,11 @@ namespace gstlrn
     Id _buildGlobalMatricesStationary(Id icov);
     Id _buildLocalMatricesNoStat(Id icov);
     Id _buildMatrices();
-    void _popsClear();
     void _computeSize();
 
   protected:
-    std::vector<PrecisionOp*> _pops;
+    std::vector<std::reference_wrapper<PrecisionOp>> _pops;
+    std::vector<std::unique_ptr<PrecisionOp>> _storedPops;
     VectorBool _isNoStatForVariance;
     std::vector<MatrixSymmetric> _sills;
     std::vector<std::vector<MatrixSymmetric>>
@@ -116,7 +116,6 @@ namespace gstlrn
     VectorInt _nmeshList;
     bool _allStat;
     bool _ready;
-    bool _destroyPrecisionOp;
 
     mutable VectorVectorDouble _works;
     mutable VectorDouble _workTot;

--- a/include/LinearOp/PrecisionOpMultiMatrix.hpp
+++ b/include/LinearOp/PrecisionOpMultiMatrix.hpp
@@ -48,7 +48,7 @@ namespace gstlrn
     void _prepareMatrix();
     void _buildQop(bool stencil = false) override;
 
-    bool _isSingle() const { return _getNVar() == 1 && _getNCov() == 1; }
+    bool _isSingle() const { return _getNVar() == 1 && getNCov() == 1; }
 
   private:
     MatrixSparse _Q;

--- a/include/LinearOp/ShiftOpStencil.hpp
+++ b/include/LinearOp/ShiftOpStencil.hpp
@@ -19,6 +19,43 @@ namespace gstlrn
   class CovAniso;
   class MeshETurbo;
   class AMesh;
+  class Grid;
+
+  /**
+   * @brief Helper class for ShiftOpStencil, it stores the weights and the
+   * relative shifts needed to apply them.
+   */
+  class GSTLEARN_EXPORT ShiftStencil
+  {
+  public:
+    ShiftStencil() = default;
+    ShiftStencil(const MeshETurbo* mesh, const CovAniso* cova, bool verbose);
+
+    const VectorVectorInt& relativeShifts() const { return _relativeShifts; }
+
+    const VectorInt& absoluteShifts() const { return _absoluteShifts; }
+
+    Id getNWeights() const { return static_cast<Id>(_weights.size()); }
+
+    const VectorDouble& weights() const;
+
+    double getLambda() const { return _lambdaVal; }
+
+    double& getLambda() { return _lambdaVal; }
+
+    void multiplyByValueAndAddDiagonal(double v1 = 1., double v2 = 0.) const;
+    void resetModif() const;
+
+    void print() const;
+
+  private:
+    VectorVectorInt _relativeShifts;
+    VectorInt _absoluteShifts;
+    VectorDouble _weights;
+    mutable VectorDouble _weightsSimu;
+    double _lambdaVal = 0.;
+    mutable bool _useModifiedShift = false;
+  };
 
   /**
    * @brief This is an implementation of ShiftOp dedicated to case where:
@@ -32,7 +69,7 @@ namespace gstlrn
    * _absoluteShifts Vector of shifts to calculate where the weights should apply
    *                 calculated on the global target grid.
    *                 This can only be used if the grid has no selection
-   * _weights        Vector of weights (only significative ones are kept)
+   * _weights        Vector of weights (only significant ones are kept)
    * _isInside       Vector telling if each node of the grid is located on its edge
    *                 and should be bypassed for matrix calculations, or not
    */
@@ -43,9 +80,9 @@ namespace gstlrn
       const MeshETurbo* mesh = nullptr,
       const CovAniso* cova = nullptr,
       bool verbose = false);
-    ShiftOpStencil(const ShiftOpStencil& shift);
-    ShiftOpStencil& operator=(const ShiftOpStencil& shift);
-    virtual ~ShiftOpStencil();
+    ShiftOpStencil(const ShiftOpStencil& shift) = default;
+    ShiftOpStencil& operator=(const ShiftOpStencil& shift) = default;
+    ~ShiftOpStencil() override = default;
     /// ICloneable interface
     IMPLEMENT_CLONING(ShiftOpStencil)
 
@@ -67,19 +104,11 @@ namespace gstlrn
       const MeshETurbo* mesh,
       const CovAniso* cova,
       bool verbose);
-    void _printStencil() const;
-
-    Id _getNWeights() const { return static_cast<Id>(_weights.size()); }
 
   private:
-    VectorVectorInt _relativeShifts;
-    VectorInt _absoluteShifts;
-    VectorDouble _weights;
-    mutable VectorDouble _weightsSimu;
+    ShiftStencil _stencil;
     VectorBool _isInside;
-    double _lambdaVal;
     bool _useLambdaSingleVal;
-    mutable bool _useModifiedShift;
     const MeshETurbo* _mesh; // not to be deleted
   };
 } // namespace gstlrn

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -106,6 +106,7 @@ namespace gstlrn
     , _nmeshList()
     , _allStat(true)
     , _ready(false)
+    , _destroyPrecisionOp(true)
   {
     if (!_isValidModel(model)) return;
 
@@ -132,6 +133,59 @@ namespace gstlrn
     {
       bool localStencil = stencil && meshes.isTurbo();
       buildQop(localStencil);
+    }
+  }
+
+  PrecisionOpMulti::PrecisionOpMulti(
+    std::vector<PrecisionOp*> pops,
+    Model* model,
+    const VectorMeshes& meshes)
+    : _pops(pops)
+    , _isNoStatForVariance(false)
+    , _sills()
+    , _localSills()
+    , _invCholSillsNoStat()
+    , _cholSillsNoStat()
+    , _invCholSillsStat()
+    , _cholSillsStat()
+    , _model(nullptr)
+    , _meshes()
+    , _size(0)
+    , _isValid(false)
+    , _covList()
+    , _nmeshList()
+    , _allStat(true)
+    , _ready(false)
+    , _destroyPrecisionOp(false)
+  {
+    if (!_isValidModel(model)) return;
+
+    if (!_isValidMeshes(meshes)) return;
+
+    if (!_matchModelAndMeshes()) return;
+
+    _isValid = true;
+    _computeSize();
+    Id ncov = static_cast<Id>(meshes.size());
+    _isNoStatForVariance.resize(ncov, false);
+
+    _works.resize(ncov);
+
+    for (Id icov = 0; icov < ncov; icov++)
+    {
+      bool nostaticov = _model->getCovAniso(icov)->isNoStatForVariance();
+      _isNoStatForVariance[icov] = nostaticov;
+      _allStat = _allStat && !nostaticov;
+    }
+    _buildMatrices();
+
+    if (static_cast<gstlrn::Id>(_pops.size()) != _getNCov())
+    {
+      messerr("List of operators does not match model.");
+    }
+    else
+    {
+      _ready = true;
     }
   }
 
@@ -165,7 +219,7 @@ namespace gstlrn
 
   PrecisionOpMulti::~PrecisionOpMulti()
   {
-    _popsClear();
+    if (_destroyPrecisionOp) _popsClear();
   }
 
   /*****************************************************************************/

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -50,7 +50,7 @@
         if (COMPUTEOP)                                                         \
         {                                                                      \
           if ((nvar > 1) || (ncov > 1)) std::fill(y.begin(), y.end(), 0.);     \
-          _pops[icov]->OP(x, y);                                               \
+          _pops[icov].get().OP(x, y);                                          \
         }                                                                      \
         if ((nvar == 1) && (ncov == 1)) break;                                 \
         if (nvar == 1)                                                         \
@@ -91,6 +91,7 @@ namespace gstlrn
     bool stencil,
     bool buildOp)
     : _pops()
+    , _storedPops()
     , _isNoStatForVariance(false)
     , _sills()
     , _localSills()
@@ -106,7 +107,6 @@ namespace gstlrn
     , _nmeshList()
     , _allStat(true)
     , _ready(false)
-    , _destroyPrecisionOp(true)
   {
     if (!_isValidModel(model)) return;
 
@@ -140,7 +140,8 @@ namespace gstlrn
     std::vector<PrecisionOp*> pops,
     Model* model,
     const VectorMeshes& meshes)
-    : _pops(pops)
+    : _pops()
+    , _storedPops()
     , _isNoStatForVariance(false)
     , _sills()
     , _localSills()
@@ -156,7 +157,6 @@ namespace gstlrn
     , _nmeshList()
     , _allStat(true)
     , _ready(false)
-    , _destroyPrecisionOp(false)
   {
     if (!_isValidModel(model)) return;
 
@@ -185,6 +185,7 @@ namespace gstlrn
     }
     else
     {
+      for (auto p: pops) _pops.push_back(*p);
       _ready = true;
     }
   }
@@ -213,13 +214,10 @@ namespace gstlrn
     {
       CovAniso* cova = _model->getCovAniso(_covList[i]);
       bool localStencil = stencil && !cova->isNoStatForAnisotropy();
-      _pops.push_back(PrecisionOp::create(_meshes(i), cova, localStencil));
+      PrecisionOp* op = PrecisionOp::create(_meshes(i), cova, localStencil);
+      _storedPops.push_back(std::unique_ptr<PrecisionOp>(op));
+      _pops.push_back(*op);
     }
-  }
-
-  PrecisionOpMulti::~PrecisionOpMulti()
-  {
-    if (_destroyPrecisionOp) _popsClear();
   }
 
   /*****************************************************************************/
@@ -270,12 +268,6 @@ namespace gstlrn
     _meshes = meshes;
 
     return true;
-  }
-
-  void PrecisionOpMulti::_popsClear()
-  {
-    for (Id i = 0, n = static_cast<Id>(_pops.size()); i < n; i++)
-      delete _pops[i];
   }
 
   bool PrecisionOpMulti::_matchModelAndMeshes() const
@@ -476,11 +468,11 @@ namespace gstlrn
 
   std::pair<double, double> PrecisionOpMulti::rangeEigenVal(Id ndiscr) const
   {
-    std::pair<double, double> result = _pops[0]->rangeEigenVal(ndiscr);
+    std::pair<double, double> result = _pops[0].get().rangeEigenVal(ndiscr);
 
     for (Id i = 1; i < static_cast<Id>(_pops.size()); i++)
     {
-      std::pair<double, double> vals = _pops[i]->rangeEigenVal(ndiscr);
+      std::pair<double, double> vals = _pops[i].get().rangeEigenVal(ndiscr);
       result.first = MIN(result.first, vals.first);
       result.second = MAX(result.second, vals.second);
     }
@@ -499,20 +491,13 @@ namespace gstlrn
     double result = 0.;
     for (const auto& e: _pops)
     {
-      result += e->computeLogDet(nMC);
+      result += e.get().computeLogDet(nMC);
     }
     return result;
   }
 
-  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx) const
+  PrecisionOp& PrecisionOpMulti::getPrecision(Id idx) const
   {
-    if (idx < 0 || idx > getNCov())
-    {
-      messerr(
-        "The index passed to getPrecision() must be between 0 and %d\n",
-        getNCov() - 1);
-      return nullptr;
-    }
     return _pops[idx];
   }
 

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -504,7 +504,7 @@ namespace gstlrn
     return result;
   }
 
-  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx)
+  PrecisionOp* PrecisionOpMulti::getPrecision(Id idx) const
   {
     if (idx < 0 || idx > _getNCov())
     {

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -179,7 +179,7 @@ namespace gstlrn
     }
     _buildMatrices();
 
-    if (static_cast<gstlrn::Id>(_pops.size()) != getNCov())
+    if (static_cast<gstlrn::Id>(pops.size()) != getNCov())
     {
       messerr("List of operators does not match model.");
     }
@@ -214,9 +214,10 @@ namespace gstlrn
     {
       CovAniso* cova = _model->getCovAniso(_covList[i]);
       bool localStencil = stencil && !cova->isNoStatForAnisotropy();
-      PrecisionOp* op = PrecisionOp::create(_meshes(i), cova, localStencil);
-      _storedPops.push_back(std::unique_ptr<PrecisionOp>(op));
-      _pops.push_back(*op);
+      auto op = std::make_unique<PrecisionOp>(_meshes(i), cova, localStencil);
+      PrecisionOp& ref_op = *op;
+      _storedPops.push_back(std::move(op));
+      _pops.push_back(ref_op);
     }
   }
 

--- a/src/LinearOp/PrecisionOpMulti.cpp
+++ b/src/LinearOp/PrecisionOpMulti.cpp
@@ -23,7 +23,7 @@
   IN, OUT, TAB, getmat, OP, IY, COMPUTEOP, XORY, START, END, IVAR, JVAR)       \
   {                                                                            \
     auto nvar = _getNVar();                                                    \
-    auto ncov = _getNCov();                                                    \
+    auto ncov = getNCov();                                                     \
     Id iad_x = 0;                                                              \
     Id iad_struct = 0;                                                         \
     vect y;                                                                    \
@@ -179,7 +179,7 @@ namespace gstlrn
     }
     _buildMatrices();
 
-    if (static_cast<gstlrn::Id>(_pops.size()) != _getNCov())
+    if (static_cast<gstlrn::Id>(_pops.size()) != getNCov())
     {
       messerr("List of operators does not match model.");
     }
@@ -209,7 +209,7 @@ namespace gstlrn
 
   void PrecisionOpMulti::_buildQop(bool stencil)
   {
-    for (Id i = 0, number = _getNCov(); i < number; i++)
+    for (Id i = 0, number = getNCov(); i < number; i++)
     {
       CovAniso* cova = _model->getCovAniso(_covList[i]);
       bool localStencil = stencil && !cova->isNoStatForAnisotropy();
@@ -280,12 +280,12 @@ namespace gstlrn
 
   bool PrecisionOpMulti::_matchModelAndMeshes() const
   {
-    if (_getNCov() != _getNMesh())
+    if (getNCov() != _getNMesh())
     {
       messerr(
         "The number of meshes (%d) and the number of covariances (%d) do not "
         "match",
-        _getNMesh(), _getNCov());
+        _getNMesh(), getNCov());
       return false;
     }
     return true;
@@ -297,7 +297,7 @@ namespace gstlrn
     return _model->getNVar();
   }
 
-  Id PrecisionOpMulti::_getNCov() const
+  Id PrecisionOpMulti::getNCov() const
   {
     if (_covList.empty()) return 0;
     return static_cast<Id>(_covList.size());
@@ -317,7 +317,7 @@ namespace gstlrn
   void PrecisionOpMulti::_computeSize()
   {
     auto nvar = _getNVar();
-    auto ncov = _getNCov();
+    auto ncov = getNCov();
     _size = 0;
     for (Id i = 0; i < ncov; i++)
     {
@@ -380,7 +380,7 @@ namespace gstlrn
     if (_model == nullptr) return 1;
     if (_getNVar() == 1) return 0;
 
-    auto ncov = _getNCov();
+    auto ncov = getNCov();
 
     // Do nothing if the array has already been calculated (correct dimension)
     if (ncov == static_cast<Id>(_cholSillsStat.size())) return 0;
@@ -419,7 +419,7 @@ namespace gstlrn
     std::stringstream sstr;
 
     sstr << "Number of Variables   = " << _getNVar() << std::endl;
-    sstr << "Number of Covariances = " << _getNCov() << std::endl;
+    sstr << "Number of Covariances = " << getNCov() << std::endl;
     sstr << "Number of Meshes      = " << _getNMesh() << std::endl;
     sstr << "Vector dimension      = " << getSize() << std::endl;
 
@@ -506,11 +506,11 @@ namespace gstlrn
 
   PrecisionOp* PrecisionOpMulti::getPrecision(Id idx) const
   {
-    if (idx < 0 || idx > _getNCov())
+    if (idx < 0 || idx > getNCov())
     {
       messerr(
         "The index passed to getPrecision() must be between 0 and %d\n",
-        _getNCov() - 1);
+        getNCov() - 1);
       return nullptr;
     }
     return _pops[idx];

--- a/src/LinearOp/PrecisionOpMultiMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMultiMatrix.cpp
@@ -111,7 +111,7 @@ namespace gstlrn
     if (_isSingle()) return;
 
     MatrixSparse current(0, 0);
-    for (Id istruct = 0; istruct < _getNCov(); istruct++)
+    for (Id istruct = 0; istruct < getNCov(); istruct++)
     {
       const MatrixSparse* Q =
         dynamic_cast<const PrecisionOpMatrix*>(_pops[istruct])->getQ();
@@ -143,7 +143,7 @@ namespace gstlrn
     {
       messerr("PrecisionOpMultiMatrix does not support stencil option\n");
     }
-    for (Id icov = 0, number = _getNCov(); icov < number; icov++)
+    for (Id icov = 0, number = getNCov(); icov < number; icov++)
     {
       CovAniso* cova = _model->getCovAniso(_getCovInd(icov));
       _pops.push_back(new PrecisionOpMatrix(_meshes(icov), cova));

--- a/src/LinearOp/PrecisionOpMultiMatrix.cpp
+++ b/src/LinearOp/PrecisionOpMultiMatrix.cpp
@@ -96,7 +96,7 @@ namespace gstlrn
   {
     if (_isSingle())
     {
-      return dynamic_cast<const PrecisionOpMatrix*>(_pops[0])->getQ();
+      return dynamic_cast<const PrecisionOpMatrix&>(getPrecision(0)).getQ();
     }
     return &_Q;
   }
@@ -114,7 +114,7 @@ namespace gstlrn
     for (Id istruct = 0; istruct < getNCov(); istruct++)
     {
       const MatrixSparse* Q =
-        dynamic_cast<const PrecisionOpMatrix*>(_pops[istruct])->getQ();
+        dynamic_cast<const PrecisionOpMatrix&>(getPrecision(istruct)).getQ();
 
       if (_model->getNVar() == 1)
       {
@@ -146,7 +146,9 @@ namespace gstlrn
     for (Id icov = 0, number = getNCov(); icov < number; icov++)
     {
       CovAniso* cova = _model->getCovAniso(_getCovInd(icov));
-      _pops.push_back(new PrecisionOpMatrix(_meshes(icov), cova));
+      PrecisionOpMatrix* op = new PrecisionOpMatrix(_meshes(icov), cova);
+      _storedPops.push_back(std::unique_ptr<PrecisionOp>(op));
+      _pops.push_back(*op);
     }
   }
 

--- a/src/LinearOp/ShiftOpStencil.cpp
+++ b/src/LinearOp/ShiftOpStencil.cpp
@@ -29,65 +29,19 @@ namespace gstlrn
     const CovAniso* cova,
     bool verbose)
     : AShiftOp()
-    , _relativeShifts()
-    , _absoluteShifts()
-    , _weights()
+    , _stencil()
     , _isInside()
-    , _lambdaVal(0.)
     , _useLambdaSingleVal(true)
-    , _useModifiedShift(false)
     , _mesh()
   {
     if (_buildInternal(mesh, cova, verbose)) return;
   }
 
-  ShiftOpStencil::ShiftOpStencil(const ShiftOpStencil& shift)
-    : AShiftOp(shift)
-    , _relativeShifts(shift._relativeShifts)
-    , _absoluteShifts(shift._absoluteShifts)
-    , _weights(shift._weights)
-    , _weightsSimu(shift._weightsSimu)
-    , _isInside(shift._isInside)
-    , _lambdaVal(shift._lambdaVal)
-    , _useLambdaSingleVal(shift._useLambdaSingleVal)
-    , _useModifiedShift(shift._useModifiedShift)
-    , _mesh(shift._mesh)
-  {
-  }
-
-  ShiftOpStencil& ShiftOpStencil::operator=(const ShiftOpStencil& shift)
-  {
-    AShiftOp::operator=(shift);
-    if (this != &shift)
-    {
-      _relativeShifts = shift._relativeShifts;
-      _absoluteShifts = shift._absoluteShifts;
-      _weights = shift._weights;
-      _weightsSimu = shift._weightsSimu;
-      _isInside = shift._isInside;
-      _lambdaVal = shift._lambdaVal;
-      _useLambdaSingleVal = shift._useLambdaSingleVal;
-      _useModifiedShift = shift._useModifiedShift;
-      _mesh = shift._mesh;
-    }
-    return *this;
-  }
-
-  ShiftOpStencil::~ShiftOpStencil() {}
-
   Id ShiftOpStencil::_addToDest(const constvect inv, vect outv) const
   {
-    const VectorDouble* currentWeights;
-    if (_useModifiedShift)
-    {
-      currentWeights = &_weightsSimu;
-    }
-    else
-    {
-      currentWeights = &_weights;
-    }
+    const VectorDouble& currentWeights = _stencil.weights();
 
-    auto nw = _getNWeights();
+    auto nw = _stencil.getNWeights();
     Id size = static_cast<Id>(inv.size());
     const Indirection& indirect = _mesh->getGridIndirect();
 
@@ -95,6 +49,7 @@ namespace gstlrn
 
     if (!indirect.isDefined())
     {
+      const VectorInt& absoluteShifts = _stencil.absoluteShifts();
       // Use the fast option when no selection is defined on the Grid
 #pragma omp parallel for num_threads(nbthread)
       for (Id ic = 0; ic < size; ic++)
@@ -104,10 +59,10 @@ namespace gstlrn
         {
           for (Id iw = 0; iw < nw; iw++)
           {
-            Id iabs = ic + _absoluteShifts[iw];
+            Id iabs = ic + absoluteShifts[iw];
             if (_isInside[iabs])
             {
-              total += (*currentWeights)[iw] * inv[iabs];
+              total += currentWeights[iw] * inv[iabs];
             }
           }
         }
@@ -118,6 +73,7 @@ namespace gstlrn
     {
       const Grid& grid = _mesh->getGrid();
       Id ndim = _mesh->getNDim();
+      const VectorVectorInt& relativeShifts = _stencil.relativeShifts();
 
       VectorInt center(ndim);
       VectorInt local(ndim);
@@ -134,10 +90,10 @@ namespace gstlrn
           grid.rankToIndice(rank, center);
           for (Id iw = 0; iw < nw; iw++)
           {
-            VH::add(local, center, _relativeShifts[iw]);
+            VH::add(local, center, relativeShifts[iw]);
             Id ie = grid.indiceToRank(local);
             rank = indirect.getAToR(ie);
-            if (rank >= 0) total += (*currentWeights)[iw] * inv[rank];
+            if (rank >= 0) total += currentWeights[iw] * inv[rank];
           }
         }
         outv[ic] = total;
@@ -148,7 +104,7 @@ namespace gstlrn
 
   void ShiftOpStencil::resetModif() const
   {
-    _useModifiedShift = false;
+    _stencil.resetModif();
   }
 
   void ShiftOpStencil::normalizeLambdaBySills(const AMesh* mesh)
@@ -158,21 +114,21 @@ namespace gstlrn
       _Lambda.resize(_napices);
       for (auto& e: _Lambda)
       {
-        e = _lambdaVal;
+        e = _stencil.getLambda();
       }
       AShiftOp::normalizeLambdaBySills(mesh);
       _useLambdaSingleVal = false;
     }
     else
     {
-      _lambdaVal /= sqrt(_cova->getSill(0, 0));
+      _stencil.getLambda() /= sqrt(_cova->getSill(0, 0));
     }
   }
 
   double ShiftOpStencil::_getMaxEigenValue() const
   {
     double s = 0.;
-    for (const auto& e: _weights)
+    for (const auto& e: _stencil.weights())
     {
       s += ABS(e);
     }
@@ -181,24 +137,19 @@ namespace gstlrn
 
   double ShiftOpStencil::getLambda(Id iapex) const
   {
-    if (_useLambdaSingleVal) return _lambdaVal;
+    if (_useLambdaSingleVal) return _stencil.getLambda();
     return AShiftOp::getLambda(iapex);
   }
 
   double ShiftOpStencil::logDetLambda() const
   {
-    if (_useLambdaSingleVal) return 2. * log(_lambdaVal) * _napices;
+    if (_useLambdaSingleVal) return 2. * log(_stencil.getLambda()) * _napices;
     return AShiftOp::logDetLambda();
   }
 
   void ShiftOpStencil::multiplyByValueAndAddDiagonal(double v1, double v2) const
   {
-    _weightsSimu = VectorDouble(_weights.size());
-    for (Id i = 0; i < static_cast<Id>(_weights.size()); i++)
-      _weightsSimu[i] = v1 * _weights[i];
-    Id center = static_cast<Id>(_relativeShifts.size()) / 2;
-    _weightsSimu[center] += v2;
-    _useModifiedShift = true;
+    _stencil.multiplyByValueAndAddDiagonal(v1, v2);
   }
 
   Id ShiftOpStencil::_buildInternal(
@@ -231,7 +182,50 @@ namespace gstlrn
       return 1;
     }
 
-    // Create a local Turbo Meshing starting from a DbGrid (Dimension 5 sgould be sufficient)
+    _stencil = ShiftStencil(_mesh, _cova.get(), verbose);
+
+    const Grid& grid = mesh->getGrid();
+    VectorInt center(ndim);
+    VectorInt NXs = grid.getNXs();
+
+    // Delineate the border of the grid (not to be treated)
+    Id size = _mesh->getNApices();
+    _isInside.fill(true, size);
+
+    const Indirection& indirect = _mesh->getGridIndirect();
+    for (Id i = 0; i < size; i++)
+    {
+      Id rank = indirect.isDefined() ? indirect.getRToA(i) : i;
+      grid.rankToIndice(rank, center);
+      bool flagInside = true;
+      for (Id idim = 0; idim < ndim && flagInside; idim++)
+      {
+        Id ival = center[idim];
+        if (ival <= 0 || ival >= NXs[idim] - 1) flagInside = false;
+      }
+      _isInside[i] = flagInside;
+    }
+
+    if (verbose)
+    {
+      Id ntreated = 0;
+      for (Id i = 0; i < size; i++)
+        if (_isInside[i]) ntreated++;
+      message(
+        "Number of pixels inside the grid (no edge effect) = %d/%d\n", ntreated,
+        size);
+    }
+
+    return 0;
+  }
+
+  ShiftStencil::ShiftStencil(
+    const MeshETurbo* mesh,
+    const CovAniso* cova,
+    bool verbose)
+  {
+    // Create a local Turbo Meshing starting from a DbGrid (dimension 3 should be sufficient but 5 is safer)
+    Id ndim = mesh->getNDim();
     const Grid& grid = mesh->getGrid();
     VectorInt NXs = grid.getNXs();
     VectorInt nxlocal(ndim, 5);
@@ -254,8 +248,6 @@ namespace gstlrn
     localMesh.getApexIndicesInPlace(centerApex, center);
 
     // Get the non-zero elements of the center column
-    _relativeShifts.clear();
-    _weights.clear();
     for (Id i = 0, n = static_cast<Id>(centerColumn.size()); i < n; i++)
     {
       double weight = centerColumn[i];
@@ -265,7 +257,8 @@ namespace gstlrn
       _relativeShifts.push_back(other);
       _weights.push_back(weight);
     }
-    auto nw = _getNWeights();
+
+    auto nw = getNWeights();
 
     // Calculate the shifts (from the center cell) for each weight
     // This is calculated for a reference pixel (center of the grid)
@@ -281,37 +274,44 @@ namespace gstlrn
       _absoluteShifts[iw] = iabs - iorigin;
     }
 
-    // Delineate the border of the grid (not to be treated)
-    Id size = _mesh->getNApices();
-    _isInside.fill(true, size);
-
-    const Indirection& indirect = _mesh->getGridIndirect();
-    for (Id i = 0; i < size; i++)
-    {
-      Id rank = indirect.isDefined() ? indirect.getRToA(i) : i;
-      grid.rankToIndice(rank, center);
-      bool flagInside = true;
-      for (Id idim = 0; idim < ndim && flagInside; idim++)
-      {
-        Id ival = center[idim];
-        if (ival <= 0 || ival >= NXs[idim] - 1) flagInside = false;
-      }
-      _isInside[i] = flagInside;
-    }
-
     // Print the contents of non-zero elements
-    if (verbose) _printStencil();
-
-    return 0;
+    if (verbose) print();
   }
 
-  void ShiftOpStencil::_printStencil() const
+  const VectorDouble& ShiftStencil::weights() const
   {
-    auto nweight = _getNWeights();
-    Id ndim = _mesh->getNDim();
-    Id size = _mesh->getNApices();
+    if (_useModifiedShift)
+    {
+      return _weightsSimu;
+    }
+    else
+    {
+      return _weights;
+    }
+  }
+
+  void ShiftStencil::multiplyByValueAndAddDiagonal(double v1, double v2) const
+  {
+    _weightsSimu = VectorDouble(_weights.size());
+    for (Id i = 0; i < static_cast<Id>(_weights.size()); i++)
+      _weightsSimu[i] = v1 * _weights[i];
+    Id center = static_cast<Id>(_relativeShifts.size()) / 2;
+    _weightsSimu[center] += v2;
+    _useModifiedShift = true;
+  }
+
+  void ShiftStencil::resetModif() const
+  {
+    _useModifiedShift = false;
+  }
+
+  void ShiftStencil::print() const
+  {
+    auto nweight = _weights.size();
+    Id ndim = _relativeShifts.front().size();
+
     mestitle(0, "Stencil contents");
-    for (Id i = 0; i < nweight; i++)
+    for (size_t i = 0; i < nweight; i++)
     {
       message("Weight %d/%d - Relative (", i + 1, nweight);
       for (Id idim = 0; idim < ndim; idim++)
@@ -319,12 +319,5 @@ namespace gstlrn
       message(") - Absolute (%4d)", _absoluteShifts[i]);
       message(" : %lf\n", _weights[i]);
     }
-
-    Id ntreated = 0;
-    for (Id i = 0; i < size; i++)
-      if (_isInside[i]) ntreated++;
-    message(
-      "Number of pixels inside the grid (no edge effect) = %d/%d\n", ntreated,
-      size);
   }
 } // namespace gstlrn


### PR DESCRIPTION
Various refactoring of `ShiftOpStencil` / `PrecisionOp` / `PrecisionOpMulti`. The main change is that `ShiftOpStencil` now stores the stencil itself in a new class (`ShiftStencil`) which is independent of the `AShiftOp` itself.