### PR TITLE
Reduce memory usage of ASPDEOp by removing/reusing some work arrays

### DIFF
--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -168,14 +168,12 @@ namespace gstlrn
     APreconditioner* _precond;
     bool _verbose;
 
+    mutable VectorDouble _rhs;
     mutable VectorDouble _workdat1;
     mutable VectorDouble _workdat2;
-    mutable VectorDouble _workdat3;
-    mutable VectorDouble _workdat4;
-    mutable VectorDouble _workNoiseMesh;
-    mutable VectorDouble _workNoiseData;
-    mutable VectorDouble _rhs;
-    mutable VectorDouble _workmesh;
+    mutable VectorDouble _work1;
+    mutable VectorDouble _work2;
+    mutable bool _simCondGibbsInProgress;
     mutable VectorDouble _workGibbsData;
 
   private:

--- a/include/LinearOp/SPDEOp.hpp
+++ b/include/LinearOp/SPDEOp.hpp
@@ -173,6 +173,7 @@ namespace gstlrn
     mutable VectorDouble _workdat2;
     mutable VectorDouble _work1;
     mutable VectorDouble _work2;
+    mutable VectorDouble _work3;
     mutable bool _simCondGibbsInProgress;
     mutable VectorDouble _workGibbsData;
 

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -39,6 +39,7 @@ namespace gstlrn
     , _precond(precond)
     , _verbose(false)
     , _ndat(0)
+    , _simCondGibbsInProgress(false)
   {
     if (_projInKriging == nullptr) return;
     if (_invNoise == nullptr) return;
@@ -117,27 +118,33 @@ namespace gstlrn
 
   void ASPDEOp::_simCond(const constvect data, vect outvK, vect outvS) const
   {
-    // Resize if necessary
-    _workdat3.resize(_getNDat());
-    _workdat4.resize(_getNDat());
-    _workNoiseMesh.resize(getSizeSimu());
-    _workNoiseData.resize(_getNDat());
+    // Resize if necessary.
+    _prepare(true, false);
+    _work1.resize(getSizeSimu());
 
     // Non conditional simulation on Simulation mesh
-    VH::simulateGaussianInPlace(_workNoiseMesh);
-    _QSimu->evalSimulate(_workNoiseMesh, outvS);
+    VH::simulateGaussianInPlace(_work1);
+    _QSimu->evalSimulate(_work1, outvS);
 
     // Simulation at data locations (projection + noise)
-    _projInSimu->mesh2point(outvS, _workdat3); // Projection on data locations
-    VH::simulateGaussianInPlace(_workNoiseData);
-    _invNoise->addSimulateToDest(_workNoiseData, _workdat3); // Add noise
+    _projInSimu->mesh2point(outvS, _workdat1); // Projection on data locations
+    _work1.resize(_getNDat());
+    VH::simulateGaussianInPlace(_work1);
+    _invNoise->addSimulateToDest(_work1, _workdat1); // Add noise
 
-    // compute residual _workdat4 = data - outv
-    VH::subtractInPlace(_workdat3, data, _workdat4);
+    // compute residual _work1 = data - outv
+    VH::subtractInPlace(_workdat1, data, _work1);
+
+    // _simCondGibbs() reuses some intermediate results. _workdat1 is reused
+    // in _kriging() so copy it elsewhere first.
+    if (_simCondGibbsInProgress)
+    {
+      _work2 = _workdat1;
+    }
 
     // Co-Kriging of the residual on the Kriging mesh
     _solver->setTolerance(1e-5);
-    _kriging(_workdat4, outvK);
+    _kriging(_work1, outvK);
   }
 
   void ASPDEOp::_simCondGibbs(
@@ -165,10 +172,11 @@ namespace gstlrn
       _workGibbsData.assign(data.begin(), data.end());
     }
 
+    _simCondGibbsInProgress = true; // notify _simCond() to keep intermediate
     for (Id i_gibbs = 0; i_gibbs < nIter; ++i_gibbs)
     {
       _simCond(_workGibbsData.asConstVect(), outvK, outvS);
-      VectorDouble means = _workdat3 + _workdat4;
+      VectorDouble means = _work2 + _work1;
 
       for (Id i_data = 0; i_data < _getNDat(); ++i_data)
       {
@@ -192,6 +200,7 @@ namespace gstlrn
         _workGibbsData[i_data] = mean + noise / invNoiseSqrt;
       }
     }
+    _simCondGibbsInProgress = false;
 
     _simCond(_workGibbsData.asConstVect(), outvK, outvS);
   }
@@ -199,11 +208,11 @@ namespace gstlrn
   void ASPDEOp::_simNonCond(vect outv) const
   {
     // Resize if necessary
-    _workNoiseMesh.resize(getSizeSimu());
+    _work1.resize(getSizeSimu());
 
     // Non conditional simulation on mesh
-    VH::simulateGaussianInPlace(_workNoiseMesh);
-    _QSimu->evalSimulate(_workNoiseMesh, outv);
+    VH::simulateGaussianInPlace(_work1);
+    _QSimu->evalSimulate(_work1, outv);
   }
 
   VectorDouble
@@ -477,20 +486,19 @@ namespace gstlrn
 
   void ASPDEOp::evalInvCov(const constvect inv, vect result) const
   {
-    _prepare(false, true);
+    _prepare();
 
     // InvNoise - InvNoise * Proj' * (Q + Proj * InvNoise * Proj')^-1 * Proj * InvNoise
 
     _rhs.resize(getSize());
-    _workmesh.resize(getSize());
-    _workdat3.resize(_getNDat());
+    _work2.resize(getSize());
 
     _invNoise->evalDirect(inv, result);
     _projInKriging->point2mesh(result, _rhs);
-    _solve(_rhs, _workmesh);
-    _projInKriging->mesh2point(_workmesh, _workdat2);
-    _invNoise->evalDirect(_workdat2, _workdat3);
-    VectorHelper::subtractInPlace(_workdat3, result, result);
+    _solve(_rhs, _work2);
+    _projInKriging->mesh2point(_work2, _workdat2);
+    _invNoise->evalDirect(_workdat2, _workdat1);
+    VectorHelper::subtractInPlace(_workdat1, result, result);
   }
 
   VectorDouble ASPDEOp::computeDriftCoeffs(
@@ -533,11 +541,11 @@ namespace gstlrn
 
   double ASPDEOp::getMaxEigenValProj() const
   {
-    _workmesh.resize(getSize());
-    _workNoiseMesh.resize(getSize());
-    std::fill(_workmesh.begin(), _workmesh.end(), 1.);
-    _projOp(_workmesh, _workNoiseMesh);
-    return _workNoiseMesh.maximum();
+    _work2.resize(getSize());
+    _work1.resize(getSize());
+    std::fill(_work2.begin(), _work2.end(), 1.);
+    _projOp(_work2, _work1);
+    return _work1.maximum();
   }
 
   VectorDouble ASPDEOp::getRangeEigenVal(Id ndiscr) const
@@ -572,23 +580,23 @@ namespace gstlrn
   {
     Chebychev logPoly;
     _preparePoly(logPoly);
-    _workNoiseMesh.resize(getSize());
-    _workmesh.resize(getSize());
+    _work1.resize(getSize());
+    _work2.resize(getSize());
     double val = 0.;
     for (Id i = 0; i < nbsimu; i++)
     {
-      VH::simulateGaussianInPlace(_workNoiseMesh);
-      std::fill(_workmesh.begin(), _workmesh.end(), 0.);
-      logPoly.addEvalOp(this, _workNoiseMesh, _workmesh);
-      val += _workNoiseMesh.innerProduct(_workmesh);
+      VH::simulateGaussianInPlace(_work1);
+      std::fill(_work2.begin(), _work2.end(), 0.);
+      logPoly.addEvalOp(this, _work1, _work2);
+      val += _work1.innerProduct(_work2);
     }
     return val / nbsimu;
   }
 
   double ASPDEOp::computeQuadratic(const VectorDouble& x) const
   {
-    _workdat4.resize(_getNDat());
-    vect w1s(_workdat4);
+    _work1.resize(_getNDat());
+    vect w1s(_work1);
     constvect xm(x);
     evalInvCov(xm, w1s);
     return VH::innerProductCV(w1s, xm);

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -173,6 +173,7 @@ namespace gstlrn
     }
 
     _simCondGibbsInProgress = true; // notify _simCond() to keep intermediate
+    _work2.resize(_getNDat());
     for (Id i_gibbs = 0; i_gibbs < nIter; ++i_gibbs)
     {
       _simCond(_workGibbsData.asConstVect(), outvK, outvS);
@@ -507,27 +508,25 @@ namespace gstlrn
     const MatrixDense& driftMat,
     bool verbose) const
   {
-    _prepare(true, false);
-
     Id xsize = (driftMat.getNCols());
     VectorDouble XtInvSigmaZ(xsize);
     MatrixSymmetric XtInvSigmaX(xsize);
     VectorDouble result(xsize);
 
-    vect w1s(_workdat1);
+    _work3.resize(_getNDat());
+    vect w3s(_work3);
     for (Id i = 0; i < xsize; i++)
     {
       auto xm = driftMat.getViewOnColumn(i);
-      evalInvCov(xm, w1s);
+      evalInvCov(xm, w3s);
 
       constvect ym(Z.data(), Z.size());
-      constvect wd1(_workdat1.data(), _workdat1.size());
-      XtInvSigmaZ[i] = VH::innerProductCV(ym, wd1);
+      XtInvSigmaZ[i] = VH::innerProductCV(ym, w3s);
 
       for (Id j = i; j < xsize; j++)
       {
         constvect xmj = driftMat.getViewOnColumn(j);
-        double prod = VH::innerProductCV(xmj, w1s);
+        double prod = VH::innerProductCV(xmj, w3s);
         XtInvSigmaX.setValue(i, j, prod);
       }
     }
@@ -596,11 +595,11 @@ namespace gstlrn
 
   double ASPDEOp::computeQuadratic(const VectorDouble& x) const
   {
-    _work1.resize(_getNDat());
-    vect w1s(_work1);
+    _work3.resize(_getNDat());
+    vect w3s(_work3);
     constvect xm(x);
-    evalInvCov(xm, w1s);
-    return VH::innerProductCV(w1s, xm);
+    evalInvCov(xm, w3s);
+    return VH::innerProductCV(w3s, xm);
   }
 
   double ASPDEOp::computeLogDetQ(Id nMC) const

--- a/src/LinearOp/SPDEOp.cpp
+++ b/src/LinearOp/SPDEOp.cpp
@@ -38,8 +38,8 @@ namespace gstlrn
     , _solver(nullptr)
     , _precond(precond)
     , _verbose(false)
-    , _ndat(0)
     , _simCondGibbsInProgress(false)
+    , _ndat(0)
   {
     if (_projInKriging == nullptr) return;
     if (_invNoise == nullptr) return;
@@ -486,19 +486,20 @@ namespace gstlrn
 
   void ASPDEOp::evalInvCov(const constvect inv, vect result) const
   {
-    _prepare();
+    _prepare(false, true);
 
     // InvNoise - InvNoise * Proj' * (Q + Proj * InvNoise * Proj')^-1 * Proj * InvNoise
 
     _rhs.resize(getSize());
-    _work2.resize(getSize());
+    _work1.resize(getSize());
+    _work2.resize(_getNDat());
 
     _invNoise->evalDirect(inv, result);
     _projInKriging->point2mesh(result, _rhs);
-    _solve(_rhs, _work2);
-    _projInKriging->mesh2point(_work2, _workdat2);
-    _invNoise->evalDirect(_workdat2, _workdat1);
-    VectorHelper::subtractInPlace(_workdat1, result, result);
+    _solve(_rhs, _work1);
+    _projInKriging->mesh2point(_work1, _workdat2);
+    _invNoise->evalDirect(_workdat2, _work1);
+    VectorHelper::subtractInPlace(_work1, result, result);
   }
 
   VectorDouble ASPDEOp::computeDriftCoeffs(

--- a/tests/cpp/output/test_SPDEDrift.ref
+++ b/tests/cpp/output/test_SPDEDrift.ref
@@ -138,11 +138,11 @@ Data Base Statistics
 5 - Name KrigingSPDE.January_temp.estim - Locator NA
  Nb of data          =      11097
  Nb of active values =       3092
- Minimum value       =     -9.430
- Maximum value       =      4.943
- Mean value          =      1.250
- Standard Deviation  =      2.094
- Variance            =      4.383
+ Minimum value       =     -5.600
+ Maximum value       =      4.925
+ Mean value          =      1.840
+ Standard Deviation  =      1.520
+ Variance            =      2.310
 6 - Name Kriging.January_temp.estim - Locator z1
  Nb of data          =      11097
  Nb of active values =       3092

--- a/tests/ipynb/output/Tuto_SPDE.asciidoc
+++ b/tests/ipynb/output/Tuto_SPDE.asciidoc
@@ -337,7 +337,7 @@ Projection of 'dbin' for Kriging: Created from Db and Mesh(es)
 - Number of Apices    = 5625
 - Number of Points    = 1000
 Drift coefficients = 
-      0.079
+      0.064
 LogDet of Q + ADA': 11568.583760
 LogDet of Q: 11585.782711
 LogDet of InvNoise: 2302.585093
@@ -347,7 +347,7 @@ Nb. active samples = 1000
 Nb. Monte-Carlo    = 100
 Cholesky           = 0
 Log-Determinant    = -2319.784044
-Quadratic term     = 1105.223469
-Log-likelihood     = -311.658246
--> likelihood by New API with cholesky=0 -311.6582
+Quadratic term     = 1105.216289
+Log-likelihood     = -311.654656
+-> likelihood by New API with cholesky=0 -311.6547
 ----

--- a/tests/py/output/test_SPDECoKriging.ref
+++ b/tests/py/output/test_SPDECoKriging.ref
@@ -22,15 +22,15 @@ Difference with Kriging.Data.V2.stdev (Matrix) = 0.01394
 Co-Kriging using SPDE (Matrix-Free)
 -----------------------------------
                         Mean
-KF.Data.V1.estim      -0.278
-KF.Data.V2.estim      -1.657
+KF.Data.V1.estim      -0.070
+KF.Data.V2.estim      -1.538
 KF.Data.V1.stdev       7.515
 KF.Data.V2.stdev       6.280
 Difference with Kriging.Data.V1.estim  = 0.0578
-Difference with Kriging.Data.V2.estim  = 0.02516
+Difference with Kriging.Data.V2.estim  = 0.02493
 Difference with Kriging.Data.V1.stdev  = 0.02787
 Difference with Kriging.Data.V2.stdev  = 0.02032
-Difference between Matrix-Free and Matrix (estim) for variable estim 1  = 0.00964
-Difference between Matrix-Free and Matrix (estim) for variable estim 2  = 0.00849
+Difference between Matrix-Free and Matrix (estim) for variable estim 1  = 0.00035
+Difference between Matrix-Free and Matrix (estim) for variable estim 2  = 0.00025
 Difference between Matrix-Free and Matrix (stdev) for variable stdev 1  = 0.02711
 Difference between Matrix-Free and Matrix (stdev) for variable stdev 2  = 0.01871


### PR DESCRIPTION
Some arrays have been renamed as they no longer are always on "mesh" or "data". An internal flag `_simCondGibbsInProgress` has been added as `_simCondGibbs()` calls `_simCond()` and reuses some intermediate results, but when this is not the case we can save one intermediate array.