### PR TITLE
Implement heterogenous back-end for Db

### DIFF
--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -82,9 +82,11 @@ namespace gstlrn
   {
   public:
     Db();
-    Db(const Db& r);
-    Db& operator=(const Db& r);
-    virtual ~Db();
+    Db(const Db& r) = default;
+    Db& operator=(const Db& r) = default;
+    Db(Db&& r) = default;
+    Db& operator=(Db&& r) = default;
+    ~Db() override = default;
 
   public:
     /// Has a specific implementation in the Target language
@@ -273,8 +275,6 @@ namespace gstlrn
       bool flagAddSampleRank = true);
 
     /**@}*/
-
-    const VectorDouble& getArrays() const { return _array; }
 
     /** @addtogroup DB_Names Manipulating Names of the variables contained in a Db
      * \ingroup DB
@@ -613,7 +613,6 @@ namespace gstlrn
       double value);
 
     double getValueByColIdx(Id iech, Id icol, bool flagCheck = true) const;
-    const double* getColAdressByColIdx(Id icol) const;
 
     void
       setValueByColIdx(Id iech, Id icol, double value, bool flagCheck = true);
@@ -1149,11 +1148,6 @@ namespace gstlrn
 
   private:
     Id _getNextLocator(const ELoc& locatorType) const;
-
-    const VectorInt& _getUIDcol() const { return _uidcol; }
-
-    VectorString _getNames() const { return _colNames; }
-
     Id _getUIDcol(Id iuid) const;
     Id _getAddress(Id iech, Id icol) const;
     void _columnInit(

--- a/include/Db/Db.hpp
+++ b/include/Db/Db.hpp
@@ -22,6 +22,7 @@
 #include "Basic/ICloneable.hpp"
 #include "Basic/Limits.hpp"
 #include "Basic/NamingConvention.hpp"
+#include "Db/DbCol.hpp"
 #include "Db/PtrGeos.hpp"
 #include "Matrix/MatrixDense.hpp"
 #include "Matrix/Table.hpp"
@@ -1107,11 +1108,11 @@ namespace gstlrn
       auto icol = getColIdxByUID(iuid);
       if (!isColIdxValid(icol)) return dummy;
       if (!isSampleIndexValid(iech)) return dummy;
-      auto iad = _getAddress(iech, icol);
-      return _array[iad];
+      auto& vec = _data.GetArray(icol)->get().getVector<VectorDouble>()->get();
+      return vec[iech];
     }
 
-    const double& operator()(Id iech, const String& name) const
+    double operator()(Id iech, const String& name) const
     {
       static const double dummy = std::numeric_limits<double>::quiet_NaN();
       auto iuid = getUID(name);
@@ -1119,8 +1120,7 @@ namespace gstlrn
       auto icol = getColIdxByUID(iuid);
       if (!isColIdxValid(icol)) return dummy;
       if (!isSampleIndexValid(iech)) return dummy;
-      auto iad = _getAddress(iech, icol);
-      return _array[iad];
+      return *_data.getValue<double>(iech, icol);
     }
 
   protected:
@@ -1218,7 +1218,7 @@ namespace gstlrn
   private:
     Id _ncol; //!< Number of Columns of data
     Id _nech; //!< Number of samples
-    VectorDouble _array; //!< Array of values
+    DbData _data;
     VectorInt _uidcol; //!< UID to Column
     VectorString _colNames; //!< Names of the variables
     std::vector<PtrGeos> _p; //!< Locator characteristics

--- a/include/Db/DbCol.hpp
+++ b/include/Db/DbCol.hpp
@@ -1,0 +1,488 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2025) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+
+#pragma once
+
+#include "Basic/VectorNumT.hpp"
+#include "Basic/VectorT.hpp"
+#include "gstlearn_export.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+namespace gstlrn
+{
+
+  class GSTLEARN_EXPORT Dictionary
+  {
+  public:
+    using Category = std::pair<Id, std::string_view>;
+
+    Dictionary() = default;
+
+    Dictionary(std::map<Id, String>&& data)
+      : _data{std::move(data)}
+    {
+    }
+
+    bool addCategory(const Id key, const String& val)
+    {
+      for (const auto& p: this->_data)
+      {
+        if (p.first == key || p.second == val)
+        {
+          return false;
+        }
+      }
+      this->_data[key] = val;
+      return true;
+    }
+
+    bool hasCategory(const Category& cat) const
+    {
+      const auto it = this->_data.find(cat.first);
+      if (it == this->_data.end()) return false;
+      if (it->second != cat.second) return false;
+      return true;
+    }
+
+    std::optional<Category> operator[](const Id key) const
+    {
+      const auto it = this->_data.find(key);
+      if (it == this->_data.end()) return {};
+      return *it;
+    }
+
+  private:
+    std::map<Id, String> _data;
+  };
+
+  class GSTLEARN_EXPORT VectorCategory
+  {
+  public:
+    using Category = Dictionary::Category;
+    using value_type = Category;
+
+    VectorCategory(const size_t n, const Dictionary& dict)
+      : _data(n)
+      , _dict{dict}
+    {
+    }
+
+    void resize(const size_t count) { this->_data.resize(count); }
+
+    size_t size() const { return this->_data.size(); }
+
+    std::optional<Category> getCategory(const size_t pos) const
+    {
+      if (pos >= this->_data.size()) return {};
+      return this->_data[pos];
+    }
+
+    bool setCategory(const size_t pos, const Category& cat)
+    {
+      if (pos >= this->_data.size()) return false;
+      if (!this->_dict.hasCategory(cat)) return false;
+      this->_data[pos] = cat;
+      return true;
+    }
+
+    std::optional<Category>& operator[](const size_t o)
+    {
+      return this->_data[o];
+    }
+
+    const std::optional<Category>& operator[](const size_t o) const
+    {
+      return this->_data[o];
+    }
+
+  private:
+    std::vector<std::optional<Category>> _data;
+    Dictionary _dict;
+  };
+
+  template<typename VectorType>
+  class Array2D
+  {
+  public:
+    using vector_type = VectorType;
+    using value_type = typename VectorType::value_type;
+
+    Array2D() = default;
+
+    Array2D(VectorType&& vector)
+      : _inner{static_cast<Id>(vector.size())}
+      , _outer{1}
+      , _buf{std::forward<VectorType>(vector)}
+    {
+    }
+
+    Array2D(const Id inner, const Id outer = 1, const value_type val = {})
+      : _inner{inner}
+      , _outer{outer}
+      , _buf(outer * inner, val)
+    {
+    }
+
+    void resize(const Id inner, const Id outer = 1, const value_type val = {})
+    {
+      this->_inner = inner;
+      this->_outer = outer;
+      this->_buf.resize(this->_outer * this->_inner, val);
+    }
+
+    void addSamples(const Id nnewsamp, const value_type val)
+    {
+      VectorType newbuf(this->_outer * (this->_inner + nnewsamp), val);
+      for (Id o = 0; o < this->_outer; ++o)
+      {
+        for (Id i = 0; i < this->_inner; ++i)
+        {
+          newbuf[(o * this->_inner) + i] = this->_buf[(o * this->_inner) + i];
+        }
+      }
+      this->_inner += nnewsamp;
+      std::swap(this->_buf, newbuf);
+    }
+
+    void deleteSample(const Id isamp)
+    {
+      VectorType newbuf(this->_buf);
+      newbuf.resize(this->_outer * (this->_inner - 1));
+
+      for (Id o = 0; o < this->_outer; ++o)
+      {
+        Id a{};
+        for (Id i = 0; i < this->_inner; ++i)
+        {
+          if (i == isamp)
+          {
+            continue;
+          }
+          newbuf[(o * (this->_inner - 1)) + a] =
+            this->_buf[(o * this->_inner) + i];
+          a++;
+        }
+      }
+
+      this->_inner -= 1;
+      std::swap(this->_buf, newbuf);
+    }
+
+    std::optional<value_type> getValue(const size_t o, const size_t i) const
+    {
+      if constexpr (std::is_same_v<VectorType, VectorCategory>)
+      {
+        return this->_buf.getCategory((o * this->_inner) + i);
+      }
+      else
+      {
+        return this->_buf[(o * this->_inner) + i];
+      }
+    }
+
+    bool setValue(const size_t o, const size_t i, const value_type& val)
+    {
+      if constexpr (std::is_same_v<VectorType, VectorCategory>)
+      {
+        return this->_buf.setCategory((o * this->_inner) + i, val);
+      }
+      else
+      {
+        this->_buf[(o * this->_inner) + i] = val;
+        return true;
+      }
+    }
+
+    Id inner() const { return this->_inner; }
+
+    Id outer() const { return this->_outer; }
+
+    value_type* data() { return this->_buf.data(); }
+
+    const value_type* data() const { return this->_buf.data(); }
+
+    VectorType& getBuffer() { return this->_buf; }
+
+  private:
+    Id _inner{};
+    Id _outer{};
+    VectorType _buf;
+    // VectorString _names; // TODO one name per sub-column
+  };
+
+  /**
+   * @brief Generic implementation of a Column inside a Db
+   */
+  class GSTLEARN_EXPORT ADbCol
+  {
+  public:
+    ADbCol(String&& name, const Id i = 0, const Id o = 1)
+      : _name{std::move(name)}
+      , _data{Array2D<VectorDouble>{i, o}}
+    {
+    }
+
+    template<typename VectorType>
+    ADbCol(String&& name, VectorType&& array)
+      : _name{std::move(name)}
+      , _data{std::forward<VectorType>(array)}
+    {
+    }
+
+    template<typename VectorType>
+    ADbCol(const String& name, VectorType&& array)
+      : _name{name}
+      , _data{std::forward<VectorType>(array)}
+    {
+    }
+
+    const String& GetName() const { return this->_name; }
+
+    void SetName(const String& newName) { this->_name = newName; }
+
+    template<typename T, typename VectorType>
+    static constexpr bool isConsistent()
+    {
+      return std::is_same_v<T, typename VectorType::value_type>
+          || (std::is_same_v<T, bool> && std::is_same_v<VectorType, VectorBool>)
+          || std::is_convertible_v<T, typename VectorType::value_type>;
+    }
+
+    template<typename T>
+    std::optional<T> getValue(const Id i, const Id o) const
+    {
+      std::optional<T> v{};
+      std::visit(
+        [i, o, &v](auto&& arg)
+        {
+          if (o < 0 || o >= arg.outer() || i < 0 || i >= arg.inner())
+          {
+            return;
+          }
+          using VectorType = std::decay_t<decltype(arg)>::vector_type;
+          if constexpr (isConsistent<T, VectorType>())
+          {
+            auto val = arg.getValue(o, i);
+            if (val) v = val.value();
+          }
+        },
+        this->_data);
+      return v;
+    }
+
+    template<typename T>
+    bool setValue(const Id i, const Id o, const T& v)
+    {
+      bool res = false;
+      std::visit(
+        [i, o, &v, &res](auto&& arg)
+        {
+          if (o < 0 || o >= arg.outer() || i < 0 || i >= arg.inner())
+          {
+            return;
+          }
+          using VectorType = std::decay_t<decltype(arg)>::vector_type;
+          if constexpr (isConsistent<T, VectorType>())
+          {
+            res = arg.setValue(o, i, v);
+          }
+        },
+        this->_data);
+      return res;
+    }
+
+    template<typename T>
+    void addSamples(const Id nnewsamp, const T val)
+    {
+      std::visit(
+        [nnewsamp, val](auto&& arg)
+        {
+          using VectorType = std::decay_t<decltype(arg)>::vector_type;
+          if constexpr (isConsistent<T, VectorType>())
+          {
+            arg.addSamples(nnewsamp, val);
+          }
+        },
+        this->_data);
+    }
+
+    void deleteSample(const Id isamp)
+    {
+      std::visit([isamp](auto&& arg) { arg.deleteSample(isamp); }, this->_data);
+    }
+
+    template<typename VectorType>
+    std::optional<std::reference_wrapper<VectorType>> getVector()
+    {
+      auto* pv = std::get_if<Array2D<VectorType>>(&this->_data);
+      if (pv == nullptr) return {};
+      return pv->getBuffer();
+    }
+
+  private:
+    String _name;
+    std::variant<
+      Array2D<VectorDouble>,
+      Array2D<VectorFloat>,
+      Array2D<VectorInt>,
+      Array2D<VectorUChar>,
+      Array2D<VectorString>,
+      Array2D<VectorBool>,
+      Array2D<VectorCategory>>
+      _data;
+  };
+
+  /**
+   * @brief Similar to vtkFieldData
+   */
+  class DbData
+  {
+  public:
+    template<typename VectorType>
+    void AddArray(VectorType&& array, String&& name)
+    {
+      Id index{};
+      for (auto& col: this->_cols)
+      {
+        if (col.GetName() == name)
+        {
+          this->RemoveArray(index);
+        }
+        index++;
+      }
+      this->_cols.emplace_back(
+        std::move(name), std::forward<VectorType>(array));
+    }
+
+    template<typename VectorType>
+    void AddArray(VectorType&& array, const String& name)
+    {
+      Id index{};
+      for (auto& col: this->_cols)
+      {
+        if (col.GetName() == name)
+        {
+          this->RemoveArray(index);
+        }
+        index++;
+      }
+      this->_cols.emplace_back(name, std::forward<VectorType>(array));
+    }
+
+    bool RenameArray(const Id index, const String& newName)
+    {
+      // check if newName already in use
+      for (const auto& col: this->_cols)
+      {
+        if (col.GetName() == newName)
+        {
+          return false;
+        }
+      }
+
+      this->_cols[index].SetName(newName);
+      return true;
+    }
+
+    void RemoveArray(const String& name)
+    {
+      const auto col = this->GetArray(name);
+      const auto id = col ? col->second : -1;
+      this->RemoveArray(id);
+    }
+
+    void RemoveArray(const Id index)
+    {
+      if (index < 0 || index >= static_cast<Id>(this->_cols.size()))
+      {
+        return;
+      }
+
+      this->_cols.erase(this->_cols.begin() + index);
+    }
+
+    std::optional<std::reference_wrapper<ADbCol>> GetArray(const Id index)
+    {
+      if (index < 0 || index >= static_cast<Id>(this->_cols.size()))
+      {
+        return {};
+      }
+      return {this->_cols[index]};
+    }
+
+    std::optional<std::reference_wrapper<const ADbCol>>
+      GetArray(const Id index) const
+    {
+      if (index < 0 || index >= static_cast<Id>(this->_cols.size()))
+      {
+        return {};
+      }
+      return {this->_cols[index]};
+    }
+
+    std::optional<std::pair<std::reference_wrapper<ADbCol>, Id>>
+      GetArray(const String& name)
+    {
+      Id index{};
+      for (auto& col: this->_cols)
+      {
+        if (col.GetName() == name)
+        {
+          return {{col, index}};
+        }
+        index++;
+      }
+
+      return {};
+    }
+
+    std::optional<String> GetArrayName(const Id index)
+    {
+      auto arr = this->GetArray(index);
+      return arr ? std::optional<String>{arr->get().GetName()} : std::nullopt;
+    }
+
+    bool HasArray(const String& name)
+    {
+      auto arr = this->GetArray(name);
+      return arr.has_value();
+    }
+
+    template<typename T>
+    std::optional<T>
+      getValue(const Id iech, const Id icol, const Id isubcol = 0) const
+    {
+      const auto array = this->GetArray(icol);
+      if (!array) return {};
+      const auto val = array->get().getValue<T>(iech, isubcol);
+      return val;
+    }
+
+    template<typename T>
+    bool setValue(const Id iech, const Id icol, const Id subcol, const T value)
+    {
+      const auto array = this->GetArray(icol);
+      if (!array) return false;
+      return array->get().setValue<T>(iech, subcol, value);
+    }
+
+  private:
+    std::vector<ADbCol> _cols;
+  };
+
+} // namespace gstlrn

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -55,37 +55,6 @@ namespace gstlrn
   {
     _clear();
   }
-
-  Db::Db(const Db& r)
-    : AStringable(r)
-    , ASerializable(r)
-    , _ncol(r._ncol)
-    , _nech(r._nech)
-    , _array(r._array)
-    , _uidcol(r._uidcol)
-    , _colNames(r._colNames)
-    , _p(r._p)
-  {
-  }
-
-  Db& Db::operator=(const Db& r)
-  {
-    if (this != &r)
-    {
-      AStringable::operator=(r);
-      ASerializable::operator=(r);
-      _ncol = r._ncol;
-      _nech = r._nech;
-      _array = r._array;
-      _uidcol = r._uidcol;
-      _colNames = r._colNames;
-      _p = r._p;
-    }
-    return *this;
-  }
-
-  Db::~Db() {}
-
   Id Db::resetFromSamples(
     Id nech,
     const ELoadBy& order,
@@ -2641,11 +2610,6 @@ namespace gstlrn
       if (!isColIdxValid(icol)) return TEST;
     }
     return (_array[_getAddress(iech, icol)]);
-  }
-
-  const double* Db::getColAdressByColIdx(Id icol) const
-  {
-    return &_array[_getAddress(0, icol)];
   }
 
   VectorDouble Db::getValuesByNames(

--- a/src/Db/Db.cpp
+++ b/src/Db/Db.cpp
@@ -48,13 +48,14 @@ namespace gstlrn
     , ASerializable()
     , _ncol(0)
     , _nech(0)
-    , _array()
+    , _data()
     , _uidcol()
     , _colNames()
     , _p()
   {
     _clear();
   }
+
   Id Db::resetFromSamples(
     Id nech,
     const ELoadBy& order,
@@ -512,7 +513,13 @@ namespace gstlrn
 
     /* Main array */
 
-    if (nech * ncol > 0) _array.resize(ncol * nech, 0);
+    if (nech * ncol > 0)
+    {
+      for (Id i = 0; i < ncol; ++i)
+      {
+        _data.AddArray(VectorDouble(nech), _colNames[i]);
+      }
+    }
   }
 
   /**
@@ -526,7 +533,7 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return;
     auto icol = getColIdxByUID(iuid);
     if (!isColIdxValid(icol)) return;
-    _array[_getAddress(iech, icol)] = value;
+    _data.setValue(iech, icol, 0, value);
   }
 
   /**
@@ -542,7 +549,7 @@ namespace gstlrn
     auto icol = getColIdxByUID(iuid);
     if (!isColIdxValid(icol)) return;
     for (Id i = 0, n = static_cast<Id>(iechs.size()); i < n; i++)
-      _array[_getAddress(iechs[i], icol)] = values[i];
+      _data.setValue(iechs[i], icol, 0, values[i]);
   }
 
   /**
@@ -582,7 +589,7 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return (TEST);
     auto icol = getColIdxByUID(iuid);
     if (!isColIdxValid(icol)) return (TEST);
-    return (_array[_getAddress(iech, icol)]);
+    return *_data.getValue<double>(iech, icol);
   }
 
   /**
@@ -599,7 +606,7 @@ namespace gstlrn
     if (!isColIdxValid(icol)) return;
     for (Id i = 0, n = static_cast<Id>(iechs.size()); i < n; i++)
     {
-      values[i] = _array[_getAddress(iechs[i], icol)];
+      values[i] = *_data.getValue<double>(iechs[i], icol);
     }
   }
 
@@ -665,10 +672,9 @@ namespace gstlrn
     auto icol = getColIdxByUID(iuid);
     if (!isColIdxValid(icol)) return;
 
-    auto internalAddress = _getAddress(iech, icol);
-    double oldval = _array[internalAddress];
+    double oldval = *_data.getValue<double>(iech, icol);
     double newval = modifyOperator(oper, oldval, value);
-    _array[internalAddress] = newval;
+    _data.setValue(iech, icol, 0, newval);
   }
 
   void Db::updArrayVec(
@@ -680,15 +686,11 @@ namespace gstlrn
     auto icol = getColIdxByUID(iuid);
     if (!isColIdxValid(icol)) return;
 
-    Id iad;
-    double oldval;
-    double newval;
     for (Id i = 0, n = static_cast<Id>(iechs.size()); i < n; i++)
     {
-      iad = _getAddress(iechs[i], icol);
-      oldval = _array[iad];
-      newval = modifyOperator(oper, oldval, values[i]);
-      _array[iad] = newval;
+      double oldval = *_data.getValue<double>(iechs[i], icol);
+      double newval = modifyOperator(oper, oldval, values[i]);
+      _data.setValue(iechs[i], icol, 0, newval);
     }
   }
 
@@ -894,7 +896,7 @@ namespace gstlrn
     {
       auto icol = getColIdxByLocator(ELoc::X, idim);
       if (icol < 0) continue;
-      coor[idim] = _array[_getAddress(iech, icol)];
+      coor[idim] = *_data.getValue<double>(iech, icol);
     }
   }
 
@@ -1027,7 +1029,7 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return;
     auto icol = getColIdxByLocator(ELoc::X, idim);
     if (!isColIdxValid(icol)) return;
-    _array[_getAddress(iech, icol)] = value;
+    _data.setValue(iech, icol, 0, value);
   }
 
   void Db::setCoordinates(Id idim, const VectorDouble& coor, bool useSel)
@@ -1061,7 +1063,7 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return;
     auto icol = getColIdxByLocator(locatorType, locatorIndex);
     if (!isColIdxValid(icol)) return;
-    _array[_getAddress(iech, icol)] = value;
+    _data.setValue(iech, icol, 0, value);
   }
 
   double
@@ -1070,14 +1072,14 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return TEST;
     auto icol = getColIdxByLocator(locatorType, locatorIndex);
     if (!isColIdxValid(icol)) return TEST;
-    return (_array[_getAddress(iech, icol)]);
+    return *_data.getValue<double>(iech, icol);
   }
 
   const double* Db::getColumnPtr(const ELoc& locatorType, Id locatorIndex)
   {
     auto icol = getColIdxByLocator(locatorType, locatorIndex);
     if (icol < 0) return nullptr;
-    return &_array[_getAddress(0, icol)];
+    return _data.GetArray(icol)->get().getVector<VectorDouble>()->get().data();
   }
 
   bool Db::hasLocator(const ELoc& locatorType) const
@@ -1379,10 +1381,6 @@ namespace gstlrn
 
     if (_nech <= 0) _nech = nechInit;
 
-    /* Dimension the array */
-
-    _array.resize(_nech * nnew);
-
     /* Dimension the UID pointer */
 
     _uidcol.resize(nmax + nadd);
@@ -1396,6 +1394,13 @@ namespace gstlrn
       newNames = generateMultipleNames(radix, nadd);
     (void)correctNamesForDuplicates(newNames, _colNames);
     _colNames.insert(_colNames.end(), newNames.begin(), newNames.end());
+
+    /* Dimension the array */
+
+    for (Id i = ncol; i < nnew; ++i)
+    {
+      _data.AddArray(VectorDouble(_nech), _colNames[i]);
+    }
 
     // Initialize the variables with a given value
     _columnInit(nadd, ncol, true, valinit);
@@ -1439,7 +1444,10 @@ namespace gstlrn
 
     /* Dimension the array */
 
-    _array.resize(_nech * nnew);
+    for (Id i = 0; i < nnew; ++i)
+    {
+      _data.AddArray(VectorDouble(_nech), _colNames[i]);
+    }
 
     /* Dimension the UID pointer */
 
@@ -1939,23 +1947,15 @@ namespace gstlrn
     Id nnew = nech + nadd;
     if (nadd <= 0) return (-1);
 
-    /* Core allocation */
-
-    VectorDouble new_array(_ncol * nnew);
-    for (Id i = 0; i < _ncol * nnew; i++) new_array[i] = valinit;
-
     /* Copy the array */
 
     for (Id icol = 0; icol < _ncol; icol++)
-      for (Id iech = 0; iech < nech; iech++)
-      {
-        Id iad1 = iech + nnew * icol;
-        new_array[iad1] = _array[_getAddress(iech, icol)];
-      }
+    {
+      _data.GetArray(icol)->get().addSamples(nadd, valinit);
+    }
 
     /* Core deallocation */
 
-    _array = new_array;
     _nech = nnew;
     return (nech);
   }
@@ -1990,24 +1990,15 @@ namespace gstlrn
     Id nnew = nech - 1;
     if (!isSampleIndexValid(e_del)) return 1;
 
-    /* Core allocation */
-
-    VectorDouble new_array(_ncol * nnew);
-
     /* Copy the array */
 
     for (Id icol = 0; icol < _ncol; icol++)
-      for (Id iech = 0; iech < nech; iech++)
-      {
-        if (iech == e_del) continue;
-        Id jech = (iech < e_del) ? iech : iech - 1;
-        Id iad1 = jech + nnew * icol;
-        new_array[iad1] = _array[_getAddress(iech, icol)];
-      }
+    {
+      _data.GetArray(icol)->get().deleteSample(e_del);
+    }
 
     /* Core deallocation */
 
-    _array = new_array;
     _nech = nnew;
     return 0;
   }
@@ -2032,7 +2023,6 @@ namespace gstlrn
   void Db::deleteColumnByUID(Id iuid_del)
   {
     Id ncol = _ncol;
-    Id nech = _nech;
     auto nmax = getNUIDMax();
     Id nnew = ncol - 1;
     if (!isUIDValid(iuid_del)) return;
@@ -2048,12 +2038,7 @@ namespace gstlrn
       _uidcol[iuid]--;
     }
 
-    /* Dimension the array */
-
-    for (Id icol = c_del + 1; icol < ncol; icol++)
-      for (Id iech = 0; iech < nech; iech++)
-        _array[_getAddress(iech, icol - 1)] = _array[_getAddress(iech, icol)];
-    _array.resize(nech * nnew);
+    _data.RemoveArray(c_del);
 
     /* Resize the variable pointers */
 
@@ -2570,19 +2555,17 @@ namespace gstlrn
           || !hasLocator(ELoc::DOM))
       {
         for (Id iech = 0; iech < _nech; iech++)
-          _array[_getAddress(iech, icol)] =
-            (flagCst) ? valinit : law_gaussian();
+          _data.setValue(iech, icol, 0, flagCst ? valinit : law_gaussian());
       }
       else
       {
         for (Id iech = 0; iech < _nech; iech++)
         {
           value = getFromLocator(ELoc::DOM, iech, 0);
-          auto iad = _getAddress(iech, icol);
           if (GlobalEnvironment::getEnv()->matchDomainReference(value))
-            _array[iad] = value;
+            _data.setValue(iech, icol, 0, value);
           else
-            _array[iad] = TEST;
+            _data.setValue(iech, icol, 0, TEST);
         }
       }
     }
@@ -2609,7 +2592,7 @@ namespace gstlrn
     {
       if (!isColIdxValid(icol)) return TEST;
     }
-    return (_array[_getAddress(iech, icol)]);
+    return *_data.getValue<double>(iech, icol);
   }
 
   VectorDouble Db::getValuesByNames(
@@ -2662,7 +2645,7 @@ namespace gstlrn
       if (!isColIdxValid(icol)) return;
       if (!isSampleIndexValid(iech)) return;
     }
-    _array[_getAddress(iech, icol)] = value;
+    _data.setValue(iech, icol, 0, value);
   }
 
   void Db::setValuesByNames(
@@ -2702,7 +2685,7 @@ namespace gstlrn
           Id iech = iechs[j];
           if (!isColIdxValid(icol)) return;
           if (!isSampleIndexValid(iech)) return;
-          _array[_getAddress(iech, icol)] = values[lec++];
+          _data.setValue(iech, icol, 0, values[lec++]);
         }
     }
     else
@@ -2714,7 +2697,7 @@ namespace gstlrn
           Id iech = iechs[j];
           if (!isColIdxValid(icol)) return;
           if (!isSampleIndexValid(iech)) return;
-          _array[_getAddress(iech, icol)] = values[lec++];
+          _data.setValue(iech, icol, 0, values[lec++]);
         }
     }
   }
@@ -2832,11 +2815,10 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return;
     auto icol = getColIdxByLocator(loctype, item);
     if (icol < 0) return;
-    auto internalAddress = _getAddress(iech, icol);
 
-    double oldval = _array[internalAddress];
-    double newval = modifyOperator(oper, oldval, value);
-    _array[internalAddress] = newval;
+    const double oldval = *_data.getValue<double>(iech, icol);
+    const double newval = modifyOperator(oper, oldval, value);
+    _data.setValue(iech, icol, 0, newval);
   }
 
   void Db::updZVariable(Id iech, Id item, const EOperator& oper, double value)
@@ -2844,11 +2826,10 @@ namespace gstlrn
     if (!isSampleIndexValid(iech)) return;
     auto icol = getColIdxByLocator(ELoc::Z, item);
     if (icol < 0) return;
-    auto internalAddress = _getAddress(iech, icol);
 
-    double oldval = _array[internalAddress];
-    double newval = modifyOperator(oper, oldval, value);
-    _array[internalAddress] = newval;
+    const double oldval = *_data.getValue<double>(iech, icol);
+    const double newval = modifyOperator(oper, oldval, value);
+    _data.setValue(iech, icol, 0, newval);
   }
 
   /**
@@ -3305,11 +3286,10 @@ namespace gstlrn
     // This direct addressing is meant to save time
     auto icol = getColIdxByLocator(locatorType, item);
     if (icol < 0) return;
-    auto internalAddress = _getAddress(iech, icol);
 
-    double oldval = _array[internalAddress];
-    double newval = modifyOperator(oper, oldval, value);
-    _array[internalAddress] = newval;
+    const double oldval = *_data.getValue<double>(iech, icol);
+    const double newval = modifyOperator(oper, oldval, value);
+    _data.setValue(iech, icol, 0, newval);
   }
 
   bool Db::isActive(Id iech) const
@@ -3496,6 +3476,7 @@ namespace gstlrn
     if (!isColIdxValid(icol)) return;
     _colNames[icol] = name;
     correctNewNameForDuplicates(_colNames, icol);
+    _data.RenameArray(icol, _colNames[icol]);
   }
 
   void Db::setNameByUID(Id iuid, const String& name)
@@ -3504,12 +3485,14 @@ namespace gstlrn
     if (icol < 0) return;
     _colNames[icol] = name;
     correctNewNameForDuplicates(_colNames, icol);
+    _data.RenameArray(icol, _colNames[icol]);
   }
 
   void Db::setNameByColIdx(Id icol, const String& name)
   {
     if (!isColIdxValid(icol)) return;
     _colNames[icol] = name;
+    _data.RenameArray(icol, _colNames[icol]);
   }
 
   void Db::setName(const String& old_name, const String& name)
@@ -3518,6 +3501,7 @@ namespace gstlrn
     if (icol < 0) return;
     _colNames[icol] = name;
     correctNewNameForDuplicates(_colNames, icol);
+    _data.RenameArray(icol, _colNames[icol]);
   }
 
   void Db::setName(const VectorString& list, const String& name)
@@ -3527,6 +3511,7 @@ namespace gstlrn
       auto icol = getColIdx(list[i]);
       if (icol < 0) continue;
       _colNames[icol] = incrementStringVersion(name, i + 1);
+      _data.RenameArray(icol, _colNames[icol]);
     }
     correctNamesForDuplicates(_colNames);
   }
@@ -3541,6 +3526,7 @@ namespace gstlrn
       auto icol = getColIdxByLocator(locatorType, i);
       if (icol < 0) continue;
       _colNames[icol] = incrementStringVersion(name, i + 1);
+      _data.RenameArray(icol, _colNames[icol]);
     }
     correctNamesForDuplicates(_colNames);
   }
@@ -5284,8 +5270,9 @@ namespace gstlrn
       // read the column index (H5::Attribute)
       SerializeHDF5::readValue<Id>(data, "ColId", colIds[i]);
       // read the column values from H5::DataSet
-      data.read(
-        &_array[_getAddress(0, colIds[i])], H5::PredType::NATIVE_DOUBLE);
+      auto& vec =
+        _data.GetArray(colIds[i])->get().getVector<VectorDouble>()->get();
+      data.read(vec.data(), H5::PredType::NATIVE_DOUBLE);
     }
 
     if (ret)
@@ -6345,7 +6332,7 @@ namespace gstlrn
     if (!isColIdxValid(icolOut)) return;
 
     for (Id iech = 0, nech = getNSample(); iech < nech; iech++)
-      _array[_getAddress(iech, icolOut)] = _array[_getAddress(iech, icolIn)];
+      _data.setValue(iech, icolOut, 0, *_data.getValue<double>(iech, icolIn));
   }
 
   void Db::dumpGeometry(Id iech, Id jech) const

--- a/src/Db/RankHandler.cpp
+++ b/src/Db/RankHandler.cpp
@@ -218,12 +218,8 @@ namespace gstlrn
     VectorInt ranks;
     for (Id ivar = 0; ivar < _nvar; ivar++)
     {
-      const double* zadd = nullptr;
       ranks.clear();
-      if (!_iptrZ.empty())
-      {
-        zadd = _db->getColAdressByColIdx(_iptrZ[ivar]);
-      }
+      const auto icol = _iptrZ.empty() ? -1 : _iptrZ[ivar];
       // Loop on the elligible sample ranks
       for (Id irel = 0; irel < nech; irel++)
       {
@@ -233,7 +229,7 @@ namespace gstlrn
         // The sample is valid for the current variable: its Z value is stored
         if (!_iptrZ.empty())
         {
-          value = zadd[iabs];
+          value = _db->getValueByColIdx(iabs, icol);
           _Zflatten->push_back(value);
         }
         // The sample is finally accepted: its ABSOLUTE index is stored

--- a/tests/cpp/output/test_Db_het.ref
+++ b/tests/cpp/output/test_Db_het.ref
@@ -1,0 +1,2 @@
+3 7 baz 1 NOK
+4 8 foobar 0 red

--- a/tests/cpp/test_Db_het.cpp
+++ b/tests/cpp/test_Db_het.cpp
@@ -1,0 +1,64 @@
+/******************************************************************************/
+/*                                                                            */
+/*                            gstlearn C++ Library                            */
+/*                                                                            */
+/* Copyright (c) (2023) MINES Paris / ARMINES                                 */
+/* Authors: gstlearn Team                                                     */
+/* Website: https://gstlearn.org                                              */
+/* License: BSD 3-clause                                                      */
+/*                                                                            */
+/******************************************************************************/
+#include "Basic/File.hpp"
+#include "Basic/VectorNumT.hpp"
+#include "Db/DbCol.hpp"
+
+using namespace gstlrn;
+
+/****************************************************************************/
+/*!
+ ** Main Program
+ **
+ ** This program is meant to check the manipulation of the Db
+ **
+ *****************************************************************************/
+int main(int argc, char* argv[])
+{
+  std::stringstream sfn;
+  sfn << gslBaseName(__FILE__) << ".out";
+  StdoutRedirect sr(sfn.str(), argc, argv);
+
+  DbData data{};
+
+  data.AddArray(VectorDouble{1., 2., 3.}, "hello");
+  data.AddArray(VectorInt{5, 6, 7}, "world");
+  data.AddArray(VectorString{"foo", "bar", "baz"}, "foobar");
+  data.AddArray(VectorBool{true, false, true}, "gstlearn");
+
+  Dictionary dict{{{1, "red"}, {3, "blue"}, {7, "green"}}};
+  data.AddArray(VectorCategory{3, dict}, "categories");
+
+  std::cout << data.getValue<double>(2, 0).value_or(-1.) << " "
+            << data.getValue<int>(2, 1).value_or(-1) << " "
+            << data.getValue<String>(2, 2).value_or("failed") << " "
+            << data.getValue<bool>(2, 3).value_or(false) << " "
+            << data.getValue<Dictionary::Category>(2, 4)
+                 .value_or(Dictionary::Category{-1, "NOK"})
+                 .second
+            << "\n";
+
+  data.setValue(2, 0, 0, 4);
+  data.setValue(2, 1, 0, 8);
+  data.setValue(2, 2, 0, "foobar");
+  data.setValue(2, 3, 0, false);
+  data.setValue(2, 4, 0, Dictionary::Category{1, "red"});
+
+  std::cout << data.getValue<double>(2, 0).value_or(-1.) << " "
+            << data.getValue<int>(2, 1).value_or(-1) << " "
+            << data.getValue<String>(2, 2).value_or("failed") << " "
+            << data.getValue<bool>(2, 3).value_or(false) << " "
+            << data.getValue<Dictionary::Category>(2, 4)
+                 .value_or(Dictionary::Category{-1, "NOK"})
+                 .second
+            << "\n";
+  return 0;
+}


### PR DESCRIPTION
This PR replaces the `VectorDouble _array` storage buffer in the `Db` class with a heterogeneous (in-memory) back-end.
This back-end supports:

- `double`, `int`, `bool` and `string` columns,
- multiple sub-columns,
- categorical data,
- swapping the storage back-end in `Db` and
- a small test.

Nothing should change much, this is only infrastructure work.

Pierre