### PR TITLE
Add Python dependency for doxy2rd

### DIFF
--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -4,6 +4,7 @@ endif()
 
 # TODO : Do not regenerate doxymentation if nothing has changed in the source code
 find_package(Doxygen REQUIRED)
+find_package(Python3 REQUIRED)
 
 # Configure doxyfile
 

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -21,6 +21,9 @@ find_package(SWIG 4.3.0 REQUIRED)
 message(STATUS "Found SWIG: " ${SWIG_EXECUTABLE} " (found version \"" ${SWIG_VERSION} "\")")
 include(${SWIG_USE_FILE})
 
+# Look for Python 3.11+ (needed by doxy2rd.py)
+find_package(Python3 3.11 COMPONENTS Interpreter REQUIRED)
+
 # Generation folders
 if (IS_MULTI_CONFIG)
   set(R_PACKAGE_ROOT_FOLDER        ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
@@ -37,6 +40,7 @@ set(R_PACKAGE_SRC_FOLDER           ${R_PACKAGE_DESTINATION_FOLDER}/src)
 #
 
 add_custom_target(r_doc
+  COMMAND ${CMAKE_COMMAND} -E echo "Launching doxy2rd.py"
   COMMAND ${Python3_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/doc/doxy2rd.py
     ${PROJECT_BINARY_DIR}/doxygen/xml
@@ -256,9 +260,8 @@ else()
   else()
     set(VENDOR "pc")
     if(DEFINED ENV{CONDA_PREFIX})
-        set(VENDOR "conda")
+      set(VENDOR "conda")
     endif()
-
     set(ARCHIVE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}_R_x86_64-${VENDOR}-linux-gnu.tar.gz")
     set(DST_ARCHIVE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}.tar.gz")
   endif()

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT SWIG)
   return()
 endif()
 
-find_package(Python3 REQUIRED)  # Trouver Python3
+find_package(Python3 REQUIRED)
 
 set(PYTHON_SCRIPT  ${PROJECT_SOURCE_DIR}/tools/scripts/classanalysis.py)
 set(PYTHON_SCRIPT2 ${PROJECT_SOURCE_DIR}/tools/scripts/toString.py)


### PR DESCRIPTION
The new feature for generating R package documentation from doxygen output was broken because Python was not available for executing doxy2rd.py script.
CMake find_package instruction to look for a minimal 3.11 python has been added to fix this issue.