### PR TITLE
Really fix boost cmake warning (and fix publish python linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ message(STATUS "USE_HDF5="      ${USE_HDF5})
 # Create gstlearn cmake file path in the build tree
 cmake_path(APPEND GSTLEARN_CMAKE_FILE ${PROJECT_BINARY_DIR} "gstlearn.cmake")
 
+# Activate the support of upper case XXX_ROOT variables
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
 ####################################################
 ## EXTERNAL LIBS
 add_subdirectory(3rd-party/gmtsph)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For **compiling and installing** *gstlearn* C++ library, the following tools mus
   * Windows:
     * Python users: Microsoft Visual Studio C++ 14 or higher
     * R users: MinGW 7 (RTools 4.2) or higher
-* Boost header files 1.65 or higher
+* Boost header files 1.70 or higher
 * Eigen3 header files 3.4 or higher
 * NLopt library 2.7 or higher
 * HDF5 [Optional] C++ library and header files 1.8 or higher

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -123,7 +123,13 @@ endif()
 
 # Look for Boost
 #set(Boost_DEBUG 1)
-find_package(Boost CONFIG REQUIRED)
+
+# Get rid of the warning CMP0167
+# https://stackoverflow.com/a/79147222
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+find_package(Boost 1.70 REQUIRED)
 # TODO : If Boost not found, fetch it from the web ?
 option(USE_BOOST_SPAN "Use Boost span instead of std (C++17 builds)" OFF)
 mark_as_advanced(USE_BOOST_SPAN)


### PR DESCRIPTION
This PR roll back find_package instruction for Boost to the previous version (without CONFIG keyword).
It also fixes the CMake warning CMP0167 and add the capability to CMake to handle XXX_ROOT variables in uppercase (for retro compatibility)