### PR TITLE
Prevent doxygen from running html for package creation

### DIFF
--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -102,6 +102,7 @@ add_dependencies(doxygen_html doc_macro)
 set(DOXYGEN_GENERATE_HTML NO)
 set(DOXYGEN_GENERATE_XML YES)
 set(DOXYGEN_PREDEFINED ${COMMON_PREDEFINED})
+set(DOXYGEN_LAYOUT_FILE "")
 
 doxygen_add_docs(doxygen_xml
                  ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(python_doc
 
 # Tell that we need to generate doxymentation before building python package
 if (BUILD_DOC)
-  add_dependencies(python_doc doxygen)
+  add_dependencies(python_doc doxygen_xml)
 endif()
 
 ####CUSTOM WRAPPER

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -53,10 +53,6 @@ add_custom_target(r_doc
   VERBATIM
 )
 
-if (BUILD_DOC)
-  add_dependencies(r_doc doxygen)
-endif()
-
 ####CUSTOM WRAPPER
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/swig/generated_r.i
 COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/swig/generated_r.i
@@ -76,7 +72,7 @@ add_custom_target(r_clean_namespace
 
 # Tell that we need to generate doxymentation before building R package (if required)
 if (BUILD_DOC)
-  add_dependencies(r_doc doxygen)
+  add_dependencies(r_doc doxygen_xml)
 endif()
 
 ######################################


### PR DESCRIPTION
This PR prevents old doxygen version from creating errors about html Layout (like the ones below) while generating XML documentation

<img width="911" height="567" alt="image" src="https://github.com/user-attachments/assets/d8788de1-ced6-4e0e-bd29-3458855f9a3c" />
