### PR TITLE
GitHub Actions: Make CMake find Sphinx in publish_python_windows

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -81,7 +81,6 @@ jobs:
           -DHDF5_USE_STATIC_LIBRARIES=ON \
           -DBUILD_PYTHON=ON \
           -DBUILD_R=OFF \
-          -DPython3_ROOT_DIR="${{env.pythonLocation}}" \
           -DBUILD_DOC=ON
       env:
         CC: ${{matrix.arch.pat}}/opt/llvm/bin/clang

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -91,7 +91,6 @@ jobs:
           -A ${{matrix.arch.of}} `
           -DBUILD_PYTHON=ON `
           -DBUILD_R=OFF `
-          -DPython3_ROOT_DIR="${{env.pythonLocation}}" `
           -DSphinx_DIR=${{ env.VIRTUAL_ENV }}/share/Sphinx/cmake `
           -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DBUILD_DOC=ON

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -92,6 +92,7 @@ jobs:
           -DBUILD_PYTHON=ON `
           -DBUILD_R=OFF `
           -DPython3_ROOT_DIR="${{env.pythonLocation}}" `
+          -DSphinx_DIR=${{ env.VIRTUAL_ENV }}/share/Sphinx/cmake `
           -DHDF5_USE_STATIC_LIBRARIES=ON `
           -DBUILD_DOC=ON
 


### PR DESCRIPTION
This PR sets the CMake variable `Sphinx_DIR` to make CMake find the installed `sphinx-cmake` files in the `uv` virtualenv.

In addition, the `Python3_ROOT_DIR` CMake define has been removed, since the environment variable `pythonLocation` is not set anymore and the double quotes prevent the variable expansion.

Corresponding `publish` run: https://github.com/pierre-guillou/gstlearn/actions/runs/32154253886/job/95767490083

Pierre