### PR TITLE
Fix installation of ggpubr while publishing under windows

### DIFF
--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -57,12 +57,16 @@ jobs:
       with:
         r-version: ${{matrix.r_version}}
 
-    # In R 4.2 ggplot2 & ggpubr prefer older Matrix version
+    # In R 4.2, ggplot2 & ggpubr prefer older Matrix version
     - name: Install R Matrix dependency
       run: Rscript -e "install.packages ('https://cran.r-project.org/src/contrib/Archive/Matrix/Matrix_1.6-5.tar.gz')"
 
+    # In R 4.3 & R 4.4, ggpubr needs rstatix >=1 which is not preinstalled
+    - name: Install R rstatix dependency
+      run: Rscript -e "install.packages (c('rstatix', type='source'))"
+
     - name: Install R dependencies (binary)
-      run: Rscript -e "install.packages (c('ggplot2', 'ggpubr', 'ggnewscale', 'roxygen2', 'pkgbuild'), type='binary')"
+      run: Rscript -e "install.packages (c('ggplot2', 'ggpubr', 'ggnewscale', 'roxygen2','pkgbuild'), type='binary')"
 
     - name: Fix CMake Path (system prefered to rtools)
       run: |
@@ -156,6 +160,10 @@ jobs:
     # In R 4.2 ggplot2 & ggpubr prefer older Matrix version
     - name: Install R Matrix dependency
       run: Rscript -e "install.packages ('https://cran.r-project.org/src/contrib/Archive/Matrix/Matrix_1.6-5.tar.gz')"
+
+    # In R 4.3 & R 4.4, ggpubr needs rstatix >=1 which is not preinstalled
+    - name: Install R rstatix dependency
+      run: Rscript -e "install.packages (c('rstatix', type='source'))"
 
     - name: Install R dependencies (binary)
       run: Rscript -e "install.packages (c('ggplot2', 'ggpubr', 'ggnewscale', 'roxygen2', 'pkgbuild'), type='binary')"

--- a/python/pygstlearn.i
+++ b/python/pygstlearn.i
@@ -873,7 +873,7 @@ namespace gstlrn
 }
 
 %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) const std::string_view {
-  $1 = PyString_Check($input) ? 1 : 0;
+  $1 = PyUnicode_Check($input) || PyBytes_Check($input);
 }
 }//namespace gstlrn
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
The package rstatix (>= v1) is required by ggpubr but for some reasons, it is not installed automatically under R 4.2/4.3. Installation of rstatix (sources) has been added before installing ggpubr in publish_r_windows.

Corresponding workflow : https://github.com/gstlearn/gstlearn/actions/runs/32247036582